### PR TITLE
Docs: record post-rewrite GitHub queue recovery

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,6 +29,7 @@ The canonical "what's true right now" snapshot lives in [`docs/current-state/`](
 | [`current-state/AURORA-ISSUE-SWARM-2026-05-19.md`](current-state/AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics and routed stale design issues into the Track B lane |
 | [`current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md`](current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe rewrite/force-push preflight |
 | [`current-state/CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md`](current-state/CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md) | Execution log of the rewrite, force-updated branches, and post-rewrite recovery steps |
+| [`current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md`](current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md) | Queue recovery after rewrite: replacement PRs, CI gate fix, merges, and cleanup |
 | [`current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md`](current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md) | Current agent-swarm lanes and execution order |
 | [`current-state/SWARM-STATUS-2026-05-18.md`](current-state/SWARM-STATUS-2026-05-18.md) | Current command-desk status after the first bounded swarm |
 | [`current-state/DRAFT-PUBLISHING-DISCOVERY-2026-05-18.md`](current-state/DRAFT-PUBLISHING-DISCOVERY-2026-05-18.md) | Next-batch Notion inventory and local dry-run packs |

--- a/docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md
+++ b/docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md
@@ -1,0 +1,35 @@
+# GitHub Queue Recovery — 2026-05-19
+
+## Why this exists
+
+The credential-history rewrite force-push (documented in `CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md`) auto-closed open PRs whose head/base commit ancestry changed.
+
+This note records the queue recovery actions so reviewers have a clean audit trail.
+
+## Recovery actions completed
+
+1. Re-opened Aurora redesign review as replacement PR #87.
+2. Rebuilt the sidebar promos lane from rewritten `main` as replacement PR #88 (old PR #73 branch was heavily diverged).
+3. Fixed CI workflow gating in `.github/workflows/test-pr.yml` so WPCS install works with Composer allow-plugins.
+4. Merged replacement PRs:
+   - #87 -> `aurora/v2`
+   - #88 -> `main`
+5. Deleted temporary recovery branches after merge:
+   - `codex/aurora-redesign-2026-05-18`
+   - `codex/sidebar-promos-recovery-2026-05-19`
+6. Added recovery comments on closed PRs #77 and #73 linking to their replacement merges.
+
+## Current queue state after recovery
+
+- Open PRs: none
+- `main`: includes sidebar promos plugin + CI allow-plugins fix from PR #88
+- `aurora/v2`: includes Aurora redesign merge from PR #87
+
+## Remaining branch hygiene (manual decision)
+
+Remote branches still present that were not touched in this recovery:
+
+- `claude/automate-sidebar-graphics-55OBU`
+- `claude/setup-wordpress-rebuild-KVLxh`
+
+Recommend deciding whether to archive/delete these in a separate branch-hygiene pass.

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -24,6 +24,7 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [AURORA-ISSUE-SWARM-2026-05-19.md](AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics #80-#86 and routed old design issues #24-#35. |
 | [CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe force-push preflight; no rewrite performed. |
 | [CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md) | Execution log for the credential history rewrite, affected branch force-updates, and post-rewrite follow-ups. |
+| [GITHUB-QUEUE-RECOVERY-2026-05-19.md](GITHUB-QUEUE-RECOVERY-2026-05-19.md) | Queue recovery log for replacement PRs #87/#88, CI fix, and post-rewrite branch cleanup. |
 | [GITHUB-QUEUE-SWEEP-2026-05-18.md](GITHUB-QUEUE-SWEEP-2026-05-18.md) | PR, branch, and issue classification after the GitHub queue sweep. |
 | [AGENT-SWARM-OPERATING-PLAN-2026-05-18.md](AGENT-SWARM-OPERATING-PLAN-2026-05-18.md) | Current swarm lanes across GitHub issues, draft publishing, Aurora, and content/nav structure. |
 | [SWARM-STATUS-2026-05-18.md](SWARM-STATUS-2026-05-18.md) | Current command-desk status after the first bounded issue/content/Aurora swarm. |


### PR DESCRIPTION
## Summary
Adds an explicit recovery log for the post-history-rewrite PR/branch cleanup.

## Included
- New doc: docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md
- Index updates in docs/current-state/README.md and docs/INDEX.md

## Context
Tracks how closed PR #77/#73 were recovered via #87/#88 and merged.
