### PR TITLE
[codex] Guard Notion Feature category routing

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-05-21.md
+++ b/docs/current-state/WORK-PLAN-2026-05-21.md
@@ -73,13 +73,13 @@ Current evidence:
 - `--update` is explicit,
 - slug lookup and title-similarity guards exist,
 - tests cover the title-similarity guard,
+- `Type=Feature` category routing uses tag hints or explicit `--category`, and ambiguous Feature posts abort before live WP writes,
 - GitHub issue `#75` still has six open acceptance criteria.
 
 Done when:
 - the exposed WordPress application password is rotated and the old credential no longer works,
 - a repo secret scan is documented,
 - publishing docs require dry-run and review before live connector runs,
-- Feature/category behavior is safe or requires explicit override,
 - next-post inventory reconciles live WP, local draft packs, and Notion rows,
 - no `--publish` run happens until KK signs off on a reviewed WP draft.
 

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -53,6 +53,9 @@ pip install -r requirements.txt
 # Dry-run: writes content/drafts/<slug>/, prints REST payload, does NOT post
 python kk_notion_to_wp.py --dry-run https://www.notion.so/<page-id>
 
+# Dry-run with an explicit category decision
+python kk_notion_to_wp.py --dry-run --category "AI Ethics & Philosophy" https://www.notion.so/<page-id>
+
 # Live: also uploads images, creates a DRAFT post on kriskrug.co
 python kk_notion_to_wp.py https://www.notion.so/<page-id>
 
@@ -63,6 +66,18 @@ python kk_notion_to_wp.py --publish https://www.notion.so/<page-id>
 python kk_notion_to_wp.py --update https://www.notion.so/<page-id>
 ```
 
+## Live-write gate
+
+Do not run the connector against production WordPress until all of these are true:
+
+1. `make backup-check BACKUP_DIR=backup/YYYY-MM-DD STRICT=1` passes.
+2. A dry-run package has been reviewed in `content/drafts/<slug>/`.
+3. The target slug, title, category, and update/create intent are verified.
+4. For `Type=Feature`, the category is intentional: either the tags route it clearly or `--category` is passed.
+5. `--publish` is only used after KK signs off on the reviewed WP draft.
+
+Without WordPress credentials the command is always effectively dry-run only.
+
 ## Notion property mapping
 
 KK's "News & Content Database" has these properties; the connector reads them:
@@ -72,7 +87,7 @@ KK's "News & Content Database" has these properties; the connector reads them:
 | Title | post title | required |
 | AI summary | excerpt (→ meta description) | falls back to Summary if absent |
 | Tags | tags | auto-created if missing |
-| Type | category routing | `Report` → "Vancouver AI Ecosystem"; others → "Misc" until categorized |
+| Type | category routing | Known types map directly; `Feature` uses tag hints or requires `--category`; unknown types fall back to "Misc" only for non-Feature content. |
 | Featured | post meta `kk_featured` | "YES" sets it |
 | Status | publish context | recorded from Notion, but not a publish gate |
 | Publication Date | post date | if absent, uses today |
@@ -89,6 +104,27 @@ Default behavior is CREATE-only:
 - To update an existing post, pass `--update`. The update path also checks that the existing title is similar to the new title before it sends a REST update. The current threshold lives in `TITLE_SIMILARITY_UPDATE_THRESHOLD` and is covered by tests.
 
 This makes reruns safe by default. If you need a new version rather than an update, pass `--slug` with a new slug.
+
+## Category routing
+
+Known Notion types map directly:
+
+| Notion Type | WP Category |
+|---|---|
+| `Report` | `Vancouver AI Ecosystem` |
+| `Manifesto` | `AI Ethics & Philosophy` |
+| `Interview` | `Conversations & Interviews` |
+| `Tutorial` | `AI for Creatives` |
+| `Field Note` | `Field Notes` |
+
+`Feature` is intentionally guarded. It routes from obvious tags:
+
+- community/event tags such as `BC + AI`, `Comox`, `Vancouver AI`, `Web Summit`, `Recap` → `Vancouver AI Ecosystem`
+- ethics/certification tags such as `AI Ethics`, `Responsible AI`, `Certification` → `AI Ethics & Philosophy`
+- creative workflow tags such as `Creative`, `Artist`, `Tools`, `Workflow` → `AI for Creatives`
+- appearance tags such as `Interview`, `Podcast`, `Media` → `Conversations & Interviews`
+
+If a `Feature` post has ambiguous tags, dry-run output is marked `NEEDS CATEGORY REVIEW`, and live mode aborts before uploading media or creating a WP draft. Re-run with `--category "..."` after the editorial decision.
 
 ## Local tests
 

--- a/scripts/notion-to-wp/kk_notion_to_wp.py
+++ b/scripts/notion-to-wp/kk_notion_to_wp.py
@@ -30,6 +30,8 @@ Usage:
         --title "Custom Title"        Override the title derived from Notion
         --slug custom-slug            Override the slug derived from the title
         --date 2026-05-07T11:37:33    Override the post date
+        --category "AI Ethics & Philosophy"
+                                      Override Notion Type → WP category routing
 
 Auth:
     - Notion: NOTION_TOKEN from scripts/notion-to-wp/.env OR
@@ -536,12 +538,74 @@ TYPE_TO_CATEGORY = {
     "Field Note": "Field Notes",
 }
 
+CATEGORY_REVIEW_REQUIRED = "NEEDS CATEGORY REVIEW"
+
+FEATURE_CATEGORY_TAG_HINTS = (
+    ("Vancouver AI Ecosystem", (
+        "bc + ai",
+        "comox",
+        "community spotlight",
+        "industry",
+        "recap",
+        "vancouver ai",
+        "web summit",
+    )),
+    ("AI Ethics & Philosophy", (
+        "ai ethics",
+        "certification",
+        "responsible ai",
+        "sovereign ai",
+        "values",
+    )),
+    ("AI for Creatives", (
+        "artist",
+        "creative",
+        "creatives",
+        "tools",
+        "workflow",
+    )),
+    ("Conversations & Interviews", (
+        "appearance",
+        "interview",
+        "media",
+        "podcast",
+    )),
+)
+
+
+def resolve_category(
+    type_notion: str,
+    tags_notion: list[str],
+    category_override: str | None = None,
+) -> tuple[str, str]:
+    override = (category_override or "").strip()
+    if override:
+        return override, "override"
+
+    notion_type = (type_notion or "").strip()
+    if notion_type in TYPE_TO_CATEGORY:
+        return TYPE_TO_CATEGORY[notion_type], f"type:{notion_type}"
+
+    if notion_type.lower() == "feature":
+        tags_text = " ".join(str(tag).lower() for tag in (tags_notion or []))
+        for category, hints in FEATURE_CATEGORY_TAG_HINTS:
+            if any(hint in tags_text for hint in hints):
+                return category, "feature-tags"
+        return CATEGORY_REVIEW_REQUIRED, "feature-needs-category"
+
+    return "Misc", "fallback"
+
+
+def category_requires_review(category_name: str) -> bool:
+    return category_name == CATEGORY_REVIEW_REQUIRED
+
 
 def run(notion_url: str, dry_run: bool, force_publish: bool,
         allow_update: bool = False,
         title_override: str | None = None,
         slug_override: str | None = None,
-        date_override: str | None = None) -> int:
+        date_override: str | None = None,
+        category_override: str | None = None) -> int:
     cfg = load_config()
     nclient = Notion(cfg.notion_token)
     page_id = parse_page_id(notion_url)
@@ -631,7 +695,11 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
     meta_desc = excerpt  # Jetpack accepts up to ~300 chars; same source as excerpt for consistency
     seo_title = text_polish.polish_text(derive_seo_title(title, max_chars=60))
 
-    category_name = TYPE_TO_CATEGORY.get(type_notion, "Misc")
+    category_name, category_route = resolve_category(type_notion, tags_notion, category_override)
+    log(
+        f"category route: Type={type_notion!r}, tags={tags_notion!r} "
+        f"→ {category_name!r} ({category_route})"
+    )
 
     frontmatter = {
         "title": title,
@@ -700,6 +768,14 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
         log(json.dumps({**payload, "content": payload["content"][:400] + "...(truncated)"}, indent=2)[:2000])
         log("To publish: add WP_USER + WP_APP_PASSWORD to scripts/notion-to-wp/.env and re-run without --dry-run.")
         return 0
+
+    if category_requires_review(category_name):
+        log("ABORTING: Notion Type=Feature needs an explicit category decision before a live WP write.")
+        log(
+            'Re-run with --category "AI Ethics & Philosophy", '
+            '--category "Vancouver AI Ecosystem", or another intentional category.'
+        )
+        return 4
 
     # 6. Live mode — upload images, then create/update post
     wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
@@ -882,6 +958,11 @@ def main():
                    help="Override the post slug (otherwise slugified from title).")
     p.add_argument("--date", default=None,
                    help="Override the post date, ISO format e.g. 2026-05-07T11:37:33.")
+    p.add_argument(
+        "--category",
+        default=None,
+        help="Override Notion Type → WP category routing. Required for Feature posts when tags are ambiguous.",
+    )
     args = p.parse_args()
     sys.exit(run(
         args.notion_url,
@@ -891,6 +972,7 @@ def main():
         title_override=args.title,
         slug_override=args.slug,
         date_override=args.date,
+        category_override=args.category,
     ))
 
 

--- a/scripts/notion-to-wp/tests/test_category_routing.py
+++ b/scripts/notion-to-wp/tests/test_category_routing.py
@@ -1,0 +1,56 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import kk_notion_to_wp  # noqa: E402
+
+
+class CategoryRoutingTests(unittest.TestCase):
+    def test_known_type_routes_directly(self):
+        category, route = kk_notion_to_wp.resolve_category("Report", [])
+
+        self.assertEqual(category, "Vancouver AI Ecosystem")
+        self.assertEqual(route, "type:Report")
+
+    def test_explicit_override_wins(self):
+        category, route = kk_notion_to_wp.resolve_category(
+            "Feature",
+            ["AI Ethics"],
+            category_override="Field Notes",
+        )
+
+        self.assertEqual(category, "Field Notes")
+        self.assertEqual(route, "override")
+
+    def test_feature_routes_from_community_tags(self):
+        category, route = kk_notion_to_wp.resolve_category(
+            "Feature",
+            ["BC + AI", "Comox", "Community Spotlight"],
+        )
+
+        self.assertEqual(category, "Vancouver AI Ecosystem")
+        self.assertEqual(route, "feature-tags")
+
+    def test_feature_routes_from_ethics_tags(self):
+        category, route = kk_notion_to_wp.resolve_category(
+            "Feature",
+            ["Responsible AI", "Certification"],
+        )
+
+        self.assertEqual(category, "AI Ethics & Philosophy")
+        self.assertEqual(route, "feature-tags")
+
+    def test_ambiguous_feature_requires_review(self):
+        category, route = kk_notion_to_wp.resolve_category("Feature", [])
+
+        self.assertEqual(category, kk_notion_to_wp.CATEGORY_REVIEW_REQUIRED)
+        self.assertEqual(route, "feature-needs-category")
+        self.assertTrue(kk_notion_to_wp.category_requires_review(category))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR advances issue #75 by making Notion `Type=Feature` category handling explicit instead of silently falling into `Misc`.

It:
- adds `--category` as an explicit publisher override;
- routes obvious Feature posts from tag hints into existing editorial categories;
- marks ambiguous Feature dry-runs as `NEEDS CATEGORY REVIEW`;
- aborts live WordPress writes for ambiguous Feature posts before media upload or WP draft creation;
- documents the live-write gate in the connector README;
- adds focused unit tests for category routing.

## Production Safety

No live WordPress requests were made. This only changes the local connector and docs.

Live publishing remains blocked by the backup/restore proof gate and issue #75's remaining acceptance criteria.

## Verification

Passed locally:

```bash
git diff --check
scripts/notion-to-wp/.venv/bin/python -m py_compile scripts/notion-to-wp/kk_notion_to_wp.py scripts/notion-to-wp/tests/test_category_routing.py
scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
```

Unit test count increased from 6 to 11.

## Remaining #75 Work

- Rotate/revoke the exposed WordPress application password.
- Document a repo secret scan.
- Reconcile live WP, local draft packs, and Notion rows before choosing the next post.
- Keep `--publish` blocked until KK signs off on a reviewed WP draft.