### PR TITLE
Docs: prepare Track A issue swarm

### DIFF
--- a/content/drafts/accessibility-statement-2026-05/README.md
+++ b/content/drafts/accessibility-statement-2026-05/README.md
@@ -1,0 +1,87 @@
+# Accessibility Statement Draft - May 2026
+
+Status: editorial draft for GitHub issue #48. Not published. Not legal advice. Do not treat this as a compliance claim until KK and an accessibility/legal reviewer approve the wording.
+
+Target page: `/accessibility/`
+
+## Draft Page Copy
+
+# Accessibility
+
+KrisKrug.co should be useful to as many people as possible, including people using screen readers, keyboard navigation, voice control, browser zoom, captions, high-contrast settings, and other assistive technologies.
+
+This site is a long-running WordPress archive with current writing, older posts, photography, event coverage, project pages, and AI education material. The goal is to keep improving the experience while being honest about what has and has not been reviewed.
+
+## Current Status
+
+As of May 2026, the site has not completed an independent accessibility audit. Recent site work has improved parts of the content structure, including heading hierarchy on the homepage and About page, and the newsletter popup was changed so it no longer appears immediately after page load.
+
+Known areas that still need review or cleanup include:
+
+- Alt text coverage on older images and image-heavy posts.
+- Mobile and tablet behavior across the current Catch Responsive theme.
+- Keyboard and focus behavior for menus, popups, forms, search, and embedded media.
+- The blog index heading structure, which may need theme-level work or the Aurora theme migration.
+- Colour contrast and focus states across older theme elements and legacy content.
+- Captions, transcripts, or descriptive context for older video and audio embeds where available.
+
+## What We Are Working Toward
+
+The working accessibility target is WCAG 2.1 AA for the site, with the published Accessibility page itself built as a simple, semantic page that can meet a higher bar where practical. Do not publish a sitewide WCAG 2.1 AAA claim unless an audit verifies it.
+
+Near-term improvements:
+
+- Write and review descriptive alt text for the most visible images first, then continue through recent posts and the older archive.
+- Run mobile checks at phone and tablet widths.
+- Test the main navigation, newsletter popup, contact paths, and forms with keyboard-only navigation.
+- Keep page headings to one clear H1 followed by logical H2 and H3 sections.
+- Use descriptive link text instead of vague "click here" links.
+- Carry these checks into the Aurora v2 theme work before any production cutover.
+
+## Feedback And Accommodation Requests
+
+If something on this site is hard to read, navigate, hear, understand, or use, please contact Kris through the contact page:
+
+https://kriskrug.co/contact/
+
+When possible, include:
+
+- The page URL.
+- What you were trying to do.
+- The barrier you hit.
+- Your browser, device, and assistive technology if you are comfortable sharing it.
+- The format or accommodation that would help.
+
+Kris will review accessibility feedback and make a reasonable effort to respond or fix the issue. Response timing should be confirmed before publication.
+
+## Review Cycle
+
+This statement should be reviewed whenever the site theme changes, major plugins change, a new accessibility audit is completed, or a user reports a barrier.
+
+Last reviewed: May 2026 draft. Confirm the final publication date before this goes live.
+
+## Editorial Review Notes
+
+- Confirm whether the target standard should be worded as WCAG 2.1 AA, WCAG 2.2 AA, or another standard before publishing.
+- Confirm the reporting channel. The draft uses `/contact/` instead of inventing a direct accessibility email address.
+- Confirm expected response timing before adding any commitment such as "within 5 business days."
+- Do not claim the whole site is compliant. Current docs show known gaps, especially older image alt text, mobile checks, keyboard/focus checks, and legacy theme behaviour.
+- If legal compliance language is needed, get legal review before publication.
+- Avoid tables, decorative images, embeds, accordions, or complex layout on this page. The issue requires the page itself to be highly accessible.
+
+## Publication Checklist
+
+- [ ] Verify backup/snapshot path before editing production WordPress.
+- [ ] Confirm no existing live page already owns `/accessibility/`.
+- [ ] Create the page as a WordPress draft first, not published.
+- [ ] Use exactly one H1: `Accessibility`.
+- [ ] Use semantic H2 sections matching this draft.
+- [ ] Add no required images. If an image is added, give it reviewed alt text or mark it decorative correctly.
+- [ ] Check every link has descriptive text and a valid target.
+- [ ] Confirm the contact path is correct and works.
+- [ ] Run keyboard-only review: tab order, visible focus, skip links, menu access, form access.
+- [ ] Run automated checks with at least Lighthouse and one accessibility scanner such as WAVE or axe.
+- [ ] Test at desktop, tablet, and mobile widths.
+- [ ] Add footer link only after the page content is reviewed.
+- [ ] After publication, verify `https://kriskrug.co/accessibility/` returns 200 and is crawlable.
+- [ ] Add the published URL to issue #48 with review notes and remaining gaps.

--- a/content/drafts/ai-glossary-2026-05/README.md
+++ b/content/drafts/ai-glossary-2026-05/README.md
@@ -1,0 +1,223 @@
+# AI Glossary Draft - May 2026
+
+Status: editorial draft for GitHub issue #44. Not published. Definitions are plain-language starters for review, not final authority. Terms touching Indigenous governance, law, culture, rights, and protocol need KK and subject-matter review before publication.
+
+Target page: `/glossary/`
+
+## Draft Page Copy
+
+# AI Glossary
+
+AI conversations get hard to enter when every sentence assumes you already know the vocabulary. This glossary is a plain-language bridge for readers of KrisKrug.co, especially people arriving through posts about creative AI, local AI, data centres, Indigenous governance, public-interest technology, and community accountability.
+
+The goal is not to flatten complex ideas. The goal is to give newcomers enough context to keep reading, ask better questions, and notice when a term is being used too loosely.
+
+## A
+
+**Agent:** An AI system that can take multiple steps toward a goal, often using tools, files, web search, or other software along the way.
+
+**AI alignment:** The work of making AI systems behave in ways that match human goals, safety needs, and social values. Alignment is not only a technical problem; it also depends on whose goals and values are being centered.
+
+**AI ethics:** The practice of asking whether AI systems are fair, accountable, understandable, safe, consent-based, and worth building in the first place.
+
+**Algorithm:** A set of instructions for solving a problem or making a decision. In AI, algorithms help systems find patterns, rank options, generate content, or make predictions.
+
+**Artificial intelligence (AI):** Software that performs tasks people often associate with intelligence, such as recognizing patterns, generating language or images, planning, translating, summarizing, or making recommendations.
+
+**Automation:** Using software or machines to do work that people otherwise do manually. Automation can save time, but it can also hide decisions, remove context, or shift power away from workers and communities.
+
+## B
+
+**Benchmark:** A test used to compare AI systems. Benchmarks can be useful, but they rarely capture the full social, cultural, or local impact of a tool.
+
+**Bias:** A pattern that causes a system to treat people, groups, languages, places, or ideas unevenly. Bias can come from training data, design choices, deployment context, or the assumptions of the people building the system.
+
+## C
+
+**Chatbot:** A conversational interface for software. Modern chatbots often use large language models to answer questions, draft text, summarize files, or help with tasks.
+
+**ChatGPT:** OpenAI's conversational AI product. It is a product built around AI models, not the same thing as the underlying model itself.
+
+**Claude:** Anthropic's conversational AI product. Like ChatGPT, it is a product experience wrapped around underlying models and safety systems.
+
+**Community benefits agreement:** A negotiated agreement that spells out how a project will benefit local communities, often including jobs, infrastructure, training, environmental safeguards, or accountability measures.
+
+**Compute:** The processing power needed to train or run AI systems. Compute often depends on specialized chips, energy, cooling, networking, and data centre infrastructure.
+
+**Consent:** Clear permission from people or communities before their data, stories, likeness, cultural knowledge, or creative work is used. Consent should be informed, specific, and revocable where possible.
+
+**Consultation:** A process for asking affected people or communities for input. Consultation is not the same as consent, shared governance, or decision-making power.
+
+**Corpus:** A collection of text, images, audio, video, code, or other material used for search, research, analysis, or AI training.
+
+## D
+
+**Data centre:** A building or campus that houses servers, networking, storage, cooling, and power systems. AI data centres can have major effects on electricity demand, water use, land, labour, and local infrastructure.
+
+**Data governance:** The rules, responsibilities, and decision-making processes for collecting, storing, using, sharing, and deleting data.
+
+**Data sovereignty:** The idea that data should be governed by the laws, rights, values, and decision-making authority of the people, communities, or nations it comes from.
+
+**Digital colonialism:** A pattern where technology systems extract data, labour, knowledge, attention, or value from communities without meaningful consent, benefit, or governance power.
+
+## E
+
+**Embedding:** A mathematical representation of text, images, audio, or other data that helps AI systems compare meaning and similarity.
+
+**Explainability:** The ability to understand why an AI system produced a result or recommendation. Some AI systems are hard to explain, which can make accountability harder.
+
+**Extractive technology:** Technology that takes more value from people, communities, workers, creators, or environments than it returns.
+
+## F
+
+**Fine-tuning:** Additional training that adapts a model for a specific style, task, domain, or dataset.
+
+**Foundation model:** A large model trained on broad data that can be adapted to many tasks, such as writing, coding, image generation, search, or analysis.
+
+**Free, prior and informed consent (FPIC):** A standard in Indigenous rights that means consent should be given freely, before a project proceeds, and with enough information for communities to make a real decision.
+
+**Frontier model:** A model at or near the leading edge of AI capability. The term is often used for powerful systems from major AI labs.
+
+## G
+
+**Generative AI:** AI that creates new text, images, audio, video, code, or other outputs from prompts, examples, or source material.
+
+**GPU:** A graphics processing unit. GPUs are chips that are especially useful for the parallel calculations behind modern AI.
+
+**Guardrails:** Rules, filters, prompts, policies, or product design choices meant to reduce harmful outputs or unsafe behaviour.
+
+## H
+
+**Hallucination:** A confident AI output that is false, unsupported, or invented. Hallucinations are one reason important AI outputs need review.
+
+**Host Nation:** An Indigenous Nation on whose territory an event, project, facility, or decision is taking place. Confirm wording and protocol with the Nation and local context.
+
+**Human-in-the-loop:** A workflow where a person reviews, approves, edits, or can override AI output before it affects people or systems.
+
+## I
+
+**Indigenomics:** An Indigenous economic lens and movement associated with building Indigenous economic power, governance, and participation at scale. Confirm final wording with current Indigenomics.ai language before publication.
+
+**Indigenous AI:** AI work shaped by Indigenous rights, governance, knowledge systems, community priorities, and self-determination rather than imposed from outside.
+
+**Indigenous data sovereignty:** The right of Indigenous Peoples and Nations to govern data about their peoples, lands, resources, knowledge, and communities.
+
+**Indigenous governance:** Decision-making authority grounded in Indigenous laws, institutions, rights, protocols, and relationships. Do not reduce this to stakeholder feedback.
+
+**Indigenous rights holder:** An Indigenous Nation or people with rights that must be respected. A rights holder is not the same as a stakeholder.
+
+**Inference:** Running a trained model to produce an output, such as an answer, image, classification, or recommendation.
+
+## L
+
+**Large language model (LLM):** An AI model trained to work with language. LLMs can draft, summarize, translate, classify, reason over text, and power chatbot products.
+
+**Local AI:** AI that runs on a user's own device, server, or private infrastructure instead of relying entirely on a cloud service.
+
+## M
+
+**Machine learning:** A branch of AI where systems learn patterns from data instead of being programmed with every rule by hand.
+
+**Model:** The trained system that turns inputs into outputs. In AI writing tools, the model is the engine, while the app is the product wrapped around it.
+
+**Model weights:** The learned parameters inside a model. Weights are part of what allow a trained model to produce useful outputs.
+
+**Multimodal AI:** AI that can work across more than one kind of input or output, such as text, images, audio, video, and code.
+
+## O
+
+**OCAP:** A First Nations data governance framework standing for ownership, control, access, and possession. Confirm final wording and attribution before publication.
+
+**Open model:** A model released with enough access for others to inspect, use, adapt, or run it, depending on the license and release terms.
+
+**Open weights:** Model weights that are available for others to download or run. Open weights do not automatically mean open data, open training methods, or unrestricted rights.
+
+## P
+
+**Prompt:** The instruction, question, context, file, or example given to an AI system.
+
+**Prompt engineering:** The practice of designing prompts and workflows so AI systems produce more useful, reliable, or constrained outputs.
+
+**Public-interest compute:** Compute capacity reserved or governed for civic, academic, public, Indigenous, nonprofit, or community benefit rather than only private profit.
+
+## R
+
+**Retrieval-augmented generation (RAG):** A method where an AI system retrieves relevant documents or data before generating an answer, making it easier to cite sources and use current context.
+
+**Reconciliation:** The ongoing work of repairing relationships and systems shaped by colonialism. In technology work, this should include material commitments, governance, accountability, and respect for Indigenous rights.
+
+**Red teaming:** Testing a system by trying to make it fail, break rules, expose vulnerabilities, or produce harmful outputs.
+
+**Rights holder:** A person, people, or Nation with legal, inherent, or recognized rights affected by a decision. Rights holders require a different level of respect and authority than general stakeholders.
+
+## S
+
+**Self-determination:** The right of a people or community to make decisions about its own future, governance, resources, culture, and development.
+
+**Sovereign AI:** AI infrastructure, capability, or governance controlled by a country, Nation, region, or community. The term should always raise the question: sovereign for whom?
+
+**Stakeholder:** A person or group with an interest in a decision. Stakeholders matter, but the term should not be used to flatten rights holders, host Nations, workers, creators, or affected communities into one generic category.
+
+**Synthetic media:** Images, audio, video, or text created or heavily modified by AI.
+
+## T
+
+**Token:** A chunk of text that an AI model processes. Tokens can be words, parts of words, punctuation, or other units.
+
+**Traditional knowledge:** Knowledge held by Indigenous Peoples and communities through lived practice, relationship, stewardship, language, and culture. It should not be treated as free training data.
+
+**Training data:** The material used to teach an AI model patterns. Training data can include text, images, audio, video, code, or structured records.
+
+**Transformer:** A model architecture that helped make modern language models possible by allowing systems to track relationships across large amounts of text.
+
+**Two-Eyed Seeing:** A concept associated with Mi'kmaw Elder Albert Marshall about learning to see from both Indigenous and Western knowledge systems. Confirm wording and attribution before publication.
+
+## U
+
+**Unceded territory:** Land that was not surrendered through treaty. Use local wording carefully and confirm with the relevant Nation or trusted local sources.
+
+## V
+
+**Vector database:** A database designed to store and search embeddings, often used for semantic search and RAG systems.
+
+**Vision model:** An AI model that can interpret images or video.
+
+## W
+
+**Water and energy footprint:** The water, electricity, cooling, land, and infrastructure demands created by technology systems, including AI data centres.
+
+**Workflow automation:** Software that connects steps in a process so repeated work can happen with less manual effort. Good automation should still keep accountability clear.
+
+## Editorial Review Notes
+
+- This draft includes more than 50 terms to satisfy the issue acceptance criterion while leaving room to cut or merge terms during editorial review.
+- Indigenous, legal, rights, and protocol terms need subject-matter review before publication. Do not publish those definitions as final without review.
+- Consider adding short source links for FPIC, OCAP, Two-Eyed Seeing, Indigenous data sovereignty, and land/territory language.
+- Decide whether this should be a general glossary or a narrower "AI, community, and Indigenous governance glossary."
+- Keep the page plain. Avoid dense tables so the page stays mobile friendly and screen-reader friendly.
+- If "searchable" means strict in-page filtering, scope a small accessible search/filter enhancement after the editorial content is approved. A-Z anchors plus browser/site search may be enough for the first draft, but issue #44 should confirm the expectation.
+
+## Suggested Internal Links After Publication
+
+- Link `AI glossary` from posts and pages that use dense AI terminology.
+- Link `sovereign AI`, `Indigenous governance`, `public-interest compute`, and `data centre` from current posts about AI infrastructure and Web Summit Vancouver.
+- Link `local AI`, `model`, `open weights`, `RAG`, and `vector database` from posts about local AI stacks and creative workflows.
+- Link `reconciliation`, `unceded territory`, `Host Nation`, and `Traditional knowledge` from the reconciliation page only after review.
+- Link from `/generative-ai-services/`, `/about/`, `/blog/`, and future AI education pages if KK wants the glossary to become a permanent reader aid.
+
+## Publication Checklist
+
+- [ ] Confirm the page title: `AI Glossary`.
+- [ ] Confirm target slug `/glossary/` is available.
+- [ ] Review all Indigenous, legal, and governance terms with appropriate sources or reviewers.
+- [ ] Add A-Z anchor links at the top of the WordPress page.
+- [ ] Decide whether to ship MVP search via browser/site search or build an accessible in-page filter.
+- [ ] Use semantic headings only: one H1, then letter sections as H2s.
+- [ ] Avoid tables; use definition list or heading plus paragraph blocks.
+- [ ] Add SEO title: `AI Glossary | Kris Krug`.
+- [ ] Add meta description: `Plain-language definitions for AI, local technology, data governance, Indigenous governance, and creative AI terms used on KrisKrug.co.`
+- [ ] Check mobile layout with long terms such as `retrieval-augmented generation`.
+- [ ] Run accessibility checks on the draft page before publishing.
+- [ ] Add internal links from relevant pages and posts after publication.
+- [ ] Verify `https://kriskrug.co/glossary/` returns 200 after publication.
+- [ ] Update issue #44 with the published URL, review notes, and any follow-up search/filter work.

--- a/docs/current-state/INTERNAL-LINKING-STRATEGY-2026-05-18.md
+++ b/docs/current-state/INTERNAL-LINKING-STRATEGY-2026-05-18.md
@@ -1,0 +1,419 @@
+# Internal Linking Strategy - Issue #38
+
+**Date:** 2026-05-18
+**Lane:** Track A content + SEO
+**Scope:** Report-only strategy artifact for GitHub issue #38, "[SEO] Implement Internal Linking Strategy."
+**Production status:** No WordPress writes, no theme edits, no connector run.
+
+## Issue #38 Success Criteria
+
+Issue #38 asks for a stronger internal-linking system:
+
+| Acceptance criterion | Strategy translation |
+|---|---|
+| All pages have 2-5 internal links | Every page should link up to its parent hub, sideways to related pages/posts, and forward to one clear next action. |
+| Important pages have 5+ links | About, Work/Projects, Services, Speaking, Blog, Events, Contact, and new topic pillars should each act as hubs with 5+ contextual internal links. |
+| No orphaned pages | Every published page and priority post should have at least one inbound link from nav, a hub page, a related post, or footer/sidebar. |
+| All pages reachable within 3 clicks | Top nav/footer to hubs, hubs to cluster pages/posts, posts back to hubs. |
+| Anchor text descriptive | Use intent-rich anchors like "AI keynote speaking", "Vancouver AI meetup recaps", "BC + AI work", not "click here". |
+| Related content cross-linked | Each topic cluster gets bidirectional links between pillar, recent posts, evergreen posts, and commercial/booking surfaces. |
+| Session duration increased | Measurement depends on GA4/Jetpack Stats access and remains human-gated. |
+
+## Source Surfaces Inspected
+
+Primary required docs:
+
+- `AGENTS.md`
+- `docs/current-state/README.md`
+- `docs/current-state/TWO-TRACK-MODEL.md`
+- `docs/current-state/REPO_STATE.md`
+- `docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`
+- `docs/current-state/SEO_AUDIT.md`
+- `docs/current-state/CONTENT_AUDIT.md`
+- `docs/current-state/SITE_INVENTORY.md`
+
+Supporting current-state docs:
+
+- `docs/current-state/TRAFFIC-DIAGNOSTIC-2026-05-15.md`
+- `docs/current-state/NAV-IA-DECISION-PACK-2026-05-18.md`
+- `docs/current-state/OWNED-SITES-LINKING-RECOMMENDATION-2026-05-18.md`
+- `docs/current-state/POST-ENRICHMENT-2026-05-16.md`
+- `docs/current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md`
+- `docs/current-state/FIX_QUEUE.md`
+- `docs/current-state/POST-DRAFT-BACKLOG-AUDIT-2026-05-18.md`
+- GitHub issue #38 via `gh issue view 38`
+
+Local evidence:
+
+- `docs/current-state/raw/pages.json`
+- `docs/current-state/raw/posts-page1.json`
+- `docs/current-state/raw/posts-page2.json`
+- `docs/current-state/raw/categories.json`
+- `docs/current-state/raw/tags.json`
+- `scripts/notion-to-wp/text_polish.py`
+- `scripts/notion-to-wp/README.md`
+- Existing local link audits:
+  - `content/drafts/2026-05-07-web-summit-vancouver-2026/internal-links.md`
+  - `content/drafts/2026-05-14-calling-us-all-in/internal-links.md`
+  - `content/drafts/2026-05-16-why-we-built-the-responsible-ai-professional-certification/internal-links.md`
+  - `content/drafts/2026-05-13-sovereign-ai-for-whom/internal-links.md`
+  - `content/drafts/2026-05-06-comox-valley-ai-is-becoming-its-own-thing/internal-links.md`
+  - `content/drafts/wp-draft-11178-post-11178/links.txt`
+  - `content/drafts/wp-draft-10594-post-10594/links.txt`
+
+Not inspected in this pass:
+
+- wp-admin page editor screens
+- authenticated WordPress database/link table
+- GA4, Jetpack Stats, or Google Search Console behavior data
+- a full live crawl of all 900+ posts
+- production edits after 2026-05-18 unless represented in repo docs
+
+## Current Link-Graph Baseline
+
+The audits agree on the failure mode:
+
+- The site has 34 published pages in the May 14 public snapshot, all top-level.
+- The May 14 public category snapshot shows only `Misc` and `Oil Spill`; later docs note a few real categories were started, but the corpus remains largely uncategorized.
+- The public archive has roughly 900+ posts, with the recent AI/community material concentrated in 2023-2026.
+- `CONTENT_AUDIT.md` explicitly did not complete a full internal link graph.
+- `SEO_AUDIT.md` flags internal linking/navigation as a weak surface and calls out the flat page hierarchy.
+- `TRAFFIC-DIAGNOSTIC-2026-05-15.md` identifies the internal link graph as the secondary SEO lever after categorization.
+- Local draft link audits show uneven internal-link coverage:
+  - `web-summit-vancouver-2026`: 5 internal links, good start for a cluster post.
+  - `calling-us-all-in`: 2 internal links.
+  - `sovereign-ai-for-whom`: 1 internal link.
+  - `why-we-built-the-responsible-ai-professional-certification`: 1 internal link.
+  - `comox-valley-ai-is-becoming-its-own-thing`: 0 internal links.
+  - `wp-draft-11178-post-11178/links.txt` and `wp-draft-10594-post-10594/links.txt`: empty local audit files even though later docs say the posts were enriched live.
+- `scripts/notion-to-wp/text_polish.py` has a useful starter `LINK_MAP`, but it is term-based, not a complete cluster strategy.
+
+## Priority Hub Pages
+
+These are the pages that should receive and distribute the most internal link equity.
+
+| Priority | Hub | Current URL | Status | Role in the graph |
+|---|---|---|---|---|
+| P0 | About | `/about/` | Existing | Entity hub for Kris Krug, credibility, current roles, and project network. |
+| P0 | Work / Projects | `/recent-projects-include/` now, future `/work/` pending decision | Existing, awkward slug | Portfolio hub for BC + AI, speaking portals, AI projects, Indigenomics, and selected proof. |
+| P0 | Services | `/generative-ai-services/` with `/services/` redirect noted in docs | Existing | Commercial hub linking to AI media, creative, coaching, workshop, speaking, testimonials, and contact. |
+| P0 | Speaking | `/speaking/` | Existing and recently strengthened | Speaking/keynote hub; should link to talk portals, companion essays, testimonials, events, and contact. |
+| P0 | Blog / Writing | `/blog/` | Existing but template has no H1 in audit | Archive hub for topic clusters and recent writing. |
+| P0 | Contact | `/contact/` | Existing | Conversion endpoint linked from services, speaking, work, and high-intent posts. |
+| P1 | Vancouver AI | Proposed `/vancouver-ai/` or `/vancouver-ai-meetup/` | Not yet created | Collection for Vancouver AI meetup recaps and BC ecosystem posts. |
+| P1 | BC + AI | Proposed `/bc-ai/` | Not yet created | Personal-role page for KK's BC + AI work, linking out to `bc-ai.ca` with context. |
+| P1 | Web Summit Vancouver | Proposed `/web-summit-vancouver/` | Not yet created | Evergreen annual coverage hub linking 2024, 2025, and 2026 Web Summit posts. |
+| P1 | AI for Creatives | Proposed `/ai-for-creatives/` or service-child route | Not yet created | Bridge between creative AI posts and the creative professionals offer. |
+| P1 | AI for Media | Proposed `/ai-for-media/` or service-child route | Not yet created | Bridge between journalism/media posts and the media leaders offer. |
+| P2 | Podcast | `/motleykrug-podcast/` | Existing | Series hub for interviews, guest spots, and audio/video work. |
+| P2 | Press | Proposed `/press/` | Not yet created | Media kit, bios, headshots, citations, and booking proof. |
+| P2 | Worldview | `/the-kk-worldview/`, possible future `/worldview/` | Existing | Philosophy/entity reinforcement hub. |
+| P2 | Reconciliation | `/reconciliation-indigenous-land-acknowledgement/`, possible future `/reconciliation/` | Existing | Values hub, especially for Indigenous tech and Indigenomics content. |
+
+## Recommended Link Graph
+
+Use a hub-and-spoke graph with bidirectional links:
+
+1. Site spine: top nav and footer point to `About`, `Work`, `Services`, `Speaking`, `Events`, `Blog`, `Podcast`, and `Contact`.
+2. Hub pages point down to their cluster posts/pages.
+3. Cluster posts point back up to the hub.
+4. Cluster posts cross-link to 2-3 sibling posts.
+5. High-intent posts point to the relevant conversion page.
+
+### Entity And Conversion Spine
+
+| From | Link to | Anchor pattern | Why |
+|---|---|---|---|
+| About | Work / Projects | `current AI projects` or `project network` | Turns identity into proof. |
+| About | Speaking | `AI keynote speaking` | Routes event/booker intent. |
+| About | Services | `generative AI services` | Routes commercial intent. |
+| About | Reconciliation | `reconciliation and Indigenous land acknowledgement` | Makes values visible and reachable. |
+| Work / Projects | Services | `AI strategy and creative services` | Converts proof into inquiry. |
+| Work / Projects | Speaking | `keynote portals and talks` | Connects project artifacts to stage work. |
+| Services | Testimonials | `client testimonials` | Adds proof near conversion. |
+| Services | Contact | `start a project conversation` | Clear next action. |
+| Speaking | Contact | `book Kris for a keynote` | Primary conversion. |
+| Speaking | Work / Projects | `current AI work` | Shows speaker proof beyond a speaking page. |
+| Blog posts | About | `Kris Krug` | Entity reinforcement. |
+| Blog posts | Contact | `bring Kris into your organization` | Only on high-intent posts; avoid spammy repetition. |
+
+### Vancouver AI / BC + AI Cluster
+
+Target hub: create `/vancouver-ai/` or `/vancouver-ai-meetup/`, then create `/bc-ai/` if KK wants a personal-role page separate from the external association.
+
+Priority posts to link into the hub:
+
+- `/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/`
+- `/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/`
+- `/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/`
+- `/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/`
+- `/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/`
+- `/2025/02/02/vancouver-ai-january-2025-recap-one-year-of-creative-rebellion-open-source-disruption/`
+- `/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/`
+- `/2024/12/28/system-check-vancouver-ai-community-meetups-december/`
+- `/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/`
+- `/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/`
+- `/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/`
+- `/2023/12/27/2024-vancouver-ai-community-meetups/`
+- `/2023/11/20/empowering-community-in-the-ai-era-fostering-authentic-connections-and-creative-collaboration/`
+- `/2023/10/20/vancouver-ai-community-lunch-meetup-fostering-community-in-vancouvers-budding-ai-landscape/`
+- `/2023/10/05/teasing-the-launch-vancouver-ai-community-meetup/`
+
+Recommended pattern:
+
+- Hub links to the latest 6 recaps, then a chronological archive.
+- Each recap links back to the hub using `Vancouver AI meetup recaps`.
+- Each recap links sideways to the previous and next recap when available.
+- BC + AI founding/strategy posts link to `Work`, `About`, and the external `bc-ai.ca` site.
+
+### Web Summit Vancouver Cluster
+
+Target hub: create `/web-summit-vancouver/`.
+
+Priority posts:
+
+- `/2026/05/07/web-summit-vancouver-2026/`
+- `/2025/04/13/web-summit-vancouver-2025-survival-guide/`
+- `/2024/09/05/the-outsiders-insider-guide-to-web-summit-vancouver/`
+- `/2024/08/22/web-summit-vancouver-2025-and-how-you-can-shape-it/`
+- `/2024/06/19/blog-rise-of-the-vancouver-technopunks-hosting-the-web-summit-on-our-terms/`
+
+Recommended pattern:
+
+- Hub explains the annual coverage and links each year/guide.
+- Every Web Summit post links to the hub using `Web Summit Vancouver coverage`.
+- Older posts should link forward to the 2026 post where context is still relevant.
+- The 2026 post already has 5 internal links; keep it as the model for this cluster.
+
+### AI For Creatives Cluster
+
+Target hub: create `/ai-for-creatives/` or route through the existing `/ai-upgrade-for-creative-professionals/` offer until a hub exists.
+
+Priority posts/pages:
+
+- `/ai-upgrade-for-creative-professionals/`
+- `/generative-ai-workshop-for-artists-creatives/`
+- `/2026/05/04/punk-rock-ai/`
+- `/2026/01/24/both-hands-full/`
+- `/2026/05/15/your-taste-is-your-moat/`
+- `/2026/05/16/make-culture-not-content/`
+- `/2025/03/30/a-creative-technologists-ai-age-manifesto/`
+- `/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/`
+- `/2025/04/07/we-dont-do-panels-we-do-portals/`
+- `/2024/11/22/great-creative-reckoning-a-techartists-manifesto-on-generative-artificial-intelligence/`
+- `/2024/10/28/kicking-ass-in-2025-a-techartists-guide-to-creative-survival/`
+- `/2024/07/19/fuck-the-status-quo-ais-messy-love-child-with-creativity/`
+
+Recommended pattern:
+
+- Creative offer page links to 3-5 proof essays.
+- Proof essays link back to the offer with contextual anchors like `AI workshops for creative teams`.
+- `Punk Rock AI`, `Both Hands Full`, `Your Taste Is Your Moat`, and `Make Culture, Not Content` should cross-link as one creative AI keynote/proof cluster.
+- `scripts/notion-to-wp/text_polish.py` already links several of these terms; expand only after final hub URLs exist.
+
+### AI For Media / Journalism Cluster
+
+Target hub: use `/ai-upgrade-for-modern-media-leaders/` now; create `/ai-for-media/` only if KK wants a separate editorial landing page.
+
+Priority posts/pages:
+
+- `/ai-upgrade-for-modern-media-leaders/`
+- `/2025/06/24/what-journalists-need-to-know-about-ai-right-now/`
+- `/2025/07/08/ai-training-for-media-pr-and-creative-professionals/`
+- `/2025/12/11/vancouver-tech-journal-isnt-journalism/`
+- `/2023/10/31/deconstruct-your-business-model-on-a-lean-canvas-google-news-initiative-launch-lab-week-two-report/`
+- `/2023/10/26/mapping-the-blueprint-the-genesis-of-a-media-venture-google-news-initiative-pre-launch-lab/`
+- `/2023/10/26/embarking-on-a-digital-news-voyage-week-1-recap-of-the-google-news-initiative-pre-launch-lab/`
+- `/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/`
+
+Recommended pattern:
+
+- Media offer page links to journalism/training posts as proof.
+- Journalism posts link back to the media offer using `AI training for media leaders` or similar.
+- Add one link from this cluster to `Speaking` for media conference/booker intent.
+
+### Responsible AI / Ethics Cluster
+
+Target hub: no new hub until the RAP duplication question is resolved; temporarily use `/the-kk-worldview/`, `/reconciliation-indigenous-land-acknowledgement/`, and the live RAP/certification post as anchors.
+
+Priority posts/pages:
+
+- `/the-kk-worldview/`
+- `/reconciliation-indigenous-land-acknowledgement/`
+- `/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/`
+- local draft `content/drafts/2026-05-16-why-we-built-the-responsible-ai-professional-certification/`
+- `/2026/02/03/name-the-bias/`
+- `/2025/06/09/ai-ate-the-future/`
+- `/2025/03/09/transcending-techs-darker-impulses/`
+- `/2024/12/20/fears-hopes-and-dreams-for-our-relationship-with-ai/`
+- `/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/`
+- `/2023/10/22/ais-true-threats-corporate-control-centralization-of-power-and-cultural-adaptation/`
+
+Recommended pattern:
+
+- Do not publish the RAP draft until the live RAP post relationship is resolved.
+- Ethics posts should link to `Worldview`, `Reconciliation`, and one commercial/service page only when the post naturally supports a training offer.
+- RAP/certification posts should cross-link with descriptive anchors, not duplicate each other's role.
+
+### Indigenous Tech / Reconciliation Cluster
+
+Target hub: use `/reconciliation-indigenous-land-acknowledgement/` now; consider an Indigenomics section on Work before creating a standalone page.
+
+Priority posts/pages:
+
+- `/reconciliation-indigenous-land-acknowledgement/`
+- `/recent-projects-include/`
+- `/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/`
+- `/2024/11/14/indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai/`
+- `/2024/10/15/indigenous-innovation-in-technology-and-the-future-of-indigenous-economies/`
+- local draft `content/drafts/2026-05-13-sovereign-ai-for-whom/`
+
+Recommended pattern:
+
+- Indigenomics posts link to `Reconciliation` and `Work`.
+- The Work page links to the external `indigenomics.ai` with context.
+- Do not create or rename pages here without KK review because the topic is values-sensitive.
+
+### Podcast / Conversations Cluster
+
+Target hub: `/motleykrug-podcast/`.
+
+Priority posts/pages:
+
+- `/motleykrug-podcast/`
+- `/podcast-guesting-page-epk/`
+- `/2025/03/01/shane-gibsons-ai-sales-dojo/`
+- `/2025/01/25/human-biography-podcast-w-sharad-khare/`
+- `/2024/12/17/generative-ai-cinematic-podcasts-how-kevin-friel-is-hacking-the-future-of-media/`
+- `/cinematic-podcasts-hollywood-grade-storytelling-meets-generative-ai/`
+- `/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/`
+
+Recommended pattern:
+
+- Podcast page lists or links notable episodes/appearances.
+- Guesting/EPK page links to Speaking, Podcast, About, and Contact.
+- Interview posts link back to Podcast or Guesting depending on user intent.
+
+## Minimum Link Rules
+
+Use these rules for every future Track A content edit:
+
+1. Every pillar or page gets 5+ internal links.
+2. Every standard page gets 2-5 contextual internal links.
+3. Every new post gets:
+   - one link up to a hub,
+   - two links to sibling posts,
+   - one link to About, Work, Services, Speaking, or Contact when intent fits.
+4. Every cluster hub links to 6-12 high-priority child posts/pages, then to an archive/category page if available.
+5. Avoid self-links and avoid linking headings.
+6. Use exact, descriptive anchors:
+   - Good: `Vancouver AI meetup recaps`, `AI keynote speaking`, `Responsible AI Professional certification`
+   - Weak: `read more`, `here`, `this post`
+7. Prefer body-copy links over sidebar-only links for SEO weight.
+8. Preserve external links where they provide evidence, but each long post should have at least 2 internal links before publish.
+
+## Quick Wins
+
+These can be prepared without changing production, then applied by a publisher session after backup/target checks.
+
+| Quick win | File/surface | Recommendation |
+|---|---|---|
+| Fix the zero-link Comox draft | `content/drafts/2026-05-06-comox-valley-ai-is-becoming-its-own-thing/internal-links.md` | Add links to Vancouver AI/BC + AI posts, community-building posts, and Work or Contact before any publish attempt. |
+| Strengthen RAP draft before publish decision | `content/drafts/2026-05-16-why-we-built-the-responsible-ai-professional-certification/` | Add links to the live RAP post, ethics/worldview material, and media/creative training surfaces, but only after duplicate-risk review. |
+| Build the Sovereign AI bridge | `content/drafts/2026-05-13-sovereign-ai-for-whom/` | Add links to Reconciliation, Indigenomics-related posts, BC + AI, Web Summit, and Work. Human review required before publishing. |
+| Use Web Summit as the model cluster | `content/drafts/2026-05-07-web-summit-vancouver-2026/internal-links.md` | Its 5 internal links are the closest existing local example of a cluster graph; older Web Summit posts should link forward and back when edited. |
+| Update `LINK_MAP` after hubs exist | `scripts/notion-to-wp/text_polish.py` | Add final canonical hub URLs for `Vancouver AI`, `BC + AI`, `Web Summit Vancouver`, `AI for Creatives`, and `AI for Media` only after URLs are confirmed. |
+| Add hub links to page copy | About, Work, Services, Speaking, Blog, Events | When those pages are next edited, add contextual links to the hub graph. Keep nav/footer changes separate from body copy changes. |
+| Create a tracking checklist before production work | Future issue comment or follow-up doc | Track page/post URL, desired inbound links, desired outbound internal links, anchor text, owner, status, and verification date. |
+
+## Verification Plan
+
+This is the verification path for a future implementation pass.
+
+### 1. Preflight
+
+- Confirm current branch and clean/known worktree.
+- Confirm Track A scope only.
+- Confirm full backup status before any production write.
+- Pull current page/post inventory through authenticated WordPress if available.
+- Export a pre-change list of candidate URLs and their current body links.
+
+### 2. Local Strategy Checks
+
+- For each proposed hub, confirm whether it exists.
+- For each post in a cluster, record:
+  - inbound hub link exists: yes/no
+  - outbound hub link exists: yes/no
+  - sibling links count
+  - conversion link count
+  - anchor text quality
+- Update the Notion connector `LINK_MAP` only after final URLs exist and self-link behavior is still covered by tests.
+
+### 3. Production Application Checks
+
+- Apply changes in small batches by cluster, not site-wide all at once.
+- After each page/post edit, GET the live URL and confirm 200.
+- Click-check or curl-check every new internal link.
+- Confirm no links point to draft/private/404 URLs.
+- Confirm canonical URLs remain unchanged unless a separate redirect/IA task explicitly handles a rename.
+- Do not use the connector against production without dry-run first.
+
+### 4. Crawl Checks
+
+- Run a crawler pass over the changed URLs and verify:
+  - no 404 internal links,
+  - no redirect chains for new links,
+  - no orphaned target pages in the changed set,
+  - each hub reachable from nav/footer within 1-2 clicks,
+  - each cluster child reachable from hub within 1 click.
+
+Suggested tooling:
+
+- `curl -I` for individual URLs
+- a small script using `requests` + BeautifulSoup for changed URLs
+- Screaming Frog/Sitebulb if KK has access
+- Google Search Console URL inspection for new/updated pillar pages
+
+### 5. Measurement
+
+Needs GA4, Jetpack Stats, or GSC access:
+
+- Baseline before implementation:
+  - top landing pages,
+  - engagement time/session duration,
+  - clicks to Contact/Speaking/Services,
+  - GSC impressions/clicks by cluster query.
+- Re-check 2-4 weeks after implementation:
+  - internal pathing from posts to hubs,
+  - hub impressions,
+  - long-tail queries for Vancouver AI, Web Summit Vancouver, AI for creatives, AI media training.
+
+## Human-Gated Decisions
+
+These should not be silently decided by an agent:
+
+1. Final URL for the Work hub: keep `/recent-projects-include/`, rename to `/work/`, or choose `/projects/`/`/portfolio/`.
+2. Whether `/services/` becomes the canonical service URL or remains a redirect to `/generative-ai-services/`.
+3. Whether to create both `/vancouver-ai/` and `/bc-ai/`, or combine them.
+4. Whether `/web-summit-vancouver/` should be a permanent annual hub.
+5. Whether `AI for Creatives` and `AI for Media` are editorial hubs, service pages, or both.
+6. Whether multilingual pages become a real international IA set, creative artifacts, or noindex pages.
+7. Whether `Reconciliation` and `Worldview` get shorter canonical slugs.
+8. Whether RAP draft content supplements, replaces, or redirects to the existing live RAP post.
+9. Which analytics source defines "session duration increased" for issue #38 closeout.
+10. Any production WordPress write, redirect, category migration, or page slug rename.
+
+## Recommended Closeout Path For Issue #38
+
+Issue #38 should not close on this report alone. This report scopes the work.
+
+Close #38 only after a future implementation pass can show:
+
+1. A current crawl confirms no orphaned priority pages.
+2. All 34 published pages have 2-5 contextual internal links or documented exceptions.
+3. The important hubs have 5+ internal links.
+4. Priority clusters have bidirectional hub/post links.
+5. Changed links have been click-checked.
+6. Analytics has a baseline and a dated follow-up plan for session duration.
+
+Until then, this artifact should be treated as the implementation map for #38, not the completed implementation.

--- a/docs/current-state/TRACK-A-SEO-SOCIAL-PREP-2026-05-18.md
+++ b/docs/current-state/TRACK-A-SEO-SOCIAL-PREP-2026-05-18.md
@@ -1,0 +1,146 @@
+# Track A SEO/social prep for issues #36 and #43 - 2026-05-18
+
+**Lane:** Track A - Content + SEO
+**Scope:** implementation notes only; no production writes, no theme edits.
+**Issues:** #36 unique meta descriptions, #43 Twitter/X card tags.
+
+## Assumptions and success criteria
+
+- This prep note is the only SEO/social file in this lane.
+- Production remains untouched from this branch.
+- Any later production session starts with backup confirmation and read-only preflight checks.
+- Jetpack is treated as the current meta, Open Graph, and Twitter-card owner unless admin verification proves otherwise.
+- Success for this note means future implementers can decide what to apply, what to skip, and what evidence closes each issue.
+
+## What is already prepared
+
+### Issue #36
+
+- `fixes/issue-36-meta-descriptions.md` contains draft descriptions for eight page surfaces: homepage, About, Services/Work, Blog/Insights, Contact, Vancouver AI Community, Photography Portfolio, and Speaking.
+- `docs/current-state/SEO_AUDIT.md` says all inspected pages already had meta descriptions, though quality and length were mixed.
+- The audit identifies Jetpack SEO Tools as the likely current surface for per-page descriptions. There is no confirmed dedicated SEO plugin in use.
+
+### Issue #43
+
+- `fixes/issue-43-twitter-cards.php` contains a PHP snippet intended to output Twitter card metadata.
+- `docs/current-state/SEO_AUDIT.md` says Open Graph tags are present site-wide and `twitter:card` is present on most audited pages through Jetpack.
+- The remaining audit gap is narrower than the issue title: the blog index was missing `twitter:card` and canonical, and social image/handle quality needed cleanup.
+- `docs/current-state/TRACK-A-QUICK-FIX-PACK-2026-05-18.md` adds fresher live evidence: `twitter:site` still rendered as `@feelmoreplants`, and old `twitter.com/feelmoreplants` links still appeared in live HTML on 2026-05-18.
+
+## Redundant or risky
+
+### Issue #36
+
+- The issue is not a blank-slate "add meta descriptions" task. The audited pages already have descriptions, so the safe implementation is a targeted refresh after current-value readback.
+- The prepared descriptions are not deploy-ready as labeled. A UTF-8 character count of the eight code-block descriptions reads about 189-221 characters, not the stated 150-160.
+- Several claims need owner/source verification before publication, including current roles, organizational names, "2,000+ community members", "250+ monthly attendees", and Fortune 500/Indigenous organization positioning.
+- Adding descriptions through `functions.php` or a front-end Code Snippet would risk duplicate `<meta name="description">` output while Jetpack is already emitting metadata.
+- Installing Yoast solely for this issue is too broad. If a future SEO plugin migration happens, Jetpack SEO/Open Graph ownership must be disabled or intentionally superseded first.
+
+### Issue #43
+
+- The PHP snippet is mostly redundant with Jetpack on singular pages where Jetpack already emits Open Graph and Twitter tags.
+- The snippet does not fix the exact blog-index gap from the audit because it returns early unless `is_singular()` or `is_front_page()` is true.
+- The snippet ships with `@YourTwitterHandle` placeholders and should not be activated as-is.
+- The fallback logo path can set `$twitter_image` without defining `$image_id`, then later use `$image_id` for `twitter:image:alt`.
+- `substr()` can split multibyte text and is not ideal for site copy that includes names like Kris Krug.
+- Installing the snippet in theme `functions.php` is not appropriate for Track A. Theme files are out of scope on `main`, and this repo is not a live theme mirror.
+
+## No-live-write verification plan
+
+Run these from any shell with network access before any admin edits. They are read-only and do not require credentials.
+
+### 1. Confirm target URLs before treating issue #36 copy as page-specific
+
+Use confirmed audit URLs first, then resolve the Vancouver AI and Photography targets before applying those two drafts.
+
+```bash
+for url in \
+  https://kriskrug.co/ \
+  https://kriskrug.co/about/ \
+  https://kriskrug.co/generative-ai-services/ \
+  https://kriskrug.co/blog/ \
+  https://kriskrug.co/contact/ \
+  https://kriskrug.co/speaking/
+do
+  echo "### $url"
+  curl -ILs "$url" | rg -i '^(HTTP|location:)'
+done
+```
+
+### 2. Read current SEO/social descriptions without changing them
+
+```bash
+for url in \
+  https://kriskrug.co/ \
+  https://kriskrug.co/about/ \
+  https://kriskrug.co/generative-ai-services/ \
+  https://kriskrug.co/blog/ \
+  https://kriskrug.co/contact/ \
+  https://kriskrug.co/speaking/
+do
+  echo "### $url"
+  curl -Ls "$url" \
+    | perl -0777 -ne 'print "meta: $1\n" if /<meta name="description" content="([^"]*)"/s; print "og: $1\n" if /<meta property="og:description" content="([^"]*)"/s; print "twitter: $1\n" if /<meta name="twitter:description" content="([^"]*)"/s'
+done
+```
+
+Expected pre-implementation evidence:
+
+- exactly one standard meta description per target page,
+- no duplicate metadata from competing SEO systems,
+- current values captured before deciding whether the draft copy is an improvement.
+
+### 3. Read current Twitter/X card state without changing it
+
+```bash
+for url in \
+  https://kriskrug.co/ \
+  https://kriskrug.co/about/ \
+  https://kriskrug.co/generative-ai-services/ \
+  https://kriskrug.co/blog/
+do
+  echo "### $url"
+  curl -Ls "$url" \
+    | rg -n 'Jetpack Open Graph|twitter:card|twitter:site|twitter:creator|twitter:title|twitter:description|twitter:image|feelmoreplants|x.com/kriskrug|twitter.com/kriskrug|rel="canonical"'
+done
+```
+
+Expected pre-implementation evidence:
+
+- Jetpack remains the active social-meta layer.
+- Singular pages already have Twitter card tags.
+- `/blog/` is checked separately for the missing card/canonical finding.
+- `feelmoreplants` occurrences are inventoried before any search-replace or admin setting change.
+
+### 4. Only after a separate authorized production session
+
+Use the same commands before and after any approved admin change. Do not activate the issue #43 PHP snippet unless Jetpack social metadata has been intentionally disabled or proven absent. Do not add issue #36 descriptions through code while Jetpack is still outputting `<meta name="description">`.
+
+## Recommended issue outcomes
+
+### Issue #36
+
+Recommended outcome: keep the issue, but narrow it to "verify and refresh Jetpack page meta descriptions" instead of "add missing descriptions."
+
+Close #36 only when:
+
+- each target URL has exactly one meta description,
+- the value is unique and intentionally written for that page,
+- the final copy is trimmed and fact-checked,
+- no new SEO plugin or code snippet creates duplicate meta tags.
+
+Do not close #36 by deploying the current `functions.php` example. Treat the existing file as copy draft material, not an implementation plan.
+
+### Issue #43
+
+Recommended outcome: mark the current PHP-snippet approach as superseded/redundant, then close or re-scope the issue based on read-only evidence.
+
+Close #43 if:
+
+- Jetpack already emits valid Twitter card tags for the intended share pages,
+- `twitter:site` and `twitter:creator` use the current KK handle,
+- stale `feelmoreplants` links/handles are removed through admin settings or a dry-run-verified search-replace,
+- the blog index gap is either fixed through the owning meta layer or split into a smaller follow-up.
+
+Do not close #43 by activating `fixes/issue-43-twitter-cards.php` as-is. The safer Track A work is handle cleanup plus targeted verification, not adding a second social-meta generator.


### PR DESCRIPTION
## Summary
- add a report-only internal linking strategy for issue #38
- add SEO/social implementation notes that narrow issues #36 and #43 around Jetpack-owned metadata
- add draft Accessibility and AI Glossary page copy for issues #48 and #44

## Safety
- Track A only: docs and content drafts
- no WordPress writes, no connector runs, no production changes
- no theme files touched

## Verification
- git diff --cached --check
- LC_ALL=C rg -n "[^\x00-\x7F]" docs/current-state/INTERNAL-LINKING-STRATEGY-2026-05-18.md docs/current-state/TRACK-A-SEO-SOCIAL-PREP-2026-05-18.md content/drafts/accessibility-statement-2026-05/README.md content/drafts/ai-glossary-2026-05/README.md

Refs #36
Refs #38
Refs #43
Refs #44
Refs #48