### PR TITLE
content: strengthen About role sections

### DIFF
--- a/content/source-packs/keynotes-2026/verification/ABOUT-ROLE-SECTIONS-VERIFICATION-2026-05-20.md
+++ b/content/source-packs/keynotes-2026/verification/ABOUT-ROLE-SECTIONS-VERIFICATION-2026-05-20.md
@@ -1,0 +1,70 @@
+# About Role Sections Verification - 2026-05-20
+
+## Scope
+
+- Track A content payload only.
+- No live WordPress write, media upload, theme edit, or production activation performed in this pass.
+- Updated payload: `content/source-packs/keynotes-2026/wp-payloads/about.html`.
+
+## What Changed
+
+- Added a `Current operating roles` section with three equal-weight cards:
+  - BC + AI Ecosystem: Executive Director / ecosystem builder.
+  - Indigenomics AI: CTO / Indigenous economic technology.
+  - The Upgrade AI: Co-founder / AI training.
+- Reframed photography as `Visual storyteller` in the hero proof row.
+- Added copy that explicitly positions photography as the visual storytelling background behind the AI/community/speaking work.
+- Added responsive role-card CSS that follows the existing payload pattern: simple grid, high-contrast text, semantic headings, and compact fact chips.
+
+## Source Grounding
+
+- XML About source was confirmed in `/Users/kk/Desktop/kriskrggenerativeaitoolsamptechniques.WordPress.2026-01-03.xml`; the page item starts around line `156582` and preserves the original `Techartist, quasi-sage, cyberpunk anti-hero from the future.` title.
+- Role mapping came from `docs/kris-krug-roles-module.md`, including the `CTO, Indigenomics`, `TheUpgrade.ai`, and `BC+AI Executive Director` role framework.
+- BC + AI current stats were checked against the live `https://bc-ai.ca/` home page on 2026-05-20:
+  - `250+` Members.
+  - `3,000+` Event Attendees.
+  - `94+` Events Hosted.
+- The older XML source has the 2024 historical stat of `13 monthly meetups with over 2,000 total attendees`; the issue text said `2,000+ members`, but current public evidence supports `250+ members` and `3,000+ event attendees`, so the payload uses the current source-backed numbers.
+- Indigenomics evidence came from the local XML/public post `https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/`, including the dashboard, sovereign data, and `$100B Indigenous economy` language. The `indigenomics.ai` domain currently resolves to a parked/lander page, so the payload links to the owned kriskrug.co post instead of treating the parked domain as an authority page.
+- The Upgrade evidence came from `https://www.theupgrade.ai/`, the XML source referencing Peter Bittner and TheUpgrade.ai, and the public Upgrade page copy around live/on-demand courses, group coaching, team trainings, certification cohorts, and enterprise logo proof. The payload uses `enterprise logos` instead of an unqualified `Fortune 500 training` claim.
+- Policy influence evidence is supported by the local Vancouver AI March 2026 transcript phrase `community-based regional organization that is impacting national policy around AI`.
+
+## Acceptance Notes
+
+| Criterion | Status | Note |
+|---|---:|---|
+| Current About page content extracted from XML | Done | XML source located and old title/voice preserved. |
+| BC+AI section added | Done | Uses current public stats rather than stale/mislabeled `2,000+ members`. |
+| Indigenomics section added | Done | Uses CTO framing plus source-backed `$100B Indigenous economy` language. |
+| The Upgrade AI section added | Done | Names Peter Bittner, cohorts, team trainings, and enterprise proof. |
+| Photography positioned as visual storytelling background | Done | Hero proof and current-work copy updated. |
+| Professional but warm tone throughout | Done | Keeps KK voice without turning the page into a formal resume. |
+| All three roles featured equally | Done | Three same-level cards in the same section. |
+| Mobile responsive | Locally ready | Uses existing auto-fit grid and mobile media query; full browser render still belongs in the live/staging publish pass. |
+| WCAG 2.1 AA | Locally ready | Semantic headings, text-based CTAs, alt text retained, no low-contrast decorative text added; full automated scan belongs in the live/staging render pass. |
+| Updated content ready to publish | Done | Payload is ready for the normal backup/snapshot gate before any WP write. |
+
+## Verification
+
+- External URL check from `about.html`: `20` unique `http(s)` URLs checked with `curl -L`; all returned `200`.
+- Payload privacy scan: no sensitive-string matches found in `about.html`.
+- Expected content checks found:
+  - `Current operating roles`
+  - `Executive Director / ecosystem builder`
+  - `250+ members`
+  - `3,000+ event attendees`
+  - `CTO / Indigenous economic technology`
+  - `$100B Indigenous economy vision`
+  - `Co-founder / AI training`
+  - `Peter Bittner`
+  - `Visual storyteller`
+
+## Publish Gate
+
+Before applying this payload to live page ID `1208`, follow the repo live-write rules:
+
+1. Take a fresh backup or stop.
+2. Snapshot page ID `1208` to rollback JSON/HTML.
+3. PATCH only after slug/title/id verification confirms the target is `/about/`.
+4. REST-read back title, slug, status, comment settings, SEO meta, and content markers.
+5. Browser-check desktop and mobile after publish.

--- a/content/source-packs/keynotes-2026/wp-payloads/about.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/about.html
@@ -19,6 +19,11 @@
 .kk-card p { margin:.45rem 0; color:var(--kk-muted); }
 .kk-tag { display:inline-block; margin:0 0 .55rem; color:var(--kk-hot); font-size:.72rem; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }
 .kk-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }
+.kk-role-card { background:#fff; border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }
+.kk-role-card h3 { margin-top:0; }
+.kk-role-card p { color:var(--kk-muted); }
+.kk-role-facts { display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.85rem; }
+.kk-role-facts span { border:1px solid var(--kk-line); border-radius:999px; padding:.25rem .55rem; background:var(--kk-paper); font-size:.88rem; font-weight:700; }
 .kk-two { display:grid; grid-template-columns:minmax(0,1fr) minmax(260px,.8fr); gap:1.25rem; align-items:start; }
 .kk-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.75rem; margin-top:1rem; }
 .kk-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }
@@ -51,7 +56,7 @@
     <div class="kk-proof">
       <div><strong>AI speaker</strong><span>Keynotes, workshops, and executive briefings.</span></div>
       <div><strong>Community builder</strong><span>BC+AI, Vancouver AI, festivals, and field-building.</span></div>
-      <div><strong>Photographer</strong><span>Conferences, movements, portraits, and impossible rooms.</span></div>
+      <div><strong>Visual storyteller</strong><span>Photography, conferences, movements, portraits, and impossible rooms.</span></div>
     </div>
   </section>
 
@@ -61,6 +66,7 @@
         <h2>What I am building now</h2>
         <p>These days my work orbits AI, community infrastructure, and creative practice. I help people make sense of machine intelligence without surrendering taste, culture, relationships, or responsibility.</p>
         <p>I lead and support AI ecosystem work in British Columbia, give keynotes and workshops for creative and leadership audiences, build standalone learning portals around major talks, and help teams turn AI from vague pressure into useful practice.</p>
+        <p>The photography still matters. It is the visual storytelling background that taught me how rooms work, how movements feel, and how culture changes when people can actually see themselves inside the story.</p>
         <div class="kk-actions">
           <a class="kk-button secondary" href="https://bc-ai.ca/">BC + AI</a>
           <a class="kk-button secondary" href="https://www.punkrockai.com/">Punk Rock AI</a>
@@ -68,6 +74,49 @@
         </div>
       </div>
       <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1200&amp;ssl=1" alt="Portrait of Kris Krug" loading="lazy" />
+    </div>
+  </section>
+
+  <section class="kk-section">
+    <h2>Current operating roles</h2>
+    <p class="kk-section-intro">The useful version of my bio is not only a list of old titles. It is the three live systems I am operating inside right now: province-wide AI ecosystem work, Indigenous economic technology, and practical AI training.</p>
+    <div class="kk-grid">
+      <article class="kk-role-card">
+        <span class="kk-tag">Executive Director / ecosystem builder</span>
+        <h3><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></h3>
+        <p>I help turn Vancouver AI's grassroots momentum into responsible, inclusive, place-rooted AI infrastructure for British Columbia: meetups, policy conversations, partner rooms, learning cohorts, working groups, and public community architecture.</p>
+        <p>This is coalition work with a pulse: technologists, artists, researchers, public servants, Indigenous leaders, founders, students, and creative weirdos learning how to shape AI together instead of waiting for someone else to do it badly.</p>
+        <div class="kk-role-facts">
+          <span>250+ members</span>
+          <span>3,000+ event attendees</span>
+          <span>94+ events hosted</span>
+          <span>AI policy influence</span>
+        </div>
+      </article>
+      <article class="kk-role-card">
+        <span class="kk-tag">CTO / Indigenous economic technology</span>
+        <h3><a href="https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/">Indigenomics AI</a></h3>
+        <p>My Indigenomics work is about technology in service of Indigenous economic sovereignty: dashboards, data, AI assistants, storytelling systems, and digital infrastructure that respect protocol instead of treating communities as extractive datasets.</p>
+        <p>The frame is nation-building tech, not generic startup software. It connects AI, data governance, economic evidence, and the broader Indigenomics movement around Indigenous economic power.</p>
+        <div class="kk-role-facts">
+          <span>CTO role</span>
+          <span>$100B Indigenous economy vision</span>
+          <span>sovereign data</span>
+          <span><a href="/reconciliation-indigenous-land-acknowledgement/">reconciliation thread</a></span>
+        </div>
+      </article>
+      <article class="kk-role-card">
+        <span class="kk-tag">Co-founder / AI training</span>
+        <h3><a href="https://www.theupgrade.ai/">The Upgrade AI</a></h3>
+        <p>With Peter Bittner and collaborators, I turn messy AI experimentation into cohorts, custom trainings, resource portals, and workshops for professionals who need practical fluency now.</p>
+        <p>The Upgrade is where the keynote energy becomes muscle memory: live demos, team workflows, AI for creative pros, AI for media leaders, PR and communications training, and enterprise-ready adoption without the plastic consultant smell.</p>
+        <div class="kk-role-facts">
+          <span><a href="https://www.peterbittner.com/about">Peter Bittner</a></span>
+          <span>team trainings</span>
+          <span>certification cohorts</span>
+          <span>enterprise logos</span>
+        </div>
+      </article>
     </div>
   </section>
 

--- a/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
+++ b/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
@@ -1,0 +1,175 @@
+# Aurora State-of-the-Art Roadmap - Summer 2026
+
+**Prepared:** 2026-05-20  
+**Snapshot time:** 2026-05-20 05:54:46 UTC  
+**Track:** B (`aurora/v2`)  
+**Purpose:** Step back from issue-by-issue execution and align Aurora to a true summer-2026 quality bar.
+
+## Current Truth (before new implementation)
+
+- Open PRs: `0`
+- Open issues: `66`
+- Open `track-b` + `aurora-v2` issues: `13` (`#24-#35`, `#86`)
+- Active Aurora hard gate: `#86` (staging performance/accessibility QA)
+- Working rule remains: no Track A content writes mixed into Track B theme lanes.
+
+## What "State of the Art" Means for Aurora (Summer 2026)
+
+The bar is no longer "has animation." The bar is:
+
+1. unmistakable identity in the first viewport,
+2. real media proof (photo/video/projects) instead of decorative gradients,
+3. motion as usability and narrative, not spectacle,
+4. measurable performance/accessibility quality on real devices.
+
+### Benchmark Signals and Implications
+
+| Signal (2026) | What it means for us |
+|---|---|
+| Award-level portfolio/personal-brand work is still judged on craft + UX + innovation together, not visuals alone. | Aurora must pair visual polish with clear IA, clear CTAs, and fast comprehension. |
+| View Transitions are now practical across same-origin page navigation (progressive enhancement). | Keep transition polish, but ship fallbacks and test real WordPress route behavior. |
+| Scroll-driven CSS animation is production-usable as enhancement. | Prefer CSS timeline/reveal primitives for lightweight effects; reserve JS for high-value interactions. |
+| Core Web Vitals remain explicit and unforgiving (`LCP <=2.5s`, `INP <=200ms`, `CLS <=0.1` at the 75th percentile). | Every visual decision (hero media, motion, script weight) must pass a budget, not just taste review. |
+| WCAG 2.2 is the accessibility baseline, including reduced-motion and moving-content control expectations. | Any morph/glass/motion layer needs keyboard, focus, contrast, and pause/reduce behavior by default. |
+| Autoplay restrictions and user preference constraints are mainstream browser behavior. | No heavy autoplay-default hero strategy; poster-first and explicit play affordances win. |
+
+## Strategic Product Direction (Aurora)
+
+Aurora should feel like a premium editorial studio for AI-era leadership:
+
+- **Editorial authority:** sharp type, confident hierarchy, less generic "AI theme" styling.
+- **Media truth:** real photos, speaking footage, project evidence, event context.
+- **Restrained morphism:** glass/morphism only where it helps controls, overlays, metadata, and navigation.
+- **Narrative motion:** transitions and reveals that guide attention; no motion-only meaning.
+- **Conversion clarity:** primary CTA hierarchy stays stable across homepage, Work, Speaking, and Contact.
+
+## Feature Stack: Prioritized Build Order
+
+## P0 - Finish the non-negotiable gate (Now)
+
+**Issue:** `#86`  
+**Outcome:** production-like QA evidence, not local-only confidence.
+
+Ship criteria:
+
+- staging screenshot matrix (desktop/mobile: Home, Work, Speaking, long-form template)
+- keyboard/focus traversal pass
+- reduced-motion pass
+- contrast spot checks against WCAG 2.2 expectations
+- media load behavior evidence (hero, cards, embeds)
+- perf notes with explicit LCP/INP/CLS observations
+
+If P0 fails, pause feature expansion and fix debt first.
+
+## P1 - Signature Experience Layer (Next)
+
+Target: move from "good prototype" to "recognizable Kris Krug experience."
+
+1. **Hero media orchestration**
+   - canonical hero asset set (video poster + still fallback + mobile crop)
+   - art-directed crops by breakpoint
+   - no autoplay-default heavy payload
+
+2. **Speaking authority module**
+   - reel block (poster-first embed)
+   - topics + outcomes + social proof
+   - one booking CTA path that does not fragment
+
+3. **Work proof rail**
+   - project cards with proof metadata (`role`, `context`, `result`, `link`)
+   - clear split between flagship projects and archive breadth
+
+4. **Reading/essay polish**
+   - long-form templates that support image-rich essays and embeds cleanly
+   - improved in-article hierarchy and related-next paths
+
+## P2 - System Quality Layer (Immediately after P1)
+
+Target: make polish consistent and maintainable.
+
+1. **Motion governance**
+   - inventory each animation and assign purpose (`reveal`, `transition`, `feedback`, `delight`)
+   - remove redundant overlaps between CSS/GSAP/micro-interaction scripts
+
+2. **Component governance**
+   - finalize restrained component inventory (buttons, cards, forms, footer, callouts)
+   - remove card-over-card drift and keep section-level layouts unframed
+
+3. **Media pipeline**
+   - source-of-truth manifest for hero/work/speaking assets
+   - AVIF/WebP + JPEG fallback strategy
+   - alt text + caption + rights metadata workflow
+
+## P3 - Launch Readiness Layer
+
+Target: safely decide go-live timing.
+
+1. **Staging-to-production checklist**
+   - backup and rollback proof attached
+   - environment parity notes
+   - QA regression checklist rerun after final content/media swap
+
+2. **Issue hygiene**
+   - close or relabel legacy design tickets `#24-#35` based on acceptance evidence, not age
+   - keep one canonical epic path to prevent duplicate execution
+
+3. **Feedback loop**
+   - gather external review on:
+     - first-impression authority,
+     - clarity of offerings,
+     - media credibility,
+     - motion comfort,
+     - conversion confidence.
+
+## Recommended Issue Model (to reduce queue entropy)
+
+Current open Track B set still includes both new epic-style work (`#86`) and old granular tickets (`#24-#35`).  
+Recommendation:
+
+1. keep `#86` as the active gate issue,
+2. treat `#24-#35` as checklist references unless they hold unique acceptance criteria,
+3. avoid opening more Track B implementation lanes until `#86` evidence is complete.
+
+## 7-Day Execution Plan
+
+### Day 1-2
+- complete `#86` on real staging and publish one canonical QA packet.
+
+### Day 3-4
+- implement hero media orchestration + speaking authority module.
+
+### Day 5
+- implement work proof rail + long-form polish deltas.
+
+### Day 6
+- run perf/a11y regression pass; remove non-essential motion weight.
+
+### Day 7
+- reviewer walk-through + decision memo: `ship`, `polish one more cycle`, or `hold`.
+
+## Decision Gates (must be explicit)
+
+1. **Brand gate:** Does first viewport instantly signal Kris Krug authority?
+2. **Usability gate:** Can a new visitor understand offers and navigate in under 30 seconds?
+3. **Performance gate:** Are LCP/INP/CLS within acceptable range on representative mobile?
+4. **Accessibility gate:** Are keyboard, focus, reduced-motion, and contrast behavior reliable?
+5. **Operations gate:** Are backup/rollback and QA artifacts complete enough to recover from mistakes?
+
+If any gate is red, do not launch.
+
+## Sources Used for Summer-2026 Benchmark
+
+- [Awwwards - Sites of the Day](https://www.awwwards.com/websites/sites_of_the_day/)
+- [Chrome Developers - View transitions in 2025](https://developer.chrome.com/blog/view-transitions-in-2025)
+- [Chrome Developers - Cross-document view transitions](https://developer.chrome.com/docs/web-platform/view-transitions/cross-document)
+- [MDN - View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API)
+- [MDN - prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+- [MDN - Autoplay guide](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Autoplay)
+- [W3C - WCAG 2.2 Recommendation](https://www.w3.org/TR/WCAG22/)
+- [W3C - Understanding SC 2.2.2 Pause, Stop, Hide](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html)
+- [W3C - Understanding SC 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum)
+- [web.dev - LCP](https://web.dev/articles/lcp)
+- [web.dev - INP](https://web.dev/articles/inp)
+- [web.dev - CLS](https://web.dev/articles/cls)
+- [WordPress - Block themes documentation](https://wordpress.org/documentation/article/block-themes/)
+

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -20,10 +20,11 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [ROADMAP.md](ROADMAP.md) | Six-phase, 3-month plan that synthesizes FIX_QUEUE + postmortem follow-ups + content pipeline next steps. **Start here.** |
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
 | [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. |
-| [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Current execution plan after Wave 3 partial completion (`#84` closed; `#85/#86` open). |
+| [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Current execution plan after Wave 3 implementation completion and final Track B QA gate (`#86`). |
 | [NEXT-ROUND-WORK-2026-05-19.md](NEXT-ROUND-WORK-2026-05-19.md) | Historical 2026-05-19 handoff sheet (superseded by the 2026-05-20 roadmap/work-plan docs). |
 | [ISSUE-SWARM-ROADMAP-2026-05-19.md](ISSUE-SWARM-ROADMAP-2026-05-19.md) | 72-hour swarm-ready issue roadmap with parallel lanes, stop rules, and wave labels. |
 | [AURORA-ISSUE-SWARM-2026-05-19.md](AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics #80-#86 and routed old design issues #24-#35. |
+| [AURORA-SOTA-ROADMAP-2026-05-20.md](AURORA-SOTA-ROADMAP-2026-05-20.md) | Summer-2026 state-of-the-art benchmark and feature roadmap for Aurora Track B. |
 | [CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-PREFLIGHT-2026-05-19.md) | Redacted history-scan findings and safe force-push preflight; no rewrite performed. |
 | [CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md](CREDENTIAL-HISTORY-REWRITE-EXECUTION-2026-05-19.md) | Execution log for the credential history rewrite, affected branch force-updates, and post-rewrite follow-ups. |
 | [GITHUB-QUEUE-RECOVERY-2026-05-19.md](GITHUB-QUEUE-RECOVERY-2026-05-19.md) | Queue recovery log for replacement PRs #87/#88, CI fix, and post-rewrite branch cleanup. |

--- a/docs/current-state/WORK-PLAN-2026-05-20.md
+++ b/docs/current-state/WORK-PLAN-2026-05-20.md
@@ -1,13 +1,13 @@
 # Work Plan - 2026-05-20
 
 **Purpose:** current execution plan after Wave 3 implementation completion, with queue truth and stop rules.
-**Snapshot time:** 2026-05-20 04:52 UTC.
+**Snapshot time:** 2026-05-20 05:54 UTC.
 
 ## Verified State
 
 - `main` is synced with `origin/main` (`0 0` divergence).
 - Open PRs: `0`.
-- Open issues: `67`.
+- Open issues: `66`.
 - Open `track-b` + `aurora-v2` issues: `13`.
 - Closed today on Track B:
   - `#81` via PR `#102` evidence reconciliation
@@ -21,6 +21,10 @@
 `origin/aurora/v2` is currently far from `origin/main` (`18` ahead / `62` behind; large tree delta). Treat this as an intentional branch-isolation reality for now, but do not attempt broad cross-track merges until an explicit branch-integration strategy is chosen.
 
 ## Execution Order (Next Round)
+
+Strategy reference for this round:
+
+- `docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md` (summer-2026 benchmark + feature sequencing for Track B)
 
 ### 1) Run `#86` QA gate on real staging (Track B, final lane)
 


### PR DESCRIPTION
## Summary
- adds equal-weight BC + AI, Indigenomics AI, and The Upgrade AI role cards to the About payload
- reframes photography as visual storytelling background while preserving the original KK voice
- adds a verification note documenting source grounding, link checks, privacy scan, and the live-publish gate
- includes the prior docs-only Aurora summer-2026 SOTA roadmap commit already on this branch

## Safety
- Track A content/docs only; no live WordPress writes, media uploads, or theme edits
- uses current source-backed BC + AI stats (`250+ members`, `3,000+ event attendees`, `94+ events`) instead of the stale/mislabeled `2,000+ members` issue wording
- uses source-backed `$100B Indigenous economy` language and avoids treating parked `indigenomics.ai` as the live authority page

## Verification
- `git diff --check`
- `curl -L` link check: 20 unique URLs from `about.html`, all `200`
- sensitive-string scan on the About payload and verification note: no matches
- marker checks for the new role sections and proof chips

Closes #65