### PR TITLE
content: verify keynote draft batch

### DIFF
--- a/content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext/publish-gate.md
+++ b/content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current image is a planning thumbnail, with a cleared ChannelNext event/stage asset preferred before public use.
+- [x] Source evidence is public video plus local metadata/transcript pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, audience names, private client claims, private contact, travel, or credential material.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm ChannelNext event naming and title style.

--- a/content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college/publish-gate.md
+++ b/content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current image is a planning thumbnail, with a WP-hosted LaSalle stage photo preferred before public use.
+- [x] Source evidence is public video plus local metadata/transcript pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, audience names, private client claims, private contact, travel, or credential material.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm LaSalle College naming and event context.

--- a/content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/publish-gate.md
+++ b/content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current image is a planning thumbnail, with an approved Vancouver AI stage photo preferred before public use.
+- [x] Source evidence is public video plus local metadata/transcript pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, audience names, private client claims, private contact, travel, or credential material.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm final title tone. It is strong and useful, but should be KK-approved.

--- a/content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage/publish-gate.md
+++ b/content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current image is a planning thumbnail, with a rights-cleared Bass Coast stage/photo asset preferred before public use.
+- [x] Source evidence is public video plus local metadata/transcript pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, audience names, private client claims, private contact, travel, or credential material.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm Bass Coast Brain Stage event naming.

--- a/content/drafts/2026-05-19-horizons-ai-models-future-machine-learning/publish-gate.md
+++ b/content/drafts/2026-05-19-horizons-ai-models-future-machine-learning/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current images are planning thumbnails, with embeds-only or an approved WP-hosted still preferred before public use.
+- [x] Source evidence is public Horizons/Compass series material plus local metadata pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, private client claims, private contact, travel, credential material, and endorsement language beyond the public appearance.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm the preferred series URL and Horizons/Compass naming.

--- a/content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute/publish-gate.md
+++ b/content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute/publish-gate.md
@@ -2,6 +2,17 @@
 
 Status: local draft prepared; do not publish without KK review.
 
+## Issue #99 source-pack readiness
+
+- [x] Clean title, slug, excerpt, SEO title, meta description, category, and tag recommendations are recorded in `seo-meta.md`.
+- [x] Internal-link notes and post-publish backlink targets are recorded in `internal-links.md`.
+- [x] Image/media decision is recorded in `alt-text.md`; current image is a planning thumbnail, with an approved Whistler Institute stage/event image preferred before public use.
+- [x] Source evidence is public video plus local metadata/transcript pointers; no private Notion material is copied into the post body.
+- [x] Draft avoids raw transcript dumps, audience names, private client claims, private contact, travel, or credential material.
+- [x] Link check and privacy scan are recorded in `content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`.
+
+Ready for WP draft? Yes, for private draft creation after the normal Track A backup, slug-check, and rollback gates. Do not publish publicly until KK completes the review items below.
+
 ## Required review
 
 - [ ] Confirm Whistler Institute naming and event context.

--- a/content/source-packs/keynotes-2026/post-packages/README.md
+++ b/content/source-packs/keynotes-2026/post-packages/README.md
@@ -38,7 +38,7 @@ This order gives the site a clean spine: keynote topic, regional authority, comm
 
 ## Local Draft Status
 
-P0 and P1 local draft folders were prepared on 2026-05-19:
+P0 and P1 local draft folders were prepared on 2026-05-19 and source-pack readiness was verified for issue `#99` on 2026-05-20:
 
 - `../../../drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college/`
 - `../../../drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute/`
@@ -48,3 +48,12 @@ P0 and P1 local draft folders were prepared on 2026-05-19:
 - `../../../drafts/2026-05-19-dear-ai-bass-coast-brain-stage/`
 
 These are not published. Each has a `publish-gate.md` file for KK review, final image choice, and fact-check/privacy checks.
+
+Readiness artifacts:
+
+- `review-ready-draft-batch-2026-05-20.md`
+- `../verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md`
+
+## Issue #99 Verdict
+
+The selected batch is ready for private WordPress draft creation after the normal Track A live-write gates: fresh backup or approved rollback path, authenticated slug check, and KK review. It is not approved for public publish, media upload, or backlink changes from this issue.

--- a/content/source-packs/keynotes-2026/post-packages/review-ready-draft-batch-2026-05-20.md
+++ b/content/source-packs/keynotes-2026/post-packages/review-ready-draft-batch-2026-05-20.md
@@ -1,0 +1,61 @@
+# Review-Ready Keynote Draft Batch - 2026-05-20
+
+Issue: `#99`
+Track: Track A
+Mode: repo-local source-pack and draft prep only
+Live WordPress writes: none
+
+## Scope
+
+This batch verifies the six existing P0/P1 keynote and appearance-support draft folders created from `content/source-packs/keynotes-2026/`.
+
+Included draft packages:
+
+| Priority | Draft folder | Authority job | Ready for WP draft? |
+| --- | --- | --- | --- |
+| P0 | `content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college/` | Creative-AI keynote anchor for schools, agencies, and cultural orgs. | Yes, after final image and KK event-naming review. |
+| P0 | `content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute/` | BC/Vancouver AI ecosystem authority proof. | Yes, after image selection and named-claim fact-check. |
+| P0 | `content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/` | Community-stage proof for the `Both Hands Full` frame. | Yes, after title/tone and ethical-claim review. |
+| P1 | `content/drafts/2026-05-19-horizons-ai-models-future-machine-learning/` | Produced-media and guesting proof for speaking/media bookings. | Yes, after Horizons/Compass naming and image/embed decision. |
+| P1 | `content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext/` | Practical AI transformation, live synthesis, and training proof. | Yes, after event naming and tool/project-name review. |
+| P1 | `content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage/` | Festival/workshop range and participatory AI ethics proof. | Yes, after event naming, image rights, and audience-reference review. |
+
+Excluded from this batch:
+
+- `content/drafts/2026-05-19-ai-media-appearances-podcast-guesting/` remains governed by issue `#95` because that work specifically requested a live private WP draft and is blocked by the fresh-backup rule.
+- `content/source-packs/keynotes-2026/post-packages/cbc-ai-sandbox-and-appearance-queue.md` remains a source/appearance queue rather than a standalone draft package in this pass.
+
+## Acceptance Matrix
+
+| Package | Title/slug/SEO/excerpt/category/tags | Internal links | Image/media decision | Fact-check/privacy checklist | Source evidence | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| LaSalle `Both Hands Full` | `seo-meta.md` complete | `internal-links.md` complete | Planning YouTube thumbnail; prefer WP-hosted LaSalle stage photo | `publish-gate.md` complete for source-pack readiness | Public YouTube video, local metadata, local transcript pointer | Ready for private WP draft after live-write gates |
+| Whistler Institute | `seo-meta.md` complete | `internal-links.md` complete | Planning YouTube thumbnail; prefer approved Whistler stage/event image | `publish-gate.md` complete for source-pack readiness | Public YouTube video, local metadata, local transcript pointer | Ready for private WP draft after live-write gates |
+| Vancouver AI March 2026 | `seo-meta.md` complete | `internal-links.md` complete | Planning YouTube thumbnail; prefer approved Vancouver AI stage photo | `publish-gate.md` complete for source-pack readiness | Public YouTube video, local metadata, local transcript pointer | Ready for private WP draft after live-write gates |
+| Horizons series | `seo-meta.md` complete | `internal-links.md` complete | Planning thumbnails; prefer embeds-only or approved WP-hosted still | `publish-gate.md` complete for source-pack readiness | Public Horizons series plus local metadata pointers | Ready for private WP draft after live-write gates |
+| ChannelNext | `seo-meta.md` complete | `internal-links.md` complete | Planning YouTube thumbnail; prefer cleared event/stage asset | `publish-gate.md` complete for source-pack readiness | Public YouTube video, local metadata, local transcript pointer | Ready for private WP draft after live-write gates |
+| Bass Coast Brain Stage | `seo-meta.md` complete | `internal-links.md` complete | Planning YouTube thumbnail; prefer rights-cleared Bass Coast photo | `publish-gate.md` complete for source-pack readiness | Public YouTube video, local metadata, local transcript pointer | Ready for private WP draft after live-write gates |
+
+## Publish Order
+
+Recommended next private-draft order:
+
+1. `both-hands-full-ai-creatives-lasalle-college`
+2. `inside-vancouvers-ai-boom-whistler-institute`
+3. `both-hands-full-vancouver-ai-march-2026`
+4. `horizons-ai-models-future-machine-learning`
+5. `ai-keynote-chaos-creativity-channelnext`
+6. `dear-ai-bass-coast-brain-stage`
+
+That order builds the strongest authority spine first: keynote topic, regional ecosystem proof, community proof, produced media proof, practical enterprise/event proof, and festival/workshop proof.
+
+## Required Live-Write Gate
+
+Before any of these become WordPress drafts:
+
+- Take a fresh backup or stop under the repo's live-write safety rule.
+- Run authenticated exact-slug checks across `any` status.
+- Confirm categories/tags exist or document any proposed taxonomy changes before creating them.
+- Use WP-hosted/owned images or embeds; do not use expiring Notion S3 URLs.
+- Create private drafts only unless KK explicitly approves public publishing.
+- Add backlinks from Speaking/About/Work/Services only after a draft/post URL exists and has been reviewed.

--- a/content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md
+++ b/content/source-packs/keynotes-2026/verification/DRAFT-BATCH-READINESS-VERIFICATION-2026-05-20.md
@@ -1,0 +1,109 @@
+# Draft Batch Readiness Verification - 2026-05-20
+
+Issue: `#99`
+Scope: repo-local keynote/source-pack draft batch only. No live WordPress writes, no media uploads, no page updates, no backlink changes.
+
+## Files Verified
+
+Draft folders:
+
+- `content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college/`
+- `content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute/`
+- `content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/`
+- `content/drafts/2026-05-19-horizons-ai-models-future-machine-learning/`
+- `content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext/`
+- `content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage/`
+
+Source-pack files:
+
+- `content/source-packs/keynotes-2026/post-packages/README.md`
+- `content/source-packs/keynotes-2026/post-packages/review-ready-draft-batch-2026-05-20.md`
+
+## Structure Check
+
+Each selected draft folder has:
+
+- `post.md`
+- `post.html`
+- `seo-meta.md`
+- `internal-links.md`
+- `alt-text.md`
+- `publish-gate.md`
+- `images/`
+
+Word-count/line-count sanity check showed each package has substantive body copy plus separate SEO, link, image, and publish-gate notes.
+
+## Link Check
+
+Command:
+
+```bash
+urls=$(rg --no-filename -o 'https?://[^"`<> )\]]+' \
+  content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext \
+  content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college \
+  content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026 \
+  content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage \
+  content/drafts/2026-05-19-horizons-ai-models-future-machine-learning \
+  content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute \
+  content/source-packs/keynotes-2026/post-packages \
+  | sed 's/[`),.;]*$//' \
+  | sort -u)
+printf '%s\n' "$urls" | while IFS= read -r url; do
+  [ -n "$url" ] || continue
+  code=$(curl -L -s -o /dev/null -w '%{http_code}' --max-time 20 "$url" || printf 'curl-failed')
+  printf '%s %s\n' "$code" "$url"
+done
+```
+
+Results:
+
+```text
+200 https://bc-ai.ca/
+200 https://horizons.compassdatacenters.com/series/exploring-ai-models-the-future-of-machine-learning/
+200 https://kriskrug.co/about/
+200 https://kriskrug.co/contact/
+200 https://kriskrug.co/podcast-guesting-page-epk/
+200 https://kriskrug.co/recent-projects-include/
+200 https://kriskrug.co/services/
+200 https://kriskrug.co/speaking/
+200 https://www.bothhandsfull.com/
+200 https://www.punkrockai.com/
+200 https://www.youtube.com/watch?v=-XEsqsEbpoo
+200 https://www.youtube.com/watch?v=-c7mgY2aSgM
+200 https://www.youtube.com/watch?v=1OcC-0X6Nb8
+200 https://www.youtube.com/watch?v=EBGdM6T9Fr8
+200 https://www.youtube.com/watch?v=T5ANAthZewE
+200 https://www.youtube.com/watch?v=owtSPcpRinI
+200 https://www.youtube.com/watch?v=pfecN8_1boA
+200 https://www.youtube.com/watch?v=tfXkDhlqnrE
+```
+
+## Privacy Scan
+
+Command:
+
+```bash
+rg -n -i 'visa|boarding|passport|hotel|whatsapp|phone|tel:|mailto:|app[_ -]?password|application password|token|nonce|secret|private email|@[A-Za-z0-9._%+-]+\.[A-Za-z]{2,}' \
+  content/drafts/2026-05-19-ai-keynote-chaos-creativity-channelnext \
+  content/drafts/2026-05-19-both-hands-full-ai-creatives-lasalle-college \
+  content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026 \
+  content/drafts/2026-05-19-dear-ai-bass-coast-brain-stage \
+  content/drafts/2026-05-19-horizons-ai-models-future-machine-learning \
+  content/drafts/2026-05-19-inside-vancouvers-ai-boom-whistler-institute \
+  content/source-packs/keynotes-2026/post-packages
+```
+
+Result: no matches.
+
+## Readiness Verdict
+
+The six selected draft packages satisfy issue `#99` for repo-local readiness:
+
+- title, slug, excerpt, SEO fields, category recommendations, and tag recommendations are present;
+- internal-link notes and backlink targets are present;
+- image/media decisions and rights/safety notes are present;
+- per-package fact-check/privacy checklists are present in `publish-gate.md`;
+- link checks passed for all selected public/internal URLs;
+- privacy scan returned no matches.
+
+Ready for WP draft? Yes, as private draft candidates only, after the normal Track A backup, authenticated exact-slug check, and rollback gates. Public publishing, media upload, and live backlinks remain out of scope for this issue.


### PR DESCRIPTION
## Summary

- adds a review-ready matrix for the six selected keynote/source-pack draft folders
- adds per-draft Issue #99 readiness checklists to each publish gate
- records link-check and privacy-scan verification for the batch

## Safety

- repo-local source-pack/draft prep only
- no live WordPress writes
- no media uploads
- no page updates or backlink changes

## Verification

- `git diff --cached --check`
- link check: all selected internal/public URLs returned `200`
- privacy scan: no matches across selected draft folders and post-package files

Closes #99