### PR TITLE
content: expand services role positioning

### DIFF
--- a/content/source-packs/keynotes-2026/README.md
+++ b/content/source-packs/keynotes-2026/README.md
@@ -23,6 +23,8 @@ Applied after the media-appearance intake: `/podcast-guesting-page-epk/` is now 
 
 Prepared but not deployed on 2026-05-20: a homepage hero candidate for page `3930` that leads with the BC+AI, Indigenomics AI, and The Upgrade AI authority story. See `verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md`.
 
+Prepared but not deployed on 2026-05-20: a Services page candidate for page `2666` at `/generative-ai-services/` that realigns the offer around AI strategy, community ecosystem building, The Upgrade AI training, Indigenomics advisory, and keynotes/workshops. See `verification/SERVICES-ROLE-ALIGNMENT-VERIFICATION-2026-05-20.md`.
+
 ## Source Inputs
 
 - Notion page: `Keynotes` (`cd4ce83f-afa5-440d-8405-4caf04a480d1`)
@@ -53,6 +55,7 @@ Prepared but not deployed on 2026-05-20: a homepage hero candidate for page `393
 - `post-packages/README.md` - review-ready companion-post packages for the speaking authority network.
 - `media-appearances/README.md` - public-source inventory and Podcast EPK refresh package.
 - `wp-payloads/speaking.html` - publish-ready content for page `1887`.
+- `wp-payloads/services.html` - prepared Services page replacement for page `2666`; not deployed.
 - `wp-payloads/work.html` - publish-ready content for page `2672`.
 - `wp-payloads/about.html` - publish-ready content for page `1208`.
 - `wp-payloads/podcast-guesting-page-epk.html` - deployed content for page `3609`.
@@ -71,6 +74,7 @@ Prepared but not deployed on 2026-05-20: a homepage hero candidate for page `393
 - `verification/PODCAST-EPK-DEPLOY-VERIFICATION-2026-05-19.md` - live Podcast EPK deploy, rollback, REST, link, and screenshot verification.
 - `verification/ABOUT-ROLE-SECTIONS-VERIFICATION-2026-05-20.md` - About-page role-section source grounding and publish gate.
 - `verification/HOMEPAGE-HERO-VERIFICATION-2026-05-20.md` - homepage hero source grounding, issue comment, and publish gate.
+- `verification/SERVICES-ROLE-ALIGNMENT-VERIFICATION-2026-05-20.md` - Services page source grounding, issue comment, and publish gate.
 - `media-appearances/public-source-inventory-2026-05-19.md` - public CBC/podcast/media appearance source inventory.
 
 ## Local Draft Outputs

--- a/content/source-packs/keynotes-2026/assets/asset-manifest.md
+++ b/content/source-packs/keynotes-2026/assets/asset-manifest.md
@@ -19,6 +19,11 @@ The live WordPress payloads use stable owned-site URLs, not temporary Notion-hos
 - `https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1200&ssl=1`
 - `https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03`
 - `https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/04/AI-Immortality-w-Guy-Kawasaki.png?fit=1200%2C604&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&ssl=1`
 - `https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1200&ssl=1`
 - `https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5637672371_fca291d598_o-1.jpg?w=800&ssl=1`
 - `https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/05/9818127715_416df9a481_o.jpg?w=612&ssl=1`

--- a/content/source-packs/keynotes-2026/verification/SERVICES-ROLE-ALIGNMENT-VERIFICATION-2026-05-20.md
+++ b/content/source-packs/keynotes-2026/verification/SERVICES-ROLE-ALIGNMENT-VERIFICATION-2026-05-20.md
@@ -1,0 +1,126 @@
+# Services Role Alignment Verification - 2026-05-20
+
+Issue: https://github.com/WalksWithASwagger/kriskrug-wp/issues/67
+Issue comment: https://github.com/WalksWithASwagger/kriskrug-wp/issues/67#issuecomment-4500142718
+
+## Status
+
+Prepared, committed locally, and ready for publication review. No live WordPress write was made in this pass.
+
+## Target
+
+- Page ID: `2666`
+- Current slug: `generative-ai-services`
+- Current public URL: `https://kriskrug.co/generative-ai-services/`
+- Current live title readback: `Generative AI Creative Services & Strategy`
+- Proposed title: `AI Services, Training & Strategy`
+- Proposed payload: `content/source-packs/keynotes-2026/wp-payloads/services.html`
+- Proposed metadata: `content/source-packs/keynotes-2026/wp-payloads/page-meta.json`
+
+## Source Grounding
+
+- Current Services page was extracted from `docs/current-state/raw/pages/generative-ai-services.html`.
+- Public REST readback confirmed page ID `2666`, slug `generative-ai-services`, status `publish`, and link `https://kriskrug.co/generative-ai-services/`.
+- Current live page content is heavily weighted toward media, photography, older generic AI consulting, creative workshops, Discord/community management, and photography/video production.
+- BC+AI source check confirmed public site positioning and stats:
+  - `250+` members
+  - `3,000+` event attendees
+  - `94+` events hosted
+  - `4` BC regions
+- The Upgrade AI source check confirmed public positioning around live/on-demand courses, 1:1 and group coaching, team trainings, Creative Pros, PR/Communications Pros, and Sales Leaders.
+- Indigenomics AI public post check confirmed the dashboard, sovereign data governance, and the `$100 billion Indigenous economy` frame.
+
+## Content Changes Prepared
+
+- Reframed Services from a photography/media-first page into a current 2026 offer around AI capacity, community strategy, training, Indigenomics advisory, and speaking/workshops.
+- Added five service categories:
+  - `AI Strategy Consulting`
+  - `Community & Ecosystem Building`
+  - `The Upgrade AI Training`
+  - `Indigenomics Advisory`
+  - `Keynotes, Workshops & Executive Briefings`
+- Each service category includes:
+  - ideal-client language
+  - what the service does
+  - practical outcomes
+  - a direct CTA
+- Added engagement models instead of invented pricing:
+  - Advisory Sprint
+  - Team Training / Cohort
+  - Ecosystem Buildout
+  - Keynote + Workshop
+- Added social proof:
+  - BC+AI public ecosystem stats
+  - Indigenomics `$100B` economy context
+  - existing named Holly Rosenfeld quote from the current page
+  - source links to BC+AI, The Upgrade AI, Indigenomics AI, Speaking, Work, and About
+- Added a clear photography de-emphasis section: photography remains available when it strengthens an event, training, community program, archive, or campaign, but is no longer the center of the offer.
+
+## SEO Metadata Prepared
+
+```json
+{
+  "id": 2666,
+  "slug": "generative-ai-services",
+  "title": "AI Services, Training & Strategy",
+  "comment_status": "closed",
+  "ping_status": "closed",
+  "content_file": "services.html",
+  "meta": {
+    "jetpack_seo_html_title": "AI Services, Training & Strategy | Kris Krüg",
+    "advanced_seo_description": "AI strategy, responsible AI consulting, BC+AI community building, The Upgrade AI training, Indigenomics advisory, and keynote/workshop support with Kris Krüg."
+  }
+}
+```
+
+## Checks Run
+
+- `python3 -m json.tool content/source-packs/keynotes-2026/wp-payloads/page-meta.json` passed.
+- `git diff --check` passed.
+- Sensitive-string scan across the payload, metadata, checklist, README, and asset-manifest changes returned no matches for the requested sensitive/privacy patterns.
+- Temporary Notion/cloud-asset scan returned no matches.
+- Content marker checks passed for:
+  - `AI Strategy Consulting`
+  - `Community &amp; Ecosystem Building`
+  - `The Upgrade AI Training`
+  - `Indigenomics Advisory`
+  - `Keynotes, Workshops &amp; Executive Briefings`
+  - `Engagement Models`
+  - `Where Photography Fits Now`
+  - `Start a conversation`
+
+## URL Checks
+
+All returned `200`:
+
+- `https://bc-ai.ca/`
+- `https://www.theupgrade.ai/`
+- `https://kriskrug.co/contact/`
+- `https://kriskrug.co/speaking/`
+- `https://kriskrug.co/recent-projects-include/`
+- `https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/`
+- `https://kriskrug.co/podcast-guesting-page-epk/`
+- `https://kriskrug.co/about/`
+- `https://kriskrug.co/generative-ai-services/`
+- `https://kriskrug.co/work/` redirected to `https://kriskrug.co/recent-projects-include/`
+
+## Media Checks
+
+All selected image URLs returned `200` with image content types:
+
+- `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&ssl=1`
+- `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&ssl=1`
+
+## Publish Gate
+
+Before any live WordPress update:
+
+1. Take a fresh full-site backup, or get explicit KK approval for a narrower rollback path.
+2. Snapshot page ID `2666` to JSON and HTML.
+3. Dry-run the REST payload.
+4. Patch only page `2666` after slug readback confirms `generative-ai-services`.
+5. Recheck title, slug, status, SEO meta, comment status, ping status, page content markers, URL status, and image URLs.

--- a/content/source-packs/keynotes-2026/wp-payloads/deploy-checklist.md
+++ b/content/source-packs/keynotes-2026/wp-payloads/deploy-checklist.md
@@ -13,6 +13,7 @@ Continuation issue: https://github.com/WalksWithASwagger/kriskrug-wp/issues/76
 - Confirm target page IDs:
   - `1208` -> `/about/`
   - `1887` -> `/speaking/`
+  - `2666` -> `/generative-ai-services/`
   - `2672` -> `/recent-projects-include/`
 - Keep `/recent-projects-include/` slug unchanged. `/work/` already redirects there.
 - Close comments and pings on `/speaking/`.
@@ -24,6 +25,7 @@ Use `page-meta.json` for titles, comment settings, ping settings, and Jetpack SE
 Payload files:
 
 - `speaking.html` -> page `1887`
+- `services.html` -> page `2666`
 - `work.html` -> page `2672`
 - `about.html` -> page `1208`
 
@@ -34,6 +36,15 @@ Status: prepared, not deployed. See `../verification/HOMEPAGE-HERO-VERIFICATION-
 - `homepage-hero.html` -> page `3930`, public URL `/`
 - Insert before existing page content unless KK approves replacing the current top copy.
 - The separate `/home/` page ID `2315` is the old latest-posts page and is not the target for this hero.
+
+## Services Page Candidate
+
+Status: prepared, not deployed. See `../verification/SERVICES-ROLE-ALIGNMENT-VERIFICATION-2026-05-20.md`.
+
+- `services.html` -> page `2666`, public URL `/generative-ai-services/`
+- Replace the current page content after a fresh live backup or an explicitly approved narrower rollback path.
+- Keep the existing `/generative-ai-services/` slug for this pass; menu label can remain `Services`.
+- Close comments and pings on the page.
 
 ## Post-Deploy REST Checks
 
@@ -54,6 +65,7 @@ Check these fields after update:
 - `/recent-projects-include/` returns `200`.
 - `/work/` redirects to `/recent-projects-include/`.
 - `/about/` returns `200`.
+- `/generative-ai-services/` returns `200`.
 - `/speaking/` does not contain `Leave a Reply`.
 - Selected image URLs return `200`.
 - Desktop and mobile pages show the new hero/CTA sections.
@@ -65,4 +77,6 @@ Check these fields after update:
 - `/speaking/` links to `Both Hands Full`, `Punk Rock AI`, `Developing an AI Mindset`, `BC + AI Ecosystem`, and `/contact/`.
 - `/recent-projects-include/` title is `Work`.
 - `/about/` title is `About Kris Krüg`.
+- `/generative-ai-services/` title is `AI Services, Training & Strategy`.
+- `/generative-ai-services/` contains `AI Strategy Consulting`, `Community & Ecosystem Building`, `The Upgrade AI Training`, `Indigenomics Advisory`, and `Keynotes, Workshops & Executive Briefings`.
 - No temporary Notion asset URLs appear in any live page.

--- a/content/source-packs/keynotes-2026/wp-payloads/page-meta.json
+++ b/content/source-packs/keynotes-2026/wp-payloads/page-meta.json
@@ -39,6 +39,18 @@
       }
     },
     {
+      "id": 2666,
+      "slug": "generative-ai-services",
+      "title": "AI Services, Training & Strategy",
+      "comment_status": "closed",
+      "ping_status": "closed",
+      "content_file": "services.html",
+      "meta": {
+        "jetpack_seo_html_title": "AI Services, Training & Strategy | Kris Krüg",
+        "advanced_seo_description": "AI strategy, responsible AI consulting, BC+AI community building, The Upgrade AI training, Indigenomics advisory, and keynote/workshop support with Kris Krüg."
+      }
+    },
+    {
       "id": 1208,
       "slug": "about",
       "title": "About Kris Krüg",

--- a/content/source-packs/keynotes-2026/wp-payloads/services.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/services.html
@@ -1,0 +1,223 @@
+<!-- wp:html -->
+<style>
+.kk-services { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); }
+.kk-services a { font-weight:700; }
+.kk-services-hero { padding:1.35rem 0 1.5rem; border-bottom:1px solid var(--kk-line); }
+.kk-services-kicker { margin:0 0 .5rem; text-transform:uppercase; letter-spacing:.08em; font-size:.78rem; color:var(--kk-hot); font-weight:800; }
+.kk-services-display { margin:.15rem 0 .75rem; font-size:1.9rem; line-height:1.18; max-width:56rem; }
+.kk-services-lead { font-size:1.14rem; line-height:1.65; max-width:56rem; }
+.kk-services-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.25rem 0 0; }
+.kk-services-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }
+.kk-services-button.secondary { background:#fff; color:var(--kk-ink) !important; }
+.kk-services-section { padding:2rem 0; border-bottom:1px solid var(--kk-line); }
+.kk-services-section-intro { max-width:56rem; margin-bottom:1rem; color:var(--kk-muted); }
+.kk-services-hero-grid { display:grid; grid-template-columns:minmax(0,1.08fr) minmax(280px,.92fr); gap:1.25rem; align-items:center; }
+.kk-services-hero-photo { margin:0; border:1px solid var(--kk-line); border-radius:6px; overflow:hidden; background:#fff; }
+.kk-services-hero-photo img { display:block; width:100%; aspect-ratio:4/3; object-fit:cover; }
+.kk-services-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.75rem; margin-top:1.1rem; }
+.kk-services-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }
+.kk-services-proof strong { display:block; font-size:1.35rem; line-height:1.1; }
+.kk-services-proof span { display:block; color:var(--kk-muted); margin-top:.25rem; }
+.kk-services-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:1rem; }
+.kk-services-card { border:1px solid var(--kk-line); border-radius:6px; background:var(--kk-card); overflow:hidden; }
+.kk-services-card img { display:block; width:100%; aspect-ratio:16/9; object-fit:cover; background:#eee; }
+.kk-services-card-body { padding:1rem; }
+.kk-services-card h3 { margin-top:0; margin-bottom:.4rem; font-size:1.12rem; }
+.kk-services-card p { margin:.45rem 0; color:var(--kk-muted); }
+.kk-services-card ul { margin:.6rem 0 .8rem 1.1rem; }
+.kk-services-card li { margin:.25rem 0; }
+.kk-services-tag { display:inline-block; margin:0 0 .55rem; color:var(--kk-hot); font-size:.72rem; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }
+.kk-services-two { display:grid; grid-template-columns:minmax(0,1fr) minmax(260px,.82fr); gap:1.25rem; align-items:start; }
+.kk-services-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }
+.kk-services-models { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:.85rem; margin-top:1rem; }
+.kk-services-model { border:1px solid var(--kk-line); border-radius:6px; padding:1rem; background:#fff; }
+.kk-services-model h3 { margin-top:0; margin-bottom:.45rem; font-size:1.05rem; }
+.kk-services-model p { color:var(--kk-muted); margin:.45rem 0; }
+.kk-services-quote { border-left:4px solid var(--kk-accent); padding-left:1rem; margin:0; }
+.kk-services-quote p { margin:.25rem 0; }
+.kk-services-links { columns:2 16rem; padding-left:1.2rem; }
+@media (max-width:760px){ .kk-services-display{font-size:1.45rem;} .kk-services-hero-grid,.kk-services-two{grid-template-columns:1fr;} .kk-services-actions{display:block;} .kk-services-actions a{margin:.35rem 0;} .kk-services-links{columns:1;} }
+</style>
+
+<div class="kk-services">
+  <section class="kk-services-hero">
+    <div class="kk-services-hero-grid">
+      <div>
+        <p class="kk-services-kicker">AI strategy, training, community, and keynote work</p>
+        <h2 class="kk-services-display">Build AI capacity that serves people, communities, and culture.</h2>
+        <p class="kk-services-lead">I help organizations move from AI pressure to practical fluency: responsible strategy, community systems, custom training, Indigenous-tech advisory, and talks that make complicated technology feel usable without sanding off the weird, human, and political edges.</p>
+        <p class="kk-services-lead">This is not generic AI consulting. It is field-building work shaped by BC+AI, Indigenomics AI, The Upgrade AI, and two decades of creative technology, media, and community practice.</p>
+        <div class="kk-services-actions">
+          <a class="kk-services-button" href="/contact/">Start a conversation</a>
+          <a class="kk-services-button secondary" href="/speaking/">Book a keynote</a>
+          <a class="kk-services-button secondary" href="/recent-projects-include/">See the work</a>
+        </div>
+      </div>
+      <figure class="kk-services-hero-photo">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug speaking on stage about creativity and AI" loading="eager" />
+      </figure>
+    </div>
+    <div class="kk-services-proof">
+      <div><strong>250+</strong><span>BC+AI members in a growing provincial ecosystem.</span></div>
+      <div><strong>3,000+</strong><span>BC+AI event attendees across public learning rooms.</span></div>
+      <div><strong>$100B</strong><span>Indigenous economy vision supported through Indigenomics AI.</span></div>
+      <div><strong>20+ years</strong><span>Creative technology, media, storytelling, and community work.</span></div>
+    </div>
+  </section>
+
+  <section class="kk-services-section">
+    <h2>How I Can Help</h2>
+    <p class="kk-services-section-intro">Five ways to work together, from focused advisory sprints to public keynotes and hands-on team training. Each lane can stand alone or combine into a larger engagement.</p>
+    <div class="kk-services-grid">
+      <article class="kk-services-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug speaking at a Vancouver AI community event" loading="lazy" />
+        <div class="kk-services-card-body">
+          <span class="kk-services-tag">Strategy</span>
+          <h3>AI Strategy Consulting</h3>
+          <p><strong>For:</strong> leadership teams, associations, public-interest organizations, creative companies, and teams trying to make AI decisions without getting swallowed by hype.</p>
+          <p><strong>What we do:</strong> map opportunities, risks, tools, workflows, governance questions, and adoption patterns that fit the real organization in front of us.</p>
+          <ul>
+            <li>AI readiness and opportunity map</li>
+            <li>Responsible adoption roadmap</li>
+            <li>Pilot backlog and decision language</li>
+          </ul>
+          <p><a href="/contact/">Talk about an advisory sprint</a></p>
+        </div>
+      </article>
+
+      <article class="kk-services-card">
+        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC+AI living ecosystem graphic" loading="lazy" />
+        <div class="kk-services-card-body">
+          <span class="kk-services-tag">Community</span>
+          <h3>Community &amp; Ecosystem Building</h3>
+          <p><strong>For:</strong> cities, innovation groups, regional hubs, event organizers, associations, and organizations that need more than a one-off meetup.</p>
+          <p><strong>What we do:</strong> turn scattered interest into a functioning community system: programming, partner strategy, sponsorship, communications, membership, and rituals people want to return to.</p>
+          <ul>
+            <li>Event-series and chapter architecture</li>
+            <li>Partner, sponsor, and member pathways</li>
+            <li>Community operating model and metrics</li>
+          </ul>
+          <p><a href="https://bc-ai.ca/">See BC+AI</a> or <a href="/contact/">ask about ecosystem work</a></p>
+        </div>
+      </article>
+
+      <article class="kk-services-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1" alt="The Upgrade AI courses workshops and trainings graphic" loading="lazy" />
+        <div class="kk-services-card-body">
+          <span class="kk-services-tag">Training</span>
+          <h3>The Upgrade AI Training</h3>
+          <p><strong>For:</strong> creative, communications, media, sales, leadership, and cross-functional teams that need hands-on AI fluency rather than another abstract trend report.</p>
+          <p><strong>What we do:</strong> live and on-demand courses, 1:1 and group coaching, team trainings, custom workflows, and practical demos that help people use AI with judgment and taste.</p>
+          <ul>
+            <li>AI mindset and workflow training</li>
+            <li>Role-specific prompt and tool systems</li>
+            <li>Team practice plans and follow-up support</li>
+          </ul>
+          <p><a href="https://www.theupgrade.ai/">Explore The Upgrade AI</a> or <a href="/contact/">plan a team training</a></p>
+        </div>
+      </article>
+
+      <article class="kk-services-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&amp;ssl=1" alt="Indigenomics AI visual from Kris Krug's public writing" loading="lazy" />
+        <div class="kk-services-card-body">
+          <span class="kk-services-tag">Advisory</span>
+          <h3>Indigenomics Advisory</h3>
+          <p><strong>For:</strong> Indigenous-led organizations, public-sector teams, allies, institutions, and technology groups trying to work with data, AI, and economic evidence without extractive shortcuts.</p>
+          <p><strong>What we do:</strong> CTO-level support around sovereign data, dashboard strategy, AI assistants, evidence systems, respectful technology architecture, and public storytelling.</p>
+          <ul>
+            <li>Sovereign-data and governance questions</li>
+            <li>Dashboard and evidence-product strategy</li>
+            <li>AI implementation briefings and narrative systems</li>
+          </ul>
+          <p><a href="/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/">Read the Indigenomics AI post</a></p>
+        </div>
+      </article>
+
+      <article class="kk-services-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug presenting an AI keynote at LaSalle College Vancouver" loading="lazy" />
+        <div class="kk-services-card-body">
+          <span class="kk-services-tag">Rooms</span>
+          <h3>Keynotes, Workshops &amp; Executive Briefings</h3>
+          <p><strong>For:</strong> conferences, festivals, leadership offsites, boards, associations, schools, creative communities, and teams that need the room to move.</p>
+          <p><strong>What we do:</strong> keynote talks, panels, podcast guesting, moderation, emcee work, executive briefings, and hands-on workshops on AI, creativity, culture, ethics, and community.</p>
+          <ul>
+            <li>High-voltage keynote plus Q&amp;A</li>
+            <li>Keynote plus workshop packages</li>
+            <li>Hosting, moderation, and media appearances</li>
+          </ul>
+          <p><a href="/speaking/">See speaking topics</a> or <a href="/podcast-guesting-page-epk/">view the media EPK</a></p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="kk-services-section">
+    <div class="kk-services-two">
+      <div>
+        <h2>Engagement Models</h2>
+        <p>Pricing is scoped after a short discovery call because a keynote, a board briefing, a community buildout, and a training cohort are different animals. The useful question is not "what package can I sell you?" It is "what change do we need the room, team, or ecosystem to make?"</p>
+        <p>Most engagements begin with one of these shapes and then get tightened around audience, urgency, budget, and implementation needs.</p>
+      </div>
+      <div class="kk-services-callout">
+        <h3>Good fit when you need</h3>
+        <ul>
+          <li>Executive clarity on AI adoption</li>
+          <li>A team training that produces actual workflows</li>
+          <li>A public room that leaves smarter and braver</li>
+          <li>A community program that can keep growing</li>
+          <li>Protocol-aware AI and data strategy</li>
+        </ul>
+      </div>
+    </div>
+    <div class="kk-services-models">
+      <article class="kk-services-model">
+        <h3>Advisory Sprint</h3>
+        <p>Two to four weeks of discovery, interviews, strategy, and a usable roadmap.</p>
+      </article>
+      <article class="kk-services-model">
+        <h3>Team Training / Cohort</h3>
+        <p>Half-day, full-day, or multi-week training with demos, exercises, and follow-up resources.</p>
+      </article>
+      <article class="kk-services-model">
+        <h3>Ecosystem Buildout</h3>
+        <p>Six to twelve weeks of program design, partner mapping, event architecture, and operating rhythms.</p>
+      </article>
+      <article class="kk-services-model">
+        <h3>Keynote + Workshop</h3>
+        <p>A public talk paired with a practical lab so the energy turns into action.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="kk-services-section">
+    <h2>Proof and Source Trails</h2>
+    <div class="kk-services-two">
+      <blockquote class="kk-services-quote">
+        <p><em>"Kris brings out the best in others and connects those around him."</em></p>
+        <p><strong>Holly Rosenfeld</strong>, Seattle Cancer Care Alliance</p>
+      </blockquote>
+      <div>
+        <p>Some of the proof is public and easy to inspect: BC+AI's current ecosystem stats, The Upgrade AI course/training surface, the Indigenomics AI writing and dashboard story, and the speaking archive. The rest is best handled in conversation because private executive work, client workshops, and Indigenous-tech advisory often need discretion.</p>
+        <ul class="kk-services-links">
+          <li><a href="https://bc-ai.ca/">BC+AI Ecosystem</a></li>
+          <li><a href="https://www.theupgrade.ai/">The Upgrade AI</a></li>
+          <li><a href="/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/">Indigenomics AI article</a></li>
+          <li><a href="/speaking/">Speaking page</a></li>
+          <li><a href="/recent-projects-include/">Work archive</a></li>
+          <li><a href="/about/">About Kris</a></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="kk-services-section">
+    <h2>Where Photography Fits Now</h2>
+    <p class="kk-services-section-intro">Visual storytelling is still part of the toolkit. I still understand rooms, faces, stages, social proof, and the value of a killer image. But photography is no longer the center of this services page.</p>
+    <p>Bring it in when it strengthens a keynote, training, community program, event, archive, or campaign. The main offer now is AI capacity, strategic clarity, community momentum, and rooms that leave with better instincts.</p>
+    <div class="kk-services-actions">
+      <a class="kk-services-button" href="/contact/">Start a conversation</a>
+      <a class="kk-services-button secondary" href="/speaking/">Book Kris for a keynote</a>
+    </div>
+  </section>
+</div>
+<!-- /wp:html -->


### PR DESCRIPTION
## Summary
- add a publish-ready Services page payload for page 2666 at /generative-ai-services/
- add Services metadata with proposed title, closed comments/pings, and Jetpack SEO fields
- document verification, source grounding, media/link checks, and the live publish gate

## Verification
- python3 -m json.tool content/source-packs/keynotes-2026/wp-payloads/page-meta.json >/dev/null
- git diff --check
- sensitive-string scan across changed source-pack files
- temporary Notion/cloud asset scan
- content marker checks for all five service lanes and CTAs
- curl checks for internal/external links and selected media URLs

No live WordPress write was made in this pass.

Closes #67