### PR TITLE
[codex] Prepare issue swarm closeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# BC+AI Development Makefile
+# kriskrug-wp Development Makefile
 # Quick access to common development commands
 
 .PHONY: help test validate health issues pr dashboard stats agent-status backup-check clean
@@ -7,7 +7,7 @@
 .DEFAULT_GOAL := help
 
 help: ## Show this help message
-	@echo "🌲 BC+AI Development Commands"
+	@echo "kriskrug-wp Development Commands"
 	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo ""
@@ -75,7 +75,7 @@ list-workflows: ## List recent workflow runs
 	@gh run list --limit 10
 
 stats: ## Show repository statistics
-	@echo "📊 BC+AI Repository Stats"
+	@echo "kriskrug-wp Repository Stats"
 	@echo ""
 	@echo "Issues:"
 	@gh issue list --state all --json number --jq '. | length' | xargs -I {} echo "  Total: {}"
@@ -127,14 +127,14 @@ clean: ## Clean up test artifacts and temporary files
 	@echo "✓ Cleanup complete"
 
 setup: ## Initial setup for new contributors
-	@echo "🌲 Setting up BC+AI development environment..."
+	@echo "Setting up kriskrug-wp development environment..."
 	@echo ""
 	@bash skills/github-workflow-automation/scripts/gh_health_check.sh
 	@echo ""
 	@echo "✅ Setup complete! Run 'make help' to see available commands."
 
 quick-start: ## Quick start guide for new contributors
-	@echo "🌲 Welcome to BC+AI Development!"
+	@echo "Welcome to kriskrug-wp development!"
 	@echo ""
 	@echo "Quick commands to get you started:"
 	@echo "  make health       - Check system health"

--- a/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
+++ b/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
@@ -1,8 +1,8 @@
 # Issue Swarm Roadmap - 2026-05-19
 
 **Prepared:** 2026-05-19
-**Last refreshed:** 2026-05-20 (UTC, diagnostic polish pass)
-**Queue snapshot (as of 2026-05-20 17:30 UTC):** 63 open issues, 0 open PRs
+**Last refreshed:** 2026-05-21 (post-PR `#113` and branch cleanup)
+**Queue snapshot (as of 2026-05-21):** 63 open issues, 0 open PRs
 **Scope:** Convert the current backlog into bounded parallel lanes with clear stop rules.
 
 ## Assumptions
@@ -20,6 +20,21 @@
 - `needs-human-review`: `3` (`#23`, `#75`, `#95`)
 - `swarm-ready`: `13`
 - `swarm-parked`: `11`
+- `swarm-wave-1`: `7`
+- `swarm-wave-2`: `4`
+- `swarm-wave-3`: `2`
+- Open PRs: `0`
+- Branch hygiene: merged remote `codex/swarm-*` branches from PRs `#102`-`#106` were deleted; only `main` and `aurora/v2` remain as remote heads.
+
+## Swarm Launch Protocol
+
+Use this before assigning agents:
+
+1. Run `git fetch --prune`, `gh pr list --state open --limit 50`, `gh issue list --state open --limit 200`, and `git worktree list --porcelain`.
+2. Keep the main checkout clean; create one isolated worktree per lane.
+3. If PRs appear, inspect checks, draft state, scope, and issue linkage before editing.
+4. Do not start `needs-human-review`, live WordPress, or Aurora activation work without the relevant gate cleared.
+5. Leave concise GitHub breadcrumbs for start, blocker, fix, and final state.
 
 ## Roadmap Issues Added
 
@@ -37,7 +52,8 @@ Goal: remove ambiguity before implementation.
 
 - Normalize canonical issue mappings (old design tickets to Aurora epics).
 - Mark issues as `swarm-ready` vs `swarm-parked`.
-- Keep `#23` and `#75` explicitly blocked for human review.
+- Keep `#23`, `#75`, and `#95` explicitly blocked for human review or backup proof.
+- Keep branch cleanup evidence in the handoff before deleting more refs.
 
 Primary issues:
 
@@ -98,7 +114,7 @@ Current gate note (2026-05-20):
 
 - `#84` closed after PR `#104` merged to `aurora/v2`.
 - `#85` closed after PR `#103` inventory plus PR `#105` component implementation merged to `aurora/v2`.
-- `#86` has local QA evidence from PR `#106` and remains open for real staging QA with production-like media, backup, and rollback evidence.
+- `#86` has local QA evidence from PR `#106` and remains open for real staging QA with production-like media, backup, and rollback evidence. Do not treat it as a generic quick-win issue.
 
 ### Lane 4 - Track A Content Sprint (parallel after Aurora Wave 1)
 
@@ -123,6 +139,15 @@ Done when:
 
 - Each issue has a narrow proof artifact or patch.
 - Any broad/refactor-shaped scope is split into smaller follow-up issues.
+- No lane performs a live WordPress write before the backup/restore proof gate passes.
+
+### Lane 6 - Duplicate and shipped-scope reconciliation
+
+Goal: reduce queue noise before another broad wave.
+
+- Verify whether `#3`, `#12`, and `#16` are already satisfied by merged work; close only with evidence.
+- Consolidate Work/Projects scope across `#17` and `#68`.
+- Consolidate photography/archive scope across `#21`, `#30`, and `#59`.
 
 ## Stop Rules
 
@@ -138,12 +163,13 @@ Done when:
 - `swarm-parked`: intentionally deferred / broad / dependency-heavy
 - `swarm-wave-1`: Aurora Wave 1 + first Track A quick wins
 - `swarm-wave-2`: second execution wave
+- `swarm-wave-3`: final hardening/QA wave
 
 Note: `auto-implement` is now a historical intent label only. `agent-pr-generator.yml` no longer auto-runs from that label.
-- `swarm-wave-3`: final hardening/QA wave
 
 ## Notes
 
 - Legacy design issues `#24-#35` remain open but routed; they are not standalone build targets.
 - `docs/current-state/AURORA-ISSUE-SWARM-2026-05-19.md` now reflects Wave 1/2/3 progress through PRs `#93/#94/#100/#101/#102/#103/#104/#105/#106`.
 - Media appearances are parked in `#95` until the fresh full-site backup gate is cleared; see `APPEARANCES-ROUNDUP-WP-DRAFT-BLOCKED-2026-05-19.md`.
+- PR `#113` satisfies the Feature/category routing slice of the publishing-trust gate, but `#75` remains open for credential, scan, backup, inventory, and publish sign-off evidence.

--- a/docs/current-state/WORK-PLAN-2026-05-21.md
+++ b/docs/current-state/WORK-PLAN-2026-05-21.md
@@ -1,18 +1,20 @@
 # Work Plan - 2026-05-21
 
-**Purpose:** current post-merge operating plan after the diagnostic/polish closeout, docs tidy pass, and backup-gate hardening.
-**Snapshot time:** 2026-05-21, refreshed after PRs `#111` and `#112` merged.
+**Purpose:** current post-merge operating plan after the diagnostic/polish closeout, backup-gate hardening, Notion category guard, and swarm-readiness cleanup.
+**Snapshot time:** 2026-05-21, refreshed after PRs `#111`, `#112`, and `#113` merged plus branch cleanup.
 **Branch:** `main`
 
 ## Verified State
 
 - `main` is synced with `origin/main`.
 - Latest `main` commits:
+  - `0ed28d4 fix: guard notion feature categories`
+  - `f0f6014 docs: refresh post-merge work plan`
   - `c08b271 tools: require restore proof marker`
-  - `2d49dae ops: ship diagnostic polish closeout`
 - Merged PRs:
   - `#111` diagnostic polish, workflow parking, docs refresh, sidebar promo hardening, and backup verifier
   - `#112` strict backup verifier marker hardening
+  - `#113` Feature/category routing guard for the Notion-to-WP connector
 - Open PRs: `0`.
 - Open issues: `63`.
 - Open issues with `auto-implement`: `47`. This is now a historical intent label only; it does not start the parked Agent PR Generator.
@@ -21,8 +23,9 @@
 - Open `swarm-ready` issues: `13`.
 - Open `swarm-parked` issues: `11`.
 - Open `priority:high` issues: `28`.
-- `origin/aurora/v2` is `18` ahead and `71` behind `origin/main`.
+- `origin/aurora/v2` is `18` ahead and `72` behind `origin/main`.
 - Active worktrees: primary `main` checkout plus one locked Aurora agent worktree on `aurora/v2`.
+- Visible stale worktrees were removed; merged remote `codex/swarm-*` branches from PRs `#102`-`#106` were deleted; local stale Aurora carryover branches were deleted after confirming they are contained in `origin/aurora/v2`.
 - Live WordPress writes remain blocked until fresh backup and restore proof exists.
 
 ## What Shipped
@@ -40,6 +43,8 @@
   - featured/expiry/pillar selection behavior has smoke coverage.
 - Added `scripts/verify-backup-set.sh` and `make backup-check`.
 - Tightened strict backup verification so `restore-notes.md` must explicitly include `restore_status: passed` or `production_write_gate: passed`.
+- Guarded Notion `Type=Feature` category routing so ambiguous Feature posts require an explicit `--category` decision before live WordPress writes.
+- Pruned merged branch clutter so the visible repo state is ready for isolated issue/PR swarm lanes.
 
 ## Documentation Tidy Decisions
 
@@ -128,6 +133,18 @@ Recommended order:
 3. Batch small `swarm-ready` issues (`#8`, `#9`, `#10`, `#36`, `#43`, `#48`) only after confirming none require live writes before the backup gate.
 4. Re-triage `#49`-`#64` as product/strategy epics or park them explicitly.
 
+### 7. Swarm from clean lanes
+
+Goal: let agents work all day without colliding in the shared checkout.
+
+Protocol:
+1. Start every swarm with `git fetch --prune`, `gh pr list`, `gh issue list`, and `git worktree list`.
+2. Treat the PR queue as empty until `gh pr list` says otherwise; for new PRs, inspect checks, draft state, scope, and issue linkage before touching code.
+3. Create one isolated worktree per issue lane; never let workers edit the main checkout directly.
+4. Use wave 1 for repo-safe quick wins (`#8`, `#9`, `#10`, `#36`, `#43`, `#48`).
+5. Use wave 2 for content/source-pack lanes (`#13`, `#14`, `#15`, `#18`) and duplicate reconciliation (`#12`, `#16`, `#17`/`#68`).
+6. Keep blocked lanes (`#23`, `#75`, `#95`, live WordPress writes, Aurora activation/staging promotion) out of autonomous implementation until the human or backup gate clears them.
+
 ## Stop Rules
 
 1. No live WordPress writes before backup/restore proof.
@@ -135,7 +152,8 @@ Recommended order:
 3. No broad `aurora/v2` merge into `main` without an explicit cutover plan.
 4. No issue closure without evidence or a clear superseded note.
 5. No extra roadmap docs unless an existing current plan cannot hold the information.
-6. Do not delete branches or worktrees without an explicit cleanup command, even when they appear stale.
+6. Do not delete branches or worktrees without an explicit cleanup command and merge/containment evidence.
+7. No issue-worker swarm starts until the main checkout is clean and the queue has been refreshed live.
 
 ## Useful Startup Commands
 
@@ -145,6 +163,7 @@ git status --short --branch
 git rev-list --left-right --count origin/aurora/v2...origin/main
 gh pr list --state open --limit 50
 gh issue list --state open --limit 200
+git worktree list --porcelain
 make backup-check BACKUP_DIR=backup/2026-05-16
 php plugins/kk-sidebar-promos/tests/smoke.php
 scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests


### PR DESCRIPTION
## Summary
- refresh the current work plan after PR #113 and branch cleanup
- document the GitHub-first swarm launch protocol and current queue counts
- rename stale BC+AI Makefile labels to kriskrug-wp

## Verification
- `make test`
- `php plugins/kk-sidebar-promos/tests/smoke.php`
- `git diff --check`
- `gh pr list --state open --limit 50`
- `git worktree list --porcelain`

Refs #75
