### PR TITLE
content: draft homepage polymath hero

### DIFF
--- a/content/source-packs/keynotes-2026/README.md
+++ b/content/source-packs/keynotes-2026/README.md
@@ -21,6 +21,8 @@ Applied after the Horizons update: an IA polish continuation tightened Work hier
 
 Applied after the media-appearance intake: `/podcast-guesting-page-epk/` is now the podcast, broadcast, produced-interview, hosting, moderation, and emcee booking surface. See `verification/PODCAST-EPK-DEPLOY-VERIFICATION-2026-05-19.md`.
 
+Prepared but not deployed on 2026-05-20: a homepage hero candidate for page `3930` that leads with the BC+AI, Indigenomics AI, and The Upgrade AI authority story. See `verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md`.
+
 ## Source Inputs
 
 - Notion page: `Keynotes` (`cd4ce83f-afa5-440d-8405-4caf04a480d1`)
@@ -54,6 +56,7 @@ Applied after the media-appearance intake: `/podcast-guesting-page-epk/` is now 
 - `wp-payloads/work.html` - publish-ready content for page `2672`.
 - `wp-payloads/about.html` - publish-ready content for page `1208`.
 - `wp-payloads/podcast-guesting-page-epk.html` - deployed content for page `3609`.
+- `wp-payloads/homepage-hero.html` - prepared homepage hero candidate for page `3930`; not deployed.
 - `wp-payloads/page-meta.json` - target titles, SEO meta, slugs, and comment settings.
 - `wp-payloads/deploy-checklist.md` - live-write gate and verification checklist.
 - `verification/DEPLOY-VERIFICATION-2026-05-18.md` - REST, URL, screenshot, and rollback verification after deploy.
@@ -66,6 +69,8 @@ Applied after the media-appearance intake: `/podcast-guesting-page-epk/` is now 
 - `verification/P1-DRAFT-PREP-VERIFICATION-2026-05-19.md` - P1 Speaking companion-post local draft prep verification.
 - `verification/MEDIA-APPEARANCE-SOURCE-VERIFICATION-2026-05-19.md` - public CBC/podcast/media appearance source and draft verification.
 - `verification/PODCAST-EPK-DEPLOY-VERIFICATION-2026-05-19.md` - live Podcast EPK deploy, rollback, REST, link, and screenshot verification.
+- `verification/ABOUT-ROLE-SECTIONS-VERIFICATION-2026-05-20.md` - About-page role-section source grounding and publish gate.
+- `verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md` - homepage hero source grounding, issue comment, and publish gate.
 - `media-appearances/public-source-inventory-2026-05-19.md` - public CBC/podcast/media appearance source inventory.
 
 ## Local Draft Outputs

--- a/content/source-packs/keynotes-2026/verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md
+++ b/content/source-packs/keynotes-2026/verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md
@@ -1,0 +1,106 @@
+# Homepage Hero Verification - 2026-05-20
+
+## Scope
+
+- Track A content/copy package only.
+- No live WordPress write, media upload, theme edit, or production activation performed in this pass.
+- Target page for future publish: page ID `3930`, slug `empowering-events-organizations-for-the-ai-age`, public URL `https://kriskrug.co/`.
+- New payload: `content/source-packs/keynotes-2026/wp-payloads/homepage-hero.html`.
+- Metadata pointer updated: `content/source-packs/keynotes-2026/wp-payloads/page-meta.json`.
+
+## Current Homepage Extraction
+
+- XML export source: `/Users/kk/Desktop/kriskrggenerativeaitoolsamptechniques.WordPress.2026-01-03.xml`.
+- Current front page item starts around line `161660`.
+- Current page ID is `3930`; it renders at `https://kriskrug.co/`.
+- Current hero/body starts with:
+  - `I believe in the power of connection.`
+  - `not just about revealing moments through photographs or managing social media feeds`
+  - `a patchwork quilt of creative awesomeness`
+- The current page is still rooted in event photography, digital engagement, social media, and older services positioning.
+- The separate `/home/` page ID `2315` is the old `Recent Posts & Updates:` latest-posts page and was not targeted.
+
+## What Changed
+
+- Added a paste-ready homepage hero block that leads with:
+  - `Bridging art, AI, Indigenous wisdom, and justice.`
+  - Community-serving technology instead of extraction.
+  - Equal role badges for BC + AI Ecosystem, Indigenomics AI, and The Upgrade AI.
+  - Primary CTA: `Explore My Work` -> `/recent-projects-include/`.
+  - Secondary CTA: `Let's Connect` -> `/contact/`.
+- De-emphasized photography by moving the frame to 20+ years of art, technology, media, and community work.
+- Kept the tone professional, warm, and direct.
+
+## Metric Grounding
+
+- The issue text requested `2,000+ members`, `Fortune 500`, and `$200B`; public/source-backed evidence in this pass supports different wording.
+- BC + AI live stats checked at `https://bc-ai.ca/` on 2026-05-20:
+  - `250+` members.
+  - `3,000+` event attendees.
+  - `94+` events hosted.
+  - `4` BC regions.
+- Older XML/source material supports `13 monthly meetups with over 2,000 total attendees` as a 2024 historical attendee stat, not a current member count.
+- Indigenomics public post supports the dashboard, sovereign-data framing, and Carol Anne Hilton's `$100 billion Indigenous economy` vision.
+- The Upgrade live site supports live/on-demand courses, coaching, team trainings, certification cohorts, and visible enterprise/global-brand logo proof. The hero uses `Enterprise teams` rather than an unqualified `Fortune 500` claim.
+
+## Issue Comment Copy
+
+Posted to issue `#66`: `https://github.com/WalksWithASwagger/kriskrug-wp/issues/66#issuecomment-4495271077`.
+
+Use this concise comment on issue `#66`:
+
+```md
+Drafted the ready-to-implement homepage hero package in `content/source-packs/keynotes-2026/wp-payloads/homepage-hero.html`.
+
+Recommended hero:
+
+**Bridging art, AI, Indigenous wisdom, and justice.**
+
+I build technology programs, communities, keynotes, and learning systems that serve people instead of extraction. My work connects creative practice, responsible AI, Indigenous economic sovereignty, and the messy human work of building trust.
+
+Roles:
+- BC + AI Ecosystem: Executive Director building responsible, inclusive AI infrastructure across British Columbia.
+- Indigenomics AI: CTO work around sovereign data, economic evidence, and Indigenous-led technology futures.
+- The Upgrade AI: Co-founder helping professionals and teams build practical AI fluency without losing judgment or taste.
+
+Impact markers:
+- 250+ BC + AI members
+- 3,000+ BC + AI event attendees
+- 94+ community events hosted
+- $100B Indigenous economy vision supported through Indigenomics AI
+- 20+ years bridging art, technology, media, and community
+- Enterprise teams trained/coached through The Upgrade AI
+
+CTAs:
+- Explore My Work -> `/recent-projects-include/`
+- Let's Connect -> `/contact/`
+
+Note: I used current source-backed stats instead of the stale/mislabeled `2,000+ members`, `Fortune 500`, and `$200B` wording. Verification is in `content/source-packs/keynotes-2026/verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md`.
+```
+
+## Verification
+
+- External URL check from `homepage-hero.html`: all links returned `200`.
+- Payload privacy scan: no sensitive-string matches found in `homepage-hero.html`.
+- Content marker checks found:
+  - `Bridging art, AI, Indigenous wisdom, and justice.`
+  - `BC + AI Ecosystem`
+  - `Indigenomics AI`
+  - `The Upgrade AI`
+  - `250+`
+  - `3,000+`
+  - `94+`
+  - `$100B`
+  - `Explore My Work`
+  - `Let's Connect`
+
+## Publish Gate
+
+Before applying this hero to live page ID `3930`, follow the repo live-write rules:
+
+1. Take a fresh backup or stop.
+2. Snapshot page ID `3930` to rollback JSON/HTML.
+3. Verify REST target fields: `id=3930`, slug `empowering-events-organizations-for-the-ai-age`, public link `https://kriskrug.co/`.
+4. Insert the hero before the existing page content, or replace the existing top copy only after KK approval.
+5. REST-read back title, slug, status, comment settings, SEO meta, and content markers.
+6. Browser-check desktop and mobile after publish.

--- a/content/source-packs/keynotes-2026/wp-payloads/deploy-checklist.md
+++ b/content/source-packs/keynotes-2026/wp-payloads/deploy-checklist.md
@@ -27,6 +27,14 @@ Payload files:
 - `work.html` -> page `2672`
 - `about.html` -> page `1208`
 
+## Homepage Hero Candidate
+
+Status: prepared, not deployed. See `../verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md`.
+
+- `homepage-hero.html` -> page `3930`, public URL `/`
+- Insert before existing page content unless KK approves replacing the current top copy.
+- The separate `/home/` page ID `2315` is the old latest-posts page and is not the target for this hero.
+
 ## Post-Deploy REST Checks
 
 Check these fields after update:

--- a/content/source-packs/keynotes-2026/wp-payloads/homepage-hero.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/homepage-hero.html
@@ -1,0 +1,42 @@
+<!-- wp:html -->
+<style>
+.kk-home-hero { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); border-bottom:1px solid var(--kk-line); padding:1.5rem 0 2rem; }
+.kk-home-hero a { font-weight:700; }
+.kk-home-kicker { margin:0 0 .5rem; color:var(--kk-hot); font-size:.78rem; font-weight:800; letter-spacing:.08em; text-transform:uppercase; }
+.kk-home-title { margin:.15rem 0 .85rem; max-width:56rem; font-size:2.2rem; line-height:1.12; }
+.kk-home-lead { max-width:56rem; font-size:1.14rem; line-height:1.65; color:var(--kk-muted); }
+.kk-home-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.2rem 0; }
+.kk-home-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }
+.kk-home-button.secondary { background:#fff; color:var(--kk-ink) !important; }
+.kk-home-roles, .kk-home-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:.85rem; margin-top:1rem; }
+.kk-home-role, .kk-home-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:var(--kk-card); }
+.kk-home-role strong, .kk-home-proof strong { display:block; margin-bottom:.25rem; font-size:1.05rem; }
+.kk-home-role span, .kk-home-proof span { display:block; color:var(--kk-muted); }
+.kk-home-proof strong { font-size:1.35rem; line-height:1.1; }
+@media (max-width:760px){ .kk-home-title{font-size:1.55rem;} .kk-home-actions{display:block;} .kk-home-actions a{margin:.35rem 0;} }
+</style>
+
+<section class="kk-home-hero" aria-labelledby="kk-home-hero-title">
+  <p class="kk-home-kicker">Kris Krüg / AI, community, culture</p>
+  <h1 id="kk-home-hero-title" class="kk-home-title">Bridging art, AI, Indigenous wisdom, and justice.</h1>
+  <p class="kk-home-lead">I build technology programs, communities, keynotes, and learning systems that serve people instead of extraction. My work connects creative practice, responsible AI, Indigenous economic sovereignty, and the messy human work of building trust.</p>
+  <p class="kk-home-lead">I am the Executive Director of BC + AI Ecosystem, CTO for Indigenomics AI work, co-founder of The Upgrade AI, and a creative technologist with 20+ years of experience turning emerging tools into public learning, community infrastructure, and useful action.</p>
+  <div class="kk-home-actions">
+    <a class="kk-home-button" href="/recent-projects-include/">Explore My Work</a>
+    <a class="kk-home-button secondary" href="/contact/">Let's Connect</a>
+  </div>
+  <div class="kk-home-roles" aria-label="Current roles">
+    <div class="kk-home-role"><strong><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></strong><span>Executive Director building responsible, inclusive AI infrastructure across British Columbia.</span></div>
+    <div class="kk-home-role"><strong><a href="https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/">Indigenomics AI</a></strong><span>CTO work around sovereign data, economic evidence, and Indigenous-led technology futures.</span></div>
+    <div class="kk-home-role"><strong><a href="https://www.theupgrade.ai/">The Upgrade AI</a></strong><span>Co-founder helping professionals and teams build practical AI fluency without losing judgment or taste.</span></div>
+  </div>
+  <div class="kk-home-proof" aria-label="Impact markers">
+    <div><strong>250+</strong><span>BC + AI members</span></div>
+    <div><strong>3,000+</strong><span>BC + AI event attendees</span></div>
+    <div><strong>94+</strong><span>community events hosted</span></div>
+    <div><strong>$100B</strong><span>Indigenous economy vision supported through Indigenomics AI</span></div>
+    <div><strong>20+ years</strong><span>bridging art, technology, media, and community</span></div>
+    <div><strong>Enterprise teams</strong><span>AI training and coaching for professionals, companies, and global brands</span></div>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/source-packs/keynotes-2026/wp-payloads/page-meta.json
+++ b/content/source-packs/keynotes-2026/wp-payloads/page-meta.json
@@ -1,6 +1,20 @@
 {
   "pages": [
     {
+      "id": 3930,
+      "slug": "empowering-events-organizations-for-the-ai-age",
+      "live_url": "https://kriskrug.co/",
+      "title": "Kris Krüg | Generative AI Tools & Techniques",
+      "comment_status": "closed",
+      "ping_status": "closed",
+      "content_file": "homepage-hero.html",
+      "placement": "insert before existing page content",
+      "meta": {
+        "jetpack_seo_html_title": "Kris Krüg | AI Speaker, Creative Technologist & Community Builder",
+        "advanced_seo_description": "Kris Krüg bridges art, AI, Indigenous wisdom, and justice through BC+AI, Indigenomics AI, The Upgrade AI, keynote speaking, and community-first technology."
+      }
+    },
+    {
       "id": 1887,
       "slug": "speaking",
       "title": "AI Keynote Speaker Kris Krüg",


### PR DESCRIPTION
## Summary
- adds a paste-ready homepage hero block for page `3930` / `https://kriskrug.co/`
- leads with the polymath authority story across BC + AI, Indigenomics AI, and The Upgrade AI
- indexes the new payload in the source-pack README, deploy checklist, and page metadata
- posts the ready copy back to issue #66 for review and implementation

## Safety
- Track A content package only; no live WordPress write, media upload, or theme edit
- targets page `3930`, not the old `/home/` latest-posts page `2315`
- uses current source-backed stats (`250+ members`, `3,000+ event attendees`, `94+ events`, `$100B Indigenous economy vision`) instead of stale/mislabeled issue metrics

## Verification
- `python3 -m json.tool content/source-packs/keynotes-2026/wp-payloads/page-meta.json`
- `git diff --check`
- URL checks for hero/page links all returned `200`
- sensitive-string scan on the hero payload and verification note: no matches
- marker checks for hero headline, roles, metrics, and CTAs

Closes #66