### PR TITLE
Docs: record branch hygiene follow-through

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,7 +24,7 @@ The canonical "what's true right now" snapshot lives in [`docs/current-state/`](
 | [`current-state/FIX_QUEUE.md`](current-state/FIX_QUEUE.md) | P0 → P3 backlog |
 | [`current-state/ROADMAP.md`](current-state/ROADMAP.md) | Six-phase, 3-month plan |
 | [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit, roadmap, and human decision list |
-| [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/TOMORROW-ROADMAP-2026-05-20.md) | Next-session roadmap for credential-history cleanup, Aurora P0, draft prep, and backlog hygiene |
+| [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery and branch/worktree cleanup |
 | [`current-state/NEXT-ROUND-WORK-2026-05-19.md`](current-state/NEXT-ROUND-WORK-2026-05-19.md) | Next-round command sheet after queue sweep, Track A prep, and authority-page polish |
 | [`current-state/AURORA-ISSUE-SWARM-2026-05-19.md`](current-state/AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics and routed stale design issues into the Track B lane |
 | [`current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md`](current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe rewrite/force-push preflight |

--- a/docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md
+++ b/docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md
@@ -25,11 +25,24 @@ This note records the queue recovery actions so reviewers have a clean audit tra
 - `main`: includes sidebar promos plugin + CI allow-plugins fix from PR #88
 - `aurora/v2`: includes Aurora redesign merge from PR #87
 
-## Remaining branch hygiene (manual decision)
+## Branch hygiene follow-through
 
-Remote branches still present that were not touched in this recovery:
+Follow-up cleanup completed after the initial recovery:
 
-- `claude/automate-sidebar-graphics-55OBU`
-- `claude/setup-wordpress-rebuild-KVLxh`
+1. Created local backup refs for both remaining `claude/*` branches before deletion:
+   - `backup/claude-automate-sidebar-graphics-55OBU-20260519`
+   - `backup/claude-setup-wordpress-rebuild-KVLxh-20260519`
+2. Deleted remote branches:
+   - `claude/automate-sidebar-graphics-55OBU`
+   - `claude/setup-wordpress-rebuild-KVLxh`
+3. Reconciled local Aurora worktrees onto fresh branches tracking `origin/aurora/v2`:
+   - `/Users/kk/Code/kriskrug-wp-aurora-redesign` -> `codex/aurora-redesign-sync-2026-05-19`
+   - `/Users/kk/Code/kriskrug-wp-aurora-staging-qa` -> `codex/aurora-staging-qa-sync-2026-05-19`
+4. Deleted obsolete local stale branches:
+   - `codex/aurora-redesign-2026-05-18`
+   - `codex/aurora-staging-qa-2026-05-18`
 
-Recommend deciding whether to archive/delete these in a separate branch-hygiene pass.
+### Remote branch state after follow-through
+
+- `origin/main`
+- `origin/aurora/v2`

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -19,7 +19,7 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [FIX_QUEUE.md](FIX_QUEUE.md) | Prioritized P0→P3 backlog from both audits. |
 | [ROADMAP.md](ROADMAP.md) | Six-phase, 3-month plan that synthesizes FIX_QUEUE + postmortem follow-ups + content pipeline next steps. **Start here.** |
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
-| [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Next-session roadmap for credential-history cleanup, Aurora P0, draft prep, and backlog hygiene. |
+| [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. |
 | [NEXT-ROUND-WORK-2026-05-19.md](NEXT-ROUND-WORK-2026-05-19.md) | Current next-round command sheet after the queue sweep, Track A prep, and keynote authority-page polish. |
 | [AURORA-ISSUE-SWARM-2026-05-19.md](AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics #80-#86 and routed old design issues #24-#35. |
 | [CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe force-push preflight; no rewrite performed. |

--- a/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
+++ b/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
@@ -15,9 +15,12 @@
    - `#88` merged to `main` (KK Sidebar Promos plugin + CI fix)
    - `#89` merged to `main` (queue-recovery documentation)
 4. Open PR queue: none.
-5. Remaining remote branches:
-   - `claude/automate-sidebar-graphics-55OBU`
-   - `claude/setup-wordpress-rebuild-KVLxh`
+5. Branch hygiene follow-through completed:
+   - Remaining `claude/*` remotes were deleted after local backup refs were created.
+   - Aurora side worktrees were repointed to fresh branches off `origin/aurora/v2`.
+6. Current remote branches:
+   - `origin/main`
+   - `origin/aurora/v2`
 
 ## Non-Negotiable Guardrails
 
@@ -28,40 +31,7 @@
 
 ## Next Session Priority Order
 
-### 1) Local/worktree reconciliation after rewrite (P0)
-
-Goal: prevent accidental work on stale pre-rewrite branch pointers.
-
-Do:
-
-- Fetch/prune in each active worktree.
-- Confirm branch tracking and divergence for:
-  - `/Users/kk/Code/kriskrug-wp` (main worktree)
-  - `/Users/kk/Code/kriskrug-wp-aurora-redesign`
-  - `/Users/kk/Code/kriskrug-wp-aurora-staging-qa`
-- Preserve uncommitted local content assets before any resets/rebases.
-
-Done when:
-
-- Each active worktree has an explicit sync decision logged (rebase/reset/keep-diverged).
-
-### 2) Branch hygiene pass on remaining remote branches (P1)
-
-Goal: clean branch surface without deleting needed work.
-
-Do:
-
-- Compare each remaining remote branch to its intended base.
-- Identify unique commits not already merged.
-- Either:
-  - open a clean replacement PR (if unique work still matters), or
-  - archive/delete branch with a short audit note.
-
-Done when:
-
-- `origin` branch list only contains active branches with clear ownership.
-
-### 3) Aurora review prep refresh (P1, Track B)
+### 1) Aurora review prep refresh (P1, Track B)
 
 Goal: keep Aurora demo narrative current after merge to `aurora/v2`.
 
@@ -75,7 +45,7 @@ Done when:
 
 - Fresh smoke artifacts and one current review packet are present under `docs/current-state/`.
 
-### 4) Track A content lane continuation (P2)
+### 2) Track A content lane continuation (P2)
 
 Goal: continue authority/support content without crossing into risky publish actions.
 
@@ -89,7 +59,7 @@ Done when:
 
 - Next draft batch has clear review verdicts and no accidental publish.
 
-### 5) Issue queue alignment for swarming (P2)
+### 3) Issue queue alignment for swarming (P2)
 
 Goal: keep the issue board trustworthy for agentic execution.
 
@@ -116,6 +86,5 @@ git branch -r
 
 Ask KK before:
 
-- Any destructive branch cleanup on branches with uncertain unique commits.
 - Any production publish operation from draft packs.
 - Any Aurora move that changes public production theme state.


### PR DESCRIPTION
## Summary
Updates current-state docs after post-rewrite follow-through cleanup.

## Included
- Records deletion of remaining remote claude branches after local backup refs
- Records Aurora worktree reconciliation onto fresh branches from origin/aurora/v2
- Refreshes tomorrow roadmap/status language to reflect completed work

## Scope
Docs-only; no code or production behavior changes.
