### PR TITLE
[codex] Diagnostic polish and sidebar promo hardening

### DIFF
--- a/.github/workflows/agent-pr-generator.yml
+++ b/.github/workflows/agent-pr-generator.yml
@@ -1,141 +1,22 @@
 name: Agent PR Generator
 
 on:
-  issues:
-    types: [labeled]
+  workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
-  contents: write
+  contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
-  # Only trigger when 'auto-implement' label is added
-  check-trigger:
-    runs-on: ubuntu-latest
-    if: github.event.label.name == 'auto-implement'
-    outputs:
-      should_run: ${{ steps.check.outputs.result }}
-    steps:
-      - id: check
-        run: echo "result=true" >> $GITHUB_OUTPUT
-
-      - name: Acknowledge automation request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body: `🤖 **Agent Automation Initiated**\n\nThe agent swarm has been activated to work on this issue.\n\n**Pipeline stages:**\n1. ⏳ Analyzing issue and creating technical specification\n2. ⏳ Writing tests (TDD approach)\n3. ⏳ Implementing solution\n4. ⏳ Running tests and validations\n5. ⏳ Creating pull request\n\nYou can monitor progress in the [Actions tab](https://github.com/${context.repo.owner}/${context.repo.repo}/actions).\n\n*This is a fully automated workflow. A pull request will be created if all tests pass.*`
-            });
-
-  # Initialize agent state
-  initialize-agent-state:
-    needs: check-trigger
-    runs-on: ubuntu-latest
-    outputs:
-      state_file: ${{ steps.init.outputs.state_file }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create agent state directory
-        id: init
-        run: |
-          mkdir -p .github/agent-state/${{ github.event.issue.number }}
-          STATE_FILE=".github/agent-state/${{ github.event.issue.number }}/state.json"
-          echo "state_file=$STATE_FILE" >> $GITHUB_OUTPUT
-
-          # Initialize state file
-          cat > $STATE_FILE <<EOF
-          {
-            "issue_number": ${{ github.event.issue.number }},
-            "workflow_id": "${{ github.run_id }}",
-            "current_stage": "initialized",
-            "status": "in_progress",
-            "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "stages": {
-              "analysis": {"status": "pending"},
-              "test_writing": {"status": "pending"},
-              "implementation": {"status": "pending"},
-              "testing": {"status": "pending"},
-              "review": {"status": "pending"},
-              "pr_creation": {"status": "pending"}
-            },
-            "metadata": {
-              "branch_name": "feature/issue-${{ github.event.issue.number }}-auto-fix",
-              "base_branch": "main"
-            }
-          }
-          EOF
-
-      - name: Commit state file
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/agent-state
-          git commit -m "Initialize agent state for issue #${{ github.event.issue.number }}" || true
-          git push || true
-
-  # Placeholder for actual agent orchestration
-  # This would integrate with gh agent-task or custom orchestration
-  simulate-agent-workflow:
-    needs: initialize-agent-state
+  diagnostic:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Placeholder - Agent Orchestration
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issue = context.payload.issue;
-
-            // This is a placeholder for the actual agent orchestration
-            // In a full implementation, this would:
-            // 1. Call gh agent-task create with custom agents
-            // 2. Monitor agent progress
-            // 3. Update state file after each stage
-            // 4. Create PR when all stages complete
-
-            core.info('Agent orchestration would run here');
-            core.info(`Issue: #${issue.number} - ${issue.title}`);
-            core.info('Agents: orchestrator → analyzer → test-writer → implementer → qa → reviewer → pr-creator');
-
-            // For now, just comment on the issue
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              body: `⚠️ **Agent Workflow - Development Mode**\n\nThe full agent swarm orchestration is not yet implemented in this workflow.\n\nTo enable full automation, you would need to:\n1. Set up custom agents in \`.github/agents/\` directory\n2. Configure \`gh agent-task\` integration\n3. Implement the orchestration logic\n\nFor now, this workflow demonstrates the structure and can be extended with actual agent calls.\n\n**Current capabilities:**\n- ✅ Issue auto-triage and labeling\n- ✅ Agent state initialization\n- ✅ Workflow triggers and permissions\n- ⏳ Agent orchestration (requires setup)\n- ⏳ Automated PR creation (requires agents)\n\nSee the [automation guide](../../docs/automation-guide.md) for setup instructions.`
-            });
-
-      - name: Update state - mark as awaiting setup
+      - name: Report parked automation status
         run: |
-          # In production, this would update based on actual agent progress
-          echo "Agent workflow simulation complete"
-          echo "Full implementation requires agent setup in .github/agents/"
-
-  # Cleanup on failure
-  handle-failure:
-    needs: [initialize-agent-state, simulate-agent-workflow]
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body: `❌ **Agent Automation Failed**\n\nThe automated workflow encountered an error.\n\nPlease check the [workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}) for details.\n\nThis issue will need manual attention. The \`needs-human-review\` label has been added.`
-            });
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              labels: ['needs-human-review']
-            });
+          echo "Agent PR Generator is intentionally parked."
+          echo "Adding the auto-implement label no longer starts this workflow."
+          echo "This stub is kept so the old workflow name remains discoverable in Actions history."
+          echo "It has read-only permissions and does not comment, commit state, push branches, or create PRs."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 2. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 3. [`docs/current-state/REPO_STATE.md`](docs/current-state/REPO_STATE.md) — what's actually built vs. just documented
 4. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
-5. [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md) — latest repo-truth, workflow, fix-queue, and polish diagnostic
+5. [`docs/current-state/WORK-PLAN-2026-05-21.md`](docs/current-state/WORK-PLAN-2026-05-21.md) — current next-session front door and stop rules
+
+For the detailed diagnostic behind that plan, read [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md).
 
 After those five, the rest of the repo will make sense.
 
@@ -67,4 +69,4 @@ Read [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODE
 
 ---
 
-**Last verified:** 2026-05-20. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` as the source of truth and flag the drift for a fresh audit.
+**Last verified:** 2026-05-21. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` as the source of truth and flag the drift for a fresh audit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the entry point for any AI agent (Claude Code, Cursor, Codex, etc.)
 
 ## What this repo is
 
-The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site running Catch Responsive. The repo is **adjacent to** the live site, not a mirror of it. `main` does not contain a full production theme/plugin/database/media mirror; Track B theme code lives on `aurora/v2`, and curated source-pack media/proofs are tracked. There is one custom WP module (`inc/digital-composting.php`) which is merged but not yet deployed to prod.
+The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site running Catch Responsive. The repo is **adjacent to** the live site, not a mirror of it. `main` does not contain a full production theme/database/media mirror; Track B theme code lives on `aurora/v2`, and curated source-pack media/proofs are tracked. Custom repo-side WP code now includes `inc/digital-composting.php` (merged, not yet deployed to prod) and `plugins/kk-sidebar-promos/` (packaged helper plugin, deploy only after backup/rollback proof).
 
 ## Read this in order (top of repo, top of context)
 
@@ -12,8 +12,9 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 2. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 3. [`docs/current-state/REPO_STATE.md`](docs/current-state/REPO_STATE.md) — what's actually built vs. just documented
 4. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
+5. [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md) — latest repo-truth, workflow, fix-queue, and polish diagnostic
 
-After those four, the rest of the repo will make sense.
+After those five, the rest of the repo will make sense.
 
 ## Two tracks — pick one per session
 
@@ -35,9 +36,11 @@ Full decision tree: [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md
 3. **No theme file changes on `main`.** Theme work belongs on `aurora/v2`.
 4. **Don't run the connector on production without `--dry-run` first.**
 
-## What's dormant (don't get distracted)
+## What's historical or parked (don't get distracted)
 
-- **`.github/agents/` + `.github/workflows/`** — the older GitHub Actions agent swarm (orchestrator → analyzer → test-writer → implementer → QA → reviewer → PR creator). It produced PRs #71 and #72 in May 2026 and is not used by current sessions.
+- **`.github/agents/`** — the older GitHub Actions agent swarm (orchestrator → analyzer → test-writer → implementer → QA → reviewer → PR creator). It produced PRs #71 and #72 in May 2026 and is not used by current sessions.
+- **`.github/workflows/agent-pr-generator.yml`** — parked on 2026-05-20. It is now a manual, read-only diagnostic stub and no longer auto-runs when `auto-implement` is labeled.
+- **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
 - **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. The current roadmap is [`docs/current-state/ROADMAP.md`](docs/current-state/ROADMAP.md).
@@ -64,4 +67,4 @@ Read [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODE
 
 ---
 
-**Last verified:** 2026-05-17. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` as the source of truth and flag the drift for a fresh audit.
+**Last verified:** 2026-05-20. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` as the source of truth and flag the drift for a fresh audit.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # BC+AI Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test validate health issues pr dashboard stats clean
+.PHONY: help test validate health issues pr dashboard stats agent-status clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -93,9 +93,11 @@ stats: ## Show repository statistics
 	@echo "Recent Activity:"
 	@gh run list --limit 5
 
-agent-status: ## Show active agent automations
+agent-status: ## Show parked agent automation state records
 	@echo "🤖 Agent Automation Status"
 	@echo ""
+	@echo "  Agent PR Generator is parked; auto-implement labels do not start automation."
+	@echo "  Historical state records:"
 	@if [ -d ".github/agent-state" ]; then \
 		find .github/agent-state -name "state.json" -exec sh -c 'jq -r "select(.status == \"in_progress\") | \"Issue #\" + (.issue_number | tostring) + \": \" + .current_stage" {} 2>/dev/null || true' \; | \
 		while read line; do \
@@ -104,7 +106,7 @@ agent-status: ## Show active agent automations
 			fi; \
 		done; \
 	fi
-	@echo "  (No active automations)" 2>/dev/null || true
+	@echo "  (These records are not proof of active automation.)" 2>/dev/null || true
 
 clean: ## Clean up test artifacts and temporary files
 	@echo "Cleaning up..."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # BC+AI Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test validate health issues pr dashboard stats agent-status clean
+.PHONY: help test validate health issues pr dashboard stats agent-status backup-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -107,6 +107,17 @@ agent-status: ## Show parked agent automation state records
 		done; \
 	fi
 	@echo "  (These records are not proof of active automation.)" 2>/dev/null || true
+
+backup-check: ## Verify a backup set (use BACKUP_DIR=backup/YYYY-MM-DD; STRICT=1 requires restore proof)
+	@if [ -z "$(BACKUP_DIR)" ]; then \
+		echo "❌ Error: Please specify BACKUP_DIR=backup/YYYY-MM-DD"; \
+		exit 1; \
+	fi
+	@if [ "$(STRICT)" = "1" ]; then \
+		bash scripts/verify-backup-set.sh "$(BACKUP_DIR)"; \
+	else \
+		bash scripts/verify-backup-set.sh --allow-incomplete "$(BACKUP_DIR)"; \
+	fi
 
 clean: ## Clean up test artifacts and temporary files
 	@echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Repo:** [WalksWithASwagger/kriskrug-wp](https://github.com/WalksWithASwagger/kriskrug-wp)
 **Operating model:** Two tracks — see [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md)
 
-This repository is the **operations + content hub** for [kriskrug.co](https://kriskrug.co/). The live WordPress install is not file-synced here (it runs on Pagely). This repo holds everything *adjacent* to the site: audit snapshots, draft content before publication, deployment-ready code snippets, and the Notion → WordPress publisher.
+This repository is the **operations + content hub** for [kriskrug.co](https://kriskrug.co/). The live WordPress install is not file-synced here (it runs on Pagely). This repo holds everything *adjacent* to the site: audit snapshots, draft content before publication, deployment-ready code snippets, packaged helper plugins, and the Notion → WordPress publisher.
 
 **If you're an AI agent landing in this repo cold, start at [`AGENTS.md`](AGENTS.md).**
 
@@ -34,7 +34,7 @@ This repository is used for:
 
 1. **Site audits + state snapshots** of the live kriskrug.co WordPress install (see [`docs/current-state/`](docs/current-state/))
 2. **Content pipeline** — Notion → kriskrug.co publisher with safety guards (see [`scripts/notion-to-wp/`](scripts/notion-to-wp/))
-3. **Custom WordPress code** — schema markup, theme tweaks, helper plugins (see [`fixes/`](fixes/) and [`inc/`](inc/))
+3. **Custom WordPress code** — schema markup, theme tweaks, helper plugins (see [`fixes/`](fixes/), [`inc/`](inc/), and [`plugins/`](plugins/))
 4. **Aurora v2 theme work** — separate `aurora/v2` branch, paced sprints (see [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md))
 5. **Issue tracking + project management** for fixes, content, and theme work
 
@@ -66,6 +66,9 @@ fixes/                           # Production-ready code snippets / migrations
   ├── robots-txt-update.txt      # Two AI-crawler stance options
   └── issue-*.{css,php,md}       # Older queued fixes from earlier batches
 
+plugins/
+  └── kk-sidebar-promos/         # Packaged helper plugin for auto-expiring sidebar promos
+
 docs/current-state/              # Frozen baseline snapshot — what was true on 2026-05-14
   ├── README.md                  # Index of the snapshot
   ├── SITE_INVENTORY.md          # Live-site fingerprint: host, theme, plugins, content shape
@@ -86,12 +89,13 @@ issues-to-create/                # Markdown drafts of GitHub issues waiting to b
 inc/                             # Custom WordPress modules (e.g., digital-composting CPT)
 
 skills/                          # Claude Code skills used in this repo
-.github/                         # Agent swarm definitions + workflows (older pipeline)
+.github/                         # PR validation plus parked historical agent-swarm definitions
 ```
 
 ### Where to start
 
 - **Reading the site state:** `docs/current-state/README.md`
+- **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
 - **Planning next work:** `docs/current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`, then `docs/current-state/ROADMAP.md` and `FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
 - **Reviewing staged drafts:** `content/drafts/README.md`
@@ -131,14 +135,14 @@ Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](do
 3. Use issue templates when filing new issues
 4. Follow WordPress coding standards for PHP/JS in `fixes/` and `inc/`
 
-### Dormant: GitHub Actions agent swarm
-`.github/agents/` and `.github/workflows/` define an older issue-to-PR pipeline (orchestrator → analyzer → test-writer → implementer → QA → reviewer → PR creator). It produced PRs #71 and #72 in May 2026 and is not used by current sessions. See [`docs/architecture.md`](docs/architecture.md) and [`docs/automation-guide.md`](docs/automation-guide.md) for reference if/when it's revived.
+### Historical / parked: GitHub Actions agent swarm
+`.github/agents/` defines an older issue-to-PR pipeline (orchestrator → analyzer → test-writer → implementer → QA → reviewer → PR creator). It produced PRs #71 and #72 in May 2026 and is not used by current sessions. `agent-pr-generator.yml` is now a manual, read-only diagnostic stub and no longer runs from the `auto-implement` label. `test-pr.yml` remains active PR validation. See [`docs/architecture.md`](docs/architecture.md) and [`docs/automation-guide.md`](docs/automation-guide.md) for reference if/when the swarm is rebuilt intentionally.
 
 ## Technology Stack
 
 - **Platform:** WordPress 6.9+ on Pagely (production), Catch Responsive theme
 - **Content pipeline:** Python (Notion API → WordPress REST API)
-- **Custom code:** PHP snippets (Code Snippets plugin on prod), one custom module (`inc/digital-composting.php`)
+- **Custom code:** PHP snippets (Code Snippets plugin on prod), `inc/digital-composting.php`, and packaged helper plugins such as `plugins/kk-sidebar-promos/`
 - **CLI Tools:** GitHub CLI (`gh`), Claude Code / Cursor agents
 - **Languages:** PHP, JavaScript, Python, Bash
 
@@ -151,7 +155,7 @@ Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](do
 - `seo` - Search engine optimization
 - `content` - Content updates and UX
 - `documentation` - Documentation improvements
-- `auto-implement` - Ready for agent automation
+- `auto-implement` - Historical automation-intent label; does not currently start the parked Agent PR Generator
 - `needs-human-review` - Requires manual review
 
 ## Project Links

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fixes/                           # Production-ready code snippets / migrations
 plugins/
   └── kk-sidebar-promos/         # Packaged helper plugin for auto-expiring sidebar promos
 
-docs/current-state/              # Frozen baseline snapshot — what was true on 2026-05-14
+docs/current-state/              # Frozen baseline snapshot plus dated recovery/redesign handoffs
   ├── README.md                  # Index of the snapshot
   ├── SITE_INVENTORY.md          # Live-site fingerprint: host, theme, plugins, content shape
   ├── REPO_STATE.md              # What's actually built vs. just documented
@@ -95,8 +95,9 @@ skills/                          # Claude Code skills used in this repo
 ### Where to start
 
 - **Reading the site state:** `docs/current-state/README.md`
+- **Planning next work:** `docs/current-state/WORK-PLAN-2026-05-21.md`
 - **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
-- **Planning next work:** `docs/current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`, then `docs/current-state/ROADMAP.md` and `FIX_QUEUE.md`
+- **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
 - **Reviewing staged drafts:** `content/drafts/README.md`
 - **Filing an issue:** `issues-to-create/` for drafts; existing ones at [WalksWithASwagger/kriskrug-wp/issues](https://github.com/WalksWithASwagger/kriskrug-wp/issues)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,9 +6,9 @@ Navigation for everything in this repo. Entries are grouped by what they're for,
 
 ---
 
-## 🟢 Current — read these first
+## 🟢 Current State And Dated Evidence
 
-The canonical "what's true right now" snapshot lives in [`docs/current-state/`](current-state/). Written May 14–17, 2026.
+The canonical baseline snapshot and current handoffs live in [`docs/current-state/`](current-state/). The May 14 files are frozen evidence; the latest dated work plan is the active front door.
 
 | File | What it covers |
 |---|---|
@@ -22,10 +22,14 @@ The canonical "what's true right now" snapshot lives in [`docs/current-state/`](
 | [`current-state/SEO_AUDIT.md`](current-state/SEO_AUDIT.md) | Technical SEO + AI search readiness |
 | [`current-state/CONTENT_AUDIT.md`](current-state/CONTENT_AUDIT.md) | Per-page review + post inventory + IA proposal |
 | [`current-state/FIX_QUEUE.md`](current-state/FIX_QUEUE.md) | P0 → P3 backlog |
-| [`current-state/ROADMAP.md`](current-state/ROADMAP.md) | Six-phase, 3-month plan |
-| [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit, roadmap, and human decision list |
-| [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery and branch/worktree cleanup |
-| [`current-state/WORK-PLAN-2026-05-20.md`](current-state/WORK-PLAN-2026-05-20.md) | Current execution plan after Wave 3 partial completion (`#84` closed; `#85/#86` open) |
+| [`current-state/ROADMAP.md`](current-state/ROADMAP.md) | Six-phase, 3-month plan; use as longer-range reference after the latest work plan |
+| [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit, roadmap, and human decision list |
+| [`current-state/WORK-PLAN-2026-05-21.md`](current-state/WORK-PLAN-2026-05-21.md) | Current next-session front door after diagnostic/polish closeout and docs tidy pass |
+| [`current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](current-state/DIAGNOSTIC-POLISH-2026-05-20.md) | Repo-truth, technical-debt, SOTA, live-fix, and workflow diagnostic |
+| [`current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md`](current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md) | Current disposition of `fixes/` artifacts against live evidence |
+| [`current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md`](current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md) | Motion budget and QA rules for Aurora |
+| [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/TOMORROW-ROADMAP-2026-05-20.md) | Historical next-session roadmap after rewrite recovery and branch/worktree cleanup |
+| [`current-state/WORK-PLAN-2026-05-20.md`](current-state/WORK-PLAN-2026-05-20.md) | Historical execution plan after Wave 3 completion and Track B QA setup |
 | [`current-state/NEXT-ROUND-WORK-2026-05-19.md`](current-state/NEXT-ROUND-WORK-2026-05-19.md) | Historical command sheet from 2026-05-19 (superseded by 2026-05-20 roadmap/work-plan docs) |
 | [`current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md`](current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md) | 72-hour swarm roadmap with bounded parallel lanes, wave labels, and stop rules |
 | [`current-state/AURORA-ISSUE-SWARM-2026-05-19.md`](current-state/AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics and routed stale design issues into the Track B lane |
@@ -103,4 +107,4 @@ Each historical doc carries a `STATUS: Historical` banner at the top pointing at
 
 ---
 
-**Last updated:** 2026-05-20. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.
+**Last updated:** 2026-05-21. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.

--- a/docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md
+++ b/docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md
@@ -3,7 +3,7 @@
 **Track:** B - Aurora v2 theme
 **Scope:** GitHub issue hygiene, PR review packet, and next Track B work lanes.
 **Production status:** No production WordPress writes. No theme activation. No merge to `main`.
-**Refresh:** 2026-05-20 queue + merge reconciliation pass (through PR `#106`).
+**Refresh:** 2026-05-20 queue + merge reconciliation pass (through PR `#106`, diagnostic polish refresh at 17:30 UTC).
 
 ## Summary
 
@@ -58,7 +58,7 @@ Current mapping:
 
 Verification after routing:
 
-- open `aurora-v2` issues: 14
+- open `aurora-v2` issues: 13
 - old design issues #24-#35 still carrying `auto-implement`: 0
 
 ## PR State (post-rewrite recovery)

--- a/docs/current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md
+++ b/docs/current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md
@@ -1,0 +1,39 @@
+# Aurora Motion Governance - 2026-05-20
+
+**Purpose:** Keep Aurora's "human-made" feel expressive without letting motion become a performance, accessibility, or maintenance liability.
+**Scope:** Track B guidance only. Do not edit `theme/kk-aurora/` from `main`.
+
+## Motion budget
+
+Aurora gets three intentional motion layers:
+
+1. **Navigation continuity:** native View Transitions where supported, no hard dependency for navigation.
+2. **Reading orientation:** low-cost reading progress and section reveal behavior.
+3. **Proof affordance:** restrained hover/focus treatment for talks, projects, event cards, and CTAs.
+
+Everything else is suspect until it earns its place in QA. Cursor glows, ripple effects, overlapping scroll libraries, and decorative parallax should be removed unless they pass the checks below.
+
+## Allowed implementation preferences
+
+- Prefer CSS transitions and CSS scroll-driven animation for simple progress/reveal effects.
+- Use GSAP only for a named interaction that CSS cannot express cleanly.
+- Do not run multiple reveal systems on the same element.
+- Honor `prefers-reduced-motion: reduce` by removing non-essential animation, not merely slowing it down.
+- Keep focus states instant and visible; never hide keyboard focus behind motion timing.
+- Avoid motion that changes layout or causes late content shifts.
+
+## QA gate for issue #86
+
+Before Aurora can be considered launchable, capture evidence for:
+
+- Desktop and mobile screenshots for homepage, Work, Speaking, and one long-form page.
+- Keyboard navigation through header, mobile nav, cards, forms, and CTAs.
+- Reduced-motion behavior on the same surfaces.
+- Console and network errors.
+- Image/media loading with production-like assets.
+- Basic Core Web Vitals notes, with special attention to INP and LCP.
+- Overflow/text clipping checks on mobile.
+
+## Keep or cut rule
+
+Keep an effect only if it improves orientation, confidence, delight, or proof comprehension and does not make the page harder to read, navigate, or measure. Cut it when the only argument is "it looks cool."

--- a/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
+++ b/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
@@ -1,17 +1,18 @@
 # Aurora State-of-the-Art Roadmap - Summer 2026
 
-**Prepared:** 2026-05-20  
-**Snapshot time:** 2026-05-20 05:54:46 UTC  
-**Track:** B (`aurora/v2`)  
+**Prepared:** 2026-05-20
+**Snapshot time:** 2026-05-20 17:30 UTC
+**Track:** B (`aurora/v2`)
 **Purpose:** Step back from issue-by-issue execution and align Aurora to a true summer-2026 quality bar.
 
 ## Current Truth (before new implementation)
 
 - Open PRs: `0`
-- Open issues: `66`
+- Open issues: `63`
 - Open `track-b` + `aurora-v2` issues: `13` (`#24-#35`, `#86`)
 - Active Aurora hard gate: `#86` (staging performance/accessibility QA)
 - Working rule remains: no Track A content writes mixed into Track B theme lanes.
+- Motion budget addendum: `AURORA-MOTION-GOVERNANCE-2026-05-20.md`.
 
 ## What "State of the Art" Means for Aurora (Summer 2026)
 
@@ -172,4 +173,3 @@ If any gate is red, do not launch.
 - [web.dev - INP](https://web.dev/articles/inp)
 - [web.dev - CLS](https://web.dev/articles/cls)
 - [WordPress - Block themes documentation](https://wordpress.org/documentation/article/block-themes/)
-

--- a/docs/current-state/BACKUP_PLAN.md
+++ b/docs/current-state/BACKUP_PLAN.md
@@ -2,14 +2,35 @@
 
 **Goal:** before any modification touches production, we have a local archive sufficient to rebuild the site from scratch.
 
+## 2026-05-21 gate status
+
+The repo has a local UpdraftPlus archive set from 2026-05-16 in `backup/2026-05-16/` with database, plugins, themes, mu-plugins, and other `wp-content` files. That set has checksums and a tracked manifest, but it is **not enough to reopen production writes** because:
+
+- the 13 GB uploads archive was skipped and is only accounted for in the manifest;
+- no `restore-notes.md` exists yet proving a local restore drill.
+
+Use this command to inspect an archive set without claiming the production-write gate is satisfied:
+
+```bash
+make backup-check BACKUP_DIR=backup/2026-05-16
+```
+
+Use strict mode for the actual gate before live WordPress changes:
+
+```bash
+make backup-check BACKUP_DIR=backup/YYYY-MM-DD STRICT=1
+```
+
+Strict mode must pass before `/llms.txt`, robots, homepage H1/alt, Work metadata, sidebar promo deploy, schema migration, or Notion-to-WP production writes.
+
 ## The four pieces of a real WordPress backup
 
 | Piece | What it contains | Have it locally? | How to get it |
 |---|---|---|---|
-| **Database dump** | Every post, page, comment, user, option, plugin setting | ❌ | `wp db export` (SSH) or AIO-WP-Migration / UpdraftPlus (plugin) |
-| **`wp-content/themes/`** | Active theme + child theme + any others | ❌ | rsync over SSH, or plugin archive |
-| **`wp-content/plugins/`** | All installed plugins | ❌ | rsync over SSH, or plugin archive |
-| **`wp-content/uploads/`** | All media files (likely the largest piece — could be many GB) | ❌ | rsync over SSH, or plugin archive |
+| **Database dump** | Every post, page, comment, user, option, plugin setting | Partial: 2026-05-16 archive exists | `wp db export` (SSH) or AIO-WP-Migration / UpdraftPlus (plugin) |
+| **`wp-content/themes/`** | Active theme + child theme + any others | Partial: 2026-05-16 archive exists | rsync over SSH, or plugin archive |
+| **`wp-content/plugins/`** | All installed plugins | Partial: 2026-05-16 archive exists | rsync over SSH, or plugin archive |
+| **`wp-content/uploads/`** | All media files (likely the largest piece — could be many GB) | Missing locally; 2026-05-16 manifest accounts for the gap | rsync over SSH, Pagely backup export, or plugin archive |
 
 Plus, optionally: `wp-config.php` (gitignore — has secrets), mu-plugins, drop-ins, root `.htaccess`.
 
@@ -43,6 +64,7 @@ Steps:
 4. When the archive set finishes, download all 5 files to `~/Downloads/kriskrug-backup-YYYY-MM-DD/`
 5. Move that folder into `kriskrug-wp/backup/2026-05-14/` (gitignored)
 6. Record what we got in `backup/<date>/manifest.md`
+7. Run `make backup-check BACKUP_DIR=backup/<date>` to verify checksums and surface any missing restore proof.
 
 Alternative plugin: **All-in-One WP Migration** — one `.wpress` file, simpler but a single proprietary format. Fine if UpdraftPlus has trouble.
 
@@ -80,6 +102,7 @@ A backup that's never been restored is a hope, not a backup. After the first arc
 2. Restore the archive into the local instance.
 3. Confirm: homepage renders, an arbitrary recent post renders, wp-admin opens, plugin settings are intact.
 4. Note any breakage in `backup/<date>/restore-notes.md`.
+5. Run `make backup-check BACKUP_DIR=backup/<date> STRICT=1`.
 
 Until step 4 is done, the backup is unverified.
 

--- a/docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md
+++ b/docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md
@@ -1,0 +1,72 @@
+# Diagnostic and Polish Pass - 2026-05-20
+
+**Purpose:** Implement the repo-truth, technical-debt, SOTA, and polish plan from the 2026-05-20 diagnostic session without touching live WordPress.
+**Snapshot time:** 2026-05-20 17:30 UTC.
+**Track:** Ops / docs / plugin hardening on `main`. No Track B theme files and no production WordPress content were changed.
+
+## Verified state
+
+- `main` is synced with `origin/main` (`0 0` divergence).
+- Open PRs: `0`.
+- Open issues: `63`.
+- Open `track-b` + `aurora-v2` issues: `13`, with `#86` still the final real-staging QA gate.
+- `origin/aurora/v2` is `18` ahead and `69` behind `origin/main`.
+- Live site is still Catch Responsive. Aurora remains isolated Track B work.
+- Live `/llms.txt` returns `404`.
+- Live `/robots.txt` returns `200`, but still uses the current default sitemap/admin rules rather than an explicit AI-crawler stance.
+- Live homepage still has two `<h1>` elements and multiple empty image alts.
+- Live `/work/` resolves to `/recent-projects-include/` and still emits a blank WordPress.com OG image.
+- Public HTML on homepage, About, Work, and Speaking includes JSON-LD scripts, so schema appears to be deployed via the Code Snippets path. Verify in wp-admin before editing or redeploying schema.
+
+## State of affairs and trajectory
+
+The codebase is cohesive in narrative direction: kriskrug.co is becoming the hub for Kris's creative AI, community-building, speaking, and field-work identity. Recent work has strengthened the About, Work, Speaking, homepage, source-pack, and owned-sites spine.
+
+The risk is not lack of direction. The risk is operational drift:
+
+- Repo docs, live WordPress, queued fixes, GitHub workflows, agent-state files, and Aurora branches were not all telling the same story.
+- The repo previously described one custom WP module, but it now also includes the `kk-sidebar-promos` plugin.
+- The repo described the old agent workflow as dormant, but `agent-pr-generator.yml` was still triggered by issue labels and could commit placeholder state.
+- The fix queue still treated schema as fully queued even though public pages now appear to include the deployed schema snippet.
+
+## Technical debt addressed in this pass
+
+- Parked the placeholder Agent PR Generator so `auto-implement` labels no longer trigger misleading comments, state commits, pushes, or simulated automation.
+- Updated agent-facing docs to say the old swarm is historical, while PR validation remains active and the generator workflow is now a manual read-only diagnostic stub.
+- Reconciled live-state notes for schema, `/llms.txt`, robots, homepage H1/alt text, and Work OG/slug drift.
+- Hardened `kk-sidebar-promos` rendering so featured images prefer the attachment alt text and fall back to decorative empty alt rather than repeating the visible promo title.
+- Added a local smoke test for `kk-sidebar-promos` covering empty render behavior, image alt behavior, featured-promo expiry behavior, and Luma iCal parsing.
+
+## SOTA direction
+
+The site should keep moving toward native platform polish, editorial proof, measurable performance, and accessible motion:
+
+- Prefer native progressive animation patterns where they fit: `https://developer.chrome.com/docs/web-platform/view-transitions/cross-document`, `https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API`, and `https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations`.
+- Treat Core Web Vitals as design constraints, especially INP, LCP, and CLS: `https://web.dev/articles/inp`, `https://web.dev/articles/lcp`, `https://web.dev/articles/cls`.
+- Keep Aurora WordPress-native: block theme architecture and `theme.json` first, Interactivity API only for small stateful UI.
+- Use WCAG 2.2 as the floor for focus visibility, target size, contrast, predictable navigation, and reduced-motion handling.
+- Let real proof do the aesthetic work: talks, videos, field notes, event communities, project outcomes, and warm editorial linking should carry more weight than decorative effects.
+
+## Interface polish and QoL backlog
+
+Do these only after the backup gate is proven:
+
+- Replace hard-coded sidebar image blocks with `kk-sidebar-promos` after a plugin deploy check and rollback path.
+- Fix the homepage duplicate/empty H1 and the highest-visibility empty image alts.
+- Add `/llms.txt` and choose the robots AI-crawler stance.
+- Fix Work page public identity: slug/canonical/OG image should say "Work", not only `recent-projects-include`.
+- Add event-card states: upcoming, recently passed, recording available, sold out when relevant.
+- Add a small "currently gathering next" or "in the field now" module that reflects Kris's live community-building work.
+- Add proof metadata to Work cards: year, role, community, artifact, outcome.
+- Keep Aurora motion meaningful: page transition, section reveal, reading progress, and proof-card affordance. Remove decorative JS unless it survives reduced-motion and INP testing.
+
+## Today's implemented checklist
+
+- [x] Refresh repo truth around issue counts, Aurora divergence, schema status, and plugin status.
+- [x] Stop the placeholder Agent PR Generator from auto-triggering on issue labels.
+- [x] Document that live WordPress writes remain blocked behind backup/restore proof.
+- [x] Audit `fixes/` against current live state at the queue level.
+- [x] Add focused `kk-sidebar-promos` smoke coverage.
+- [x] Fix sidebar promo image alt behavior.
+- [ ] Complete real-staging Aurora QA for issue `#86`. Blocked until the staging surface with production-like media is available in this session.
+- [ ] Prune Aurora theme motion code. Deferred because Track B theme files live off `main` and should be handled in the Aurora worktree/branch.

--- a/docs/current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md
+++ b/docs/current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md
@@ -1,0 +1,52 @@
+# Fixes vs Live State Reconciliation - 2026-05-20
+
+**Purpose:** Prevent duplicate, stale, or conflicting deploys from `fixes/` after the May 2026 content and schema work.
+**Rule:** This is a repo-side audit only. Production changes still require the backup gate in `BACKUP_PLAN.md` and `FIX_QUEUE.md`.
+
+## Current live checks
+
+Checked with public `curl` fetches on 2026-05-20:
+
+- Homepage, About, Work, and Speaking return `200`.
+- `/work/` redirects/resolves to `/recent-projects-include/`.
+- `/llms.txt` returns `404`.
+- `/robots.txt` returns `200` and references the sitemap, but does not yet carry the explicit AI-crawler stance from `fixes/robots-txt-update.txt`.
+- Homepage still has two `<h1>` elements.
+- Homepage, About, Work, and Speaking still contain empty image alts.
+- Work still emits `https://s0.wp.com/i/blank.jpg` as `og:image`.
+- Homepage, About, Work, and Speaking each include JSON-LD scripts, so schema appears live via the deployed Code Snippets path.
+
+## File-by-file disposition
+
+| File | Status | Next action |
+|---|---|---|
+| `fixes/schema-snippets-deployed.php` | Current source of truth for live schema. | Keep synced with the Code Snippets version. Verify in wp-admin before editing. |
+| `fixes/schema-snippets.php` | SSH/mu-plugin version, not the live deploy path today. | Keep as deploy target for a future mu-plugin migration. Do not install blindly over the Code Snippet. |
+| `fixes/issue-39-schema-markup.php` | Obsolete-replaced. | Keep historical only; do not deploy because the newer schema files supersede it. |
+| `fixes/llms-txt-template.md` | Still needed. | Deploy only after backup proof; verify `/llms.txt` returns `200` text. |
+| `fixes/robots-txt-update.txt` | Still needed. | Pick the final AI-crawler stance after backup proof and verify with curl/Search Console. |
+| `fixes/issue-12-new-homepage-hero.md` | Needs review. | Compare with the latest homepage polymath hero draft before any copy-paste. |
+| `fixes/issue-13-14-15-project-sections.md` | Needs review. | Compare against current Work/About/Speaking source packs and live pages. |
+| `fixes/UPDATED-ABOUT-PAGE-COMPLETE.md` | Likely superseded by May 2026 About updates. | Treat as historical unless a diff against live proves a missing section. |
+| `fixes/issue-67-services-page-expanded.md` | Needs review. | Compare against the merged services role-positioning work before publishing. |
+| `fixes/issue-68-work-page-complete.md` | Needs review. | Compare against live Work page and the Work OG/slug issue before publishing. |
+| `fixes/owned-sites-network-rollout.md` | Applied. | Keep as rollback/audit record. |
+| `fixes/issue-36-meta-descriptions.md` | Needs review. | Reconcile with Jetpack/OG behavior and Work blank OG before introducing another SEO source. |
+| `fixes/issue-43-twitter-cards.php` | Needs review. | Do not deploy alongside Jetpack/Rank Math without duplicate meta checks. |
+| `fixes/issue-37-xml-sitemap-setup.md` | Mostly historical. | Sitemaps already exist; revisit only if sitemap coverage breaks. |
+| `fixes/issue-5-color-contrast.css` | Needs current visual audit. | Re-test against live theme and Aurora separately. |
+| `fixes/issue-9-button-hover-states.css` | Needs current visual audit. | Re-test against live theme and Aurora separately. |
+| `fixes/issue-22-land-acknowledgment.md` | Content guidance. | Review after IA decisions; do not apply as a standalone live edit without backup. |
+| `fixes/README-FIXES-BATCH-1.md` | Historical index. | Keep bannered as historical; use this reconciliation doc as the current index. |
+
+## Safe next deployment set
+
+After backup/restore proof, the smallest safe live batch is:
+
+1. `/llms.txt`.
+2. Robots AI-crawler stance.
+3. Homepage H1 correction.
+4. Highest-visibility image alt fixes.
+5. Work OG/canonical/slug cleanup.
+
+Schema should not be part of that first batch unless wp-admin verification shows the deployed Code Snippet is missing or stale.

--- a/docs/current-state/FIX_QUEUE.md
+++ b/docs/current-state/FIX_QUEUE.md
@@ -1,11 +1,21 @@
 # Fix Queue — Prioritized Backlog
 
-**As of:** 2026-05-14
+**As of:** 2026-05-14 baseline. Reconciled against live evidence on 2026-05-20 in [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md).
 **Source:** [SEO_AUDIT.md](SEO_AUDIT.md) + [CONTENT_AUDIT.md](CONTENT_AUDIT.md).
 
 Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these first. Items list dependencies so we don't get tripped up.
 
 **Hard prerequisite for everything below**: a working backup (see [BACKUP_PLAN.md](BACKUP_PLAN.md)). Don't apply P0 until at least one verified backup exists.
+
+## 2026-05-20 live-state addendum
+
+- Keep P0.1 as the hard gate. No production writes until backup and restore proof exist.
+- P0.2 is still open: `/llms.txt` currently returns `404`.
+- P0.3 has changed status: public HTML on homepage, About, Work, and Speaking now includes JSON-LD, so schema appears deployed through the Code Snippets path represented by `fixes/schema-snippets-deployed.php`. Verify in wp-admin before changing schema; do not blindly deploy `schema-snippets.php` over it.
+- P0.4 is still open: `/robots.txt` exists but does not yet include the explicit AI-crawler stance from `fixes/robots-txt-update.txt`.
+- P0.5/P0.6 are still open: homepage still has duplicate H1 behavior and the most visible pages still contain empty image alts.
+- Work page social metadata is now an explicit P0/P1 cleanup candidate: `/work/` resolves to `/recent-projects-include/` and the page still emits a blank WordPress.com OG image.
+- Use [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md) before deploying any January-era `fixes/` file.
 
 ---
 
@@ -26,8 +36,9 @@ Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these 
 - **Dependencies:** P0.1.
 - **Verify:** `curl -i https://kriskrug.co/llms.txt` returns 200 + `Content-Type: text/plain`.
 
-### P0.3 — Deploy schema-snippets.php as mu-plugin
-- **Why:** Single highest-leverage SEO + AI change. Adds `Person`, `WebSite`, `Article`, `BreadcrumbList`, `Service` schema sitewide. Before this, every page is invisible to AI structured-data extraction.
+### P0.3 — Verify deployed schema and decide whether to migrate to mu-plugin
+- **Current status:** Public HTML now appears to include the deployed Code Snippets schema path. Treat this as verification/migration work, not a first deploy.
+- **Why:** Single highest-leverage SEO + AI change. Adds `Person`, `WebSite`, `Article`, `BreadcrumbList`, `Service` schema sitewide.
 - **Path:**
   1. Verify constants in `fixes/schema-snippets.php` (LinkedIn, X, YouTube, headshot URL, BC + AI URL — all marked `VERIFY` in the file).
   2. Drop file into `wp-content/mu-plugins/kk-schema.php` (SSH/SFTP).

--- a/docs/current-state/FIX_QUEUE.md
+++ b/docs/current-state/FIX_QUEUE.md
@@ -10,6 +10,7 @@ Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these 
 ## 2026-05-20 live-state addendum
 
 - Keep P0.1 as the hard gate. No production writes until backup and restore proof exist.
+- Use `make backup-check BACKUP_DIR=backup/YYYY-MM-DD STRICT=1` as the mechanical gate check. `backup/2026-05-16/` is useful but not sufficient because uploads were skipped and no restore drill is documented.
 - P0.2 is still open: `/llms.txt` currently returns `404`.
 - P0.3 has changed status: public HTML on homepage, About, Work, and Speaking now includes JSON-LD, so schema appears deployed through the Code Snippets path represented by `fixes/schema-snippets-deployed.php`. Verify in wp-admin before changing schema; do not blindly deploy `schema-snippets.php` over it.
 - P0.4 is still open: `/robots.txt` exists but does not yet include the explicit AI-crawler stance from `fixes/robots-txt-update.txt`.

--- a/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
+++ b/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
@@ -1,8 +1,8 @@
 # Issue Swarm Roadmap - 2026-05-19
 
 **Prepared:** 2026-05-19
-**Last refreshed:** 2026-05-20 (UTC)
-**Queue snapshot (as of 2026-05-20 04:49 UTC):** 67 open issues, 0 open PRs
+**Last refreshed:** 2026-05-20 (UTC, diagnostic polish pass)
+**Queue snapshot (as of 2026-05-20 17:30 UTC):** 63 open issues, 0 open PRs
 **Scope:** Convert the current backlog into bounded parallel lanes with clear stop rules.
 
 ## Assumptions
@@ -13,12 +13,12 @@
 
 ## Queue Baseline
 
-- Open issues: `67`
-- `auto-implement`: `51`
+- Open issues: `63`
+- `auto-implement`: `47` (historical readiness label; does not start the parked Agent PR Generator)
 - `track-b` + `aurora-v2`: `13`
-- `priority:high`: `31`
+- `priority:high`: `28`
 - `needs-human-review`: `3` (`#23`, `#75`, `#95`)
-- `swarm-ready`: `17`
+- `swarm-ready`: `13`
 - `swarm-parked`: `11`
 
 ## Roadmap Issues Added
@@ -138,6 +138,8 @@ Done when:
 - `swarm-parked`: intentionally deferred / broad / dependency-heavy
 - `swarm-wave-1`: Aurora Wave 1 + first Track A quick wins
 - `swarm-wave-2`: second execution wave
+
+Note: `auto-implement` is now a historical intent label only. `agent-pr-generator.yml` no longer auto-runs from that label.
 - `swarm-wave-3`: final hardening/QA wave
 
 ## Notes

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -3,7 +3,7 @@
 **Snapshot date:** 2026-05-14
 **Purpose:** Document the live site, the repo, the access channels, and the rollback paths *before* we start making modifications. If we break something, this is what we return to.
 
-This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the dated `2026-05-*` files as current handoff material.
+This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated `2026-05-*` work plan as the current handoff.
 
 ## Files in this folder
 
@@ -17,10 +17,11 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [SEO_AUDIT.md](SEO_AUDIT.md) | Technical SEO + on-page + AI/generative-search readiness, with specific findings. |
 | [CONTENT_AUDIT.md](CONTENT_AUDIT.md) | Per-page review of all 34 pages, posts inventory (101 recent), taxonomy, multilingual, IA proposal. |
 | [FIX_QUEUE.md](FIX_QUEUE.md) | Prioritized P0→P3 backlog from both audits. |
-| [ROADMAP.md](ROADMAP.md) | Six-phase, 3-month plan that synthesizes FIX_QUEUE + postmortem follow-ups + content pipeline next steps. **Start here.** |
-| [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
-| [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. |
-| [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Current execution plan after Wave 3 implementation completion and final Track B QA gate (`#86`). |
+| [ROADMAP.md](ROADMAP.md) | Six-phase, 3-month plan that synthesizes FIX_QUEUE + postmortem follow-ups + content pipeline next steps. Use as longer-range reference after the latest work plan. |
+| [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
+| [WORK-PLAN-2026-05-21.md](WORK-PLAN-2026-05-21.md) | Current next-session front door after the diagnostic/polish branch, docs tidy pass, and sidebar promo hardening. |
+| [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Historical next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. Superseded by `WORK-PLAN-2026-05-21.md`. |
+| [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Historical execution plan after Wave 3 implementation completion and final Track B QA gate (`#86`). Superseded by `WORK-PLAN-2026-05-21.md`. |
 | [DIAGNOSTIC-POLISH-2026-05-20.md](DIAGNOSTIC-POLISH-2026-05-20.md) | Repository truth-refresh, technical-debt audit, SOTA direction, and polish/action checklist from the 2026-05-20 diagnostic pass. |
 | [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md) | Current disposition of every `fixes/` artifact against live-site evidence after schema/page updates. |
 | [AURORA-MOTION-GOVERNANCE-2026-05-20.md](AURORA-MOTION-GOVERNANCE-2026-05-20.md) | Motion budget and QA rules for Aurora so visual polish does not degrade accessibility or Core Web Vitals. |
@@ -72,6 +73,6 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 - **Site is on Pagely** (managed WP host), running **WordPress 6.9.4** with the **Catch Responsive** classic theme.
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
-- **Current addendum:** the 2026-05-20 diagnostic pass is the latest repo-truth refresh for issue counts, live fix status, workflow governance, and plugin hardening.
+- **Current addendum:** the 2026-05-21 work plan is the latest front door; the 2026-05-20 diagnostic pass remains the detailed repo-truth refresh for live fix status, workflow governance, and plugin hardening.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** get SSH on Pagely → take a `wp db export` + `wp-content/` archive → commit a `backup/` reference set → then start modifying.

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -21,6 +21,9 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | Current post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
 | [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Refreshed next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. |
 | [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Current execution plan after Wave 3 implementation completion and final Track B QA gate (`#86`). |
+| [DIAGNOSTIC-POLISH-2026-05-20.md](DIAGNOSTIC-POLISH-2026-05-20.md) | Repository truth-refresh, technical-debt audit, SOTA direction, and polish/action checklist from the 2026-05-20 diagnostic pass. |
+| [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md) | Current disposition of every `fixes/` artifact against live-site evidence after schema/page updates. |
+| [AURORA-MOTION-GOVERNANCE-2026-05-20.md](AURORA-MOTION-GOVERNANCE-2026-05-20.md) | Motion budget and QA rules for Aurora so visual polish does not degrade accessibility or Core Web Vitals. |
 | [NEXT-ROUND-WORK-2026-05-19.md](NEXT-ROUND-WORK-2026-05-19.md) | Historical 2026-05-19 handoff sheet (superseded by the 2026-05-20 roadmap/work-plan docs). |
 | [ISSUE-SWARM-ROADMAP-2026-05-19.md](ISSUE-SWARM-ROADMAP-2026-05-19.md) | 72-hour swarm-ready issue roadmap with parallel lanes, stop rules, and wave labels. |
 | [AURORA-ISSUE-SWARM-2026-05-19.md](AURORA-ISSUE-SWARM-2026-05-19.md) | Filed Aurora epics #80-#86 and routed old design issues #24-#35. |
@@ -62,11 +65,13 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 | `fixes/llms-txt-template.md` | Curated `llms.txt` content for site root (P0.2). |
 | `fixes/robots-txt-update.txt` | Two robots.txt options with explicit AI-crawler stances (P0.4). |
 | `fixes/schema-snippets.php` | Mu-plugin: `Person`, `WebSite`, `Article`, `BreadcrumbList`, `Service` JSON-LD (P0.3). Supersedes the older `issue-39-schema-markup.php`. |
+| `fixes/schema-snippets-deployed.php` | Production Code Snippets version. Public HTML appears to include this schema path as of 2026-05-20; verify in wp-admin before editing. |
 
 ## TL;DR
 
 - **Site is on Pagely** (managed WP host), running **WordPress 6.9.4** with the **Catch Responsive** classic theme.
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
+- **Current addendum:** the 2026-05-20 diagnostic pass is the latest repo-truth refresh for issue counts, live fix status, workflow governance, and plugin hardening.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** get SSH on Pagely → take a `wp db export` + `wp-content/` archive → commit a `backup/` reference set → then start modifying.

--- a/docs/current-state/REPO_STATE.md
+++ b/docs/current-state/REPO_STATE.md
@@ -1,18 +1,24 @@
-# Repo State — `kriskrug-wp/` as of 2026-05-14
+# Repo State — `kriskrug-wp/`
+
+**Baseline date:** 2026-05-14.
+**Latest reconciliation:** 2026-05-20. Read dated addenda in this folder for current handoffs, especially `DIAGNOSTIC-POLISH-2026-05-20.md`.
 
 This repo was set up earlier in 2026 as an **issue tracking + automation hub** for kriskrug.co, not as a code mirror of the WordPress install. As of today the repo and the live site share almost no files.
 
 ## What's actually checked in (built, not just documented)
 
-### PHP modules — exactly one
+### Repo-side WordPress code
 
 | Path | What it is | Status |
 |---|---|---|
 | `inc/digital-composting.php` | Custom Post Type + Taxonomy module for ingesting transcripts ("digital composting") | Merged via PR #71 + #72 on 2026-05-07. **Not yet deployed to production.** |
+| `plugins/kk-sidebar-promos/` | Packaged helper plugin for auto-expiring sidebar promos, evergreen pillar cards, and Luma iCal import | Built in May 2026. **Do not deploy until backup/rollback proof is current.** |
 
-### Prepared but undeployed fixes (`fixes/`)
+### Prepared fixes and live-state reconciliation (`fixes/`)
 
-A staging area of 12 ready-to-paste solutions tied to specific GitHub issues. **None of these have been applied to production.**
+`fixes/` is a staging area for ready-to-paste snippets, content packs, and migration notes tied to GitHub issues. It is no longer accurate to say that none have reached production: `owned-sites-network-rollout.md` documents applied page/widget/menu content, and public HTML on key pages now appears to include the schema path represented by `schema-snippets-deployed.php`.
+
+Use `FIXES-LIVE-RECONCILIATION-2026-05-20.md` before deploying anything from `fixes/`. Several January files are now historical or superseded.
 
 | File | Tied to | Type |
 |---|---|---|
@@ -29,16 +35,21 @@ A staging area of 12 ready-to-paste solutions tied to specific GitHub issues. **
 | `issue-68-work-page-complete.md` | #68 | Content |
 | `UPDATED-ABOUT-PAGE-COMPLETE.md` | About | Content |
 | `README-FIXES-BATCH-1.md` | — | Index |
+| `llms-txt-template.md` | P0.2 | AI search |
+| `robots-txt-update.txt` | P0.4 | Robots / AI crawler policy |
+| `schema-snippets.php` | P0.3 | Future mu-plugin schema path |
+| `schema-snippets-deployed.php` | P0.3 | Code Snippets production schema source |
+| `owned-sites-network-rollout.md` | Owned-sites IA | Applied production record |
 
-### Agent swarm (`.github/agents/` + `.github/workflows/`)
+### Agent swarm and workflows (`.github/agents/` + `.github/workflows/`)
 
-A 10-agent hierarchical automation system for converting GitHub issues into PRs:
+A historical 10-agent hierarchical automation system for converting GitHub issues into PRs:
 - **Workflow agents:** orchestrator, analyzer, test-writer, implementer, qa, reviewer, pr-creator
 - **Doc swarm:** content-analyzer, readme-writer, link-validator
-- **Workflows:** `auto-triage`, `agent-pr-generator`, `sync-projects`, `test-pr`, `reusable-wordpress-validation`
-- **Per-issue state:** `.github/agent-state/<issue>/state.json` exists for 11 issues (2, 4, 5, 12, 22, 34, 41, 57, 60, 66, 70)
+- **Workflows:** `test-pr` remains active PR validation. `agent-pr-generator` is parked as a manual, read-only diagnostic stub as of 2026-05-20. Older swarm docs remain for reference.
+- **Per-issue state:** `.github/agent-state/<issue>/state.json` exists for 12 historical issues (2, 4, 5, 12, 22, 34, 41, 57, 60, 66, 70, 99). Treat these as evidence records, not live automation state.
 
-> The system is described as "Infrastructure complete, Agent swarm validated, awaiting production import" in the README. It has produced PRs (#71, #72 most recently) but the bulk of issues haven't been processed.
+> The old system produced PRs #71 and #72, but it is not the current implementation path. Do not add `auto-implement` expecting autonomous PR creation unless the swarm is rebuilt intentionally.
 
 ### Skills (`skills/`)
 
@@ -103,12 +114,8 @@ df77d7f  feat: implement enhanced digital composting module       (2026-05-07)
 9672d86  Initial commit                                            (2026-01)
 ```
 
-Cadence: heavy setup work in January, dormant Feb–April, picked back up in early May.
+Cadence: heavy setup work in January, dormant Feb-April, picked back up in early May. Since 2026-05-18, commit activity has been mostly documentation and content-pack work, with smaller code hardening passes.
 
-## How to interpret the README
+## How to interpret older docs
 
-The repo's `README.md` says: *"Status: Infrastructure complete and validated. Agent swarm proven operational. Awaiting production kk.ca import to begin real issue resolution."*
-
-That status is accurate. **"Production import"** = importing the live site into a local dev environment so the agent swarm has something to operate against. That hasn't happened yet, which is why everything in `fixes/` is staged but undeployed.
-
-The README also references the site as **`kk.ca`** in several places. The actual production URL is **`kriskrug.co`**. Likely a historical naming the docs haven't caught up to — flag for a sweep later.
+Older docs may describe the agent swarm as "infrastructure complete" or mention `kk.ca`. Treat that as historical. The production URL is `kriskrug.co`, the old autonomous swarm is parked, and current work should follow the two-track model plus the dated handoff docs in `docs/current-state/`.

--- a/docs/current-state/RESUME-HERE.md
+++ b/docs/current-state/RESUME-HERE.md
@@ -1,7 +1,7 @@
 # Resume here — 2026-05-19 handoff
 
 > STATUS: Historical handoff from 2026-05-19.
-> For current startup context, use `docs/current-state/README.md`, `docs/current-state/TOMORROW-ROADMAP-2026-05-20.md`, and `docs/current-state/WORK-PLAN-2026-05-20.md`.
+> For current startup context, use `docs/current-state/README.md` and `docs/current-state/WORK-PLAN-2026-05-21.md`.
 
 **Last session ended:** 2026-05-19, after the live Speaking/Work/About authority-page continuation and closeout push prep.
 **Author:** Claude Code / Codex working with KK across an intensive multi-session push (2026-05-15 -> 2026-05-19).

--- a/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
+++ b/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
@@ -1,7 +1,7 @@
 # Tomorrow Roadmap - 2026-05-20
 
 **Prepared after:** 2026-05-19 credential-history rewrite execution, queue recovery, and merge pass
-**Last refreshed:** 2026-05-20 (UTC, post PR `#106`)
+**Last refreshed:** 2026-05-20 (UTC, diagnostic polish pass after PR `#106`)
 **Use for:** Next operating session (date can drift; treat as next-session plan)
 **Tracks:** Track A on `main`; Track B on `aurora/v2`
 
@@ -50,6 +50,11 @@
    - PR `#105` merged (restrained component library implementation for `#85`; issue now closed)
    - PR `#106` merged (local QA packet, screenshots, contrast/focus/reduced-motion checks, and mobile overflow fix)
    - `#86` remains open as the real staging QA and production-readiness gate
+13. Diagnostic polish pass completed:
+   - `DIAGNOSTIC-POLISH-2026-05-20.md`
+   - `FIXES-LIVE-RECONCILIATION-2026-05-20.md`
+   - `AURORA-MOTION-GOVERNANCE-2026-05-20.md`
+   - `agent-pr-generator.yml` is parked as a manual, read-only diagnostic stub.
 
 ## Non-Negotiable Guardrails
 
@@ -57,6 +62,7 @@
 2. Keep Notion -> WP writes dry-run first, slug-verified, and no `--publish` without explicit approval.
 3. Keep rollback snapshots before production writes.
 4. No casual history rewrites; today’s rewrite is complete and should be treated as a closed operation.
+5. `auto-implement` no longer starts the parked Agent PR Generator workflow.
 
 ## Next Session Priority Order
 

--- a/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
+++ b/docs/current-state/TOMORROW-ROADMAP-2026-05-20.md
@@ -1,5 +1,7 @@
 # Tomorrow Roadmap - 2026-05-20
 
+> STATUS: Historical handoff. Superseded by [WORK-PLAN-2026-05-21.md](WORK-PLAN-2026-05-21.md).
+
 **Prepared after:** 2026-05-19 credential-history rewrite execution, queue recovery, and merge pass
 **Last refreshed:** 2026-05-20 (UTC, diagnostic polish pass after PR `#106`)
 **Use for:** Next operating session (date can drift; treat as next-session plan)

--- a/docs/current-state/WORK-PLAN-2026-05-20.md
+++ b/docs/current-state/WORK-PLAN-2026-05-20.md
@@ -1,6 +1,8 @@
 # Work Plan - 2026-05-20
 
-**Purpose:** current execution plan after Wave 3 implementation completion, with queue truth and stop rules.
+> STATUS: Historical handoff. Superseded by [WORK-PLAN-2026-05-21.md](WORK-PLAN-2026-05-21.md).
+
+**Purpose:** historical execution plan after Wave 3 implementation completion, with queue truth and stop rules.
 **Snapshot time:** 2026-05-20 17:30 UTC.
 
 ## Verified State

--- a/docs/current-state/WORK-PLAN-2026-05-20.md
+++ b/docs/current-state/WORK-PLAN-2026-05-20.md
@@ -1,13 +1,13 @@
 # Work Plan - 2026-05-20
 
 **Purpose:** current execution plan after Wave 3 implementation completion, with queue truth and stop rules.
-**Snapshot time:** 2026-05-20 05:54 UTC.
+**Snapshot time:** 2026-05-20 17:30 UTC.
 
 ## Verified State
 
 - `main` is synced with `origin/main` (`0 0` divergence).
 - Open PRs: `0`.
-- Open issues: `66`.
+- Open issues: `63`.
 - Open `track-b` + `aurora-v2` issues: `13`.
 - Closed today on Track B:
   - `#81` via PR `#102` evidence reconciliation
@@ -18,13 +18,17 @@
 
 ## Key Risk To Manage
 
-`origin/aurora/v2` is currently far from `origin/main` (`18` ahead / `62` behind; large tree delta). Treat this as an intentional branch-isolation reality for now, but do not attempt broad cross-track merges until an explicit branch-integration strategy is chosen.
+`origin/aurora/v2` is currently far from `origin/main` (`18` ahead / `69` behind; large tree delta). Treat this as an intentional branch-isolation reality for now, but do not attempt broad cross-track merges until an explicit branch-integration strategy is chosen.
+
+The placeholder `agent-pr-generator.yml` workflow is now parked as a manual, read-only diagnostic stub. Adding `auto-implement` no longer starts simulated automation or commits `.github/agent-state` files.
 
 ## Execution Order (Next Round)
 
 Strategy reference for this round:
 
 - `docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md` (summer-2026 benchmark + feature sequencing for Track B)
+- `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md` (repo-truth, debt, live-fix, and workflow reconciliation)
+- `docs/current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md` (motion budget and #86 QA expectations)
 
 ### 1) Run `#86` QA gate on real staging (Track B, final lane)
 
@@ -61,6 +65,7 @@ git rev-list --left-right --count main...origin/main
 git worktree list --porcelain
 gh pr list --state open --limit 50
 gh issue list --state open --limit 100
+gh run list --limit 10
 ```
 
 ## Stop Rules

--- a/docs/current-state/WORK-PLAN-2026-05-21.md
+++ b/docs/current-state/WORK-PLAN-2026-05-21.md
@@ -63,6 +63,7 @@ Done when:
 - a fresh full-site backup exists,
 - DB/plugins/themes/uploads are accounted for,
 - restore proof is documented,
+- `make backup-check BACKUP_DIR=backup/YYYY-MM-DD STRICT=1` passes,
 - [FIX_QUEUE.md](FIX_QUEUE.md) P0.1 can be marked satisfied.
 
 This blocks `/llms.txt`, robots, homepage H1/alt text, Work OG/slug cleanup, sidebar promo deploy, and any Notion-to-WP production publish.
@@ -118,6 +119,7 @@ git status --short --branch
 git rev-list --left-right --count origin/aurora/v2...origin/main
 gh pr list --state open --limit 50
 gh issue list --state open --limit 200
+make backup-check BACKUP_DIR=backup/2026-05-16
 php plugins/kk-sidebar-promos/tests/smoke.php
 scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
 ```

--- a/docs/current-state/WORK-PLAN-2026-05-21.md
+++ b/docs/current-state/WORK-PLAN-2026-05-21.md
@@ -1,0 +1,123 @@
+# Work Plan - 2026-05-21
+
+**Purpose:** close out the diagnostic/polish branch, keep documentation tidy, and define the next meaningful operating slice.
+**Snapshot time:** 2026-05-21, verified from local git and GitHub CLI.
+**Branch:** `codex/diagnostic-polish-2026-05-20`
+
+## Verified State
+
+- Current branch is clean and tracking `origin/codex/diagnostic-polish-2026-05-20`.
+- Branch commits shipped so far:
+  - `897d8fa ops: ship diagnostic polish pass`
+  - `398432a fix: harden sidebar promo rendering`
+  - `c8a8511 test: cover sidebar promo selection`
+- Open PRs: `0`.
+- Open issues: `63`.
+- Open issues with `auto-implement`: `47`. This is now a historical intent label only; it does not start the parked Agent PR Generator.
+- Open `track-b` + `aurora-v2` issues: `13`.
+- Open `needs-human-review` issues: `3`.
+- Open `swarm-ready` issues: `13`.
+- Open `swarm-parked` issues: `11`.
+- Open `priority:high` issues: `28`.
+- `origin/aurora/v2` is `18` ahead and `69` behind `origin/main`.
+- Live WordPress writes remain blocked until fresh backup and restore proof exists.
+
+## What This Branch Shipped
+
+- Parked `.github/workflows/agent-pr-generator.yml` as a manual, read-only diagnostic stub.
+- Updated agent-facing docs so the old GitHub Actions swarm is historical, while `test-pr.yml` remains active PR validation.
+- Added the diagnostic/polish truth refresh:
+  - [DIAGNOSTIC-POLISH-2026-05-20.md](DIAGNOSTIC-POLISH-2026-05-20.md)
+  - [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md)
+  - [AURORA-MOTION-GOVERNANCE-2026-05-20.md](AURORA-MOTION-GOVERNANCE-2026-05-20.md)
+- Hardened `plugins/kk-sidebar-promos/`:
+  - attachment alt text is respected,
+  - image fallback is intentionally decorative instead of title-duplicating,
+  - shortcode/block/widget limits normalize consistently,
+  - featured/expiry/pillar selection behavior has smoke coverage.
+
+## Documentation Tidy Decisions
+
+- Treat this file as the current next-session front door.
+- Keep [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) and [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) as historical handoffs, not active plans.
+- Keep the May 14 baseline docs as the frozen site snapshot; use dated addenda for current truth.
+- Keep January/early-May architecture, automation, Cloudways, and old roadmap docs as historical reference only. They already carry historical banners and should not be followed as current workflow.
+- Do not delete audit evidence, rollback snapshots, raw fetches, or historical postmortems just because they are old. Delete only scratch files, generated temp files, duplicate status sheets, or untracked local artifacts.
+
+## Next Work Order
+
+### 1. Open and review this branch
+
+Goal: get the diagnostic, workflow parking, docs cleanup, and sidebar promo hardening reviewed as one coherent maintenance branch.
+
+Done when:
+- the pushed branch has a PR or an explicit merge path,
+- reviewers can see the branch scope without reading chat logs,
+- no production WordPress changes are implied by the merge.
+
+### 2. Complete the backup/restore proof gate
+
+Goal: make Track A production work safe again.
+
+Done when:
+- a fresh full-site backup exists,
+- DB/plugins/themes/uploads are accounted for,
+- restore proof is documented,
+- [FIX_QUEUE.md](FIX_QUEUE.md) P0.1 can be marked satisfied.
+
+This blocks `/llms.txt`, robots, homepage H1/alt text, Work OG/slug cleanup, sidebar promo deploy, and any Notion-to-WP production publish.
+
+### 3. Finish Aurora issue `#86`
+
+Goal: decide whether Aurora is ready to advance beyond local QA.
+
+Done when:
+- staging uses production-like media,
+- desktop/mobile screenshots are captured,
+- keyboard/focus, reduced-motion, contrast, overflow, media, console, and performance notes are recorded,
+- production activation blockers are filed or cleared.
+
+Use:
+- [AURORA-SOTA-ROADMAP-2026-05-20.md](AURORA-SOTA-ROADMAP-2026-05-20.md)
+- [AURORA-MOTION-GOVERNANCE-2026-05-20.md](AURORA-MOTION-GOVERNANCE-2026-05-20.md)
+
+### 4. Run the first safe Track A polish batch
+
+Goal: apply small high-trust public-site fixes after the backup gate is proven.
+
+Recommended order:
+1. Add `/llms.txt`.
+2. Choose and deploy the robots AI-crawler stance.
+3. Fix homepage H1 behavior and top empty image alts.
+4. Fix Work URL/canonical/OG mismatch.
+5. Deploy `kk-sidebar-promos` only with rollback instructions.
+
+### 5. Prepare the community-proof polish pass
+
+Goal: make the site feel more like Kris's living field desk and less like a template.
+
+Candidate slices:
+- event states: upcoming, recently passed, recording available, sold out;
+- Work card metadata: year, role, community, artifact, outcome;
+- field-note navigation: related notes, next useful link, copy-link affordances;
+- warmer sidebar/footer modules for current gatherings, talks, and community proof.
+
+## Stop Rules
+
+1. No live WordPress writes before backup/restore proof.
+2. No theme file changes on `main`.
+3. No broad `aurora/v2` merge into `main` without an explicit cutover plan.
+4. No issue closure without evidence or a clear superseded note.
+5. No extra roadmap docs unless an existing current plan cannot hold the information.
+
+## Useful Startup Commands
+
+```bash
+git fetch --prune
+git status --short --branch
+git rev-list --left-right --count origin/aurora/v2...origin/main
+gh pr list --state open --limit 50
+gh issue list --state open --limit 200
+php plugins/kk-sidebar-promos/tests/smoke.php
+scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
+```

--- a/plugins/kk-sidebar-promos/DEPLOYMENT.md
+++ b/plugins/kk-sidebar-promos/DEPLOYMENT.md
@@ -35,6 +35,17 @@ If Luma changes the URL format and the sync starts failing, the plugin logs an a
 - 4 published Pillar promos: Animation Accelerator, RAP Certification, BC+AI Membership, Vancouver AI Community.
 - Two daily WP-Cron jobs: `kk_sp_expire_featured` and `kk_sp_luma_sync`.
 
+## Pre-deploy checks
+
+Run these locally before zipping or uploading the plugin:
+
+```bash
+php plugins/kk-sidebar-promos/tests/smoke.php
+find plugins/kk-sidebar-promos -name '*.php' -print0 | xargs -0 -n1 php -l
+```
+
+The smoke test covers the no-promos empty state, featured-image alt handling, featured-promo expiry behavior, and the Luma iCal parser without requiring a full WordPress install.
+
 ## Replacing the existing sidebar graphics
 
 Once the block is rendering, edit each of the seeded Pillar promos and:

--- a/plugins/kk-sidebar-promos/DEPLOYMENT.md
+++ b/plugins/kk-sidebar-promos/DEPLOYMENT.md
@@ -44,7 +44,7 @@ php plugins/kk-sidebar-promos/tests/smoke.php
 find plugins/kk-sidebar-promos -name '*.php' -print0 | xargs -0 -n1 php -l
 ```
 
-The smoke test covers limit normalization, the no-promos empty state, featured-image alt handling, featured-promo expiry behavior, and the Luma iCal parser without requiring a full WordPress install.
+The smoke test covers limit normalization, selection and weekly pillar rotation, the no-promos empty state, featured-image alt handling, featured-promo expiry behavior, and the Luma iCal parser without requiring a full WordPress install.
 
 ## Replacing the existing sidebar graphics
 

--- a/plugins/kk-sidebar-promos/DEPLOYMENT.md
+++ b/plugins/kk-sidebar-promos/DEPLOYMENT.md
@@ -44,7 +44,7 @@ php plugins/kk-sidebar-promos/tests/smoke.php
 find plugins/kk-sidebar-promos -name '*.php' -print0 | xargs -0 -n1 php -l
 ```
 
-The smoke test covers the no-promos empty state, featured-image alt handling, featured-promo expiry behavior, and the Luma iCal parser without requiring a full WordPress install.
+The smoke test covers limit normalization, the no-promos empty state, featured-image alt handling, featured-promo expiry behavior, and the Luma iCal parser without requiring a full WordPress install.
 
 ## Replacing the existing sidebar graphics
 

--- a/plugins/kk-sidebar-promos/assets/css/sidebar-promos.css
+++ b/plugins/kk-sidebar-promos/assets/css/sidebar-promos.css
@@ -42,12 +42,10 @@
 	border: 1px solid var(--kk-sp-border);
 	border-radius: var(--kk-sp-radius);
 	overflow: hidden;
-	transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+	transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.kk-sp__card:hover,
 .kk-sp__card:focus-within {
-	transform: translateY(-2px);
 	box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.3);
 	border-color: color-mix(in srgb, var(--kk-sp-accent) 40%, var(--kk-sp-border));
 }
@@ -59,8 +57,8 @@
 }
 
 .kk-sp__link:focus-visible {
-	outline: 2px solid var(--kk-sp-accent);
-	outline-offset: 2px;
+	outline: 3px solid var(--kk-sp-accent);
+	outline-offset: -3px;
 }
 
 /* Image */
@@ -121,11 +119,6 @@
 	color: var(--kk-sp-accent);
 }
 
-.kk-sp__card:hover .kk-sp__cta span[aria-hidden] {
-	transform: translateX(2px);
-	transition: transform 0.2s ease;
-}
-
 /* Tone variants tint the accent so similar promos read together. */
 .kk-sp__card--tone-event    { --kk-sp-accent: var(--kk-sp-event); }
 .kk-sp__card--tone-course   { --kk-sp-accent: var(--kk-sp-course); }
@@ -147,6 +140,23 @@
 	display: block;
 	height: 6px;
 	background: linear-gradient(90deg, var(--kk-sp-accent), color-mix(in srgb, var(--kk-sp-accent) 40%, transparent));
+}
+
+@media (hover: hover) and (pointer: fine) {
+	.kk-sp__card {
+		transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+	}
+
+	.kk-sp__card:hover {
+		transform: translateY(-2px);
+		box-shadow: 0 12px 24px -16px rgba(0, 0, 0, 0.3);
+		border-color: color-mix(in srgb, var(--kk-sp-accent) 40%, var(--kk-sp-border));
+	}
+
+	.kk-sp__card:hover .kk-sp__cta span[aria-hidden] {
+		transform: translateX(2px);
+		transition: transform 0.2s ease;
+	}
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/plugins/kk-sidebar-promos/includes/render.php
+++ b/plugins/kk-sidebar-promos/includes/render.php
@@ -108,16 +108,17 @@ function kk_sp_render( $args = [] ) {
 			$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
 			$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
 			$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
-			$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
-			$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
-			$thumb_id  = get_post_thumbnail_id( $p->ID );
-			$has_image = (bool) $thumb_id;
-			$classes   = [
-				'kk-sp__card',
-				'kk-sp__card--' . $type,
-				'kk-sp__card--tone-' . $tone,
-				$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
-			];
+				$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
+				$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
+				$thumb_id  = get_post_thumbnail_id( $p->ID );
+				$has_image = (bool) $thumb_id;
+				$image_alt = $has_image ? kk_sp_get_image_alt( $thumb_id ) : '';
+				$classes   = [
+					'kk-sp__card',
+					'kk-sp__card--' . $type,
+					'kk-sp__card--tone-' . $tone,
+					$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
+				];
 			?>
 			<article class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php if ( $link ) : ?>
@@ -133,7 +134,7 @@ function kk_sp_render( $args = [] ) {
 							[
 								'class'   => 'kk-sp__image',
 								'loading' => 'lazy',
-								'alt'     => esc_attr( get_the_title( $p ) ),
+								'alt'     => $image_alt,
 							]
 						); ?>
 						<?php if ( $type === 'featured' && $end ) : ?>
@@ -162,6 +163,12 @@ function kk_sp_render( $args = [] ) {
 	</div>
 	<?php
 	return (string) ob_get_clean();
+}
+
+function kk_sp_get_image_alt( $thumb_id ) {
+	$alt = trim( (string) get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) );
+
+	return $alt;
 }
 
 function kk_sp_format_until( $end ) {

--- a/plugins/kk-sidebar-promos/includes/render.php
+++ b/plugins/kk-sidebar-promos/includes/render.php
@@ -101,27 +101,27 @@ function kk_sp_render( $args = [] ) {
 	wp_enqueue_style( 'kk-sidebar-promos' );
 
 	ob_start();
-		?>
-		<div class="kk-sp">
-			<?php if ( ! empty( $args['title'] ) ) : ?>
-				<h2 class="kk-sp__heading"><?php echo esc_html( $args['title'] ); ?></h2>
-			<?php endif; ?>
-			<?php foreach ( $promos as $p ) :
-				$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
-				$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
-				$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
-				$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
-				$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
-				$thumb_id  = get_post_thumbnail_id( $p->ID );
-				$has_image = (bool) $thumb_id;
-				$image_alt = $has_image ? kk_sp_get_image_alt( $thumb_id ) : '';
-				$classes   = [
-					'kk-sp__card',
-					'kk-sp__card--' . $type,
-					'kk-sp__card--tone-' . $tone,
-					$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
-				];
-				?>
+	?>
+	<div class="kk-sp">
+		<?php if ( ! empty( $args['title'] ) ) : ?>
+			<h2 class="kk-sp__heading"><?php echo esc_html( $args['title'] ); ?></h2>
+		<?php endif; ?>
+		<?php foreach ( $promos as $p ) :
+			$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
+			$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
+			$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
+			$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
+			$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
+			$thumb_id  = get_post_thumbnail_id( $p->ID );
+			$has_image = (bool) $thumb_id;
+			$image_alt = $has_image ? kk_sp_get_image_alt( $thumb_id ) : '';
+			$classes   = [
+				'kk-sp__card',
+				'kk-sp__card--' . $type,
+				'kk-sp__card--tone-' . $tone,
+				$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
+			];
+			?>
 			<article class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php if ( $link ) : ?>
 					<a href="<?php echo esc_url( $link ); ?>" class="kk-sp__link" rel="noopener">

--- a/plugins/kk-sidebar-promos/includes/render.php
+++ b/plugins/kk-sidebar-promos/includes/render.php
@@ -21,6 +21,7 @@ add_action( 'widgets_init', 'kk_sp_register_widget' );
 add_action( 'init', 'kk_sp_register_block' );
 
 function kk_sp_get_promos( $limit = 4 ) {
+	$limit = kk_sp_normalize_limit( $limit );
 	$today = current_time( 'Y-m-d' );
 	$out   = [];
 
@@ -91,7 +92,8 @@ function kk_sp_render( $args = [] ) {
 		'title' => '',
 	] );
 
-	$promos = kk_sp_get_promos( (int) $args['limit'] );
+	$limit  = kk_sp_normalize_limit( $args['limit'] );
+	$promos = kk_sp_get_promos( $limit );
 	if ( ! $promos ) {
 		return '';
 	}
@@ -99,15 +101,15 @@ function kk_sp_render( $args = [] ) {
 	wp_enqueue_style( 'kk-sidebar-promos' );
 
 	ob_start();
-	?>
-	<div class="kk-sp">
-		<?php if ( ! empty( $args['title'] ) ) : ?>
-			<h2 class="kk-sp__heading"><?php echo esc_html( $args['title'] ); ?></h2>
-		<?php endif; ?>
-		<?php foreach ( $promos as $p ) :
-			$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
-			$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
-			$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
+		?>
+		<div class="kk-sp">
+			<?php if ( ! empty( $args['title'] ) ) : ?>
+				<h2 class="kk-sp__heading"><?php echo esc_html( $args['title'] ); ?></h2>
+			<?php endif; ?>
+			<?php foreach ( $promos as $p ) :
+				$type      = get_post_meta( $p->ID, KK_SP_META_TYPE, true ) ?: 'pillar';
+				$tone      = get_post_meta( $p->ID, KK_SP_META_TONE, true ) ?: 'default';
+				$link      = get_post_meta( $p->ID, KK_SP_META_LINK, true );
 				$cta       = get_post_meta( $p->ID, KK_SP_META_CTA, true );
 				$end       = get_post_meta( $p->ID, KK_SP_META_END, true );
 				$thumb_id  = get_post_thumbnail_id( $p->ID );
@@ -119,7 +121,7 @@ function kk_sp_render( $args = [] ) {
 					'kk-sp__card--tone-' . $tone,
 					$has_image ? 'kk-sp__card--has-image' : 'kk-sp__card--text-only',
 				];
-			?>
+				?>
 			<article class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>">
 				<?php if ( $link ) : ?>
 					<a href="<?php echo esc_url( $link ); ?>" class="kk-sp__link" rel="noopener">
@@ -163,6 +165,12 @@ function kk_sp_render( $args = [] ) {
 	</div>
 	<?php
 	return (string) ob_get_clean();
+}
+
+function kk_sp_normalize_limit( $limit ) {
+	$limit = (int) $limit;
+
+	return max( 1, min( 8, $limit ) );
 }
 
 function kk_sp_get_image_alt( $thumb_id ) {
@@ -218,7 +226,7 @@ function kk_sp_register_block() {
 		],
 		'render_callback' => static function ( $attrs ) {
 			return kk_sp_render( [
-				'limit' => isset( $attrs['limit'] ) ? (int) $attrs['limit'] : 4,
+				'limit' => isset( $attrs['limit'] ) ? kk_sp_normalize_limit( $attrs['limit'] ) : 4,
 				'title' => isset( $attrs['title'] ) ? (string) $attrs['title'] : '',
 			] );
 		},
@@ -236,7 +244,7 @@ class KK_SP_Widget extends WP_Widget {
 
 	public function widget( $args, $instance ) {
 		$title = $instance['title'] ?? '';
-		$limit = (int) ( $instance['limit'] ?? 4 );
+		$limit = kk_sp_normalize_limit( $instance['limit'] ?? 4 );
 		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo kk_sp_render( [ 'limit' => $limit, 'title' => $title ] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -244,7 +252,7 @@ class KK_SP_Widget extends WP_Widget {
 
 	public function form( $instance ) {
 		$title = $instance['title'] ?? '';
-		$limit = (int) ( $instance['limit'] ?? 4 );
+		$limit = kk_sp_normalize_limit( $instance['limit'] ?? 4 );
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Heading (optional):', 'kk-sidebar-promos' ); ?></label>
@@ -260,7 +268,7 @@ class KK_SP_Widget extends WP_Widget {
 	public function update( $new, $old ) {
 		return [
 			'title' => sanitize_text_field( $new['title'] ?? '' ),
-			'limit' => max( 1, min( 8, (int) ( $new['limit'] ?? 4 ) ) ),
+			'limit' => kk_sp_normalize_limit( $new['limit'] ?? 4 ),
 		];
 	}
 }

--- a/plugins/kk-sidebar-promos/kk-sidebar-promos.php
+++ b/plugins/kk-sidebar-promos/kk-sidebar-promos.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KK Sidebar Promos
  * Plugin URI:        https://github.com/WalksWithASwagger/kriskrug-wp
  * Description:       Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the rest. Pulls the next Vancouver AI meetup from Luma automatically. Block, classic widget, and [kk_sidebar_promos] shortcode all available.
- * Version:           0.1.1
+ * Version:           0.1.2
  * Requires at least: 6.2
  * Requires PHP:      7.4
  * Author:            Kris Krüg
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'KK_SP_VERSION', '0.1.1' );
+define( 'KK_SP_VERSION', '0.1.2' );
 define( 'KK_SP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'KK_SP_URL', plugin_dir_url( __FILE__ ) );
 define( 'KK_SP_FILE', __FILE__ );

--- a/plugins/kk-sidebar-promos/kk-sidebar-promos.php
+++ b/plugins/kk-sidebar-promos/kk-sidebar-promos.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KK Sidebar Promos
  * Plugin URI:        https://github.com/WalksWithASwagger/kriskrug-wp
  * Description:       Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the rest. Pulls the next Vancouver AI meetup from Luma automatically. Block, classic widget, and [kk_sidebar_promos] shortcode all available.
- * Version:           0.1.0
+ * Version:           0.1.1
  * Requires at least: 6.2
  * Requires PHP:      7.4
  * Author:            Kris Krüg
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'KK_SP_VERSION', '0.1.0' );
+define( 'KK_SP_VERSION', '0.1.1' );
 define( 'KK_SP_PATH', plugin_dir_path( __FILE__ ) );
 define( 'KK_SP_URL', plugin_dir_url( __FILE__ ) );
 define( 'KK_SP_FILE', __FILE__ );

--- a/plugins/kk-sidebar-promos/readme.txt
+++ b/plugins/kk-sidebar-promos/readme.txt
@@ -4,7 +4,7 @@ Tags: sidebar, widget, promo, automation
 Requires at least: 6.2
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.1.1
+Stable tag: 0.1.2
 License: GPLv2 or later
 
 Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the remaining slots. The next Vancouver AI meetup syncs in from Luma automatically.
@@ -31,6 +31,11 @@ Render via the **KK Sidebar Promos** block, the **KK Sidebar Promos** widget, or
 Run `php plugins/kk-sidebar-promos/tests/smoke.php` before packaging. It checks the no-promos empty state, attachment alt behavior, featured-promo expiry behavior, and Luma iCal parsing without a full WordPress install.
 
 == Changelog ==
+
+= 0.1.2 =
+* Clamp shortcode, block, and widget promo limits to the supported 1-8 range.
+* Refine card focus and hover states so keyboard focus is stable and visible while hover lift stays pointer-only.
+* Expand smoke coverage for limit normalization.
 
 = 0.1.1 =
 * Preserve real attachment alt text in promo images; treat missing alt as decorative instead of repeating the visible promo title.

--- a/plugins/kk-sidebar-promos/readme.txt
+++ b/plugins/kk-sidebar-promos/readme.txt
@@ -35,7 +35,7 @@ Run `php plugins/kk-sidebar-promos/tests/smoke.php` before packaging. It checks 
 = 0.1.2 =
 * Clamp shortcode, block, and widget promo limits to the supported 1-8 range.
 * Refine card focus and hover states so keyboard focus is stable and visible while hover lift stays pointer-only.
-* Expand smoke coverage for limit normalization.
+* Expand smoke coverage for limit normalization, selection, and weekly pillar rotation.
 
 = 0.1.1 =
 * Preserve real attachment alt text in promo images; treat missing alt as decorative instead of repeating the visible promo title.

--- a/plugins/kk-sidebar-promos/readme.txt
+++ b/plugins/kk-sidebar-promos/readme.txt
@@ -4,7 +4,7 @@ Tags: sidebar, widget, promo, automation
 Requires at least: 6.2
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 
 Auto-managed sidebar promo system. Featured promos auto-expire on their end date; evergreen "pillar" promos rotate to fill the remaining slots. The next Vancouver AI meetup syncs in from Luma automatically.
@@ -26,7 +26,15 @@ Render via the **KK Sidebar Promos** block, the **KK Sidebar Promos** widget, or
 3. Go to **Sidebar Promos → Settings** and paste your Luma iCal URL.
 4. Drop the **KK Sidebar Promos** block into your sidebar template (or use the widget / shortcode).
 
+== Development Checks ==
+
+Run `php plugins/kk-sidebar-promos/tests/smoke.php` before packaging. It checks the no-promos empty state, attachment alt behavior, featured-promo expiry behavior, and Luma iCal parsing without a full WordPress install.
+
 == Changelog ==
+
+= 0.1.1 =
+* Preserve real attachment alt text in promo images; treat missing alt as decorative instead of repeating the visible promo title.
+* Add local smoke coverage for rendering empty state, image alt behavior, featured-promo expiry behavior, and Luma iCal parsing.
 
 = 0.1.0 =
 * Initial release: CPT, auto-expiry, Luma iCal sync, block + widget + shortcode, four seeded pillars (Animation Accelerator, RAP Certification, BC + AI Membership, Vancouver AI Community).

--- a/plugins/kk-sidebar-promos/tests/smoke.php
+++ b/plugins/kk-sidebar-promos/tests/smoke.php
@@ -24,6 +24,7 @@ $GLOBALS['kk_sp_test_meta']  = [];
 $GLOBALS['kk_sp_test_posts'] = [];
 $GLOBALS['kk_sp_updated_posts'] = [];
 $GLOBALS['kk_sp_inserted_comments'] = [];
+$GLOBALS['kk_sp_get_posts_handler'] = null;
 
 function add_shortcode() {}
 function add_action() {}
@@ -40,7 +41,11 @@ function current_time( $type ) {
 	return '';
 }
 
-function get_posts() {
+function get_posts( $args = [] ) {
+	if ( is_callable( $GLOBALS['kk_sp_get_posts_handler'] ) ) {
+		return $GLOBALS['kk_sp_get_posts_handler']( $args );
+	}
+
 	return $GLOBALS['kk_sp_test_posts'];
 }
 
@@ -105,6 +110,41 @@ function kk_sp_assert_same( $expected, $actual, $message ) {
 	}
 }
 
+function kk_sp_test_post( $id, $title = '' ) {
+	return (object) [
+		'ID'           => $id,
+		'post_title'   => $title ?: 'Promo ' . $id,
+		'post_excerpt' => '',
+		'post_content' => '',
+	];
+}
+
+function kk_sp_test_ids( $posts ) {
+	return array_map(
+		static function ( $post ) {
+			return is_object( $post ) ? $post->ID : $post;
+		},
+		$posts
+	);
+}
+
+function kk_sp_test_meta_query_value( $query, $value ) {
+	foreach ( $query as $clause ) {
+		if ( is_array( $clause ) && isset( $clause['value'] ) && $clause['value'] === $value ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function kk_sp_test_rotated_pillar_ids( $pillars, $limit ) {
+	$offset  = (int) gmdate( 'W' ) % count( $pillars );
+	$rotated = array_merge( array_slice( $pillars, $offset ), array_slice( $pillars, 0, $offset ) );
+
+	return array_slice( kk_sp_test_ids( $rotated ), 0, $limit );
+}
+
 $GLOBALS['kk_sp_test_meta'][123]['_wp_attachment_image_alt'] = 'Kris speaking at a packed Vancouver AI meetup.';
 kk_sp_assert_same( 1, kk_sp_normalize_limit( 0 ), 'Limit should never fall below one card.' );
 kk_sp_assert_same( 4, kk_sp_normalize_limit( 4 ), 'Limit should preserve normal values.' );
@@ -123,6 +163,62 @@ kk_sp_assert_same( '', kk_sp_get_image_alt( 999 ), 'Missing attachment alt shoul
 
 kk_sp_assert_same( '', kk_sp_render(), 'Rendering should be empty when no promos are published.' );
 
+$featured = kk_sp_test_post( 101, 'Featured event' );
+$pillars  = [
+	kk_sp_test_post( 201, 'Pillar one' ),
+	kk_sp_test_post( 202, 'Pillar two' ),
+	kk_sp_test_post( 203, 'Pillar three' ),
+	kk_sp_test_post( 204, 'Pillar four' ),
+];
+$GLOBALS['kk_sp_get_posts_handler'] = static function ( $args ) use ( $featured, $pillars ) {
+	$meta_query = $args['meta_query'] ?? [];
+	if ( kk_sp_test_meta_query_value( $meta_query, 'featured' ) ) {
+		return [ $featured ];
+	}
+	if ( kk_sp_test_meta_query_value( $meta_query, 'pillar' ) ) {
+		$excluded = $args['post__not_in'] ?? [];
+
+		return array_values( array_filter(
+			$pillars,
+			static function ( $post ) use ( $excluded ) {
+				return ! in_array( $post->ID, $excluded, true );
+			}
+		) );
+	}
+
+	return [];
+};
+
+kk_sp_assert_same(
+	array_merge( [ 101 ], kk_sp_test_rotated_pillar_ids( $pillars, 3 ) ),
+	kk_sp_test_ids( kk_sp_get_promos( 4 ) ),
+	'Featured promo should lead, then rotated pillars should fill remaining slots.'
+);
+kk_sp_assert_same(
+	[ 101 ],
+	kk_sp_test_ids( kk_sp_get_promos( 0 ) ),
+	'Normalized limit of one should return only the featured promo when one exists.'
+);
+
+$GLOBALS['kk_sp_get_posts_handler'] = static function ( $args ) use ( $pillars ) {
+	$meta_query = $args['meta_query'] ?? [];
+	if ( kk_sp_test_meta_query_value( $meta_query, 'featured' ) ) {
+		return [];
+	}
+	if ( kk_sp_test_meta_query_value( $meta_query, 'pillar' ) ) {
+		return $pillars;
+	}
+
+	return [];
+};
+
+kk_sp_assert_same(
+	kk_sp_test_rotated_pillar_ids( $pillars, 3 ),
+	kk_sp_test_ids( kk_sp_get_promos( 3 ) ),
+	'Pillars should fill all visible slots when there is no featured promo.'
+);
+
+$GLOBALS['kk_sp_get_posts_handler'] = null;
 $GLOBALS['kk_sp_test_posts'] = [ 321, 322 ];
 kk_sp_expire_featured_promos();
 kk_sp_assert_same(

--- a/plugins/kk-sidebar-promos/tests/smoke.php
+++ b/plugins/kk-sidebar-promos/tests/smoke.php
@@ -106,6 +106,11 @@ function kk_sp_assert_same( $expected, $actual, $message ) {
 }
 
 $GLOBALS['kk_sp_test_meta'][123]['_wp_attachment_image_alt'] = 'Kris speaking at a packed Vancouver AI meetup.';
+kk_sp_assert_same( 1, kk_sp_normalize_limit( 0 ), 'Limit should never fall below one card.' );
+kk_sp_assert_same( 4, kk_sp_normalize_limit( 4 ), 'Limit should preserve normal values.' );
+kk_sp_assert_same( 8, kk_sp_normalize_limit( 99 ), 'Limit should never exceed eight cards.' );
+kk_sp_assert_same( 1, kk_sp_normalize_limit( 'not-a-number' ), 'Limit should coerce invalid values to one card.' );
+
 kk_sp_assert_same(
 	'Kris speaking at a packed Vancouver AI meetup.',
 	kk_sp_get_image_alt( 123 ),

--- a/plugins/kk-sidebar-promos/tests/smoke.php
+++ b/plugins/kk-sidebar-promos/tests/smoke.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Lightweight smoke tests for pure KK Sidebar Promos behavior.
+ *
+ * These tests intentionally stub the small WordPress surface they need so they
+ * can run in this repo without a full WordPress install.
+ */
+
+define( 'ABSPATH', __DIR__ . '/wp-stub/' );
+define( 'DAY_IN_SECONDS', 86400 );
+define( 'HOUR_IN_SECONDS', 3600 );
+define( 'KK_SP_POST_TYPE', 'kk_sidebar_promo' );
+define( 'KK_SP_META_TYPE', '_kk_sp_type' );
+define( 'KK_SP_META_TONE', '_kk_sp_tone' );
+define( 'KK_SP_META_LINK', '_kk_sp_link' );
+define( 'KK_SP_META_CTA', '_kk_sp_cta' );
+define( 'KK_SP_META_END', '_kk_sp_end' );
+define( 'KK_SP_META_SOURCE', '_kk_sp_source' );
+define( 'KK_SP_META_SOURCE_ID', '_kk_sp_source_id' );
+
+class WP_Widget {}
+
+$GLOBALS['kk_sp_test_meta']  = [];
+$GLOBALS['kk_sp_test_posts'] = [];
+$GLOBALS['kk_sp_updated_posts'] = [];
+$GLOBALS['kk_sp_inserted_comments'] = [];
+
+function add_shortcode() {}
+function add_action() {}
+function register_widget() {}
+function register_block_type() {}
+
+function current_time( $type ) {
+	if ( $type === 'Y-m-d' ) {
+		return gmdate( 'Y-m-d', strtotime( '2026-05-20 12:00:00 UTC' ) );
+	}
+	if ( $type === 'timestamp' ) {
+		return strtotime( '2026-05-20 12:00:00 UTC' );
+	}
+	return '';
+}
+
+function get_posts() {
+	return $GLOBALS['kk_sp_test_posts'];
+}
+
+function wp_list_pluck( $list, $field ) {
+	return array_map(
+		static function ( $item ) use ( $field ) {
+			return is_object( $item ) ? $item->{$field} : $item[ $field ];
+		},
+		$list
+	);
+}
+
+function wp_parse_args( $args, $defaults ) {
+	return array_merge( $defaults, $args );
+}
+
+function wp_next_scheduled() {
+	return false;
+}
+
+function wp_schedule_event() {}
+function wp_unschedule_event() {}
+
+function wp_update_post( $post_data ) {
+	$GLOBALS['kk_sp_updated_posts'][] = $post_data;
+
+	return $post_data['ID'] ?? 0;
+}
+
+function wp_insert_comment( $comment_data ) {
+	$GLOBALS['kk_sp_inserted_comments'][] = $comment_data;
+
+	return count( $GLOBALS['kk_sp_inserted_comments'] );
+}
+
+function get_post_meta( $post_id, $key, $single = false ) {
+	return $GLOBALS['kk_sp_test_meta'][ $post_id ][ $key ] ?? '';
+}
+
+function __( $text ) {
+	return $text;
+}
+
+function wp_trim_words( $text, $num_words = 55, $more = null ) {
+	$words = preg_split( '/\s+/', trim( $text ) );
+	if ( count( $words ) <= $num_words ) {
+		return $text;
+	}
+	return implode( ' ', array_slice( $words, 0, $num_words ) ) . ( $more ?? '...' );
+}
+
+require_once dirname( __DIR__ ) . '/includes/render.php';
+require_once dirname( __DIR__ ) . '/includes/luma-sync.php';
+require_once dirname( __DIR__ ) . '/includes/cron.php';
+
+function kk_sp_assert_same( $expected, $actual, $message ) {
+	if ( $expected !== $actual ) {
+		fwrite( STDERR, $message . PHP_EOL );
+		fwrite( STDERR, 'Expected: ' . var_export( $expected, true ) . PHP_EOL );
+		fwrite( STDERR, 'Actual:   ' . var_export( $actual, true ) . PHP_EOL );
+		exit( 1 );
+	}
+}
+
+$GLOBALS['kk_sp_test_meta'][123]['_wp_attachment_image_alt'] = 'Kris speaking at a packed Vancouver AI meetup.';
+kk_sp_assert_same(
+	'Kris speaking at a packed Vancouver AI meetup.',
+	kk_sp_get_image_alt( 123 ),
+	'Attachment alt text should be preserved.'
+);
+
+$GLOBALS['kk_sp_test_meta'][124]['_wp_attachment_image_alt'] = '   ';
+kk_sp_assert_same( '', kk_sp_get_image_alt( 124 ), 'Blank attachment alt should stay decorative.' );
+kk_sp_assert_same( '', kk_sp_get_image_alt( 999 ), 'Missing attachment alt should stay decorative.' );
+
+kk_sp_assert_same( '', kk_sp_render(), 'Rendering should be empty when no promos are published.' );
+
+$GLOBALS['kk_sp_test_posts'] = [ 321, 322 ];
+kk_sp_expire_featured_promos();
+kk_sp_assert_same(
+	[
+		[ 'ID' => 321, 'post_status' => 'draft' ],
+		[ 'ID' => 322, 'post_status' => 'draft' ],
+	],
+	$GLOBALS['kk_sp_updated_posts'],
+	'Expired featured promos should be moved to draft.'
+);
+kk_sp_assert_same( 2, count( $GLOBALS['kk_sp_inserted_comments'] ), 'Expired promos should get audit comments.' );
+$GLOBALS['kk_sp_test_posts'] = [];
+
+$ical = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:event-1\r\nDTSTART;TZID=America/Vancouver:20260605T183000\r\nSUMMARY:Vancouver AI\\, Community Night\r\nURL:https://lu.ma/example\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
+$events = kk_sp_parse_ical( $ical );
+kk_sp_assert_same( 1, count( $events ), 'One VEVENT should parse.' );
+kk_sp_assert_same( 'event-1', $events[0]['uid'], 'VEVENT UID should parse.' );
+kk_sp_assert_same( 'Vancouver AI, Community Night', $events[0]['summary'], 'Escaped commas should be unescaped.' );
+kk_sp_assert_same( 'https://lu.ma/example', $events[0]['url'], 'VEVENT URL should parse.' );
+
+echo "KK Sidebar Promos smoke tests passed." . PHP_EOL;

--- a/scripts/verify-backup-set.sh
+++ b/scripts/verify-backup-set.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -u
+
+allow_incomplete=0
+
+if [[ "${1:-}" == "--allow-incomplete" ]]; then
+  allow_incomplete=1
+  shift
+fi
+
+backup_dir="${1:-}"
+
+if [[ -z "$backup_dir" ]]; then
+  echo "Usage: $0 [--allow-incomplete] backup/YYYY-MM-DD" >&2
+  exit 2
+fi
+
+errors=0
+warnings=0
+
+fail() {
+  echo "ERROR: $*"
+  errors=$((errors + 1))
+}
+
+warn() {
+  echo "WARN: $*"
+  warnings=$((warnings + 1))
+}
+
+ok() {
+  echo "OK: $*"
+}
+
+has_match() {
+  compgen -G "$backup_dir/$1" >/dev/null
+}
+
+require_match() {
+  local pattern="$1"
+  local label="$2"
+
+  if has_match "$pattern"; then
+    ok "$label present"
+  else
+    fail "$label missing ($pattern)"
+  fi
+}
+
+if [[ ! -d "$backup_dir" ]]; then
+  fail "Backup directory not found: $backup_dir"
+  echo "Backup gate failed."
+  exit 1
+fi
+
+if [[ -f "$backup_dir/manifest.md" ]]; then
+  ok "manifest.md present"
+else
+  fail "manifest.md missing"
+fi
+
+if [[ -f "$backup_dir/manifest-checksums.txt" ]]; then
+  ok "manifest-checksums.txt present"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$backup_dir" && sha256sum -c manifest-checksums.txt) || fail "checksum verification failed"
+  elif command -v shasum >/dev/null 2>&1; then
+    (cd "$backup_dir" && shasum -a 256 -c manifest-checksums.txt) || fail "checksum verification failed"
+  else
+    warn "No sha256sum or shasum command found; checksum verification skipped"
+  fi
+else
+  fail "manifest-checksums.txt missing"
+fi
+
+if has_match "*.wpress"; then
+  ok "All-in-One WP Migration archive present"
+else
+  require_match "*-db.gz" "database archive"
+  require_match "*-plugins.zip" "plugins archive"
+  require_match "*-themes.zip" "themes archive"
+  require_match "*-mu-plugins.zip" "mu-plugins archive"
+  require_match "*-others.zip" "others archive"
+
+  if has_match "*-uploads.zip" || has_match "uploads.*" || [[ -d "$backup_dir/uploads" ]]; then
+    ok "uploads archive or uploads directory present"
+  elif [[ -f "$backup_dir/manifest.md" ]] && grep -Eiq 'uploads.*(skipped|deferred|missing|pagely|ssh|scp)' "$backup_dir/manifest.md"; then
+    warn "uploads are absent but explicitly accounted for in manifest.md"
+  else
+    fail "uploads archive missing and no explicit deferral found in manifest.md"
+  fi
+fi
+
+if [[ -f "$backup_dir/restore-notes.md" ]]; then
+  ok "restore-notes.md present"
+else
+  if [[ "$allow_incomplete" -eq 1 ]]; then
+    warn "restore-notes.md missing; archive can be inspected but the production-write gate is not satisfied"
+  else
+    fail "restore-notes.md missing; restore proof is required before production writes"
+  fi
+fi
+
+echo ""
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "Backup gate failed with $errors error(s) and $warnings warning(s)."
+  exit 1
+fi
+
+if [[ "$warnings" -gt 0 ]]; then
+  echo "Backup set inspected with $warnings warning(s)."
+else
+  echo "Backup gate passed."
+fi


### PR DESCRIPTION
## Summary

This maintenance branch closes the May 20 diagnostic/polish pass without touching live WordPress.

It:
- parks `.github/workflows/agent-pr-generator.yml` as a manual read-only diagnostic stub so `auto-implement` labels no longer trigger placeholder automation;
- refreshes agent-facing docs and current-state handoffs around repo truth, workflow status, live-fix status, Aurora motion governance, and the May 21 work plan;
- hardens `kk-sidebar-promos` rendering and selection behavior;
- adds smoke coverage for empty render behavior, image alt semantics, Luma feed parsing, featured/expiry selection, pillar fallback, and weekly pillar rotation;
- adds `scripts/verify-backup-set.sh` plus `make backup-check` so backup archives can be inspected separately from the strict production-write gate.

## Why

The repo had become conceptually aligned but operationally noisy: old docs, active-looking parked automation, live WordPress fix-state drift, and Aurora handoff state all competed for attention. This PR gives future agents one clearer front door, makes the sidebar promo plugin safer to deploy later, and turns the backup/restore requirement into a checkable local gate.

## Production Safety

No production WordPress content, theme state, snippets, redirects, media, or database records were changed.

Live WordPress writes remain blocked until fresh backup and restore proof exists. The new May 21 work plan and backup verifier keep that as the first Track A gate.

## Verification

Passed locally:

```bash
git diff --check
git diff --cached --check
bash -n scripts/verify-backup-set.sh
make backup-check BACKUP_DIR=backup/2026-05-16
make help | rg 'backup-check'
php plugins/kk-sidebar-promos/tests/smoke.php
find inc plugins fixes -name '*.php' -print0 | xargs -0 -n1 php -l
scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
make agent-status
```

Expected gate behavior verified:

```bash
make backup-check BACKUP_DIR=backup/2026-05-16 STRICT=1
```

That strict command correctly fails today because `backup/2026-05-16/` has no `restore-notes.md` and the uploads archive was skipped. The archive can be inspected, but it still does not satisfy the production-write gate.

## Next After Merge

1. Complete the backup/restore proof gate.
2. Finish Aurora `#86` staging QA with production-like media.
3. Run the first safe Track A polish batch: `/llms.txt`, robots AI stance, homepage H1/alts, Work OG/slug cleanup, and sidebar promo deploy with rollback notes.
