### PR TITLE
Docs: add issue swarm roadmap and lane status updates

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ The canonical "what's true right now" snapshot lives in [`docs/current-state/`](
 | [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit, roadmap, and human decision list |
 | [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery and branch/worktree cleanup |
 | [`current-state/NEXT-ROUND-WORK-2026-05-19.md`](current-state/NEXT-ROUND-WORK-2026-05-19.md) | Next-round command sheet after queue sweep, Track A prep, and authority-page polish |
+| [`current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md`](current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md) | 72-hour swarm roadmap with bounded parallel lanes, wave labels, and stop rules |
 | [`current-state/AURORA-ISSUE-SWARM-2026-05-19.md`](current-state/AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics and routed stale design issues into the Track B lane |
 | [`current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md`](current-state/CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe rewrite/force-push preflight |
 | [`current-state/CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md`](current-state/CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md) | Execution log of the rewrite, force-updated branches, and post-rewrite recovery steps |

--- a/docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md
+++ b/docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md
@@ -60,19 +60,22 @@ Verification after routing:
 - open `aurora-v2` issues: 19
 - old design issues #24-#35 still carrying `auto-implement`: 0
 
-## PR State
+## PR State (post-rewrite recovery)
 
-Open PRs after refresh:
+The old open-PR references are superseded:
 
-| PR | State | Read |
-|---|---|---|
-| #77 `[codex] Redesign Aurora visual system` | Draft, clean, base `aurora/v2` | This is the active Aurora review surface. Keep draft until human review and next polish pass. |
-| #73 `Auto-managed sidebar promos` | Open, merge state `DIRTY`, base `main` | Keep parked. It is production-adjacent plugin work and needs its own staging/backup/deploy lane. |
+- Aurora redesign was recovered as replacement PR `#87` and merged into `aurora/v2`.
+- Sidebar promos was recovered as replacement PR `#88` and merged into `main`.
+- Queue recovery and follow-through are documented in:
+  - `docs/current-state/GITHUB-QUEUE-RECOVERY-2026-05-19.md`
+  - `docs/current-state/TOMORROW-ROADMAP-2026-05-20.md`
 
 ## Aurora Review Packet
 
-PR #77 branch: `codex/aurora-redesign-2026-05-18`
-Worktree: `/Users/kk/Code/kriskrug-wp-aurora-redesign`
+Merged branch history now lives in `aurora/v2` (via PR `#87`).
+Primary local worktree for current Track B iteration:
+
+- `/Users/kk/Code/kriskrug-wp-aurora-redesign`
 
 Branch-only review docs and screenshots:
 

--- a/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
+++ b/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
@@ -1,0 +1,118 @@
+# Issue Swarm Roadmap - 2026-05-19
+
+**Prepared:** 2026-05-19  
+**Queue snapshot:** 71 open issues, 0 open PRs  
+**Scope:** Convert the current backlog into bounded parallel lanes with clear stop rules.
+
+## Assumptions
+
+1. Track B (Aurora) is the current demo-critical lane.
+2. Track A issues should be draft-first and repo-first before production publish actions.
+3. `needs-human-review` issues remain blocked unless explicitly unblocked by KK.
+
+## Queue Baseline
+
+- Open issues: `71`
+- `auto-implement`: `50`
+- `track-b` + `aurora-v2`: `19`
+- `priority:high`: `34`
+- `needs-human-review`: `2` (`#23`, `#75`)
+
+## Canonical 72-Hour Swarm
+
+### Lane 0 - Queue Control (first 4-6 hours)
+
+Goal: remove ambiguity before implementation.
+
+- Normalize canonical issue mappings (old design tickets to Aurora epics).
+- Mark issues as `swarm-ready` vs `swarm-parked`.
+- Keep `#23` and `#75` explicitly blocked for human review.
+
+Primary issues:
+
+- `#75`, `#23`
+- `#80-#86`
+- legacy design set `#24-#35`
+
+### Lane 1 - Aurora Wave 1 (parallel, Track B)
+
+Goal: mechanical stability + visual system verification.
+
+- `#80` `[AURORA P0] Rescue staging header/nav render`
+- `#81` `[AURORA P1] Define the 2026 visual system`
+
+Done when:
+
+- Six-page smoke is rerun on current `aurora/v2`.
+- Fresh desktop/mobile artifacts are attached.
+- Token/state checklist evidence exists.
+
+### Lane 2 - Aurora Wave 2 (parallel, Track B)
+
+Goal: homepage + Work/Speaking authority surfaces.
+
+- `#82` media-led homepage
+- `#83` Work/Speaking media templates
+
+Done when:
+
+- Responsive behavior is validated across mobile/tablet/desktop/wide.
+- Media proof modules include fallback/alt/source behavior evidence.
+
+### Lane 3 - Aurora Wave 3 + QA Gate (Track B)
+
+Goal: long-form/template hardening, then final QA gate.
+
+- `#84` long-form/media-heavy post templates
+- `#85` restrained component library
+- `#86` staging QA gate (final)
+
+Done when:
+
+- Component/state matrix exists.
+- Long-form validation evidence is attached.
+- QA packet confirms keyboard/focus/reduced-motion/contrast/perf readiness.
+
+### Lane 4 - Track A Content Sprint (parallel after Aurora Wave 1)
+
+Goal: high-impact content surfaces using draft-first workflow.
+
+- `#65`, `#66`, `#67`, `#68`
+- Supersede/merge intent from `#12`, `#16`, `#17` where duplicated
+
+Done when:
+
+- Draft artifacts are review-ready.
+- No production publish writes were made without explicit approval.
+
+### Lane 5 - Track A SEO/A11Y Quick Wins (parallel after Aurora Wave 1)
+
+Goal: bounded improvements with clear verification.
+
+- `#8`, `#9`, `#10`, `#36`, `#43`, `#48`
+
+Done when:
+
+- Each issue has a narrow proof artifact or patch.
+- Any broad/refactor-shaped scope is split into smaller follow-up issues.
+
+## Stop Rules
+
+1. One lane, one track: never mix Track A and Track B edits in one branch.
+2. Max two active implementation issues per lane at a time.
+3. Every lane must produce artifacts before taking more scope.
+4. No silent closure: close only when checklist evidence is attached.
+5. `needs-human-review` stays blocked until explicit human approval.
+
+## Current Labeling Convention
+
+- `swarm-ready`: safe for bounded autonomous execution now
+- `swarm-parked`: intentionally deferred / broad / dependency-heavy
+- `swarm-wave-1`: Aurora Wave 1 + first Track A quick wins
+- `swarm-wave-2`: second execution wave
+- `swarm-wave-3`: final hardening/QA wave
+
+## Notes
+
+- Legacy design issues `#24-#35` remain open but routed; they are not standalone build targets.
+- `docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md` still references old PR `#77` and should be refreshed against rewrite-recovery reality (`#87` merged).

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -21,6 +21,7 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
 | [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. |
 | [NEXT-ROUND-WORK-2026-05-19.md](NEXT-ROUND-WORK-2026-05-19.md) | Current next-round command sheet after the queue sweep, Track A prep, and keynote authority-page polish. |
+| [ISSUE-SWARM-ROADMAP-2026-05-19.md](ISSUE-SWARM-ROADMAP-2026-05-19.md) | 72-hour swarm-ready issue roadmap with parallel lanes, stop rules, and wave labels. |
 | [AURORA-ISSUE-SWARM-2026-05-19.md](AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics #80-#86 and routed old design issues #24-#35. |
 | [CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe force-push preflight; no rewrite performed. |
 | [CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md) | Execution log for the credential history rewrite, affected branch force-updates, and post-rewrite follow-ups. |


### PR DESCRIPTION
## Summary
Adds a concrete issue-swarm roadmap and updates Aurora swarm docs to current post-rewrite PR reality.

## Included
- New roadmap: docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
- Updated docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md for PR #87/#88 merge reality
- Index entries updated in docs/current-state/README.md and docs/INDEX.md

## Scope
Docs-only changes; no production behavior changes.
