### PR TITLE
[codex] Require explicit restore proof marker

### DIFF
--- a/docs/current-state/BACKUP_PLAN.md
+++ b/docs/current-state/BACKUP_PLAN.md
@@ -101,10 +101,24 @@ A backup that's never been restored is a hope, not a backup. After the first arc
 1. Spin up **Local by Flywheel** (or Docker) — see `docs/local-development-setup.md`.
 2. Restore the archive into the local instance.
 3. Confirm: homepage renders, an arbitrary recent post renders, wp-admin opens, plugin settings are intact.
-4. Note any breakage in `backup/<date>/restore-notes.md`.
+4. Note the result in `backup/<date>/restore-notes.md`.
 5. Run `make backup-check BACKUP_DIR=backup/<date> STRICT=1`.
 
 Until step 4 is done, the backup is unverified.
+
+Strict mode requires the restore notes to include one of these markers:
+
+```yaml
+restore_status: passed
+```
+
+or:
+
+```yaml
+production_write_gate: passed
+```
+
+Use `failed` or omit the marker when the restore is incomplete.
 
 ## Cadence going forward
 

--- a/scripts/verify-backup-set.sh
+++ b/scripts/verify-backup-set.sh
@@ -93,6 +93,14 @@ fi
 
 if [[ -f "$backup_dir/restore-notes.md" ]]; then
   ok "restore-notes.md present"
+
+  if [[ "$allow_incomplete" -eq 0 ]]; then
+    if grep -Eiq '^(restore_status|production_write_gate):[[:space:]]*passed[[:space:]]*$' "$backup_dir/restore-notes.md"; then
+      ok "restore proof is marked passed"
+    else
+      fail "restore-notes.md must include 'restore_status: passed' or 'production_write_gate: passed'"
+    fi
+  fi
 else
   if [[ "$allow_incomplete" -eq 1 ]]; then
     warn "restore-notes.md missing; archive can be inspected but the production-write gate is not satisfied"


### PR DESCRIPTION
## Summary

Small follow-up to the backup gate verifier merged in #111.

This PR:
- requires strict backup verification to find either `restore_status: passed` or `production_write_gate: passed` in `backup/<date>/restore-notes.md`;
- documents that marker in `docs/current-state/BACKUP_PLAN.md`.

## Why

The original strict verifier required `restore-notes.md` to exist, but an empty or placeholder file could satisfy that check. This keeps the production-write gate honest: restore notes must explicitly say the restore passed.

## Verification

Passed locally:

```bash
bash -n scripts/verify-backup-set.sh
git diff --check
```

Fixture behavior verified:

```bash
# restore_status: failed -> strict verifier fails with marker error
# restore_status: passed -> strict verifier passes, with expected uploads warning
```

Existing May 16 backup behavior verified:

```bash
make backup-check BACKUP_DIR=backup/2026-05-16
make backup-check BACKUP_DIR=backup/2026-05-16 STRICT=1
```

Non-strict inspection passes with warnings; strict mode still correctly fails because no restore drill has been documented yet.