### PR TITLE
[codex] Restore KK Sidebar Promos plugin after history rewrite

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -117,6 +117,7 @@ jobs:
         run: |
           # Install WordPress Coding Standards if not present
           if ! phpcs -i | grep -q "WordPress"; then
+            composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
             composer global require wp-coding-standards/wpcs
             phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
           fi

--- a/plugins/kk-sidebar-promos/DEPLOYMENT.md
+++ b/plugins/kk-sidebar-promos/DEPLOYMENT.md
@@ -1,0 +1,63 @@
+# Deploying KK Sidebar Promos to kriskrug.co
+
+This plugin lives in the issue-tracking repo because the live WordPress install isn't version-controlled here. Two install paths — pick whichever is easier.
+
+## Path A — Upload via WP admin (fastest)
+
+1. Zip the plugin folder:
+   ```bash
+   cd plugins
+   zip -r kk-sidebar-promos.zip kk-sidebar-promos
+   ```
+2. **Plugins → Add New → Upload Plugin** on kriskrug.co. Upload the zip and activate.
+3. **Sidebar Promos → Settings** in the admin sidebar. Paste your Luma iCal URL (see below).
+4. Click **Run Luma sync now** to verify the first event imports.
+5. **Appearance → Editor** (or **Appearance → Widgets** for the classic widget area). Add the **KK Sidebar Promos** block to the sidebar template part. Remove the four old hard-coded image blocks.
+
+## Path B — SFTP / SSH
+
+1. Upload the `kk-sidebar-promos/` directory to `/wp-content/plugins/` on the server.
+2. **Plugins** in WP admin → activate **KK Sidebar Promos**.
+3. Continue from step 3 above.
+
+## Finding your Luma iCal URL
+
+1. On lu.ma, open the calendar you want to sync (e.g. `lu.ma/vancouver-ai`).
+2. Click the calendar settings (gear icon).
+3. Look for **Subscribe via iCal** — copy that URL.
+4. Paste into **Sidebar Promos → Settings → Luma iCal URL**.
+
+If Luma changes the URL format and the sync starts failing, the plugin logs an admin notice on the settings page; just refresh the iCal URL there.
+
+## What gets created on activation
+
+- Custom post type **Sidebar Promos** in the admin menu.
+- 4 published Pillar promos: Animation Accelerator, RAP Certification, BC+AI Membership, Vancouver AI Community.
+- Two daily WP-Cron jobs: `kk_sp_expire_featured` and `kk_sp_luma_sync`.
+
+## Replacing the existing sidebar graphics
+
+Once the block is rendering, edit each of the seeded Pillar promos and:
+
+1. Set a featured image (square or 4:3 — see `assets/img-templates/SPECS.md`).
+2. Confirm the link URL is right.
+3. Tweak the excerpt copy if needed.
+
+The four old image blocks in the sidebar template can then be removed.
+
+## Adding a time-bound Featured promo
+
+1. **Sidebar Promos → Add New**.
+2. Title, excerpt, featured image as normal.
+3. In the **Promo Settings** sidebar: set **Type** to "Featured" and **Active until** to the last day it should appear.
+4. Publish. It takes the top slot until the end date passes, then auto-moves to draft.
+
+If two Featured promos overlap, the most recently published one wins. The other waits in the queue (still published, still not expired) — it just doesn't render.
+
+## Uninstall
+
+Deactivating clears the cron schedules. The CPT and existing promo posts stay until you delete the plugin entirely.
+
+## Rolling back
+
+Deactivate the plugin and re-add the old image blocks. Promo posts remain in the database; reactivating restores the system without losing data.

--- a/plugins/kk-sidebar-promos/assets/css/sidebar-promos.css
+++ b/plugins/kk-sidebar-promos/assets/css/sidebar-promos.css
@@ -1,0 +1,159 @@
+/*
+ * KK Sidebar Promos — sidebar widget styling.
+ *
+ * Inherits theme tokens via CSS custom properties so it looks at home in any
+ * sidebar context. Tone classes (--tone-event/course/community) shift the
+ * accent color. The text-only fallback (no featured image) renders as a
+ * branded card so the sidebar still looks intentional when an image is
+ * missing.
+ */
+
+.kk-sp {
+	--kk-sp-bg:        var(--wp--preset--color--base, #fff);
+	--kk-sp-fg:        var(--wp--preset--color--contrast, #1a1a1a);
+	--kk-sp-muted:     color-mix(in srgb, var(--kk-sp-fg) 65%, transparent);
+	--kk-sp-accent:    var(--wp--preset--color--primary, #ff5a1f);
+	--kk-sp-event:     #2563eb;
+	--kk-sp-course:    #7c3aed;
+	--kk-sp-community: #059669;
+	--kk-sp-radius:    14px;
+	--kk-sp-gap:       1.25rem;
+	--kk-sp-border:    color-mix(in srgb, var(--kk-sp-fg) 12%, transparent);
+
+	display: flex;
+	flex-direction: column;
+	gap: var(--kk-sp-gap);
+	font-family: inherit;
+}
+
+.kk-sp__heading {
+	font-size: 0.85rem;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--kk-sp-muted);
+	margin: 0 0 -0.25rem;
+}
+
+.kk-sp__card {
+	position: relative;
+	display: block;
+	background: var(--kk-sp-bg);
+	border: 1px solid var(--kk-sp-border);
+	border-radius: var(--kk-sp-radius);
+	overflow: hidden;
+	transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.kk-sp__card:hover,
+.kk-sp__card:focus-within {
+	transform: translateY(-2px);
+	box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.3);
+	border-color: color-mix(in srgb, var(--kk-sp-accent) 40%, var(--kk-sp-border));
+}
+
+.kk-sp__link {
+	display: block;
+	color: inherit;
+	text-decoration: none;
+}
+
+.kk-sp__link:focus-visible {
+	outline: 2px solid var(--kk-sp-accent);
+	outline-offset: 2px;
+}
+
+/* Image */
+.kk-sp__image-wrap {
+	position: relative;
+	aspect-ratio: 4 / 3;
+	background: color-mix(in srgb, var(--kk-sp-fg) 5%, transparent);
+}
+
+.kk-sp__image {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.kk-sp__badge {
+	position: absolute;
+	top: 0.6rem;
+	left: 0.6rem;
+	background: var(--kk-sp-accent);
+	color: #fff;
+	font-size: 0.72rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	padding: 0.25rem 0.55rem;
+	border-radius: 999px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+}
+
+/* Body */
+.kk-sp__body {
+	padding: 1rem 1.1rem 1.1rem;
+}
+
+.kk-sp__title {
+	font-size: 1.05rem;
+	font-weight: 700;
+	line-height: 1.25;
+	margin: 0 0 0.4rem;
+	color: var(--kk-sp-fg);
+}
+
+.kk-sp__excerpt {
+	font-size: 0.92rem;
+	line-height: 1.5;
+	color: var(--kk-sp-muted);
+	margin: 0 0 0.7rem;
+}
+
+.kk-sp__cta {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	font-size: 0.88rem;
+	font-weight: 600;
+	color: var(--kk-sp-accent);
+}
+
+.kk-sp__card:hover .kk-sp__cta span[aria-hidden] {
+	transform: translateX(2px);
+	transition: transform 0.2s ease;
+}
+
+/* Tone variants tint the accent so similar promos read together. */
+.kk-sp__card--tone-event    { --kk-sp-accent: var(--kk-sp-event); }
+.kk-sp__card--tone-course   { --kk-sp-accent: var(--kk-sp-course); }
+.kk-sp__card--tone-community { --kk-sp-accent: var(--kk-sp-community); }
+
+/* Featured cards get a subtle accent rail at the top. */
+.kk-sp__card--featured {
+	box-shadow: inset 0 4px 0 var(--kk-sp-accent);
+}
+
+/* Text-only fallback card (no featured image set) — designed to still
+   look intentional, with a typographic header in the brand accent. */
+.kk-sp__card--text-only .kk-sp__body {
+	padding-top: 1.4rem;
+}
+
+.kk-sp__card--text-only::before {
+	content: "";
+	display: block;
+	height: 6px;
+	background: linear-gradient(90deg, var(--kk-sp-accent), color-mix(in srgb, var(--kk-sp-accent) 40%, transparent));
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.kk-sp__card,
+	.kk-sp__card:hover,
+	.kk-sp__cta span[aria-hidden] {
+		transition: none;
+		transform: none;
+	}
+}

--- a/plugins/kk-sidebar-promos/assets/img-templates/SPECS.md
+++ b/plugins/kk-sidebar-promos/assets/img-templates/SPECS.md
@@ -1,0 +1,45 @@
+# Promo Graphic Specs
+
+Keep these consistent and the sidebar will look like a system instead of a scrapbook.
+
+## Dimensions
+
+| Use case            | Size        | Aspect | Notes                                               |
+| ------------------- | ----------- | ------ | --------------------------------------------------- |
+| Sidebar default     | 800 × 600   | 4:3    | What the widget renders (`aspect-ratio: 4 / 3`).    |
+| Square (alt layout) | 800 × 800   | 1:1    | If you switch the CSS aspect later.                 |
+| Retina source       | 1600 × 1200 | 4:3    | Export at 2× so it stays sharp on high-DPI screens. |
+
+Save as JPG (~80% quality) for photos, PNG for flat illustrations. Keep each under ~150 KB if possible.
+
+## Layout rules
+
+- **Title-safe area:** keep critical text inside the centre 80% of the image.
+- **Top-left corner** is reserved — that's where the "X days left" badge sits on Featured promos.
+- **Don't bake in a CTA button.** The widget renders the CTA text and arrow separately.
+
+## Brand guardrails
+
+- Use the existing site type stack — no novel display fonts per promo.
+- Pick one accent color per **tone**:
+  - Event → blue
+  - Course → purple
+  - Community → green
+  - Default → site primary
+- High contrast on any text overlay (WCAG AA at minimum).
+
+## Templates to set up once
+
+Create one template per tone in Canva/Figma with:
+- Title slot (≤ 5 words)
+- Subtitle slot (≤ 8 words)
+- Background image area
+- Brand mark in a fixed corner
+
+Then producing a new promo is just "duplicate template, swap text and image." That's the change-them-more-often part.
+
+## Naming convention for uploads
+
+`promo-{slug}-{yyyymmdd}.jpg` — e.g. `promo-rap-cohort-2-20260601.jpg`.
+
+Makes it obvious in the media library which promo it belongs to and when it was made.

--- a/plugins/kk-sidebar-promos/includes/cpt.php
+++ b/plugins/kk-sidebar-promos/includes/cpt.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Custom post type and meta for sidebar promos.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const KK_SP_POST_TYPE     = 'kk_promo';
+const KK_SP_META_TYPE     = '_kk_promo_type';        // 'pillar' | 'featured'
+const KK_SP_META_LINK     = '_kk_promo_link';
+const KK_SP_META_CTA      = '_kk_promo_cta';
+const KK_SP_META_END      = '_kk_promo_end';         // YYYY-MM-DD
+const KK_SP_META_TONE     = '_kk_promo_tone';        // default | event | course | community
+const KK_SP_META_SOURCE   = '_kk_promo_source';      // manual | luma
+const KK_SP_META_SOURCE_ID = '_kk_promo_source_id';
+
+add_action( 'init', 'kk_sp_register_post_type' );
+add_action( 'init', 'kk_sp_register_meta' );
+add_action( 'add_meta_boxes', 'kk_sp_add_meta_boxes' );
+add_action( 'save_post_' . KK_SP_POST_TYPE, 'kk_sp_save_meta', 10, 2 );
+add_filter( 'manage_' . KK_SP_POST_TYPE . '_posts_columns', 'kk_sp_admin_columns' );
+add_action( 'manage_' . KK_SP_POST_TYPE . '_posts_custom_column', 'kk_sp_admin_column_content', 10, 2 );
+
+function kk_sp_register_post_type() {
+	register_post_type( KK_SP_POST_TYPE, [
+		'labels' => [
+			'name'               => __( 'Sidebar Promos', 'kk-sidebar-promos' ),
+			'singular_name'      => __( 'Sidebar Promo', 'kk-sidebar-promos' ),
+			'add_new_item'       => __( 'Add New Promo', 'kk-sidebar-promos' ),
+			'edit_item'          => __( 'Edit Promo', 'kk-sidebar-promos' ),
+			'new_item'           => __( 'New Promo', 'kk-sidebar-promos' ),
+			'view_item'          => __( 'View Promo', 'kk-sidebar-promos' ),
+			'search_items'       => __( 'Search Promos', 'kk-sidebar-promos' ),
+			'menu_name'          => __( 'Sidebar Promos', 'kk-sidebar-promos' ),
+		],
+		'public'        => false,
+		'show_ui'       => true,
+		'show_in_rest'  => true,
+		'menu_icon'     => 'dashicons-megaphone',
+		'menu_position' => 22,
+		'supports'      => [ 'title', 'editor', 'thumbnail', 'page-attributes' ],
+		'has_archive'   => false,
+		'rewrite'       => false,
+	] );
+}
+
+function kk_sp_register_meta() {
+	$keys = [
+		KK_SP_META_TYPE,
+		KK_SP_META_LINK,
+		KK_SP_META_CTA,
+		KK_SP_META_END,
+		KK_SP_META_TONE,
+		KK_SP_META_SOURCE,
+		KK_SP_META_SOURCE_ID,
+	];
+	foreach ( $keys as $key ) {
+		register_post_meta( KK_SP_POST_TYPE, $key, [
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'string',
+			'auth_callback' => static function () {
+				return current_user_can( 'edit_posts' );
+			},
+		] );
+	}
+}
+
+function kk_sp_add_meta_boxes() {
+	add_meta_box(
+		'kk_sp_settings',
+		__( 'Promo Settings', 'kk-sidebar-promos' ),
+		'kk_sp_render_meta_box',
+		KK_SP_POST_TYPE,
+		'side',
+		'high'
+	);
+}
+
+function kk_sp_render_meta_box( $post ) {
+	wp_nonce_field( 'kk_sp_save_meta', 'kk_sp_nonce' );
+
+	$type   = get_post_meta( $post->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
+	$link   = get_post_meta( $post->ID, KK_SP_META_LINK, true );
+	$cta    = get_post_meta( $post->ID, KK_SP_META_CTA, true );
+	$end    = get_post_meta( $post->ID, KK_SP_META_END, true );
+	$tone   = get_post_meta( $post->ID, KK_SP_META_TONE, true ) ?: 'default';
+	$source = get_post_meta( $post->ID, KK_SP_META_SOURCE, true );
+	?>
+	<p>
+		<label><strong><?php esc_html_e( 'Type', 'kk-sidebar-promos' ); ?></strong></label><br>
+		<select name="kk_sp_type" style="width:100%">
+			<option value="pillar"   <?php selected( $type, 'pillar' ); ?>><?php esc_html_e( 'Pillar (evergreen)', 'kk-sidebar-promos' ); ?></option>
+			<option value="featured" <?php selected( $type, 'featured' ); ?>><?php esc_html_e( 'Featured (time-bound)', 'kk-sidebar-promos' ); ?></option>
+		</select>
+	</p>
+	<p>
+		<label><strong><?php esc_html_e( 'Link URL', 'kk-sidebar-promos' ); ?></strong></label><br>
+		<input type="url" name="kk_sp_link" value="<?php echo esc_attr( $link ); ?>" style="width:100%" placeholder="https://...">
+	</p>
+	<p>
+		<label><strong><?php esc_html_e( 'CTA text', 'kk-sidebar-promos' ); ?></strong></label><br>
+		<input type="text" name="kk_sp_cta" value="<?php echo esc_attr( $cta ); ?>" style="width:100%" placeholder="<?php esc_attr_e( 'Learn more', 'kk-sidebar-promos' ); ?>">
+	</p>
+	<p>
+		<label><strong><?php esc_html_e( 'Active until', 'kk-sidebar-promos' ); ?></strong></label><br>
+		<input type="date" name="kk_sp_end" value="<?php echo esc_attr( $end ); ?>" style="width:100%">
+		<em><?php esc_html_e( 'Required for Featured. Promo is hidden the day after this date.', 'kk-sidebar-promos' ); ?></em>
+	</p>
+	<p>
+		<label><strong><?php esc_html_e( 'Tone', 'kk-sidebar-promos' ); ?></strong></label><br>
+		<select name="kk_sp_tone" style="width:100%">
+			<?php foreach ( [ 'default', 'event', 'course', 'community' ] as $opt ) : ?>
+				<option value="<?php echo esc_attr( $opt ); ?>" <?php selected( $tone, $opt ); ?>><?php echo esc_html( ucfirst( $opt ) ); ?></option>
+			<?php endforeach; ?>
+		</select>
+	</p>
+	<?php if ( $source && $source !== 'manual' ) : ?>
+		<p style="background:#fff8e1;padding:8px;border-left:3px solid #f39c12">
+			<em><?php
+			/* translators: %s: source name */
+			printf( esc_html__( 'Auto-managed (source: %s). Manual edits may be overwritten on the next sync.', 'kk-sidebar-promos' ), esc_html( $source ) );
+			?></em>
+		</p>
+	<?php endif;
+}
+
+function kk_sp_save_meta( $post_id, $post ) {
+	if ( ! isset( $_POST['kk_sp_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['kk_sp_nonce'] ), 'kk_sp_save_meta' ) ) {
+		return;
+	}
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	$type = isset( $_POST['kk_sp_type'] ) && in_array( $_POST['kk_sp_type'], [ 'pillar', 'featured' ], true )
+		? sanitize_key( wp_unslash( $_POST['kk_sp_type'] ) )
+		: 'pillar';
+	update_post_meta( $post_id, KK_SP_META_TYPE, $type );
+
+	$link = isset( $_POST['kk_sp_link'] ) ? esc_url_raw( wp_unslash( $_POST['kk_sp_link'] ) ) : '';
+	update_post_meta( $post_id, KK_SP_META_LINK, $link );
+
+	$cta = isset( $_POST['kk_sp_cta'] ) ? sanitize_text_field( wp_unslash( $_POST['kk_sp_cta'] ) ) : '';
+	update_post_meta( $post_id, KK_SP_META_CTA, $cta );
+
+	$end = isset( $_POST['kk_sp_end'] ) ? sanitize_text_field( wp_unslash( $_POST['kk_sp_end'] ) ) : '';
+	if ( $type === 'featured' && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $end ) ) {
+		update_post_meta( $post_id, KK_SP_META_END, $end );
+	} else {
+		delete_post_meta( $post_id, KK_SP_META_END );
+	}
+
+	$tone = isset( $_POST['kk_sp_tone'] ) ? sanitize_key( wp_unslash( $_POST['kk_sp_tone'] ) ) : 'default';
+	update_post_meta(
+		$post_id,
+		KK_SP_META_TONE,
+		in_array( $tone, [ 'default', 'event', 'course', 'community' ], true ) ? $tone : 'default'
+	);
+}
+
+function kk_sp_admin_columns( $cols ) {
+	$new = [];
+	foreach ( $cols as $k => $v ) {
+		$new[ $k ] = $v;
+		if ( $k === 'title' ) {
+			$new['kk_sp_type']    = __( 'Type', 'kk-sidebar-promos' );
+			$new['kk_sp_expires'] = __( 'Expires', 'kk-sidebar-promos' );
+			$new['kk_sp_source']  = __( 'Source', 'kk-sidebar-promos' );
+		}
+	}
+	return $new;
+}
+
+function kk_sp_admin_column_content( $col, $post_id ) {
+	if ( $col === 'kk_sp_type' ) {
+		$type = get_post_meta( $post_id, KK_SP_META_TYPE, true ) ?: 'pillar';
+		echo esc_html( ucfirst( $type ) );
+	}
+	if ( $col === 'kk_sp_expires' ) {
+		$end = get_post_meta( $post_id, KK_SP_META_END, true );
+		if ( ! $end ) {
+			echo '—';
+			return;
+		}
+		$today   = current_time( 'Y-m-d' );
+		$expired = $end < $today;
+		printf(
+			'<span style="color:%s">%s%s</span>',
+			$expired ? '#b00' : '#070',
+			esc_html( $end ),
+			$expired ? ' (' . esc_html__( 'expired', 'kk-sidebar-promos' ) . ')' : ''
+		);
+	}
+	if ( $col === 'kk_sp_source' ) {
+		$source = get_post_meta( $post_id, KK_SP_META_SOURCE, true ) ?: 'manual';
+		echo esc_html( $source );
+	}
+}

--- a/plugins/kk-sidebar-promos/includes/cron.php
+++ b/plugins/kk-sidebar-promos/includes/cron.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Scheduled tasks: auto-expire featured promos and trigger Luma sync.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const KK_SP_CRON_EXPIRE = 'kk_sp_expire_featured';
+const KK_SP_CRON_LUMA   = 'kk_sp_luma_sync';
+
+add_action( KK_SP_CRON_EXPIRE, 'kk_sp_expire_featured_promos' );
+add_action( KK_SP_CRON_LUMA, 'kk_sp_run_luma_sync' );
+
+function kk_sp_schedule_events() {
+	if ( ! wp_next_scheduled( KK_SP_CRON_EXPIRE ) ) {
+		wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', KK_SP_CRON_EXPIRE );
+	}
+	if ( ! wp_next_scheduled( KK_SP_CRON_LUMA ) ) {
+		wp_schedule_event( time() + ( 2 * HOUR_IN_SECONDS ), 'daily', KK_SP_CRON_LUMA );
+	}
+}
+
+function kk_sp_unschedule_events() {
+	$timestamp = wp_next_scheduled( KK_SP_CRON_EXPIRE );
+	if ( $timestamp ) {
+		wp_unschedule_event( $timestamp, KK_SP_CRON_EXPIRE );
+	}
+	$timestamp = wp_next_scheduled( KK_SP_CRON_LUMA );
+	if ( $timestamp ) {
+		wp_unschedule_event( $timestamp, KK_SP_CRON_LUMA );
+	}
+}
+
+/**
+ * Move expired Featured promos to draft so they stop appearing
+ * (and so the rotation falls back to Pillars). Logs the change to
+ * the post for an audit trail.
+ */
+function kk_sp_expire_featured_promos() {
+	$today = current_time( 'Y-m-d' );
+
+	$expired = get_posts( [
+		'post_type'      => KK_SP_POST_TYPE,
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'meta_query'     => [
+			'relation' => 'AND',
+			[
+				'key'   => KK_SP_META_TYPE,
+				'value' => 'featured',
+			],
+			[
+				'key'     => KK_SP_META_END,
+				'value'   => $today,
+				'compare' => '<',
+				'type'    => 'DATE',
+			],
+		],
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	] );
+
+	foreach ( $expired as $post_id ) {
+		wp_update_post( [
+			'ID'          => $post_id,
+			'post_status' => 'draft',
+		] );
+		/* translators: %s: today's date */
+		$note = sprintf(
+			__( 'Auto-expired by KK Sidebar Promos on %s.', 'kk-sidebar-promos' ),
+			$today
+		);
+		wp_insert_comment( [
+			'comment_post_ID' => $post_id,
+			'comment_content' => $note,
+			'comment_type'    => 'kk_sp_log',
+			'comment_author'  => 'KK Sidebar Promos',
+			'comment_approved' => 1,
+		] );
+	}
+}

--- a/plugins/kk-sidebar-promos/includes/luma-sync.php
+++ b/plugins/kk-sidebar-promos/includes/luma-sync.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * Luma calendar sync.
+ *
+ * Pulls the next upcoming event from a configured Luma iCal feed and
+ * upserts a Featured promo for it. The promo's end date is set to the
+ * event date, so it auto-expires when the cron runs the next morning.
+ *
+ * Configure the iCal URL in Settings → Sidebar Promos. Find your calendar's
+ * iCal URL on lu.ma → calendar settings → "Subscribe via iCal".
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const KK_SP_OPT_LUMA_URL    = 'kk_sp_luma_ical_url';
+const KK_SP_OPT_LUMA_LABEL  = 'kk_sp_luma_label';
+const KK_SP_OPT_LUMA_LINK   = 'kk_sp_luma_link';
+
+function kk_sp_run_luma_sync() {
+	$ical_url = trim( (string) get_option( KK_SP_OPT_LUMA_URL, '' ) );
+	if ( $ical_url === '' ) {
+		return new WP_Error( 'kk_sp_no_url', 'No Luma iCal URL configured.' );
+	}
+
+	$response = wp_remote_get( $ical_url, [ 'timeout' => 15 ] );
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+	$code = (int) wp_remote_retrieve_response_code( $response );
+	if ( $code < 200 || $code >= 300 ) {
+		return new WP_Error( 'kk_sp_http', sprintf( 'Luma fetch returned HTTP %d.', $code ) );
+	}
+
+	$body   = (string) wp_remote_retrieve_body( $response );
+	$events = kk_sp_parse_ical( $body );
+	if ( empty( $events ) ) {
+		return new WP_Error( 'kk_sp_no_events', 'No events parsed from Luma feed.' );
+	}
+
+	$now  = current_time( 'timestamp' );
+	$next = null;
+	foreach ( $events as $ev ) {
+		if ( $ev['start_ts'] >= $now && ( $next === null || $ev['start_ts'] < $next['start_ts'] ) ) {
+			$next = $ev;
+		}
+	}
+	if ( ! $next ) {
+		return new WP_Error( 'kk_sp_no_upcoming', 'No upcoming events.' );
+	}
+
+	$label    = get_option( KK_SP_OPT_LUMA_LABEL, __( 'Vancouver AI Community', 'kk-sidebar-promos' ) );
+	$fallback = get_option( KK_SP_OPT_LUMA_LINK, 'https://lu.ma/vancouver-ai' );
+
+	$title = sprintf(
+		'%s — %s',
+		$label,
+		wp_date( get_option( 'date_format' ), $next['start_ts'] )
+	);
+	$end_date = wp_date( 'Y-m-d', $next['start_ts'] );
+	$link     = $next['url'] ?: $fallback;
+
+	$existing = get_posts( [
+		'post_type'      => KK_SP_POST_TYPE,
+		'post_status'    => [ 'publish', 'draft' ],
+		'posts_per_page' => 1,
+		'meta_query'     => [
+			[
+				'key'   => KK_SP_META_SOURCE,
+				'value' => 'luma',
+			],
+			[
+				'key'   => KK_SP_META_SOURCE_ID,
+				'value' => $next['uid'],
+			],
+		],
+		'no_found_rows'  => true,
+	] );
+
+	$post_data = [
+		'post_type'    => KK_SP_POST_TYPE,
+		'post_status'  => 'publish',
+		'post_title'   => $title,
+		'post_excerpt' => $next['summary_short'],
+	];
+
+	if ( $existing ) {
+		$post_data['ID'] = $existing[0]->ID;
+		$post_id         = wp_update_post( $post_data, true );
+	} else {
+		$post_id = wp_insert_post( $post_data, true );
+	}
+
+	if ( is_wp_error( $post_id ) ) {
+		return $post_id;
+	}
+
+	update_post_meta( $post_id, KK_SP_META_TYPE, 'featured' );
+	update_post_meta( $post_id, KK_SP_META_TONE, 'event' );
+	update_post_meta( $post_id, KK_SP_META_LINK, esc_url_raw( $link ) );
+	update_post_meta( $post_id, KK_SP_META_CTA, __( 'RSVP', 'kk-sidebar-promos' ) );
+	update_post_meta( $post_id, KK_SP_META_END, $end_date );
+	update_post_meta( $post_id, KK_SP_META_SOURCE, 'luma' );
+	update_post_meta( $post_id, KK_SP_META_SOURCE_ID, $next['uid'] );
+
+	return $post_id;
+}
+
+/**
+ * Lightweight iCal parser. Handles the common subset Luma emits:
+ * VEVENT blocks with UID, DTSTART (date or datetime), SUMMARY, URL,
+ * DESCRIPTION. Folded lines (RFC 5545) are unfolded first.
+ */
+function kk_sp_parse_ical( $raw ) {
+	if ( $raw === '' ) {
+		return [];
+	}
+
+	// Unfold continuation lines: a line beginning with space or tab
+	// is a continuation of the previous line.
+	$normalized = preg_replace( "/\r\n[ \t]/", '', $raw );
+	$lines      = preg_split( "/\r\n|\n|\r/", $normalized );
+
+	$events  = [];
+	$current = null;
+
+	foreach ( $lines as $line ) {
+		if ( $line === 'BEGIN:VEVENT' ) {
+			$current = [
+				'uid'           => '',
+				'start_ts'      => 0,
+				'summary'       => '',
+				'summary_short' => '',
+				'url'           => '',
+			];
+			continue;
+		}
+		if ( $line === 'END:VEVENT' ) {
+			if ( $current && $current['start_ts'] ) {
+				if ( $current['uid'] === '' ) {
+					$current['uid'] = md5( $current['summary'] . $current['start_ts'] );
+				}
+				$events[] = $current;
+			}
+			$current = null;
+			continue;
+		}
+		if ( $current === null ) {
+			continue;
+		}
+
+		// Split "KEY[;PARAMS]:VALUE" on the first colon.
+		$colon = strpos( $line, ':' );
+		if ( $colon === false ) {
+			continue;
+		}
+		$head  = substr( $line, 0, $colon );
+		$value = substr( $line, $colon + 1 );
+		$key   = strtoupper( strtok( $head, ';' ) );
+
+		switch ( $key ) {
+			case 'UID':
+				$current['uid'] = trim( $value );
+				break;
+			case 'SUMMARY':
+				$current['summary']       = kk_sp_ical_unescape( $value );
+				$current['summary_short'] = wp_trim_words( $current['summary'], 18, '…' );
+				break;
+			case 'URL':
+				$current['url'] = trim( $value );
+				break;
+			case 'DTSTART':
+				$current['start_ts'] = kk_sp_parse_ical_date( $value, $head );
+				break;
+		}
+	}
+
+	return $events;
+}
+
+function kk_sp_ical_unescape( $value ) {
+	return str_replace(
+		[ '\\,', '\\;', '\\n', '\\N', '\\\\' ],
+		[ ',', ';', "\n", "\n", '\\' ],
+		$value
+	);
+}
+
+function kk_sp_parse_ical_date( $value, $head ) {
+	$value = trim( $value );
+	if ( preg_match( '/^(\d{8})T(\d{6})Z$/', $value, $m ) ) {
+		// UTC datetime.
+		return strtotime( $m[1] . 'T' . $m[2] . 'Z' );
+	}
+	if ( preg_match( '/TZID=([^;:]+)/', $head, $tz ) && preg_match( '/^(\d{8})T(\d{6})$/', $value ) ) {
+		// Floating datetime in a named TZ.
+		try {
+			$dt = new DateTime(
+				substr( $value, 0, 4 ) . '-' . substr( $value, 4, 2 ) . '-' . substr( $value, 6, 2 ) . 'T' .
+				substr( $value, 9, 2 ) . ':' . substr( $value, 11, 2 ) . ':' . substr( $value, 13, 2 ),
+				new DateTimeZone( $tz[1] )
+			);
+			return $dt->getTimestamp();
+		} catch ( Exception $e ) {
+			return strtotime( $value );
+		}
+	}
+	if ( preg_match( '/^\d{8}$/', $value ) ) {
+		// All-day date.
+		return strtotime( substr( $value, 0, 4 ) . '-' . substr( $value, 4, 2 ) . '-' . substr( $value, 6, 2 ) );
+	}
+	return strtotime( $value ) ?: 0;
+}

--- a/plugins/kk-sidebar-promos/includes/render.php
+++ b/plugins/kk-sidebar-promos/includes/render.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Selection logic, widget, block, and shortcode for sidebar promos.
+ *
+ * Selection rules:
+ *   - One Featured slot: the most-recent published, not-expired Featured promo
+ *     (start date in the past, end date today or later). If none, that slot
+ *     falls back to a rotating Pillar.
+ *   - Up to 3 Pillar slots beneath, ordered by menu_order then date, but
+ *     cycled by week so they don't always look identical.
+ *   - Total visible promos defaults to 4; configurable via the block, widget,
+ *     or shortcode.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_shortcode( 'kk_sidebar_promos', 'kk_sp_shortcode' );
+add_action( 'widgets_init', 'kk_sp_register_widget' );
+add_action( 'init', 'kk_sp_register_block' );
+
+function kk_sp_get_promos( $limit = 4 ) {
+	$today = current_time( 'Y-m-d' );
+	$out   = [];
+
+	$featured = get_posts( [
+		'post_type'      => KK_SP_POST_TYPE,
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'orderby'        => 'date',
+		'order'          => 'DESC',
+		'meta_query'     => [
+			'relation' => 'AND',
+			[
+				'key'   => KK_SP_META_TYPE,
+				'value' => 'featured',
+			],
+			[
+				'relation' => 'OR',
+				[
+					'key'     => KK_SP_META_END,
+					'value'   => $today,
+					'compare' => '>=',
+					'type'    => 'DATE',
+				],
+				[
+					'key'     => KK_SP_META_END,
+					'compare' => 'NOT EXISTS',
+				],
+			],
+		],
+		'no_found_rows'  => true,
+	] );
+
+	if ( $featured ) {
+		$out[] = $featured[0];
+	}
+
+	$pillar_slots = max( 0, $limit - count( $out ) );
+	if ( $pillar_slots > 0 ) {
+		$pillars = get_posts( [
+			'post_type'      => KK_SP_POST_TYPE,
+			'post_status'    => 'publish',
+			'posts_per_page' => 20,
+			'orderby'        => [ 'menu_order' => 'ASC', 'date' => 'DESC' ],
+			'meta_query'     => [
+				[
+					'key'   => KK_SP_META_TYPE,
+					'value' => 'pillar',
+				],
+			],
+			'post__not_in'   => wp_list_pluck( $out, 'ID' ),
+			'no_found_rows'  => true,
+		] );
+
+		if ( $pillars ) {
+			$week   = (int) gmdate( 'W' );
+			$offset = $week % count( $pillars );
+			$rotated = array_merge( array_slice( $pillars, $offset ), array_slice( $pillars, 0, $offset ) );
+			$out    = array_merge( $out, array_slice( $rotated, 0, $pillar_slots ) );
+		}
+	}
+
+	return $out;
+}
+
+function kk_sp_render( $args = [] ) {
+	$args = wp_parse_args( $args, [
+		'limit' => 4,
+		'title' => '',
+	] );
+
+	$promos = kk_sp_get_promos( (int) $args['limit'] );
+	if ( ! $promos ) {
+		return '';
+	}
+
+	wp_enqueue_style( 'kk-sidebar-promos' );
+
+	ob_start();
+	?>
+	<div class="kk-sp">
+		<?php if ( ! empty( $args['title'] ) ) : ?>
+			<h2 class="kk-sp__heading"><?php echo esc_html( $args['title'] ); ?></h2>
+		<?php endif; ?>
+		<?php foreach ( $promos as $p ) :
+			$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
+			$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
+			$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
+			$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
+			$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
+			$thumb_id  = get_post_thumbnail_id( $p->ID );
+			$has_image = (bool) $thumb_id;
+			$classes   = [
+				'kk-sp__card',
+				'kk-sp__card--' . $type,
+				'kk-sp__card--tone-' . $tone,
+				$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
+			];
+			?>
+			<article class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+				<?php if ( $link ) : ?>
+					<a href="<?php echo esc_url( $link ); ?>" class="kk-sp__link" rel="noopener">
+				<?php endif; ?>
+
+				<?php if ( $has_image ) : ?>
+					<div class="kk-sp__image-wrap">
+						<?php echo wp_get_attachment_image(
+							$thumb_id,
+							'medium_large',
+							false,
+							[
+								'class'   => 'kk-sp__image',
+								'loading' => 'lazy',
+								'alt'     => esc_attr( get_the_title( $p ) ),
+							]
+						); ?>
+						<?php if ( $type === 'featured' && $end ) : ?>
+							<span class="kk-sp__badge"><?php echo esc_html( kk_sp_format_until( $end ) ); ?></span>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
+
+				<div class="kk-sp__body">
+					<h3 class="kk-sp__title"><?php echo esc_html( get_the_title( $p ) ); ?></h3>
+					<?php if ( $p->post_excerpt || $p->post_content ) : ?>
+						<p class="kk-sp__excerpt">
+							<?php echo esc_html( wp_strip_all_tags( $p->post_excerpt ?: wp_trim_words( $p->post_content, 18, '…' ) ) ); ?>
+						</p>
+					<?php endif; ?>
+					<?php if ( $cta ) : ?>
+						<span class="kk-sp__cta"><?php echo esc_html( $cta ); ?> <span aria-hidden="true">→</span></span>
+					<?php endif; ?>
+				</div>
+
+				<?php if ( $link ) : ?>
+					</a>
+				<?php endif; ?>
+			</article>
+		<?php endforeach; ?>
+	</div>
+	<?php
+	return (string) ob_get_clean();
+}
+
+function kk_sp_format_until( $end ) {
+	$ts   = strtotime( $end . ' 23:59:59' );
+	$now  = current_time( 'timestamp' );
+	$days = (int) ceil( ( $ts - $now ) / DAY_IN_SECONDS );
+
+	if ( $days <= 0 ) {
+		return __( 'Today', 'kk-sidebar-promos' );
+	}
+	if ( $days === 1 ) {
+		return __( '1 day left', 'kk-sidebar-promos' );
+	}
+	if ( $days <= 14 ) {
+		/* translators: %d: number of days remaining */
+		return sprintf( __( '%d days left', 'kk-sidebar-promos' ), $days );
+	}
+	return date_i18n( get_option( 'date_format' ), $ts );
+}
+
+function kk_sp_shortcode( $atts ) {
+	$atts = shortcode_atts(
+		[ 'limit' => 4, 'title' => '' ],
+		$atts,
+		'kk_sidebar_promos'
+	);
+	return kk_sp_render( $atts );
+}
+
+function kk_sp_register_widget() {
+	register_widget( 'KK_SP_Widget' );
+}
+
+function kk_sp_register_block() {
+	if ( ! function_exists( 'register_block_type' ) ) {
+		return;
+	}
+	register_block_type( 'kk/sidebar-promos', [
+		'api_version'     => 2,
+		'title'           => __( 'KK Sidebar Promos', 'kk-sidebar-promos' ),
+		'category'        => 'widgets',
+		'icon'            => 'megaphone',
+		'description'     => __( 'Auto-managed promotional cards. Featured promos auto-expire; pillars rotate.', 'kk-sidebar-promos' ),
+		'attributes'      => [
+			'limit' => [ 'type' => 'number', 'default' => 4 ],
+			'title' => [ 'type' => 'string', 'default' => '' ],
+		],
+		'render_callback' => static function ( $attrs ) {
+			return kk_sp_render( [
+				'limit' => isset( $attrs['limit'] ) ? (int) $attrs['limit'] : 4,
+				'title' => isset( $attrs['title'] ) ? (string) $attrs['title'] : '',
+			] );
+		},
+	] );
+}
+
+class KK_SP_Widget extends WP_Widget {
+	public function __construct() {
+		parent::__construct(
+			'kk_sp_widget',
+			__( 'KK Sidebar Promos', 'kk-sidebar-promos' ),
+			[ 'description' => __( 'Auto-managed promotional cards.', 'kk-sidebar-promos' ) ]
+		);
+	}
+
+	public function widget( $args, $instance ) {
+		$title = $instance['title'] ?? '';
+		$limit = (int) ( $instance['limit'] ?? 4 );
+		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo kk_sp_render( [ 'limit' => $limit, 'title' => $title ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	public function form( $instance ) {
+		$title = $instance['title'] ?? '';
+		$limit = (int) ( $instance['limit'] ?? 4 );
+		?>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Heading (optional):', 'kk-sidebar-promos' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
+		</p>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>"><?php esc_html_e( 'Max promos:', 'kk-sidebar-promos' ); ?></label>
+			<input class="tiny-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="number" min="1" max="8" value="<?php echo esc_attr( $limit ); ?>">
+		</p>
+		<?php
+	}
+
+	public function update( $new, $old ) {
+		return [
+			'title' => sanitize_text_field( $new['title'] ?? '' ),
+			'limit' => max( 1, min( 8, (int) ( $new['limit'] ?? 4 ) ) ),
+		];
+	}
+}

--- a/plugins/kk-sidebar-promos/includes/seed.php
+++ b/plugins/kk-sidebar-promos/includes/seed.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Seed the four pillar promos on first activation.
+ *
+ * Idempotent: skips creation if any promos already exist. Each pillar
+ * uses an internal slug stored in meta so we won't double-create on
+ * re-activation even if titles change.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const KK_SP_META_SEED_SLUG = '_kk_promo_seed_slug';
+
+function kk_sp_pillar_definitions() {
+	return [
+		[
+			'slug'    => 'animation-accelerator',
+			'title'   => __( 'Animation Accelerator', 'kk-sidebar-promos' ),
+			'excerpt' => __( 'Hands-on cohort for filmmakers and creative teams shipping AI-augmented animation.', 'kk-sidebar-promos' ),
+			'cta'     => __( 'Learn more', 'kk-sidebar-promos' ),
+			'link'    => 'https://kriskrug.co/animation-accelerator/',
+			'tone'    => 'course',
+			'order'   => 10,
+		],
+		[
+			'slug'    => 'rap-certification',
+			'title'   => __( 'RAP Certification', 'kk-sidebar-promos' ),
+			'excerpt' => __( '4-week Responsible AI Professional cohort. Live sessions, real assessments, take-home toolkit.', 'kk-sidebar-promos' ),
+			'cta'     => __( 'Apply for next cohort', 'kk-sidebar-promos' ),
+			'link'    => 'https://lu.ma/ai-ethics',
+			'tone'    => 'course',
+			'order'   => 20,
+		],
+		[
+			'slug'    => 'bc-ai-membership',
+			'title'   => __( 'BC + AI Membership', 'kk-sidebar-promos' ),
+			'excerpt' => __( 'Join the people building the most inclusive AI ecosystem in the world. Members get half off everything.', 'kk-sidebar-promos' ),
+			'cta'     => __( 'Become a member', 'kk-sidebar-promos' ),
+			'link'    => 'https://bc-ai.ca/members/',
+			'tone'    => 'community',
+			'order'   => 30,
+		],
+		[
+			'slug'    => 'vancouver-ai-community',
+			'title'   => __( 'Vancouver AI Community', 'kk-sidebar-promos' ),
+			'excerpt' => __( 'Multi-modal, multi-cultural, radically local. Monthly meetups across BC.', 'kk-sidebar-promos' ),
+			'cta'     => __( 'See upcoming events', 'kk-sidebar-promos' ),
+			'link'    => 'https://lu.ma/vancouver-ai',
+			'tone'    => 'community',
+			'order'   => 40,
+		],
+	];
+}
+
+function kk_sp_seed_pillars_if_empty() {
+	foreach ( kk_sp_pillar_definitions() as $def ) {
+		$existing = get_posts( [
+			'post_type'      => KK_SP_POST_TYPE,
+			'post_status'    => [ 'publish', 'draft', 'pending' ],
+			'posts_per_page' => 1,
+			'meta_query'     => [
+				[
+					'key'   => KK_SP_META_SEED_SLUG,
+					'value' => $def['slug'],
+				],
+			],
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		] );
+		if ( $existing ) {
+			continue;
+		}
+
+		$post_id = wp_insert_post( [
+			'post_type'    => KK_SP_POST_TYPE,
+			'post_status'  => 'publish',
+			'post_title'   => $def['title'],
+			'post_excerpt' => $def['excerpt'],
+			'menu_order'   => $def['order'],
+		] );
+
+		if ( is_wp_error( $post_id ) || ! $post_id ) {
+			continue;
+		}
+
+		update_post_meta( $post_id, KK_SP_META_TYPE, 'pillar' );
+		update_post_meta( $post_id, KK_SP_META_LINK, esc_url_raw( $def['link'] ) );
+		update_post_meta( $post_id, KK_SP_META_CTA, $def['cta'] );
+		update_post_meta( $post_id, KK_SP_META_TONE, $def['tone'] );
+		update_post_meta( $post_id, KK_SP_META_SOURCE, 'manual' );
+		update_post_meta( $post_id, KK_SP_META_SEED_SLUG, $def['slug'] );
+	}
+}

--- a/plugins/kk-sidebar-promos/includes/settings.php
+++ b/plugins/kk-sidebar-promos/includes/settings.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Settings page (Settings → Sidebar Promos).
+ *
+ * Configure the Luma iCal feed and run a manual sync.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action( 'admin_menu', 'kk_sp_settings_menu' );
+add_action( 'admin_init', 'kk_sp_settings_register' );
+add_action( 'admin_post_kk_sp_run_sync', 'kk_sp_handle_manual_sync' );
+
+function kk_sp_settings_menu() {
+	add_submenu_page(
+		'edit.php?post_type=' . KK_SP_POST_TYPE,
+		__( 'Sidebar Promos Settings', 'kk-sidebar-promos' ),
+		__( 'Settings', 'kk-sidebar-promos' ),
+		'manage_options',
+		'kk-sp-settings',
+		'kk_sp_settings_page'
+	);
+}
+
+function kk_sp_settings_register() {
+	register_setting( 'kk_sp_settings', KK_SP_OPT_LUMA_URL, [
+		'type'              => 'string',
+		'sanitize_callback' => 'esc_url_raw',
+		'default'           => '',
+	] );
+	register_setting( 'kk_sp_settings', KK_SP_OPT_LUMA_LABEL, [
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'default'           => __( 'Vancouver AI Community', 'kk-sidebar-promos' ),
+	] );
+	register_setting( 'kk_sp_settings', KK_SP_OPT_LUMA_LINK, [
+		'type'              => 'string',
+		'sanitize_callback' => 'esc_url_raw',
+		'default'           => 'https://lu.ma/vancouver-ai',
+	] );
+}
+
+function kk_sp_settings_page() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+	$ical_url   = get_option( KK_SP_OPT_LUMA_URL, '' );
+	$label      = get_option( KK_SP_OPT_LUMA_LABEL, __( 'Vancouver AI Community', 'kk-sidebar-promos' ) );
+	$link       = get_option( KK_SP_OPT_LUMA_LINK, 'https://lu.ma/vancouver-ai' );
+	$next_cron  = wp_next_scheduled( KK_SP_CRON_LUMA );
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Sidebar Promos', 'kk-sidebar-promos' ); ?></h1>
+
+		<?php if ( isset( $_GET['kk_sp_synced'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$result = sanitize_text_field( wp_unslash( $_GET['kk_sp_synced'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$class  = $result === 'ok' ? 'notice-success' : 'notice-error';
+			?>
+			<div class="notice <?php echo esc_attr( $class ); ?> is-dismissible">
+				<p><?php echo esc_html( $result === 'ok'
+					? __( 'Luma sync ran. Check the promo list for the latest event.', 'kk-sidebar-promos' )
+					: sprintf( __( 'Sync failed: %s', 'kk-sidebar-promos' ), $result )
+				); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<form action="options.php" method="post">
+			<?php settings_fields( 'kk_sp_settings' ); ?>
+			<table class="form-table">
+				<tr>
+					<th><label for="kk_sp_luma_url"><?php esc_html_e( 'Luma iCal URL', 'kk-sidebar-promos' ); ?></label></th>
+					<td>
+						<input type="url" id="kk_sp_luma_url" name="<?php echo esc_attr( KK_SP_OPT_LUMA_URL ); ?>" value="<?php echo esc_attr( $ical_url ); ?>" class="regular-text" placeholder="https://api.lu.ma/ics/get?entity=calendar&id=...">
+						<p class="description"><?php esc_html_e( 'Find this on lu.ma → calendar settings → "Subscribe via iCal".', 'kk-sidebar-promos' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="kk_sp_luma_label"><?php esc_html_e( 'Promo label', 'kk-sidebar-promos' ); ?></label></th>
+					<td>
+						<input type="text" id="kk_sp_luma_label" name="<?php echo esc_attr( KK_SP_OPT_LUMA_LABEL ); ?>" value="<?php echo esc_attr( $label ); ?>" class="regular-text">
+						<p class="description"><?php esc_html_e( 'Prefixed to the next event date in the promo title.', 'kk-sidebar-promos' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="kk_sp_luma_link"><?php esc_html_e( 'Calendar fallback URL', 'kk-sidebar-promos' ); ?></label></th>
+					<td>
+						<input type="url" id="kk_sp_luma_link" name="<?php echo esc_attr( KK_SP_OPT_LUMA_LINK ); ?>" value="<?php echo esc_attr( $link ); ?>" class="regular-text">
+						<p class="description"><?php esc_html_e( 'Used if a specific event URL is unavailable.', 'kk-sidebar-promos' ); ?></p>
+					</td>
+				</tr>
+			</table>
+			<?php submit_button(); ?>
+		</form>
+
+		<hr>
+
+		<h2><?php esc_html_e( 'Manual sync', 'kk-sidebar-promos' ); ?></h2>
+		<p>
+			<?php
+			if ( $next_cron ) {
+				/* translators: %s: human-readable date */
+				echo esc_html( sprintf( __( 'Next automatic sync: %s', 'kk-sidebar-promos' ), wp_date( 'M j, Y g:i a', $next_cron ) ) );
+			} else {
+				esc_html_e( 'Automatic sync is not currently scheduled.', 'kk-sidebar-promos' );
+			}
+			?>
+		</p>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="kk_sp_run_sync">
+			<?php wp_nonce_field( 'kk_sp_run_sync' ); ?>
+			<?php submit_button( __( 'Run Luma sync now', 'kk-sidebar-promos' ), 'secondary', 'submit', false ); ?>
+		</form>
+
+		<hr>
+
+		<h2><?php esc_html_e( 'Where this shows up', 'kk-sidebar-promos' ); ?></h2>
+		<ul style="list-style:disc;margin-left:1.5em">
+			<li><?php esc_html_e( 'Block: search "KK Sidebar Promos" in the block inserter.', 'kk-sidebar-promos' ); ?></li>
+			<li><?php esc_html_e( 'Classic widget: Appearance → Widgets → KK Sidebar Promos.', 'kk-sidebar-promos' ); ?></li>
+			<li><code>[kk_sidebar_promos limit="4"]</code></li>
+		</ul>
+	</div>
+	<?php
+}
+
+function kk_sp_handle_manual_sync() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'Insufficient permissions.', 'kk-sidebar-promos' ) );
+	}
+	check_admin_referer( 'kk_sp_run_sync' );
+
+	$result   = kk_sp_run_luma_sync();
+	$redirect = add_query_arg(
+		'kk_sp_synced',
+		is_wp_error( $result ) ? rawurlencode( $result->get_error_message() ) : 'ok',
+		admin_url( 'edit.php?post_type=' . KK_SP_POST_TYPE . '&page=kk-sp-settings' )
+	);
+	wp_safe_redirect( $redirect );
+	exit;
+}

--- a/plugins/kk-sidebar-promos/kk-sidebar-promos.php
+++ b/plugins/kk-sidebar-promos/kk-sidebar-promos.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Plugin Name:       KK Sidebar Promos
+ * Plugin URI:        https://github.com/WalksWithASwagger/kriskrug-wp
+ * Description:       Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the rest. Pulls the next Vancouver AI meetup from Luma automatically. Block, classic widget, and [kk_sidebar_promos] shortcode all available.
+ * Version:           0.1.0
+ * Requires at least: 6.2
+ * Requires PHP:      7.4
+ * Author:            Kris Krüg
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       kk-sidebar-promos
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'KK_SP_VERSION', '0.1.0' );
+define( 'KK_SP_PATH', plugin_dir_path( __FILE__ ) );
+define( 'KK_SP_URL', plugin_dir_url( __FILE__ ) );
+define( 'KK_SP_FILE', __FILE__ );
+
+require_once KK_SP_PATH . 'includes/cpt.php';
+require_once KK_SP_PATH . 'includes/render.php';
+require_once KK_SP_PATH . 'includes/luma-sync.php';
+require_once KK_SP_PATH . 'includes/cron.php';
+require_once KK_SP_PATH . 'includes/seed.php';
+require_once KK_SP_PATH . 'includes/settings.php';
+
+add_action( 'wp_enqueue_scripts', function () {
+	wp_register_style(
+		'kk-sidebar-promos',
+		KK_SP_URL . 'assets/css/sidebar-promos.css',
+		[],
+		KK_SP_VERSION
+	);
+} );
+
+register_activation_hook( __FILE__, 'kk_sp_on_activate' );
+register_deactivation_hook( __FILE__, 'kk_sp_on_deactivate' );
+
+function kk_sp_on_activate() {
+	kk_sp_register_post_type();
+	flush_rewrite_rules();
+	kk_sp_schedule_events();
+	kk_sp_seed_pillars_if_empty();
+}
+
+function kk_sp_on_deactivate() {
+	kk_sp_unschedule_events();
+	flush_rewrite_rules();
+}

--- a/plugins/kk-sidebar-promos/readme.txt
+++ b/plugins/kk-sidebar-promos/readme.txt
@@ -1,0 +1,32 @@
+=== KK Sidebar Promos ===
+Contributors: kriskrug
+Tags: sidebar, widget, promo, automation
+Requires at least: 6.2
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 0.1.0
+License: GPLv2 or later
+
+Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the remaining slots. The next Vancouver AI meetup syncs in from Luma automatically.
+
+== Description ==
+
+Solves the recurring problem of stale event promos lingering in the sidebar after the event is over.
+
+* **Pillar promos** — evergreen things that always make sense to promote (memberships, courses, communities). Rotate weekly so the sidebar doesn't look static.
+* **Featured promos** — time-bound things that require an end date. Auto-move to draft the day after they expire.
+* **Luma sync** — point at your Luma calendar's iCal feed and the next upcoming event becomes a Featured promo automatically.
+
+Render via the **KK Sidebar Promos** block, the **KK Sidebar Promos** widget, or `[kk_sidebar_promos limit="4"]`.
+
+== Installation ==
+
+1. Upload the `kk-sidebar-promos` folder to `/wp-content/plugins/`.
+2. Activate the plugin (this seeds the four pillars and schedules the daily cron jobs).
+3. Go to **Sidebar Promos → Settings** and paste your Luma iCal URL.
+4. Drop the **KK Sidebar Promos** block into your sidebar template (or use the widget / shortcode).
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial release: CPT, auto-expiry, Luma iCal sync, block + widget + shortcode, four seeded pillars (Animation Accelerator, RAP Certification, BC + AI Membership, Vancouver AI Community).


### PR DESCRIPTION
## Summary
Recreates the sidebar promos plugin PR after credential-history rewrite closed the old PR #73.

## Included
- KK Sidebar Promos plugin source under plugins/kk-sidebar-promos/
- CPT, renderer, scheduler, Luma sync, seed data, admin settings
- Deployment/readme docs bundled with plugin

## Why this replacement PR exists
The prior branch used by PR #73 diverged heavily after rewritten history. This branch was rebuilt from current origin/main and includes only the plugin feature commit to keep review and merge safe.

## Validation
- PHP lint passed across all plugin PHP files:
  - find plugins/kk-sidebar-promos -name '*.php' -print0 | xargs -0 -n1 php -l
