### PR TITLE
Aurora theme v1.3.0 — reconciled line (proof-trail→dek, #116 homepage fix, /blog archive)

### DIFF
--- a/docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md
+++ b/docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md
@@ -1,0 +1,56 @@
+# Aurora v3 — Local QA results + roadmap (2026-05-24)
+
+Branch `aurora/v3-reconcile` (theme **kk-aurora 1.3.0**), QA'd on Local (localhost:10003)
+via rendered-HTML inspection + DB checks. This is the reconciled line: the rescued 1.2.0
+build + proof-trail/dek fix + #116 reveal hardening. Deploy zip staged at `~/Desktop/kk-aurora.zip`.
+
+## What shipped in v3 (and QA verdict)
+
+| Item | What changed | Local QA |
+|---|---|---|
+| **#117 `/blog/` archive** | 1.2.0's `home.html` is a real query-loop archive | ✅ 9 post cards, query blocks, no homepage-hero markers |
+| **Proof-trail removed** | deleted the hardcoded "Proof trail: reported from…" line | ✅ 0 occurrences site-wide |
+| **Author-controlled dek** | `core/post-excerpt` + `render_block` filter (`manual_excerpt_dek_only`) shows the dek **only** when a manual `post_excerpt` exists | ✅ shows on posts w/ excerpt; **blank** on posts without (verified vs DB) |
+| **#116 homepage reveal** | hide is JS-injected (safe-fail) + new rAF pass reveals in-viewport on first frame | ✅ no static `opacity:0` served; v1.3.0 JS enqueued. Runtime visual confirm pending on prod |
+| No regressions | Speaking 200, 404 works | ✅ |
+
+**Deploy status:** zip built, awaiting KK's wp-admin upload (native file picker = KK's step;
+SFTP still blocked). After upload + Pagely purge: verify prod logged-out, then remove the
+Customizer force-visible band-aid (the homepage fix is now in-theme).
+
+## Decisions captured
+
+- **Do NOT blind-port `aurora/v2`'s fix-commits.** v2's launch-fix batch (`feb2003`) and
+  `dd2f428` (retire hero pattern) overlap with — and in places conflict with — 1.2.0 (which
+  keeps `hero-gradient.php` and already has `home.html`). QA passed on 1.2.0 without them.
+  Treat any v2 port as a per-file, QA-driven decision, not a merge. (Original task #15 → folded here.)
+- **Local DB is partial** (`/work/` absent locally; only ~9 posts) — pagination on `/blog/`
+  couldn't be exercised locally. Re-verify pagination + the archive at scale on prod.
+
+## Roadmap — next Aurora work (prioritized)
+
+### P0 — finish this deploy
+- [ ] KK uploads `~/Desktop/kk-aurora.zip` (Appearance → Themes → Add New → Upload → Replace).
+- [ ] Pagely "Purge All Caches + CDN"; verify `/`, `/blog/`, a post (dek + no proof-trail) logged-out w/ cache-bust.
+- [ ] Visual: homepage hero visible on 5 cold loads; then **remove Customizer band-aid CSS**.
+
+### P1 — remaining launch polish (open issues, now unblocked once /blog + homepage are sound)
+- [ ] **#118** duplicate H1 on generic `page.html`. · **#121** low-contrast body text (WCAG AA).
+- [ ] **#119** host canonical proof images (Upgrade-AI 400 black card) · **#120** Both Hands Full card overlap.
+- [ ] **Hardcoded "Field note" label** (`single.html` L24) — same generic-stamp smell as the
+  proof-trail; replace with the post's real category or remove. (KK flagged proof-trail; this is its sibling.)
+
+### P2 — verify/measure
+- [ ] **#127** mobile/responsive QA on real device/breakpoints (nav→hamburger, hero crop, grids, gallery columns).
+- [ ] **#125** Lighthouse (LCP/INP/CLS); consider self-hosting GSAP.
+- [ ] **#117 at scale**: `/blog/` pagination + category archives once live with all posts.
+
+### P3 — content-as-DB (per the 2026-05-24 architecture decision)
+- The ~25 undesigned pages (#122) should be **page content via REST** reusing Aurora classes,
+  NOT new theme templates — no theme deploys, KK-editable. Convert Services off its legacy
+  template when editability is wanted.
+
+## Branch / artifacts
+- `aurora/v3-reconcile`: `3c31272` (rescue) · `577c7fb` (dek) · `52a4f80` (#116) · `9f0dfd0` (1.3.0)
+- Backup of the original untracked 1.2.0: `docs/current-state/aurora-1.2.0-untracked-backup-20260524.tgz`
+- Deploy zip: `~/Desktop/kk-aurora.zip` (kk-aurora 1.3.0)

--- a/theme/kk-aurora/IMPLEMENTATION-PLAN.md
+++ b/theme/kk-aurora/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,629 @@
+# KK AURORA Theme - Implementation Plan
+
+> Award-Winning Cyberpunk WordPress Theme for kriskrug.co
+
+**Version:** 1.0.0
+**Target:** WordPress 6.9+ Full Site Editing
+**Status:** In Development
+
+---
+
+## Vision Statement
+
+AURORA is a custom WordPress FSE theme that embodies the intersection of art, AI, and Indigenous wisdom. It features flowing cyberpunk gradients, deep space aesthetics, and purposeful motion design that creates an unforgettable digital experience while maintaining WCAG 2.1 AA accessibility.
+
+**Design Philosophy:**
+- Every pixel serves a purpose
+- Motion enhances understanding, never distracts
+- Accessibility is non-negotiable
+- Performance is a feature
+- The gradient is the signature
+
+---
+
+## Technical Architecture
+
+### Theme Type: Full Site Editing (FSE) Block Theme
+
+```
+kk-aurora/
+├── style.css                 # Theme header + base styles
+├── theme.json                # Design tokens, settings, styles
+├── functions.php             # Enqueues, block registration
+├── screenshot.png            # Theme preview (1200x900)
+├── readme.txt                # WordPress.org description
+│
+├── templates/                # Full page templates
+│   ├── index.html            # Default/fallback
+│   ├── home.html             # Homepage
+│   ├── single.html           # Single post
+│   ├── page.html             # Single page
+│   ├── archive.html          # Archive/category
+│   ├── search.html           # Search results
+│   └── 404.html              # Error page
+│
+├── parts/                    # Reusable template parts
+│   ├── header.html           # Site header
+│   ├── footer.html           # Site footer
+│   ├── sidebar.html          # Optional sidebar
+│   └── comments.html         # Comments section
+│
+├── patterns/                 # Block patterns
+│   ├── hero-gradient.php     # Hero with animated gradient
+│   ├── card-glow.php         # Card with hover glow
+│   ├── stats-counter.php     # Animated statistics
+│   ├── cta-block.php         # Call to action
+│   ├── testimonial.php       # Quote with attribution
+│   └── ...
+│
+├── assets/
+│   ├── css/
+│   │   ├── custom-properties.css   # CSS variables
+│   │   ├── animations.css          # Keyframes, transitions
+│   │   ├── components.css          # Component styles
+│   │   └── utilities.css           # Utility classes
+│   ├── js/
+│   │   ├── aurora-animations.js    # GSAP/ScrollTrigger
+│   │   └── theme.js                # General functionality
+│   ├── fonts/                      # Self-hosted fonts
+│   └── images/                     # Theme images
+│
+└── blocks/                   # Custom blocks (if needed)
+    └── ...
+```
+
+---
+
+## Design System Specification
+
+### Color Palette
+
+```css
+/* ============================================
+   AURORA COLOR SYSTEM
+   Deep space with iridescent accents
+   ============================================ */
+
+/* Background Layers (darkest to lightest) */
+--aurora-void: #000000;           /* True black - reserved for borders/lines */
+--aurora-deep: #0D0D12;           /* Deep space - primary background */
+--aurora-surface: #12121A;        /* Elevated surfaces - cards, modals */
+--aurora-elevated: #1A1A25;       /* Hover states, active elements */
+--aurora-muted: #252532;          /* Disabled states, subtle dividers */
+
+/* Text Hierarchy */
+--aurora-text-primary: #F0F0F5;   /* Headlines, primary content */
+--aurora-text-secondary: #B8B8C8; /* Body text, descriptions */
+--aurora-text-muted: #6B6B80;     /* Captions, metadata, placeholders */
+--aurora-text-disabled: #4A4A5A;  /* Disabled text */
+
+/* The Gradient Spectrum */
+--aurora-cyan: #00E5FF;           /* Primary accent - links, focus */
+--aurora-teal: #00BFA5;           /* Secondary accent - success, CTAs */
+--aurora-purple: #8B5CF6;         /* Tertiary - tags, badges */
+--aurora-pink: #EC4899;           /* Quaternary - highlights, alerts */
+--aurora-blue: #3B82F6;           /* Quinary - info states */
+
+/* The Signature Gradient */
+--aurora-gradient-primary: linear-gradient(135deg, #00E5FF 0%, #00BFA5 50%, #8B5CF6 100%);
+--aurora-gradient-secondary: linear-gradient(135deg, #8B5CF6 0%, #EC4899 100%);
+--aurora-gradient-subtle: linear-gradient(135deg, #00E5FF20 0%, #8B5CF620 100%);
+
+/* Glow Effects */
+--aurora-glow-cyan: 0 0 30px #00E5FF40, 0 0 60px #00E5FF20;
+--aurora-glow-teal: 0 0 30px #00BFA540, 0 0 60px #00BFA520;
+--aurora-glow-purple: 0 0 30px #8B5CF640, 0 0 60px #8B5CF620;
+
+/* Semantic Colors */
+--aurora-success: #00BFA5;
+--aurora-warning: #F59E0B;
+--aurora-error: #EF4444;
+--aurora-info: #3B82F6;
+
+/* Border Colors */
+--aurora-border-subtle: #1F1F2E;
+--aurora-border-default: #2A2A3D;
+--aurora-border-strong: #3A3A50;
+--aurora-border-gradient: linear-gradient(135deg, #00E5FF40 0%, #8B5CF640 100%);
+```
+
+### Typography System
+
+```css
+/* ============================================
+   AURORA TYPOGRAPHY
+   Modern, readable, technical
+   ============================================ */
+
+/* Font Families */
+--font-display: 'Instrument Sans', 'Inter', system-ui, sans-serif;
+--font-body: 'Inter', system-ui, -apple-system, sans-serif;
+--font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+
+/* Font Sizes - Fluid Typography */
+--text-xs: clamp(0.75rem, 0.7rem + 0.25vw, 0.875rem);      /* 12-14px */
+--text-sm: clamp(0.875rem, 0.8rem + 0.35vw, 1rem);         /* 14-16px */
+--text-base: clamp(1rem, 0.9rem + 0.5vw, 1.125rem);        /* 16-18px */
+--text-lg: clamp(1.125rem, 1rem + 0.625vw, 1.25rem);       /* 18-20px */
+--text-xl: clamp(1.25rem, 1.1rem + 0.75vw, 1.5rem);        /* 20-24px */
+--text-2xl: clamp(1.5rem, 1.25rem + 1.25vw, 2rem);         /* 24-32px */
+--text-3xl: clamp(1.875rem, 1.5rem + 1.875vw, 2.5rem);     /* 30-40px */
+--text-4xl: clamp(2.25rem, 1.75rem + 2.5vw, 3rem);         /* 36-48px */
+--text-5xl: clamp(3rem, 2rem + 5vw, 4.5rem);               /* 48-72px */
+--text-hero: clamp(3.5rem, 2.5rem + 7vw, 7rem);            /* 56-112px */
+
+/* Font Weights */
+--weight-normal: 400;
+--weight-medium: 500;
+--weight-semibold: 600;
+--weight-bold: 700;
+--weight-black: 900;
+
+/* Line Heights */
+--leading-none: 1;
+--leading-tight: 1.15;
+--leading-snug: 1.3;
+--leading-normal: 1.5;
+--leading-relaxed: 1.65;
+--leading-loose: 1.8;
+
+/* Letter Spacing */
+--tracking-tighter: -0.03em;
+--tracking-tight: -0.015em;
+--tracking-normal: 0;
+--tracking-wide: 0.015em;
+--tracking-wider: 0.03em;
+```
+
+### Spacing System
+
+```css
+/* ============================================
+   AURORA SPACING
+   8px base unit system
+   ============================================ */
+
+--space-0: 0;
+--space-1: 0.25rem;   /* 4px */
+--space-2: 0.5rem;    /* 8px */
+--space-3: 0.75rem;   /* 12px */
+--space-4: 1rem;      /* 16px */
+--space-5: 1.25rem;   /* 20px */
+--space-6: 1.5rem;    /* 24px */
+--space-8: 2rem;      /* 32px */
+--space-10: 2.5rem;   /* 40px */
+--space-12: 3rem;     /* 48px */
+--space-16: 4rem;     /* 64px */
+--space-20: 5rem;     /* 80px */
+--space-24: 6rem;     /* 96px */
+--space-32: 8rem;     /* 128px */
+--space-40: 10rem;    /* 160px */
+--space-48: 12rem;    /* 192px */
+
+/* Content Width */
+--width-prose: 70ch;            /* Optimal reading width */
+--width-content: 1280px;        /* Main content max */
+--width-wide: 1440px;           /* Wide content max */
+--width-full: 100%;             /* Full width */
+```
+
+### Border & Radius
+
+```css
+/* ============================================
+   AURORA BORDERS & RADIUS
+   Sharp with subtle curves
+   ============================================ */
+
+--radius-none: 0;
+--radius-sm: 0.25rem;    /* 4px - buttons, inputs */
+--radius-md: 0.5rem;     /* 8px - cards, modals */
+--radius-lg: 0.75rem;    /* 12px - large cards */
+--radius-xl: 1rem;       /* 16px - featured sections */
+--radius-2xl: 1.5rem;    /* 24px - hero elements */
+--radius-full: 9999px;   /* Pills, avatars */
+
+--border-width-thin: 1px;
+--border-width-default: 2px;
+--border-width-thick: 3px;
+```
+
+### Shadows & Effects
+
+```css
+/* ============================================
+   AURORA SHADOWS & EFFECTS
+   Glows over traditional shadows
+   ============================================ */
+
+/* Elevation Shadows (subtle) */
+--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.5);
+--shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+--shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.3);
+--shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.25);
+
+/* Glow Shadows (signature) */
+--glow-sm: 0 0 10px var(--aurora-cyan, #00E5FF)20;
+--glow-md: 0 0 20px var(--aurora-cyan, #00E5FF)30;
+--glow-lg: 0 0 30px var(--aurora-cyan, #00E5FF)40, 0 0 60px var(--aurora-cyan, #00E5FF)20;
+
+/* Glass Effect */
+--glass-bg: rgba(18, 18, 26, 0.8);
+--glass-blur: blur(12px);
+--glass-border: 1px solid rgba(255, 255, 255, 0.1);
+
+/* Noise Texture */
+--noise-opacity: 0.03;
+```
+
+### Animation Tokens
+
+```css
+/* ============================================
+   AURORA ANIMATION
+   Smooth, purposeful, respectful
+   ============================================ */
+
+/* Durations */
+--duration-instant: 0ms;
+--duration-fast: 150ms;
+--duration-normal: 300ms;
+--duration-slow: 500ms;
+--duration-slower: 700ms;
+--duration-slowest: 1000ms;
+
+/* Easings */
+--ease-linear: linear;
+--ease-in: cubic-bezier(0.4, 0, 1, 1);
+--ease-out: cubic-bezier(0, 0, 0.2, 1);
+--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+--ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+--ease-smooth: cubic-bezier(0.25, 0.1, 0.25, 1);
+
+/* Gradient Animation */
+--gradient-shift-duration: 15s;
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  --duration-instant: 0ms;
+  --duration-fast: 0ms;
+  --duration-normal: 0ms;
+  --duration-slow: 0ms;
+  --gradient-shift-duration: 0ms;
+}
+```
+
+---
+
+## Component Specifications
+
+### 1. Header/Navigation
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────┐
+│  LOGO          NAV LINKS              CTA BUTTON        │
+│  [KK]    About  Work  Services  Blog    [Let's Talk]    │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Behavior:**
+- Fixed position with glass blur on scroll
+- Logo: Text "KK" with gradient on hover
+- Nav links: Gradient underline slides in on hover
+- CTA: Solid button with gradient border
+- Mobile: Hamburger menu with full-screen overlay
+
+**States:**
+- Default: Transparent background
+- Scrolled: Glass effect (`backdrop-filter: blur(12px)`)
+- Mobile open: Full viewport gradient overlay
+
+### 2. Hero Block
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                          │
+│         Bridging Art, AI,                               │
+│     Indigenous Wisdom & Justice                         │
+│                                                          │
+│     [BC+AI]  [Indigenomics]  [The Upgrade AI]          │
+│                                                          │
+│     [Explore My Work]  [Let's Connect]                  │
+│                                                          │
+│     ↓ Scroll to discover                                │
+│                                                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Visual Effects:**
+- Animated gradient background (slow shift)
+- Floating particles (WebGL or CSS, performance-conscious)
+- Text reveal animation on load
+- Role badges with gradient borders
+- Scroll indicator pulses
+
+### 3. Card Component
+
+**Variants:**
+- **Project Card:** Image + title + description + tags
+- **Blog Card:** Image + category + title + excerpt + date
+- **Stat Card:** Icon + number + label
+- **Service Card:** Icon + title + description + CTA
+
+**Hover Effects:**
+- Lift: `transform: translateY(-4px)`
+- Glow: Gradient shadow appears
+- Border: Becomes gradient
+- Content: Slight scale
+
+### 4. Stats Counter
+
+**Structure:**
+```
+┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐
+│  2,000+  │ │   250+   │ │  $200B+  │ │ Fortune  │
+│ Members  │ │ Monthly  │ │Discovery │ │   500    │
+└──────────┘ └──────────┘ └──────────┘ └──────────┘
+```
+
+**Animation:**
+- Numbers count up when scrolled into view
+- Staggered reveal (left to right)
+- Subtle glow pulse on complete
+
+### 5. CTA Block
+
+**Variants:**
+- **Primary:** Solid gradient background, white text
+- **Secondary:** Transparent with gradient border
+- **Ghost:** Text only with underline
+
+**Hover:**
+- Primary: Glow increases, slight scale
+- Secondary: Background fills with gradient
+- Ghost: Underline extends
+
+### 6. Footer
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────┐
+│  LOGO        LINKS           LINKS         NEWSLETTER   │
+│  [KK]        About           BC+AI         [Email    ]  │
+│              Work            Indigenomics  [Subscribe]  │
+│  Bridging... Services        The Upgrade               │
+│              Blog                                       │
+├─────────────────────────────────────────────────────────┤
+│  © 2026 Kris Krug    ·    Privacy    ·    Accessibility │
+│                                                          │
+│  [Twitter] [LinkedIn] [GitHub] [Instagram]              │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Visual:**
+- Subtle gradient divider at top
+- Glass effect background
+- Social icons with hover glow
+
+---
+
+## Animation Specifications
+
+### Page Load Sequence
+
+```
+0ms     - Page renders with minimal layout
+100ms   - Header fades in
+200ms   - Hero headline reveals (word by word)
+500ms   - Hero description fades up
+700ms   - Role badges stagger in
+900ms   - CTA buttons fade in
+1200ms  - Scroll indicator appears
+```
+
+### Scroll Animations (ScrollTrigger)
+
+| Element | Trigger | Animation |
+|---------|---------|-----------|
+| Section headings | 20% viewport | Fade up + slide |
+| Cards | 15% viewport | Stagger fade up |
+| Stats | 50% viewport | Count up numbers |
+| Images | 10% viewport | Fade + scale |
+| Dividers | 30% viewport | Gradient reveal |
+
+### Hover Animations
+
+| Element | Animation | Duration |
+|---------|-----------|----------|
+| Links | Gradient underline slides | 300ms |
+| Cards | Lift + glow | 300ms |
+| Buttons | Glow increase | 200ms |
+| Nav items | Background fade | 200ms |
+| Social icons | Scale + glow | 200ms |
+
+### Continuous Animations
+
+| Element | Animation | Duration |
+|---------|-----------|----------|
+| Hero gradient | Color shift | 15s loop |
+| Particles | Float + fade | Infinite |
+| Scroll indicator | Pulse | 2s loop |
+| Gradient borders | Rotate | 8s loop |
+
+---
+
+## Accessibility Requirements
+
+### WCAG 2.1 AA Compliance
+
+**Color Contrast:**
+- Normal text: 4.5:1 minimum
+- Large text (18px+): 3:1 minimum
+- UI components: 3:1 minimum
+
+**Tested Combinations:**
+| Background | Foreground | Ratio | Pass |
+|------------|------------|-------|------|
+| #0D0D12 | #F0F0F5 | 15.2:1 | ✓ |
+| #0D0D12 | #B8B8C8 | 8.9:1 | ✓ |
+| #0D0D12 | #00E5FF | 8.7:1 | ✓ |
+| #12121A | #F0F0F5 | 14.1:1 | ✓ |
+| #1A1A25 | #F0F0F5 | 12.3:1 | ✓ |
+
+**Motion:**
+- All animations respect `prefers-reduced-motion`
+- No auto-playing video/audio
+- Animations can be paused
+- No flashing content (< 3 flashes/second)
+
+**Keyboard:**
+- All interactive elements focusable
+- Visible focus indicators (cyan glow ring)
+- Logical tab order
+- Skip navigation link
+- No keyboard traps
+
+**Screen Readers:**
+- Semantic HTML structure
+- ARIA labels where needed
+- Alt text on all images
+- Heading hierarchy (h1 → h2 → h3)
+- Link text is descriptive
+
+---
+
+## Performance Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| LCP | < 2.5s | Largest Contentful Paint |
+| FID | < 100ms | First Input Delay |
+| CLS | < 0.1 | Cumulative Layout Shift |
+| TTI | < 3.8s | Time to Interactive |
+| Total Page Weight | < 1.5MB | Including images |
+| JS Bundle | < 100KB | Gzipped |
+| CSS Bundle | < 50KB | Gzipped |
+| Font Load | < 100KB | Subset + swap |
+
+### Performance Strategies
+
+1. **Critical CSS inlined** in `<head>`
+2. **Fonts:** `font-display: swap`, subset to Latin
+3. **Images:** WebP with JPEG fallback, lazy load
+4. **JS:** Deferred, code-split by route
+5. **Animations:** GPU-accelerated (transform, opacity)
+6. **Particles:** Canvas-based, max 50 particles
+7. **Gradient animations:** CSS-only where possible
+
+---
+
+## Testing Checklist
+
+### Browsers
+- [ ] Chrome (latest)
+- [ ] Firefox (latest)
+- [ ] Safari (latest)
+- [ ] Edge (latest)
+- [ ] Safari iOS
+- [ ] Chrome Android
+
+### Devices
+- [ ] Desktop 1920px
+- [ ] Desktop 1440px
+- [ ] Laptop 1280px
+- [ ] Tablet 768px
+- [ ] Mobile 375px
+- [ ] Mobile 320px
+
+### Accessibility
+- [ ] WAVE audit (0 errors)
+- [ ] axe DevTools (0 critical)
+- [ ] Lighthouse Accessibility > 95
+- [ ] Keyboard navigation complete
+- [ ] Screen reader test (VoiceOver)
+- [ ] Reduced motion test
+
+### Performance
+- [ ] Lighthouse Performance > 90
+- [ ] Core Web Vitals all green
+- [ ] PageSpeed Insights > 90
+- [ ] WebPageTest (3G test)
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation (Current)
+- [x] Directory structure
+- [ ] theme.json with design tokens
+- [ ] style.css with base styles
+- [ ] functions.php setup
+- [ ] Custom properties CSS
+
+### Phase 2: Template Parts
+- [ ] header.html
+- [ ] footer.html
+- [ ] Basic templates (index, page, single)
+
+### Phase 3: Components
+- [ ] Hero block pattern
+- [ ] Card patterns (project, blog, stat)
+- [ ] CTA patterns
+- [ ] Navigation patterns
+
+### Phase 4: Animations
+- [ ] Base transitions CSS
+- [ ] GSAP/ScrollTrigger integration
+- [ ] Scroll animations
+- [ ] Hover effects
+- [ ] Page load sequence
+
+### Phase 5: Templates
+- [ ] Homepage template
+- [ ] About page
+- [ ] Work/Projects
+- [ ] Services
+- [ ] Blog listing
+- [ ] Single post
+- [ ] 404 page
+
+### Phase 6: Polish
+- [ ] Micro-interactions
+- [ ] Loading states
+- [ ] Error states
+- [ ] Print styles
+- [ ] Final accessibility audit
+
+---
+
+## File Naming Conventions
+
+- **Templates:** `kebab-case.html` (e.g., `single-post.html`)
+- **Parts:** `kebab-case.html` (e.g., `header.html`)
+- **Patterns:** `kebab-case.php` (e.g., `hero-gradient.php`)
+- **CSS:** `kebab-case.css` (e.g., `custom-properties.css`)
+- **JS:** `kebab-case.js` (e.g., `aurora-animations.js`)
+
+---
+
+## Version Control
+
+All theme files will be committed to:
+```
+/home/user/kriskrug-wp/theme/kk-aurora/
+```
+
+Commit messages follow conventional commits:
+- `feat:` New feature
+- `fix:` Bug fix
+- `style:` Styling changes
+- `refactor:` Code refactoring
+- `docs:` Documentation
+- `test:` Testing
+- `chore:` Maintenance
+
+---
+
+**Let's build something award-winning.**

--- a/theme/kk-aurora/assets/css/animations.css
+++ b/theme/kk-aurora/assets/css/animations.css
@@ -1,0 +1,354 @@
+/**
+ * KK Aurora - Animation Styles
+ * 
+ * Keyframe animations, transitions, and motion effects.
+ * All animations respect prefers-reduced-motion.
+ */
+
+/* ============================================
+   GRADIENT ANIMATIONS
+   ============================================ */
+
+/* Slow gradient shift for backgrounds */
+@keyframes aurora-gradient-bg {
+  0%, 100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+.aurora-gradient-animated {
+  background: linear-gradient(
+    135deg,
+    var(--wp--preset--color--cyan),
+    var(--wp--preset--color--teal),
+    var(--wp--preset--color--purple),
+    var(--wp--preset--color--pink),
+    var(--wp--preset--color--cyan)
+  );
+  background-size: 300% 300%;
+  animation: aurora-gradient-bg 15s ease infinite;
+}
+
+/* Gradient border rotation */
+@keyframes aurora-border-rotate {
+  0% {
+    --angle: 0deg;
+  }
+  100% {
+    --angle: 360deg;
+  }
+}
+
+/* Subtle pulse glow */
+@keyframes aurora-pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(0, 229, 255, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 40px rgba(0, 229, 255, 0.4);
+  }
+}
+
+.aurora-pulse {
+  animation: aurora-pulse-glow 3s ease-in-out infinite;
+}
+
+/* ============================================
+   ENTRANCE ANIMATIONS
+   ============================================ */
+
+/* Fade up */
+@keyframes aurora-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.aurora-animate-fade-up {
+  animation: aurora-fade-up 0.6s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
+/* Fade in */
+@keyframes aurora-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.aurora-animate-fade-in {
+  animation: aurora-fade-in 0.5s ease forwards;
+}
+
+/* Scale in */
+@keyframes aurora-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.aurora-animate-scale-in {
+  animation: aurora-scale-in 0.5s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
+/* Slide in from left */
+@keyframes aurora-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.aurora-animate-slide-left {
+  animation: aurora-slide-left 0.6s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
+/* Slide in from right */
+@keyframes aurora-slide-right {
+  from {
+    opacity: 0;
+    transform: translateX(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.aurora-animate-slide-right {
+  animation: aurora-slide-right 0.6s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
+/* ============================================
+   INTERACTIVE ANIMATIONS
+   ============================================ */
+
+/* Button press effect */
+.aurora-button-press {
+  transition: transform 0.1s ease;
+}
+
+.aurora-button-press:active {
+  transform: scale(0.98);
+}
+
+/* Card lift on hover */
+.aurora-card-lift {
+  transition: 
+    transform 0.3s cubic-bezier(0.25, 0.1, 0.25, 1),
+    box-shadow 0.3s ease;
+}
+
+.aurora-card-lift:hover {
+  transform: translateY(-6px);
+  box-shadow: 
+    0 20px 40px rgba(0, 0, 0, 0.3),
+    0 0 30px rgba(0, 229, 255, 0.15);
+}
+
+/* Link underline slide */
+.aurora-link-slide {
+  position: relative;
+  text-decoration: none;
+}
+
+.aurora-link-slide::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--wp--preset--gradient--aurora-cyan-teal);
+  transition: width 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.aurora-link-slide:hover::after {
+  width: 100%;
+}
+
+/* ============================================
+   SCROLL INDICATOR
+   ============================================ */
+
+@keyframes aurora-scroll-bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(8px);
+  }
+}
+
+.aurora-scroll-indicator {
+  animation: aurora-scroll-bounce 2s ease-in-out infinite;
+}
+
+/* ============================================
+   LOADING ANIMATIONS
+   ============================================ */
+
+/* Spinner */
+@keyframes aurora-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.aurora-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--wp--preset--color--elevated);
+  border-top-color: var(--wp--preset--color--cyan);
+  border-radius: 50%;
+  animation: aurora-spin 0.8s linear infinite;
+}
+
+/* Dots loading */
+@keyframes aurora-dots {
+  0%, 80%, 100% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.aurora-dots {
+  display: flex;
+  gap: 4px;
+}
+
+.aurora-dots span {
+  width: 8px;
+  height: 8px;
+  background: var(--wp--preset--color--cyan);
+  border-radius: 50%;
+  animation: aurora-dots 1.4s ease-in-out infinite both;
+}
+
+.aurora-dots span:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.aurora-dots span:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+/* ============================================
+   STAGGER DELAYS
+   Used with JS to create staggered effects
+   ============================================ */
+
+[data-aurora-delay="1"] { animation-delay: 0.1s; }
+[data-aurora-delay="2"] { animation-delay: 0.2s; }
+[data-aurora-delay="3"] { animation-delay: 0.3s; }
+[data-aurora-delay="4"] { animation-delay: 0.4s; }
+[data-aurora-delay="5"] { animation-delay: 0.5s; }
+[data-aurora-delay="6"] { animation-delay: 0.6s; }
+[data-aurora-delay="7"] { animation-delay: 0.7s; }
+[data-aurora-delay="8"] { animation-delay: 0.8s; }
+
+/* ============================================
+   REDUCED MOTION
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-gradient-animated,
+  .aurora-pulse,
+  .aurora-animate-fade-up,
+  .aurora-animate-fade-in,
+  .aurora-animate-scale-in,
+  .aurora-animate-slide-left,
+  .aurora-animate-slide-right,
+  .aurora-scroll-indicator,
+  .aurora-spinner,
+  .aurora-dots span {
+    animation: none;
+  }
+  
+  .aurora-animate-fade-up,
+  .aurora-animate-fade-in,
+  .aurora-animate-scale-in,
+  .aurora-animate-slide-left,
+  .aurora-animate-slide-right {
+    opacity: 1;
+    transform: none;
+  }
+  
+  .aurora-card-lift:hover {
+    transform: none;
+  }
+  
+  .aurora-link-slide::after {
+    width: 100%;
+    transition: none;
+  }
+}
+
+/* ============================================
+   NUMBER COUNTER (JS controlled)
+   ============================================ */
+
+.aurora-counter {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+/* ============================================
+   HERO SPECIFIC ANIMATIONS
+   ============================================ */
+
+/* Hero text word reveal */
+.aurora-hero-text .word {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.aurora-hero-text.is-visible .word {
+  animation: aurora-fade-up 0.5s cubic-bezier(0.25, 0.1, 0.25, 1) forwards;
+}
+
+.aurora-hero-text.is-visible .word:nth-child(1) { animation-delay: 0s; }
+.aurora-hero-text.is-visible .word:nth-child(2) { animation-delay: 0.1s; }
+.aurora-hero-text.is-visible .word:nth-child(3) { animation-delay: 0.2s; }
+.aurora-hero-text.is-visible .word:nth-child(4) { animation-delay: 0.3s; }
+.aurora-hero-text.is-visible .word:nth-child(5) { animation-delay: 0.4s; }
+.aurora-hero-text.is-visible .word:nth-child(6) { animation-delay: 0.5s; }
+.aurora-hero-text.is-visible .word:nth-child(7) { animation-delay: 0.6s; }
+.aurora-hero-text.is-visible .word:nth-child(8) { animation-delay: 0.7s; }
+
+/* Reduced motion override */
+@media (prefers-reduced-motion: reduce) {
+  .aurora-hero-text .word,
+  .aurora-hero-text.is-visible .word {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+}

--- a/theme/kk-aurora/assets/css/bleeding-edge.css
+++ b/theme/kk-aurora/assets/css/bleeding-edge.css
@@ -1,0 +1,579 @@
+/**
+ * KK Aurora - Bleeding Edge
+ * 
+ * Advanced CSS features for 2026.
+ * Progressive enhancement - these gracefully degrade.
+ */
+
+/* ============================================
+   VIEW TRANSITIONS API
+   Smooth page transitions like native apps
+   ============================================ */
+
+@view-transition {
+  navigation: auto;
+}
+
+/* Page transition: Fade with subtle scale */
+::view-transition-old(root) {
+  animation: aurora-page-out 0.3s cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+::view-transition-new(root) {
+  animation: aurora-page-in 0.4s cubic-bezier(0, 0, 0.2, 1) forwards;
+}
+
+@keyframes aurora-page-out {
+  to {
+    opacity: 0;
+    transform: scale(0.98);
+    filter: blur(4px);
+  }
+}
+
+@keyframes aurora-page-in {
+  from {
+    opacity: 0;
+    transform: scale(1.02);
+    filter: blur(4px);
+  }
+}
+
+/* Hero gets its own transition - more dramatic */
+.aurora-hero {
+  view-transition-name: hero;
+}
+
+::view-transition-old(hero) {
+  animation: aurora-hero-out 0.4s ease-out forwards;
+}
+
+::view-transition-new(hero) {
+  animation: aurora-hero-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes aurora-hero-out {
+  to {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+
+@keyframes aurora-hero-in {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+}
+
+/* ============================================
+   SCROLL-DRIVEN ANIMATIONS
+   CSS-only scroll effects, no JS needed
+   ============================================ */
+
+/* Reading progress bar - pure CSS */
+.aurora-reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  z-index: 9999;
+}
+
+.aurora-reading-progress span {
+  display: block;
+  height: 100%;
+  background: var(--wp--preset--gradient--aurora-primary);
+  transform-origin: left;
+  transform: scaleX(0);
+  animation: aurora-scroll-progress linear;
+  animation-timeline: scroll(root);
+}
+
+@keyframes aurora-scroll-progress {
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* Fade in on scroll - CSS only */
+@supports (animation-timeline: scroll()) {
+  .aurora-scroll-reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    animation: aurora-reveal linear forwards;
+    animation-timeline: view();
+    animation-range: entry 0% entry 30%;
+  }
+  
+  @keyframes aurora-reveal {
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  
+  /* Parallax with scroll timeline */
+  .aurora-parallax-subtle {
+    animation: aurora-parallax linear;
+    animation-timeline: scroll();
+  }
+  
+  @keyframes aurora-parallax {
+    from { transform: translateY(-5%); }
+    to { transform: translateY(5%); }
+  }
+}
+
+/* ============================================
+   CONTAINER QUERIES
+   Truly responsive components
+   ============================================ */
+
+/* Cards respond to their container, not viewport */
+.aurora-card-container {
+  container-type: inline-size;
+  container-name: card;
+}
+
+@container card (max-width: 400px) {
+  .aurora-card {
+    padding: var(--wp--preset--spacing--40);
+  }
+  
+  .aurora-card h3 {
+    font-size: var(--wp--preset--font-size--lg);
+  }
+}
+
+@container card (min-width: 401px) and (max-width: 600px) {
+  .aurora-card {
+    padding: var(--wp--preset--spacing--50);
+  }
+}
+
+@container card (min-width: 601px) {
+  .aurora-card {
+    padding: var(--wp--preset--spacing--60);
+  }
+}
+
+/* Stats respond to container */
+.aurora-stats-container {
+  container-type: inline-size;
+  container-name: stats;
+}
+
+@container stats (max-width: 600px) {
+  .aurora-stat-number {
+    font-size: clamp(1.5rem, 8cqw, 2.5rem);
+  }
+}
+
+/* ============================================
+   CSS COLOR-MIX
+   Dynamic color relationships
+   ============================================ */
+
+:root {
+  /* Lighter/darker variants using color-mix */
+  --aurora-cyan-light: color-mix(in oklch, var(--wp--preset--color--cyan) 70%, white);
+  --aurora-cyan-dark: color-mix(in oklch, var(--wp--preset--color--cyan) 70%, black);
+  --aurora-cyan-muted: color-mix(in oklch, var(--wp--preset--color--cyan) 40%, var(--wp--preset--color--deep));
+  
+  /* Subtle surface variations */
+  --aurora-surface-hover: color-mix(in oklch, var(--wp--preset--color--surface) 90%, var(--wp--preset--color--cyan));
+  
+  /* Text on accent backgrounds */
+  --aurora-text-on-cyan: color-mix(in oklch, var(--wp--preset--color--deep) 95%, var(--wp--preset--color--cyan));
+}
+
+/* ============================================
+   NATIVE CSS NESTING
+   Cleaner, more maintainable styles
+   ============================================ */
+
+.aurora-card-premium {
+  background: var(--wp--preset--color--surface);
+  border: 1px solid var(--wp--preset--color--elevated);
+  border-radius: var(--wp--custom--border--radius-lg);
+  padding: var(--wp--preset--spacing--60);
+  position: relative;
+  overflow: hidden;
+  transition: 
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    border-color 0.3s ease,
+    box-shadow 0.4s ease;
+  
+  /* Gradient border effect */
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      135deg,
+      transparent 0%,
+      rgba(0, 229, 255, 0) 40%,
+      rgba(0, 229, 255, 0.3) 50%,
+      rgba(139, 92, 246, 0.3) 60%,
+      transparent 100%
+    );
+    background-size: 200% 200%;
+    background-position: 100% 100%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: 
+      opacity 0.4s ease,
+      background-position 0.6s ease;
+    pointer-events: none;
+  }
+  
+  /* Shine effect */
+  &::after {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(
+      circle at var(--mouse-x, 50%) var(--mouse-y, 50%),
+      rgba(0, 229, 255, 0.06) 0%,
+      transparent 50%
+    );
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+  
+  &:hover {
+    transform: translateY(-4px);
+    border-color: transparent;
+    box-shadow: 
+      0 20px 40px rgba(0, 0, 0, 0.3),
+      0 0 30px rgba(0, 229, 255, 0.1);
+    
+    &::before {
+      opacity: 1;
+      background-position: 0% 0%;
+    }
+    
+    &::after {
+      opacity: 1;
+    }
+  }
+  
+  /* Content hierarchy */
+  & h3 {
+    margin-bottom: var(--wp--preset--spacing--30);
+    
+    & + p {
+      margin-top: 0;
+    }
+  }
+  
+  & p {
+    color: var(--wp--preset--color--text-secondary);
+    
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
+}
+
+/* ============================================
+   VARIABLE FONT ANIMATIONS
+   Typography that breathes
+   ============================================ */
+
+@supports (font-variation-settings: normal) {
+  .aurora-hero-headline {
+    font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+    font-variation-settings: 'wght' 700;
+    transition: font-variation-settings 0.3s ease;
+  }
+  
+  /* Subtle weight shift on hover */
+  .aurora-hero-headline:hover {
+    font-variation-settings: 'wght' 800;
+  }
+  
+  /* Links get subtle weight change */
+  a.aurora-link-variable {
+    font-variation-settings: 'wght' 400;
+    transition: font-variation-settings 0.2s ease;
+    
+    &:hover {
+      font-variation-settings: 'wght' 500;
+    }
+  }
+}
+
+/* ============================================
+   ADVANCED EASING
+   Physics-based motion
+   ============================================ */
+
+:root {
+  /* Spring-like bounce */
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  
+  /* Smooth deceleration */
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  
+  /* Dramatic slowdown */
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  
+  /* Snappy */
+  --ease-out-back: cubic-bezier(0.34, 1.3, 0.64, 1);
+  
+  /* Natural feeling */
+  --ease-smooth: cubic-bezier(0.4, 0, 0, 1);
+}
+
+/* ============================================
+   SUBGRID
+   Perfect nested alignment
+   ============================================ */
+
+.aurora-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
+  gap: var(--wp--preset--spacing--60);
+}
+
+.aurora-grid-item {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 3; /* icon, title, description */
+}
+
+/* ============================================
+   HAS() SELECTOR
+   Parent styling based on children
+   ============================================ */
+
+/* Card with image gets different padding */
+.aurora-card:has(img) {
+  padding: 0;
+  overflow: hidden;
+  
+  & > *:not(img) {
+    padding-left: var(--wp--preset--spacing--60);
+    padding-right: var(--wp--preset--spacing--60);
+  }
+  
+  & > *:last-child {
+    padding-bottom: var(--wp--preset--spacing--60);
+  }
+}
+
+/* Form group with error */
+.aurora-form-group:has(:invalid:not(:placeholder-shown)) {
+  --input-border: var(--wp--preset--color--error);
+  --input-glow: rgba(239, 68, 68, 0.2);
+}
+
+/* Form group with valid input */
+.aurora-form-group:has(:valid:not(:placeholder-shown)) {
+  --input-border: var(--wp--preset--color--success);
+  --input-glow: rgba(0, 191, 165, 0.2);
+}
+
+/* Navigation with current page */
+.aurora-nav:has(.current-menu-item) .current-menu-item a {
+  color: var(--wp--preset--color--text-primary);
+  
+  &::after {
+    width: 100%;
+  }
+}
+
+/* ============================================
+   LOGICAL PROPERTIES
+   RTL-ready by default
+   ============================================ */
+
+.aurora-content {
+  padding-inline: var(--wp--preset--spacing--40);
+  margin-block: var(--wp--preset--spacing--80);
+}
+
+.aurora-aside {
+  border-inline-start: 3px solid var(--wp--preset--color--cyan);
+  padding-inline-start: var(--wp--preset--spacing--40);
+  margin-block: var(--wp--preset--spacing--60);
+}
+
+/* ============================================
+   ACCENT-COLOR
+   Native form styling
+   ============================================ */
+
+:root {
+  accent-color: var(--wp--preset--color--cyan);
+}
+
+input[type="checkbox"],
+input[type="radio"],
+input[type="range"],
+progress {
+  accent-color: var(--wp--preset--color--cyan);
+}
+
+/* ============================================
+   FOCUS-VISIBLE
+   Keyboard-only focus styles
+   ============================================ */
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--wp--preset--color--cyan);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Custom focus for buttons */
+.wp-block-button__link:focus-visible {
+  outline-offset: 4px;
+  box-shadow: 
+    0 0 0 2px var(--wp--preset--color--deep),
+    0 0 0 4px var(--wp--preset--color--cyan),
+    var(--aurora-glow-sm) rgba(0, 229, 255, 0.3);
+}
+
+/* ============================================
+   CUSTOM SCROLLBAR
+   Designed, not default
+   ============================================ */
+
+/* Webkit browsers */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--wp--preset--color--deep);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--wp--preset--color--elevated);
+  border-radius: 5px;
+  border: 2px solid var(--wp--preset--color--deep);
+  transition: background 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--wp--preset--color--muted);
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--wp--preset--color--elevated) var(--wp--preset--color--deep);
+}
+
+/* ============================================
+   TEXT SELECTION
+   Branded, not blue
+   ============================================ */
+
+::selection {
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+  text-shadow: none;
+}
+
+::-moz-selection {
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+  text-shadow: none;
+}
+
+/* ============================================
+   REDUCED DATA
+   Respect data preferences
+   ============================================ */
+
+@media (prefers-reduced-data: reduce) {
+  /* Skip hero background gradients */
+  .aurora-hero::before {
+    display: none;
+  }
+  
+  /* Use system fonts */
+  body {
+    font-family: system-ui, sans-serif;
+  }
+  
+  /* No decorative images */
+  img[loading="lazy"]:not([alt]) {
+    display: none;
+  }
+}
+
+/* ============================================
+   HIGH CONTRAST MODE
+   Accessibility override
+   ============================================ */
+
+@media (prefers-contrast: more) {
+  :root {
+    --wp--preset--color--text-primary: #FFFFFF;
+    --wp--preset--color--text-secondary: #E0E0E0;
+    --wp--preset--color--text-muted: #BBBBBB;
+  }
+  
+  .aurora-card {
+    border-width: 2px;
+    border-color: var(--wp--preset--color--text-muted);
+  }
+  
+  a {
+    text-decoration: underline;
+  }
+}
+
+/* ============================================
+   PRINT MEDIA
+   Because someone will print it
+   ============================================ */
+
+@media print {
+  .aurora-hero {
+    min-height: auto;
+    padding: 2cm 0;
+  }
+  
+  .aurora-card {
+    break-inside: avoid;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+  
+  .aurora-reading-progress,
+  .aurora-scroll-indicator,
+  .aurora-nav {
+    display: none;
+  }
+  
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+  
+  a[href^="#"]::after,
+  a[href^="javascript:"]::after {
+    content: none;
+  }
+}

--- a/theme/kk-aurora/assets/css/editor.css
+++ b/theme/kk-aurora/assets/css/editor.css
@@ -1,0 +1,82 @@
+/**
+ * KK Aurora - Editor Styles
+ * 
+ * Styles specific to the WordPress block editor.
+ */
+
+/* Match editor background to theme */
+.editor-styles-wrapper {
+  background-color: var(--wp--preset--color--deep) !important;
+  color: var(--wp--preset--color--text-primary);
+}
+
+/* Ensure blocks have proper styling in editor */
+.editor-styles-wrapper .wp-block {
+  max-width: none;
+}
+
+/* Fix placeholder text color */
+.editor-styles-wrapper .block-editor-rich-text__editable:empty::before {
+  color: var(--wp--preset--color--text-muted);
+}
+
+/* Button styles in editor */
+.editor-styles-wrapper .wp-block-button.is-style-aurora-primary .wp-block-button__link {
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+}
+
+.editor-styles-wrapper .wp-block-button.is-style-aurora-ghost .wp-block-button__link {
+  background: transparent;
+  border: 2px solid var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--text-primary);
+}
+
+/* Card styles in editor */
+.editor-styles-wrapper .is-style-aurora-card {
+  background: var(--wp--preset--color--surface);
+  border: 1px solid var(--wp--preset--color--elevated);
+  border-radius: var(--wp--custom--border--radius-lg);
+  padding: var(--wp--preset--spacing--60);
+}
+
+/* Glass style in editor */
+.editor-styles-wrapper .is-style-aurora-glass {
+  background: rgba(18, 18, 26, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--wp--custom--border--radius-lg);
+  padding: var(--wp--preset--spacing--60);
+}
+
+/* Link colors in editor */
+.editor-styles-wrapper a {
+  color: var(--wp--preset--color--cyan);
+}
+
+/* Selection in editor */
+.editor-styles-wrapper ::selection {
+  background-color: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+}
+
+/* Code blocks in editor */
+.editor-styles-wrapper code,
+.editor-styles-wrapper .wp-block-code {
+  background: var(--wp--preset--color--surface);
+  color: var(--wp--preset--color--cyan);
+  font-family: var(--wp--preset--font-family--mono);
+}
+
+.editor-styles-wrapper pre.wp-block-code {
+  border: 1px solid var(--wp--preset--color--elevated);
+}
+
+/* Quote styles in editor */
+.editor-styles-wrapper .wp-block-quote {
+  border-left-color: var(--wp--preset--color--cyan);
+}
+
+/* Separator in editor */
+.editor-styles-wrapper .wp-block-separator {
+  border-color: var(--wp--preset--color--elevated);
+}

--- a/theme/kk-aurora/assets/css/typography-refined.css
+++ b/theme/kk-aurora/assets/css/typography-refined.css
@@ -1,0 +1,638 @@
+/**
+ * KK Aurora - Typography Refinements
+ * 
+ * Obsessive attention to type.
+ * Every letter matters.
+ */
+
+/* ============================================
+   FONT LOADING STRATEGY
+   Performance meets beauty
+   ============================================ */
+
+/* Primary display font - Inter with variable font support */
+@font-face {
+  font-family: 'Inter Variable';
+  src: url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZ9hjp-Ek-_EeA.woff2') format('woff2');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* Monospace for code */
+@font-face {
+  font-family: 'JetBrains Mono';
+  src: url('https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ============================================
+   BASE TYPOGRAPHY
+   The foundation
+   ============================================ */
+
+html {
+  font-size: 100%; /* Respect user preferences */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  font-family: 'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif;
+  font-feature-settings: 
+    'kern' 1,      /* Kerning */
+    'liga' 1,      /* Ligatures */
+    'calt' 1,      /* Contextual alternates */
+    'ss01' 1,      /* Stylistic set 1: Open digits */
+    'cv05' 1;      /* Character variant: lowercase l with tail */
+  font-optical-sizing: auto;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* ============================================
+   HEADINGS
+   Bold, but not brutish
+   ============================================ */
+
+h1, h2, h3, h4, h5, h6,
+.wp-block-heading {
+  font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-wrap: balance; /* Prevent orphans */
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+
+h1, .wp-block-heading.is-style-h1 {
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.1;
+}
+
+h2, .wp-block-heading.is-style-h2 {
+  letter-spacing: 0;
+  line-height: 1.15;
+}
+
+h3, .wp-block-heading.is-style-h3 {
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+/* Smaller headings are more relaxed */
+h4, h5, h6 {
+  letter-spacing: 0;
+  line-height: 1.3;
+}
+
+/* ============================================
+   BODY TEXT
+   Readable, comfortable, human
+   ============================================ */
+
+p {
+  line-height: 1.7;
+  text-wrap: pretty; /* Better line breaks */
+  max-width: 70ch; /* Optimal reading width */
+}
+
+/* Long-form content gets more breathing room */
+article p,
+.entry-content p,
+.wp-block-post-content p {
+  line-height: 1.8;
+  margin-block: 1.5em;
+  
+  /* First paragraph after heading - no top margin */
+  h1 + &,
+  h2 + &,
+  h3 + &,
+  h4 + & {
+    margin-top: 0.75em;
+  }
+}
+
+/* Drop cap for first paragraph */
+article > p:first-of-type::first-letter,
+.entry-content > p:first-of-type::first-letter {
+  float: left;
+  font-size: 3.5em;
+  line-height: 0.8;
+  padding-right: 0.1em;
+  margin-top: 0.05em;
+  font-weight: 700;
+  color: var(--wp--preset--color--cyan);
+}
+
+/* ============================================
+   LINKS
+   Subtle, then satisfying
+   ============================================ */
+
+/* Default links in body text */
+article a,
+.entry-content a,
+.wp-block-post-content a {
+  color: var(--wp--preset--color--cyan);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--wp--preset--color--cyan) 30%, transparent);
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+  transition: 
+    text-decoration-color 0.2s ease,
+    color 0.2s ease;
+}
+
+article a:hover,
+.entry-content a:hover,
+.wp-block-post-content a:hover {
+  text-decoration-color: var(--wp--preset--color--cyan);
+}
+
+/* ============================================
+   LISTS
+   Rhythm and hierarchy
+   ============================================ */
+
+ul, ol {
+  padding-left: 1.5em;
+  margin-block: 1.5em;
+}
+
+li {
+  line-height: 1.7;
+  margin-block: 0.5em;
+}
+
+/* Nested lists */
+li > ul,
+li > ol {
+  margin-block: 0.5em;
+}
+
+/* Custom bullets */
+ul:not([class]) {
+  list-style: none;
+  padding-left: 1.25em;
+}
+
+ul:not([class]) > li {
+  position: relative;
+}
+
+ul:not([class]) > li::before {
+  content: '';
+  position: absolute;
+  left: -1.25em;
+  top: 0.7em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--wp--preset--gradient--aurora-cyan-teal);
+}
+
+/* ============================================
+   BLOCKQUOTES
+   Distinguished, not decorated
+   ============================================ */
+
+blockquote,
+.wp-block-quote {
+  position: relative;
+  font-size: 1.15em;
+  font-style: normal;
+  line-height: 1.6;
+  margin-block: 2em;
+  padding: 1.5em 0 1.5em 1.5em;
+  border-left: 3px solid var(--wp--preset--color--cyan);
+  
+  /* Remove default quotes */
+  quotes: none;
+}
+
+blockquote p,
+.wp-block-quote p {
+  font-style: italic;
+  max-width: 60ch;
+}
+
+blockquote cite,
+.wp-block-quote cite {
+  display: block;
+  margin-top: 1em;
+  font-size: 0.875rem;
+  font-style: normal;
+  color: var(--wp--preset--color--text-muted);
+}
+
+blockquote cite::before {
+  content: '— ';
+}
+
+/* Pull quotes - more dramatic */
+.wp-block-pullquote {
+  border: none;
+  padding: 2em 0;
+  text-align: center;
+}
+
+.wp-block-pullquote blockquote {
+  border: none;
+  padding: 0;
+}
+
+.wp-block-pullquote p {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 600;
+  font-style: normal;
+  line-height: 1.3;
+  letter-spacing: 0;
+  max-width: none;
+}
+
+/* ============================================
+   CODE
+   Technical, but approachable
+   ============================================ */
+
+code, kbd, samp, var {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.9em;
+  font-feature-settings: 'liga' 1; /* Enable ligatures */
+}
+
+/* Inline code */
+:not(pre) > code {
+  background: var(--wp--preset--color--surface);
+  color: var(--wp--preset--color--cyan);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+/* Code blocks */
+pre,
+.wp-block-code {
+  background: var(--wp--preset--color--surface);
+  border: 1px solid var(--wp--preset--color--elevated);
+  border-radius: var(--wp--custom--border--radius-md);
+  padding: 1.5em;
+  overflow-x: auto;
+  tab-size: 2;
+  
+  /* Line numbers aesthetic */
+  counter-reset: line;
+}
+
+pre code,
+.wp-block-code code {
+  background: none;
+  padding: 0;
+  color: var(--wp--preset--color--text-primary);
+  font-size: 0.875rem;
+  line-height: 1.7;
+  white-space: pre;
+}
+
+/* ============================================
+   SMALL TEXT
+   Subtle, not invisible
+   ============================================ */
+
+small,
+.text-small {
+  font-size: 0.875em;
+  color: var(--wp--preset--color--text-muted);
+}
+
+/* Captions */
+figcaption,
+.wp-block-image figcaption,
+.wp-element-caption {
+  font-size: 0.875rem;
+  color: var(--wp--preset--color--text-muted);
+  text-align: center;
+  margin-top: 0.75em;
+  font-style: italic;
+}
+
+/* ============================================
+   SPECIAL TREATMENTS
+   For moments that matter
+   ============================================ */
+
+/* Lead paragraph */
+.is-style-lead,
+.lead {
+  font-size: 1.25em;
+  line-height: 1.6;
+  color: var(--wp--preset--color--text-secondary);
+  max-width: 60ch;
+}
+
+/* Kicker / Eyebrow */
+.kicker,
+.eyebrow {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--wp--preset--color--cyan);
+  margin-bottom: 0.5em;
+}
+
+/* Large display text */
+.display-text {
+  font-size: clamp(2.5rem, 8vw, 5rem);
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+/* ============================================
+   NUMBERS
+   Tabular for alignment
+   ============================================ */
+
+.tabular-nums,
+.aurora-counter,
+[data-aurora-counter] {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+}
+
+/* Fractions */
+.fractions {
+  font-feature-settings: 'frac' 1;
+}
+
+/* Ordinals */
+.ordinals {
+  font-feature-settings: 'ordn' 1;
+}
+
+/* ============================================
+   HANGING PUNCTUATION
+   Optically aligned
+   ============================================ */
+
+@supports (hanging-punctuation: first) {
+  blockquote,
+  .wp-block-quote,
+  .wp-block-pullquote {
+    hanging-punctuation: first;
+  }
+}
+
+/* Manual fallback for non-supporting browsers */
+blockquote p::first-letter,
+.wp-block-quote p::first-letter {
+  margin-left: -0.4em;
+}
+
+/* ============================================
+   SPACING ADJUSTMENTS
+   Optical corrections
+   ============================================ */
+
+/* Tighten space after periods in abbreviations */
+abbr {
+  letter-spacing: 0.05em;
+}
+
+/* Proper em dash spacing */
+.em-dash {
+  margin: 0 0.1em;
+}
+
+/* ============================================
+   DARK MODE OPTIMIZATIONS
+   Subtle adjustments for dark
+   ============================================ */
+
+/* Slightly lighter weight for dark mode readability */
+@media (prefers-color-scheme: dark) {
+  body {
+    font-weight: 350; /* Slightly lighter for dark backgrounds */
+  }
+  
+  strong, b {
+    font-weight: 600;
+  }
+}
+
+/* ============================================
+   AURORA VISUAL SYSTEM SURFACES
+   ============================================ */
+
+.aurora-glass-panel,
+.is-style-aurora-glass {
+  background: var(--wp--custom--glass--surface-strong);
+  border: 1px solid var(--wp--custom--glass--border);
+  border-radius: var(--wp--custom--border--radius-lg);
+  box-shadow: var(--wp--preset--shadow--md);
+  backdrop-filter: blur(var(--wp--custom--glass--blur));
+  -webkit-backdrop-filter: blur(var(--wp--custom--glass--blur));
+}
+
+.aurora-glass-nav {
+  background: var(--wp--custom--glass--surface-soft);
+  border: 1px solid var(--wp--custom--glass--border);
+  border-radius: var(--wp--custom--border--radius-full);
+  backdrop-filter: blur(var(--wp--custom--glass--blur));
+  -webkit-backdrop-filter: blur(var(--wp--custom--glass--blur));
+}
+
+.aurora-glass-media {
+  background: var(--wp--custom--glass--surface-soft);
+  border: 1px solid var(--wp--custom--glass--border);
+  border-radius: var(--wp--custom--border--radius-lg);
+  box-shadow:
+    inset 0 1px 0 var(--wp--custom--glass--highlight),
+    var(--wp--preset--shadow--sm);
+}
+
+/* ============================================
+   TYPOGRAPHY TIERS
+   ============================================ */
+
+.aurora-hero-title {
+  font-size: var(--wp--preset--font-size--hero);
+  line-height: var(--wp--custom--line-height--tight);
+  letter-spacing: var(--wp--custom--letter-spacing--tighter);
+  max-width: 14ch;
+}
+
+.aurora-page-title {
+  font-size: var(--wp--preset--font-size--5xl);
+  line-height: var(--wp--custom--line-height--tight);
+  letter-spacing: var(--wp--custom--letter-spacing--tight);
+  max-width: 18ch;
+}
+
+.aurora-panel-title {
+  font-size: var(--wp--preset--font-size--2xl);
+  line-height: var(--wp--custom--line-height--snug);
+}
+
+.aurora-article-body {
+  font-size: var(--wp--preset--font-size--base);
+  line-height: var(--wp--custom--line-height--loose);
+  max-width: 70ch;
+}
+
+.aurora-meta {
+  font-size: var(--wp--preset--font-size--xs);
+  letter-spacing: var(--wp--custom--letter-spacing--wider);
+  text-transform: uppercase;
+  color: var(--wp--preset--color--text-muted);
+}
+
+.aurora-caption {
+  font-size: var(--wp--preset--font-size--sm);
+  line-height: var(--wp--custom--line-height--normal);
+  color: var(--wp--preset--color--text-muted);
+}
+
+/* ============================================
+   BUTTON + CTA STATES
+   ============================================ */
+
+.wp-block-button__link,
+button,
+input[type="submit"],
+input[type="button"],
+input[type="reset"] {
+  min-height: var(--wp--custom--button--min-height);
+  border-radius: var(--wp--custom--button--radius);
+  transition:
+    background-color var(--wp--custom--motion--micro-duration) var(--wp--custom--animation--ease-out),
+    color var(--wp--custom--motion--micro-duration) var(--wp--custom--animation--ease-out),
+    border-color var(--wp--custom--motion--micro-duration) var(--wp--custom--animation--ease-out),
+    box-shadow var(--wp--custom--motion--depth-duration) var(--wp--custom--animation--ease-smooth),
+    transform var(--wp--custom--motion--micro-duration) var(--wp--custom--animation--ease-out);
+}
+
+.wp-block-button.is-style-aurora-primary .wp-block-button__link {
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+  border: 1px solid transparent;
+}
+
+.wp-block-button.is-style-aurora-secondary .wp-block-button__link {
+  background: var(--wp--preset--color--surface);
+  color: var(--wp--preset--color--text-primary);
+  border: 1px solid var(--wp--preset--color--cyan);
+}
+
+.wp-block-button.is-style-aurora-ghost .wp-block-button__link {
+  background: transparent;
+  color: var(--wp--preset--color--text-primary);
+  border: 1px solid var(--wp--preset--color--elevated);
+}
+
+.wp-block-button.is-style-aurora-utility .wp-block-button__link,
+.wp-block-button.is-style-aurora-icon .wp-block-button__link {
+  min-width: var(--wp--custom--button--min-height);
+  min-height: var(--wp--custom--button--min-height);
+  padding: 0;
+  border-radius: var(--wp--custom--button--radius-pill);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--wp--custom--button--icon-size);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .wp-block-button.is-style-aurora-primary .wp-block-button__link:hover {
+    background: var(--wp--preset--color--teal);
+    transform: translateY(-1px);
+    box-shadow: var(--wp--preset--shadow--glow-teal);
+  }
+
+  .wp-block-button.is-style-aurora-secondary .wp-block-button__link:hover,
+  .wp-block-button.is-style-aurora-ghost .wp-block-button__link:hover {
+    border-color: var(--wp--preset--color--cyan);
+    color: var(--wp--preset--color--cyan);
+  }
+}
+
+.wp-block-button__link:active,
+button:active,
+input[type="submit"]:active,
+input[type="button"]:active,
+input[type="reset"]:active {
+  transform: translateY(1px);
+}
+
+.wp-block-button__link[aria-disabled="true"],
+.wp-block-button__link:disabled,
+button:disabled,
+input[type="submit"]:disabled,
+input[type="button"]:disabled,
+input[type="reset"]:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.wp-block-button__link:focus-visible,
+button:focus-visible,
+input[type="submit"]:focus-visible,
+input[type="button"]:focus-visible,
+input[type="reset"]:focus-visible {
+  outline: var(--wp--custom--focus--ring-width) solid var(--wp--custom--focus--ring-color);
+  outline-offset: var(--wp--custom--focus--ring-offset);
+  box-shadow:
+    0 0 0 2px var(--wp--custom--focus--ring-offset-color),
+    var(--wp--custom--focus--ring-glow);
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .wp-block-button__link,
+  button,
+  input[type="submit"],
+  input[type="button"],
+  input[type="reset"] {
+    min-height: var(--wp--custom--button--mobile-min-height);
+  }
+
+  .wp-block-button__link:active,
+  button:active,
+  input[type="submit"]:active,
+  input[type="button"]:active,
+  input[type="reset"]:active {
+    transform: scale(0.99);
+  }
+}
+
+/* ============================================
+   REDUCED MOTION
+   Typography doesn't need animation
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-glass-panel,
+  .aurora-glass-nav,
+  .aurora-glass-media,
+  .wp-block-button__link,
+  button,
+  input[type="submit"],
+  input[type="button"],
+  input[type="reset"] {
+    transition-duration: var(--wp--custom--motion--reduce-duration) !important;
+    animation: none !important;
+    transform: none !important;
+  }
+
+  * {
+    transition-property: color, background-color, border-color, text-decoration-color !important;
+  }
+}

--- a/theme/kk-aurora/assets/js/aurora-animations.js
+++ b/theme/kk-aurora/assets/js/aurora-animations.js
@@ -1,0 +1,424 @@
+/**
+ * KK Aurora - Animation Controller
+ * 
+ * GSAP-powered scroll animations and interactions.
+ * Respects prefers-reduced-motion automatically.
+ */
+
+(function() {
+  'use strict';
+
+  // Check for reduced motion preference
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  
+  // Don't initialize animations if reduced motion is preferred
+  if (prefersReducedMotion) {
+    // Just make everything visible
+    document.querySelectorAll('[data-aurora-animate]').forEach(el => {
+      el.style.opacity = '1';
+      el.style.transform = 'none';
+    });
+    return;
+  }
+
+  // Wait for GSAP to be available
+  if (typeof gsap === 'undefined' || typeof ScrollTrigger === 'undefined') {
+    console.warn('KK Aurora: GSAP or ScrollTrigger not loaded');
+    return;
+  }
+
+  // Register ScrollTrigger plugin
+  gsap.registerPlugin(ScrollTrigger);
+
+  // ============================================
+  // CONFIGURATION
+  // ============================================
+
+  const config = {
+    // Default animation settings
+    fadeUp: {
+      y: 30,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+    },
+    fadeIn: {
+      opacity: 0,
+      duration: 0.5,
+      ease: 'power2.out',
+    },
+    scaleIn: {
+      scale: 0.95,
+      opacity: 0,
+      duration: 0.5,
+      ease: 'power2.out',
+    },
+    stagger: {
+      each: 0.1,
+      from: 'start',
+    },
+    // ScrollTrigger defaults
+    scrollTrigger: {
+      start: 'top 85%',
+      end: 'bottom 20%',
+      toggleActions: 'play none none reverse',
+    },
+  };
+
+  // ============================================
+  // SCROLL ANIMATIONS
+  // ============================================
+
+  /**
+   * Initialize fade up animations
+   */
+  function initFadeUp() {
+    const elements = document.querySelectorAll('[data-aurora-animate="fade-up"]');
+    
+    elements.forEach(el => {
+      gsap.from(el, {
+        ...config.fadeUp,
+        scrollTrigger: {
+          trigger: el,
+          ...config.scrollTrigger,
+        },
+      });
+    });
+  }
+
+  /**
+   * Initialize fade in animations
+   */
+  function initFadeIn() {
+    const elements = document.querySelectorAll('[data-aurora-animate="fade-in"]');
+    
+    elements.forEach(el => {
+      gsap.from(el, {
+        ...config.fadeIn,
+        scrollTrigger: {
+          trigger: el,
+          ...config.scrollTrigger,
+        },
+      });
+    });
+  }
+
+  /**
+   * Initialize scale in animations
+   */
+  function initScaleIn() {
+    const elements = document.querySelectorAll('[data-aurora-animate="scale-in"]');
+    
+    elements.forEach(el => {
+      gsap.from(el, {
+        ...config.scaleIn,
+        scrollTrigger: {
+          trigger: el,
+          ...config.scrollTrigger,
+        },
+      });
+    });
+  }
+
+  /**
+   * Initialize staggered animations for groups
+   */
+  function initStagger() {
+    const groups = document.querySelectorAll('[data-aurora-stagger]');
+    
+    groups.forEach(group => {
+      const children = group.children;
+      const type = group.dataset.auroraStagger || 'fade-up';
+      
+      let animationConfig;
+      switch (type) {
+        case 'fade-in':
+          animationConfig = config.fadeIn;
+          break;
+        case 'scale-in':
+          animationConfig = config.scaleIn;
+          break;
+        case 'fade-up':
+        default:
+          animationConfig = config.fadeUp;
+      }
+      
+      gsap.from(children, {
+        ...animationConfig,
+        stagger: config.stagger,
+        scrollTrigger: {
+          trigger: group,
+          ...config.scrollTrigger,
+        },
+      });
+    });
+  }
+
+  // ============================================
+  // NUMBER COUNTERS
+  // ============================================
+
+  /**
+   * Animate number counters when they enter viewport
+   */
+  function initCounters() {
+    const counters = document.querySelectorAll('[data-aurora-counter]');
+    
+    counters.forEach(counter => {
+      const target = parseFloat(counter.dataset.auroraCounter);
+      const suffix = counter.dataset.auroraSuffix || '';
+      const prefix = counter.dataset.auroraPrefix || '';
+      const decimals = parseInt(counter.dataset.auroraDecimals, 10) || 0;
+      
+      // Set initial value
+      counter.textContent = prefix + '0' + suffix;
+      
+      ScrollTrigger.create({
+        trigger: counter,
+        start: 'top 80%',
+        onEnter: () => {
+          gsap.to(counter, {
+            duration: 2,
+            ease: 'power2.out',
+            onUpdate: function() {
+              const progress = this.progress();
+              const currentValue = target * progress;
+              counter.textContent = prefix + currentValue.toFixed(decimals).replace(/\B(?=(\d{3})+(?!\d))/g, ',') + suffix;
+            },
+          });
+        },
+        once: true,
+      });
+    });
+  }
+
+  // ============================================
+  // HEADER SCROLL EFFECTS
+  // ============================================
+
+  /**
+   * Add glass effect to header on scroll
+   */
+  function initHeaderScroll() {
+    const header = document.querySelector('.aurora-header');
+    if (!header) return;
+    
+    ScrollTrigger.create({
+      start: 'top -50',
+      onUpdate: (self) => {
+        if (self.scroll() > 50) {
+          header.classList.add('is-scrolled');
+        } else {
+          header.classList.remove('is-scrolled');
+        }
+      },
+    });
+  }
+
+  // ============================================
+  // PARALLAX EFFECTS
+  // ============================================
+
+  /**
+   * Initialize subtle parallax on images
+   */
+  function initParallax() {
+    const elements = document.querySelectorAll('[data-aurora-parallax]');
+    
+    elements.forEach(el => {
+      const speed = parseFloat(el.dataset.auroraParallax) || 0.1;
+      
+      gsap.to(el, {
+        yPercent: speed * 100,
+        ease: 'none',
+        scrollTrigger: {
+          trigger: el,
+          start: 'top bottom',
+          end: 'bottom top',
+          scrub: true,
+        },
+      });
+    });
+  }
+
+  // ============================================
+  // HERO ANIMATIONS
+  // ============================================
+
+  /**
+   * Initialize hero entrance animation
+   */
+  function initHeroAnimation() {
+    const hero = document.querySelector('.aurora-hero');
+    if (!hero) return;
+    
+    const timeline = gsap.timeline({
+      defaults: { ease: 'power2.out' },
+    });
+    
+    // Animate hero elements in sequence
+    timeline
+      .from('.aurora-hero .aurora-hero-headline', {
+        y: 40,
+        opacity: 0,
+        duration: 0.8,
+      })
+      .from('.aurora-hero .aurora-hero-description', {
+        y: 30,
+        opacity: 0,
+        duration: 0.6,
+      }, '-=0.4')
+      .from('.aurora-hero .aurora-badge', {
+        y: 20,
+        opacity: 0,
+        duration: 0.4,
+        stagger: 0.1,
+      }, '-=0.3')
+      .from('.aurora-hero .wp-block-button', {
+        y: 20,
+        opacity: 0,
+        duration: 0.4,
+        stagger: 0.1,
+      }, '-=0.2')
+      .from('.aurora-hero .aurora-scroll-indicator', {
+        opacity: 0,
+        duration: 0.6,
+      }, '-=0.1');
+  }
+
+  // ============================================
+  // CARD HOVER EFFECTS (enhanced)
+  // ============================================
+
+  /**
+   * Add tilt effect on card hover
+   */
+  function initCardTilt() {
+    const cards = document.querySelectorAll('[data-aurora-tilt]');
+    
+    cards.forEach(card => {
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = e.clientX - rect.left;
+        const y = e.clientY - rect.top;
+        
+        const centerX = rect.width / 2;
+        const centerY = rect.height / 2;
+        
+        const rotateX = (y - centerY) / 20;
+        const rotateY = (centerX - x) / 20;
+        
+        gsap.to(card, {
+          rotateX: rotateX,
+          rotateY: rotateY,
+          duration: 0.3,
+          ease: 'power2.out',
+          transformPerspective: 1000,
+        });
+      });
+      
+      card.addEventListener('mouseleave', () => {
+        gsap.to(card, {
+          rotateX: 0,
+          rotateY: 0,
+          duration: 0.5,
+          ease: 'power2.out',
+        });
+      });
+    });
+  }
+
+  // ============================================
+  // MAGNETIC BUTTONS
+  // ============================================
+
+  /**
+   * Add magnetic effect to buttons
+   */
+  function initMagneticButtons() {
+    const buttons = document.querySelectorAll('[data-aurora-magnetic]');
+    
+    buttons.forEach(button => {
+      button.addEventListener('mousemove', (e) => {
+        const rect = button.getBoundingClientRect();
+        const x = e.clientX - rect.left - rect.width / 2;
+        const y = e.clientY - rect.top - rect.height / 2;
+        
+        gsap.to(button, {
+          x: x * 0.2,
+          y: y * 0.2,
+          duration: 0.3,
+          ease: 'power2.out',
+        });
+      });
+      
+      button.addEventListener('mouseleave', () => {
+        gsap.to(button, {
+          x: 0,
+          y: 0,
+          duration: 0.5,
+          ease: 'elastic.out(1, 0.5)',
+        });
+      });
+    });
+  }
+
+  // ============================================
+  // PROGRESS BAR
+  // ============================================
+
+  /**
+   * Initialize scroll progress bar
+   */
+  function initProgressBar() {
+    const progressBar = document.querySelector('.aurora-progress-bar');
+    if (!progressBar) return;
+    
+    gsap.to(progressBar, {
+      scaleX: 1,
+      ease: 'none',
+      scrollTrigger: {
+        trigger: document.body,
+        start: 'top top',
+        end: 'bottom bottom',
+        scrub: 0.3,
+      },
+    });
+  }
+
+  // ============================================
+  // INITIALIZE
+  // ============================================
+
+  function init() {
+    // Scroll animations
+    initFadeUp();
+    initFadeIn();
+    initScaleIn();
+    initStagger();
+    
+    // Special effects
+    initCounters();
+    initHeaderScroll();
+    initParallax();
+    initHeroAnimation();
+    initProgressBar();
+    
+    // Interactive effects
+    initCardTilt();
+    initMagneticButtons();
+    
+    // Refresh ScrollTrigger after images load
+    window.addEventListener('load', () => {
+      ScrollTrigger.refresh();
+    });
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/theme/kk-aurora/assets/js/micro-interactions.js
+++ b/theme/kk-aurora/assets/js/micro-interactions.js
@@ -1,0 +1,485 @@
+/**
+ * KK Aurora - Micro-Interactions
+ * 
+ * Subtle, inevitable-feeling interactions.
+ * Taste is knowing when NOT to animate.
+ */
+
+(function() {
+  'use strict';
+
+  // Respect user preferences
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  
+  // ============================================
+  // CURSOR GLOW EFFECT
+  // Subtle light that follows the cursor
+  // ============================================
+  
+  function initCursorGlow() {
+    if (prefersReducedMotion) return;
+    
+    // Only on desktop with fine pointer
+    if (!window.matchMedia('(pointer: fine)').matches) return;
+    
+    const glow = document.createElement('div');
+    glow.className = 'aurora-cursor-glow';
+    glow.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(glow);
+    
+    // CSS for the glow
+    const style = document.createElement('style');
+    style.textContent = `
+      .aurora-cursor-glow {
+        position: fixed;
+        width: 400px;
+        height: 400px;
+        border-radius: 50%;
+        background: radial-gradient(
+          circle,
+          rgba(0, 229, 255, 0.03) 0%,
+          transparent 70%
+        );
+        pointer-events: none;
+        z-index: 0;
+        transform: translate(-50%, -50%);
+        opacity: 0;
+        transition: opacity 0.5s ease;
+        will-change: transform;
+      }
+      
+      body:hover .aurora-cursor-glow {
+        opacity: 1;
+      }
+    `;
+    document.head.appendChild(style);
+    
+    let cursorX = 0;
+    let cursorY = 0;
+    let glowX = 0;
+    let glowY = 0;
+    
+    document.addEventListener('mousemove', (e) => {
+      cursorX = e.clientX;
+      cursorY = e.clientY;
+    }, { passive: true });
+    
+    // Smooth follow with lerp
+    function animateGlow() {
+      const ease = 0.08; // Lower = smoother, slower
+      
+      glowX += (cursorX - glowX) * ease;
+      glowY += (cursorY - glowY) * ease;
+      
+      glow.style.left = glowX + 'px';
+      glow.style.top = glowY + 'px';
+      
+      requestAnimationFrame(animateGlow);
+    }
+    
+    animateGlow();
+  }
+
+  // ============================================
+  // CARD SPOTLIGHT EFFECT
+  // Light follows cursor on cards
+  // ============================================
+  
+  function initCardSpotlight() {
+    if (prefersReducedMotion) return;
+    if (!window.matchMedia('(pointer: fine)').matches) return;
+    
+    const cards = document.querySelectorAll('.aurora-card, .aurora-card-premium');
+    
+    cards.forEach(card => {
+      card.addEventListener('mousemove', (e) => {
+        const rect = card.getBoundingClientRect();
+        const x = ((e.clientX - rect.left) / rect.width) * 100;
+        const y = ((e.clientY - rect.top) / rect.height) * 100;
+        
+        card.style.setProperty('--mouse-x', x + '%');
+        card.style.setProperty('--mouse-y', y + '%');
+      }, { passive: true });
+    });
+  }
+
+  // ============================================
+  // SMOOTH REVEAL ON SCROLL
+  // Intersection Observer based, no GSAP needed
+  // ============================================
+  
+  function initScrollReveal() {
+    if (prefersReducedMotion) {
+      // Just show everything
+      document.querySelectorAll('[data-reveal]').forEach(el => {
+        el.style.opacity = '1';
+        el.style.transform = 'none';
+      });
+      return;
+    }
+    
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-revealed');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, {
+      threshold: 0.1,
+      rootMargin: '0px 0px -10% 0px'
+    });
+    
+    document.querySelectorAll('[data-reveal]').forEach(el => {
+      observer.observe(el);
+    });
+    
+    // Add base styles
+    const style = document.createElement('style');
+    style.textContent = `
+      [data-reveal] {
+        opacity: 0;
+        transform: translateY(20px);
+        transition: 
+          opacity 0.6s cubic-bezier(0.25, 0.1, 0.25, 1),
+          transform 0.6s cubic-bezier(0.25, 0.1, 0.25, 1);
+      }
+      
+      [data-reveal].is-revealed {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      
+      /* Stagger children */
+      [data-reveal-stagger] > * {
+        opacity: 0;
+        transform: translateY(15px);
+        transition: 
+          opacity 0.5s cubic-bezier(0.25, 0.1, 0.25, 1),
+          transform 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
+      }
+      
+      [data-reveal-stagger].is-revealed > *:nth-child(1) { transition-delay: 0s; opacity: 1; transform: translateY(0); }
+      [data-reveal-stagger].is-revealed > *:nth-child(2) { transition-delay: 0.1s; opacity: 1; transform: translateY(0); }
+      [data-reveal-stagger].is-revealed > *:nth-child(3) { transition-delay: 0.2s; opacity: 1; transform: translateY(0); }
+      [data-reveal-stagger].is-revealed > *:nth-child(4) { transition-delay: 0.3s; opacity: 1; transform: translateY(0); }
+      [data-reveal-stagger].is-revealed > *:nth-child(5) { transition-delay: 0.4s; opacity: 1; transform: translateY(0); }
+      [data-reveal-stagger].is-revealed > *:nth-child(6) { transition-delay: 0.5s; opacity: 1; transform: translateY(0); }
+    `;
+    document.head.appendChild(style);
+  }
+
+  // ============================================
+  // BUTTON RIPPLE
+  // Material-inspired, but subtle
+  // ============================================
+  
+  function initButtonRipple() {
+    if (prefersReducedMotion) return;
+    
+    const style = document.createElement('style');
+    style.textContent = `
+      .aurora-ripple-container {
+        position: relative;
+        overflow: hidden;
+      }
+      
+      .aurora-ripple {
+        position: absolute;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.15);
+        transform: scale(0);
+        animation: aurora-ripple-effect 0.6s ease-out;
+        pointer-events: none;
+      }
+      
+      @keyframes aurora-ripple-effect {
+        to {
+          transform: scale(4);
+          opacity: 0;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+    
+    document.querySelectorAll('.wp-block-button__link, .aurora-button').forEach(button => {
+      button.classList.add('aurora-ripple-container');
+      
+      button.addEventListener('click', function(e) {
+        const rect = button.getBoundingClientRect();
+        const size = Math.max(rect.width, rect.height);
+        const x = e.clientX - rect.left - size / 2;
+        const y = e.clientY - rect.top - size / 2;
+        
+        const ripple = document.createElement('span');
+        ripple.className = 'aurora-ripple';
+        ripple.style.width = ripple.style.height = size + 'px';
+        ripple.style.left = x + 'px';
+        ripple.style.top = y + 'px';
+        
+        button.appendChild(ripple);
+        
+        ripple.addEventListener('animationend', () => {
+          ripple.remove();
+        });
+      });
+    });
+  }
+
+  // ============================================
+  // TEXT SPLIT FOR ANIMATION
+  // Split text into words/chars for animation
+  // ============================================
+  
+  function initTextSplit() {
+    if (prefersReducedMotion) return;
+    
+    document.querySelectorAll('[data-split-text]').forEach(el => {
+      const text = el.textContent;
+      const words = text.split(' ');
+      
+      el.innerHTML = words.map((word, i) => 
+        `<span class="word" style="--word-index: ${i}">${word}</span>`
+      ).join(' ');
+    });
+    
+    const style = document.createElement('style');
+    style.textContent = `
+      [data-split-text] .word {
+        display: inline-block;
+        opacity: 0;
+        transform: translateY(0.5em);
+      }
+      
+      [data-split-text].is-revealed .word {
+        opacity: 1;
+        transform: translateY(0);
+        transition: 
+          opacity 0.5s ease,
+          transform 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
+        transition-delay: calc(var(--word-index) * 0.05s);
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  // ============================================
+  // SMOOTH NUMBER COUNTER
+  // No library needed
+  // ============================================
+  
+  function initCounters() {
+    if (prefersReducedMotion) return;
+    
+    const counters = document.querySelectorAll('[data-aurora-counter]');
+    
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          animateCounter(entry.target);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.5 });
+    
+    counters.forEach(counter => {
+      observer.observe(counter);
+    });
+    
+    function animateCounter(el) {
+      const target = parseFloat(el.dataset.auroraCounter);
+      const suffix = el.dataset.auroraSuffix || '';
+      const prefix = el.dataset.auroraPrefix || '';
+      const duration = 2000;
+      const start = performance.now();
+      
+      function update(now) {
+        const elapsed = now - start;
+        const progress = Math.min(elapsed / duration, 1);
+        
+        // Ease out quint
+        const eased = 1 - Math.pow(1 - progress, 5);
+        const current = target * eased;
+        
+        // Format with commas
+        const formatted = Math.round(current).toLocaleString();
+        el.textContent = prefix + formatted + suffix;
+        
+        if (progress < 1) {
+          requestAnimationFrame(update);
+        }
+      }
+      
+      requestAnimationFrame(update);
+    }
+  }
+
+  // ============================================
+  // HEADER SHRINK ON SCROLL
+  // Subtle, not jarring
+  // ============================================
+  
+  function initHeaderTransform() {
+    const header = document.querySelector('.aurora-header');
+    if (!header) return;
+    
+    let lastScroll = 0;
+    let ticking = false;
+    
+    // Add styles
+    const style = document.createElement('style');
+    style.textContent = `
+      .aurora-header {
+        transition: 
+          background-color 0.3s ease,
+          backdrop-filter 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+      
+      .aurora-header.is-scrolled {
+        background-color: rgba(13, 13, 18, 0.9);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+      
+      .aurora-header.is-hidden {
+        transform: translateY(-100%);
+      }
+    `;
+    document.head.appendChild(style);
+    
+    function updateHeader() {
+      const scroll = window.pageYOffset;
+      
+      // Add scrolled state
+      if (scroll > 50) {
+        header.classList.add('is-scrolled');
+      } else {
+        header.classList.remove('is-scrolled');
+      }
+      
+      // Hide on scroll down, show on scroll up (optional - disabled for now)
+      // if (scroll > lastScroll && scroll > 200) {
+      //   header.classList.add('is-hidden');
+      // } else {
+      //   header.classList.remove('is-hidden');
+      // }
+      
+      lastScroll = scroll;
+      ticking = false;
+    }
+    
+    window.addEventListener('scroll', () => {
+      if (!ticking) {
+        requestAnimationFrame(updateHeader);
+        ticking = true;
+      }
+    }, { passive: true });
+  }
+
+  // ============================================
+  // LINK HOVER PREVIEW
+  // Show a subtle preview on link hover
+  // ============================================
+  
+  function initLinkPreview() {
+    if (prefersReducedMotion) return;
+    if (!window.matchMedia('(pointer: fine)').matches) return;
+    
+    // This is intentionally minimal - just a URL preview
+    // Full page previews would be overkill
+    
+    const style = document.createElement('style');
+    style.textContent = `
+      a[href^="http"]:not(.no-preview):hover::after {
+        content: attr(href);
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        padding: 0.25em 0.5em;
+        font-size: 0.75rem;
+        background: var(--wp--preset--color--surface);
+        border: 1px solid var(--wp--preset--color--elevated);
+        border-radius: 4px;
+        white-space: nowrap;
+        max-width: 300px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        opacity: 0;
+        animation: aurora-preview-in 0.2s 0.5s ease forwards;
+        pointer-events: none;
+        z-index: 1000;
+      }
+      
+      @keyframes aurora-preview-in {
+        to {
+          opacity: 1;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+    
+    // Add relative positioning to links
+    document.querySelectorAll('a[href^="http"]').forEach(link => {
+      link.style.position = 'relative';
+    });
+  }
+
+  // ============================================
+  // IMAGE LAZY LOAD WITH BLUR
+  // Graceful reveal
+  // ============================================
+  
+  function initImageReveal() {
+    const style = document.createElement('style');
+    style.textContent = `
+      img[loading="lazy"] {
+        opacity: 0;
+        filter: blur(10px);
+        transition: 
+          opacity 0.5s ease,
+          filter 0.5s ease;
+      }
+      
+      img[loading="lazy"].is-loaded {
+        opacity: 1;
+        filter: blur(0);
+      }
+    `;
+    document.head.appendChild(style);
+    
+    document.querySelectorAll('img[loading="lazy"]').forEach(img => {
+      if (img.complete) {
+        img.classList.add('is-loaded');
+      } else {
+        img.addEventListener('load', () => {
+          img.classList.add('is-loaded');
+        }, { once: true });
+      }
+    });
+  }
+
+  // ============================================
+  // INITIALIZE
+  // ============================================
+  
+  function init() {
+    initCursorGlow();
+    initCardSpotlight();
+    initScrollReveal();
+    initButtonRipple();
+    initTextSplit();
+    initCounters();
+    initHeaderTransform();
+    initImageReveal();
+    // initLinkPreview(); // Disabled - too distracting
+  }
+  
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/theme/kk-aurora/assets/js/micro-interactions.js
+++ b/theme/kk-aurora/assets/js/micro-interactions.js
@@ -167,6 +167,18 @@
       [data-reveal-stagger].is-revealed > *:nth-child(6) { transition-delay: 0.5s; opacity: 1; transform: translateY(0); }
     `;
     document.head.appendChild(style);
+
+    // #116: reveal anything already in the initial viewport on the next frame, so the
+    // hero/above-the-fold never waits on the async observer — no cold-load flash, and a
+    // hard guarantee against a blank first paint even if the observer is slow to fire.
+    requestAnimationFrame(() => {
+      document.querySelectorAll('[data-reveal]:not(.is-revealed)').forEach((el) => {
+        const r = el.getBoundingClientRect();
+        if (r.top < window.innerHeight && r.bottom > 0) {
+          el.classList.add('is-revealed');
+        }
+      });
+    });
   }
 
   // ============================================

--- a/theme/kk-aurora/assets/js/theme.js
+++ b/theme/kk-aurora/assets/js/theme.js
@@ -1,0 +1,295 @@
+/**
+ * KK Aurora - Theme JavaScript
+ * 
+ * General theme functionality and utilities.
+ */
+
+(function() {
+  'use strict';
+
+  // ============================================
+  // MOBILE MENU
+  // ============================================
+
+  function initMobileMenu() {
+    const toggle = document.querySelector('.aurora-menu-toggle');
+    const menu = document.querySelector('.aurora-mobile-menu');
+    
+    if (!toggle || !menu) return;
+    
+    toggle.addEventListener('click', () => {
+      const isOpen = toggle.getAttribute('aria-expanded') === 'true';
+      
+      toggle.setAttribute('aria-expanded', !isOpen);
+      menu.classList.toggle('is-open');
+      document.body.classList.toggle('menu-open');
+      
+      // Trap focus within menu when open
+      if (!isOpen) {
+        menu.querySelector('a, button')?.focus();
+      }
+    });
+    
+    // Close on escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && menu.classList.contains('is-open')) {
+        toggle.click();
+        toggle.focus();
+      }
+    });
+  }
+
+  // ============================================
+  // SMOOTH SCROLL FOR ANCHOR LINKS
+  // ============================================
+
+  function initSmoothScroll() {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+      anchor.addEventListener('click', function(e) {
+        const href = this.getAttribute('href');
+        const target = href && href.length > 1 ? document.querySelector(href) : null;
+        
+        if (target) {
+          e.preventDefault();
+          
+          const headerOffset = 100;
+          const elementPosition = target.getBoundingClientRect().top;
+          const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+          
+          window.scrollTo({
+            top: offsetPosition,
+            behavior: prefersReducedMotion ? 'auto' : 'smooth'
+          });
+          
+          // Update focus for accessibility
+          target.focus({ preventScroll: true });
+          if (document.activeElement !== target) {
+            target.setAttribute('tabindex', '-1');
+            target.focus({ preventScroll: true });
+          }
+        }
+      });
+    });
+  }
+
+  // ============================================
+  // EXTERNAL LINK HANDLING
+  // ============================================
+
+  function initExternalLinks() {
+    document.querySelectorAll('a[href^="http"]').forEach(link => {
+      // Check if external
+      if (link.hostname !== window.location.hostname) {
+        link.setAttribute('target', '_blank');
+        link.setAttribute('rel', 'noopener noreferrer');
+        
+        // Add screen reader text
+        if (!link.querySelector('.sr-only')) {
+          const srText = document.createElement('span');
+          srText.className = 'sr-only';
+          srText.textContent = ' (opens in new tab)';
+          link.appendChild(srText);
+        }
+      }
+    });
+  }
+
+  // ============================================
+  // COPY CODE BLOCKS
+  // ============================================
+
+  function initCodeCopy() {
+    document.querySelectorAll('pre').forEach(pre => {
+      // Create copy button
+      const button = document.createElement('button');
+      button.className = 'aurora-copy-code';
+      button.setAttribute('type', 'button');
+      button.setAttribute('aria-label', 'Copy code');
+      button.innerHTML = `
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+      `;
+      
+      button.addEventListener('click', async () => {
+        const code = pre.querySelector('code')?.textContent || pre.textContent;
+        
+        try {
+          await navigator.clipboard.writeText(code);
+          button.classList.add('copied');
+          button.setAttribute('aria-label', 'Copied!');
+          
+          setTimeout(() => {
+            button.classList.remove('copied');
+            button.setAttribute('aria-label', 'Copy code');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy:', err);
+        }
+      });
+      
+      pre.style.position = 'relative';
+      pre.appendChild(button);
+    });
+  }
+
+  // ============================================
+  // READING PROGRESS
+  // ============================================
+
+  function initReadingProgress() {
+    const progressBar = document.querySelector('.aurora-reading-progress');
+    const progressFill = progressBar?.querySelector('span') || progressBar;
+    const article = document.querySelector('.aurora-article');
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    
+    if (!progressBar || !progressFill || !article || prefersReducedMotion) return;
+    
+    function updateProgress() {
+      const articleRect = article.getBoundingClientRect();
+      const articleTop = articleRect.top + window.pageYOffset;
+      const articleHeight = Math.max(articleRect.height - window.innerHeight, 1);
+      const windowHeight = window.innerHeight;
+      const scrollTop = window.pageYOffset;
+      
+      const progress = Math.min(
+        Math.max((scrollTop - articleTop + windowHeight * 0.35) / articleHeight, 0),
+        1
+      );
+      
+      progressFill.style.transform = `scaleX(${progress})`;
+    }
+    
+    window.addEventListener('scroll', updateProgress, { passive: true });
+    updateProgress();
+  }
+
+  // ============================================
+  // ARTICLE READING HELPERS
+  // ============================================
+
+  function initArticleReadingHelpers() {
+    const article = document.querySelector('.aurora-article');
+    const content = article?.querySelector('.aurora-prose');
+
+    if (!article || !content) return;
+
+    const readTime = article.querySelector('[data-aurora-read-time]');
+    const words = content.textContent.trim().split(/\s+/).filter(Boolean).length;
+
+    if (readTime && words > 120) {
+      const minutes = Math.max(1, Math.ceil(words / 225));
+      readTime.textContent = `${minutes} min read`;
+      readTime.hidden = false;
+      article.querySelector('.aurora-read-time-divider')?.removeAttribute('hidden');
+    }
+
+    const map = article.querySelector('[data-aurora-article-map]');
+    const nav = map?.querySelector('nav');
+    const headings = Array.from(content.querySelectorAll('h2, h3'))
+      .filter((heading) => heading.textContent.trim().length > 0)
+      .slice(0, 12);
+
+    if (!map || !nav || headings.length < 3) return;
+
+    const list = document.createElement('ol');
+
+    headings.forEach((heading, index) => {
+      if (!heading.id) {
+        heading.id = `article-section-${index + 1}`;
+      }
+
+      const item = document.createElement('li');
+      const link = document.createElement('a');
+
+      link.href = `#${heading.id}`;
+      link.textContent = heading.textContent.trim();
+      link.className = heading.tagName === 'H3' ? 'is-subsection' : '';
+      item.appendChild(link);
+      list.appendChild(item);
+    });
+
+    nav.appendChild(list);
+    map.hidden = false;
+  }
+
+  // ============================================
+  // LAZY LOAD IMAGES WITH FADE
+  // ============================================
+
+  function initLazyImages() {
+    const images = document.querySelectorAll('img[loading="lazy"]');
+    
+    images.forEach(img => {
+      img.classList.add('aurora-lazy');
+      
+      img.addEventListener('load', () => {
+        img.classList.add('is-loaded');
+      });
+      
+      // If already loaded
+      if (img.complete) {
+        img.classList.add('is-loaded');
+      }
+    });
+  }
+
+  // ============================================
+  // FORM ENHANCEMENTS
+  // ============================================
+
+  function initForms() {
+    // Add active class to form groups with focus
+    document.querySelectorAll('.aurora-form-group input, .aurora-form-group textarea').forEach(input => {
+      input.addEventListener('focus', () => {
+        input.closest('.aurora-form-group')?.classList.add('is-focused');
+      });
+      
+      input.addEventListener('blur', () => {
+        input.closest('.aurora-form-group')?.classList.remove('is-focused');
+        
+        // Add filled class if has value
+        if (input.value.trim()) {
+          input.closest('.aurora-form-group')?.classList.add('is-filled');
+        } else {
+          input.closest('.aurora-form-group')?.classList.remove('is-filled');
+        }
+      });
+    });
+  }
+
+  // ============================================
+  // DARK/LIGHT MODE (if needed in future)
+  // ============================================
+
+  function initColorScheme() {
+    // Aurora is dark-mode only, but we could add this later
+    // document.documentElement.classList.add('dark');
+  }
+
+  // ============================================
+  // INITIALIZE
+  // ============================================
+
+  function init() {
+    initMobileMenu();
+    initSmoothScroll();
+    initExternalLinks();
+    initCodeCopy();
+    initReadingProgress();
+    initArticleReadingHelpers();
+    initLazyImages();
+    initForms();
+    initColorScheme();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.2.0');
+define('KK_AURORA_VERSION', '1.3.0');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -321,3 +321,18 @@ function disable_emojis(): void {
     remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
 }
 add_action('init', __NAMESPACE__ . '\\disable_emojis');
+
+/**
+ * Article dek: render the single-post excerpt block ONLY when the author wrote a
+ * manual excerpt. Replaces the old hardcoded "proof trail" line — per-post control,
+ * blank by default (no auto-generated filler).
+ */
+function manual_excerpt_dek_only(string $block_content, array $block): string {
+    if (($block['blockName'] ?? '') === 'core/post-excerpt'
+        && is_singular()
+        && ! has_excerpt(get_the_ID())) {
+        return '';
+    }
+    return $block_content;
+}
+add_filter('render_block', __NAMESPACE__ . '\\manual_excerpt_dek_only', 10, 2);

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * KK Aurora Theme Functions
+ *
+ * @package KK_Aurora
+ * @since 1.0.0
+ */
+
+declare(strict_types=1);
+
+namespace KK_Aurora;
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Theme version for cache busting
+ */
+define('KK_AURORA_VERSION', '1.2.0');
+
+/**
+ * Theme setup
+ */
+function theme_setup(): void {
+    // Add theme support
+    add_theme_support('title-tag');
+    add_theme_support('wp-block-styles');
+    add_theme_support('editor-styles');
+    add_theme_support('responsive-embeds');
+    add_theme_support('html5', [
+        'comment-list',
+        'comment-form',
+        'search-form',
+        'gallery',
+        'caption',
+        'style',
+        'script',
+    ]);
+    
+    // Custom logo
+    add_theme_support('custom-logo', [
+        'height'      => 100,
+        'width'       => 400,
+        'flex-height' => true,
+        'flex-width'  => true,
+    ]);
+    
+    // Add editor styles
+    add_editor_style('style.css');
+    add_editor_style('assets/css/editor.css');
+}
+add_action('after_setup_theme', __NAMESPACE__ . '\\theme_setup');
+
+/**
+ * Enqueue frontend styles and scripts
+ */
+function enqueue_assets(): void {
+    wp_enqueue_style(
+        'kk-aurora-style',
+        get_stylesheet_uri(),
+        [],
+        KK_AURORA_VERSION
+    );
+
+    // Refined typography
+    wp_enqueue_style(
+        'kk-aurora-typography',
+        get_theme_file_uri('assets/css/typography-refined.css'),
+        ['kk-aurora-style'],
+        KK_AURORA_VERSION
+    );
+
+    // Custom animations CSS
+    wp_enqueue_style(
+        'kk-aurora-animations',
+        get_theme_file_uri('assets/css/animations.css'),
+        ['kk-aurora-typography'],
+        KK_AURORA_VERSION
+    );
+
+    // Bleeding edge CSS (progressive enhancement)
+    wp_enqueue_style(
+        'kk-aurora-bleeding-edge',
+        get_theme_file_uri('assets/css/bleeding-edge.css'),
+        ['kk-aurora-animations'],
+        KK_AURORA_VERSION
+    );
+
+    // Theme JavaScript (deferred)
+    wp_enqueue_script(
+        'kk-aurora-theme',
+        get_theme_file_uri('assets/js/theme.js'),
+        [],
+        KK_AURORA_VERSION,
+        [
+            'strategy' => 'defer',
+            'in_footer' => true,
+        ]
+    );
+
+    // Micro-interactions (no dependencies, vanilla JS)
+    wp_enqueue_script(
+        'kk-aurora-micro',
+        get_theme_file_uri('assets/js/micro-interactions.js'),
+        [],
+        KK_AURORA_VERSION,
+        [
+            'strategy' => 'defer',
+            'in_footer' => true,
+        ]
+    );
+
+    // GSAP for animations (loaded from CDN for performance)
+    wp_enqueue_script(
+        'gsap',
+        'https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js',
+        [],
+        '3.12.5',
+        [
+            'strategy' => 'defer',
+            'in_footer' => true,
+        ]
+    );
+
+    // GSAP ScrollTrigger
+    wp_enqueue_script(
+        'gsap-scrolltrigger',
+        'https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js',
+        ['gsap'],
+        '3.12.5',
+        [
+            'strategy' => 'defer',
+            'in_footer' => true,
+        ]
+    );
+
+    // Aurora animations (depends on GSAP)
+    wp_enqueue_script(
+        'kk-aurora-animations',
+        get_theme_file_uri('assets/js/aurora-animations.js'),
+        ['gsap', 'gsap-scrolltrigger'],
+        KK_AURORA_VERSION,
+        [
+            'strategy' => 'defer',
+            'in_footer' => true,
+        ]
+    );
+}
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets');
+
+/**
+ * Enqueue editor assets
+ */
+function enqueue_editor_assets(): void {
+    wp_enqueue_style(
+        'kk-aurora-editor',
+        get_theme_file_uri('assets/css/editor.css'),
+        [],
+        KK_AURORA_VERSION
+    );
+}
+add_action('enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_editor_assets');
+
+/**
+ * Register block patterns
+ */
+function register_block_patterns(): void {
+    // Register pattern category
+    register_block_pattern_category(
+        'kk-aurora',
+        ['label' => __('KK Aurora', 'kk-aurora')]
+    );
+    
+    register_block_pattern_category(
+        'kk-aurora-hero',
+        ['label' => __('Heroes', 'kk-aurora')]
+    );
+    
+    register_block_pattern_category(
+        'kk-aurora-cards',
+        ['label' => __('Cards', 'kk-aurora')]
+    );
+    
+    register_block_pattern_category(
+        'kk-aurora-cta',
+        ['label' => __('Call to Action', 'kk-aurora')]
+    );
+}
+add_action('init', __NAMESPACE__ . '\\register_block_patterns');
+
+/**
+ * Register block styles
+ */
+function register_block_styles(): void {
+    // Button styles
+    register_block_style('core/button', [
+        'name'  => 'aurora-primary',
+        'label' => __('Aurora Primary', 'kk-aurora'),
+    ]);
+    
+    register_block_style('core/button', [
+        'name'  => 'aurora-ghost',
+        'label' => __('Aurora Ghost', 'kk-aurora'),
+    ]);
+    
+    // Group/container styles
+    register_block_style('core/group', [
+        'name'  => 'aurora-card',
+        'label' => __('Aurora Card', 'kk-aurora'),
+    ]);
+    
+    register_block_style('core/group', [
+        'name'  => 'aurora-glass',
+        'label' => __('Aurora Glass', 'kk-aurora'),
+    ]);
+    
+    // Cover styles
+    register_block_style('core/cover', [
+        'name'  => 'aurora-hero',
+        'label' => __('Aurora Hero', 'kk-aurora'),
+    ]);
+}
+add_action('init', __NAMESPACE__ . '\\register_block_styles');
+
+/**
+ * Modify script loading attributes
+ */
+function script_loader_tag(string $tag, string $handle, string $src): string {
+    // Add crossorigin for CDN scripts
+    $cdn_scripts = ['gsap', 'gsap-scrolltrigger'];
+    
+    if (in_array($handle, $cdn_scripts, true)) {
+        $tag = str_replace(' src', ' crossorigin="anonymous" src', $tag);
+    }
+    
+    return $tag;
+}
+add_filter('script_loader_tag', __NAMESPACE__ . '\\script_loader_tag', 10, 3);
+
+/**
+ * Keep Aurora's browser titles aligned with the keynote-first positioning.
+ *
+ * SEO plugins can still override titles, but the theme fallback should not
+ * inherit the old "Generative AI Tools & Techniques" site identity.
+ *
+ * @param array<string, string> $title Document title parts.
+ * @return array<string, string>
+ */
+function filter_document_title_parts(array $title): array {
+    $site_descriptor = 'Kris Krug | AI Keynote Speaker & Creative Technologist';
+
+    unset($title['tagline']);
+
+    if (is_front_page()) {
+        $title['title'] = $site_descriptor;
+        unset($title['site']);
+        return $title;
+    }
+
+    $title['site'] = $site_descriptor;
+
+    return $title;
+}
+add_filter('document_title_parts', __NAMESPACE__ . '\\filter_document_title_parts');
+
+function filter_document_title_separator(string $separator): string {
+    return '—';
+}
+add_filter('document_title_separator', __NAMESPACE__ . '\\filter_document_title_separator');
+
+/**
+ * Add custom body classes
+ */
+function body_classes(array $classes): array {
+    // Add aurora class for styling hooks
+    $classes[] = 'aurora-theme';
+    
+    // Add reduced motion class if preference detected via JS
+    // This is also handled in CSS with @media query
+    
+    return $classes;
+}
+add_filter('body_class', __NAMESPACE__ . '\\body_classes');
+
+/**
+ * Preload critical fonts
+ */
+function preload_fonts(): void {
+    ?>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"></noscript>
+    <?php
+}
+add_action('wp_head', __NAMESPACE__ . '\\preload_fonts', 1);
+
+/**
+ * Add theme color meta tag
+ */
+function theme_color_meta(): void {
+    ?>
+    <meta name="theme-color" content="#0D0D12">
+    <meta name="color-scheme" content="dark">
+    <?php
+}
+add_action('wp_head', __NAMESPACE__ . '\\theme_color_meta', 2);
+
+/**
+ * Remove WordPress emoji scripts for performance
+ */
+function disable_emojis(): void {
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+    remove_filter('the_content_feed', 'wp_staticize_emoji');
+    remove_filter('comment_text_rss', 'wp_staticize_emoji');
+    remove_filter('wp_mail', 'wp_staticize_emoji_for_email');
+}
+add_action('init', __NAMESPACE__ . '\\disable_emojis');

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -1,0 +1,55 @@
+<!-- wp:html -->
+<footer class="aurora-footer-2026" role="contentinfo">
+  <div class="aurora-footer-shell">
+    <section class="aurora-footer-brand" aria-label="Kris Krug">
+      <p class="aurora-kicker">Kris Krug</p>
+      <h2>Authored judgment, human agency, and the camera-trained habit of paying attention.</h2>
+      <p>AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
+      <div class="aurora-footer-actions">
+        <a class="aurora-button aurora-button-primary" href="/speaking/">Book a keynote</a>
+        <a class="aurora-button aurora-button-secondary" href="https://kriskrug.beehiiv.com/">Join the dispatch</a>
+      </div>
+      <div class="aurora-newsletter-utility" aria-label="Newsletter">
+        <p class="aurora-kicker">The dispatch from the edge</p>
+        <h3>Weekly field notes on AI, creativity, and what's still ours to make.</h3>
+        <p>Sharp, useful, and short enough to actually read. Free.</p>
+        <a class="aurora-button aurora-button-secondary" href="https://kriskrug.beehiiv.com/">Join the dispatch</a>
+        <p class="aurora-form-message">Opens the Beehiiv signup.</p>
+      </div>
+    </section>
+
+    <nav class="aurora-footer-nav" aria-label="Footer navigation">
+      <div>
+        <h3>Site</h3>
+        <a href="/about/">About</a>
+        <a href="/work/">Work</a>
+        <a href="/speaking/">Speaking</a>
+        <a href="/services/">Services</a>
+        <a href="/blog/">Writing</a>
+        <a href="/motleykrug-podcast/">Podcast</a>
+      </div>
+      <div>
+        <h3>Projects</h3>
+        <a href="https://bc-ai.ca/">BC + AI</a>
+        <a href="https://www.theupgrade.ai/">The Upgrade AI</a>
+        <a href="https://indigenomics.ai/">Indigenomics.ai</a>
+        <a href="https://www.punkrockai.com/">Punk Rock AI</a>
+        <a href="https://www.bothhandsfull.com/">Both Hands Full</a>
+      </div>
+      <div>
+        <h3>Utility</h3>
+        <a href="/events/">Events</a>
+        <a href="/publications/">Press and publications</a>
+        <a href="/testimonials/">Testimonials</a>
+        <a href="/privacy-policy/">Privacy</a>
+        <a href="/contact/">Contact</a>
+      </div>
+    </nav>
+  </div>
+
+  <div class="aurora-footer-bottom">
+    <p>Copyright 2026 Kris Krug. All rights reserved.</p>
+    <p><a href="/reconciliation-indigenous-land-acknowledgement/">Reconciliation</a> / <a href="/the-kk-worldview/">Worldview</a></p>
+  </div>
+</footer>
+<!-- /wp:html -->

--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -1,0 +1,29 @@
+<!-- wp:html -->
+<header class="aurora-header aurora-header-2026" role="banner">
+  <a class="skip-link" href="#aurora-main">Skip to content</a>
+  <div class="aurora-header-shell">
+    <a class="aurora-brand" href="/">
+      <span class="aurora-brand-mark" aria-hidden="true">KK</span>
+      <span class="aurora-brand-text">
+        <span class="aurora-brand-name">Kris Krug</span>
+        <span class="aurora-brand-role">AI, culture, community</span>
+      </span>
+    </a>
+
+    <nav class="aurora-primary-nav" aria-label="Primary navigation">
+      <a href="/about/">About</a>
+      <a href="/work/">Work</a>
+      <a href="/speaking/">Speaking</a>
+      <a href="/services/">Services</a>
+      <a href="/blog/">Writing</a>
+      <a href="/motleykrug-podcast/">Podcast</a>
+      <a href="/contact/">Contact</a>
+    </nav>
+
+    <div class="aurora-header-actions">
+      <a class="aurora-utility-link" href="https://kriskrug.beehiiv.com/">Dispatch</a>
+      <a class="aurora-button aurora-button-primary aurora-header-cta" href="/speaking/">Book a keynote</a>
+    </div>
+  </div>
+</header>
+<!-- /wp:html -->

--- a/theme/kk-aurora/parts/speaking-proof-grid.html
+++ b/theme/kk-aurora/parts/speaking-proof-grid.html
@@ -1,0 +1,61 @@
+<!-- wp:html -->
+<section class="aurora-proof-section" aria-label="Speaking proof modules">
+  <article class="aurora-speaking-reel">
+    <figure class="aurora-speaking-reel-media">
+      <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1800&amp;ssl=1" alt="Kris Krug speaking from stage at a live event" loading="lazy" decoding="async">
+      <figcaption>Source: CreativeMornings Vancouver event photo</figcaption>
+    </figure>
+    <div class="aurora-speaking-reel-copy">
+      <p class="aurora-card-label">Featured speaking reel</p>
+      <h2>Live room energy plus practical signal.</h2>
+      <p>Keynotes are built for people who need concrete direction after the talk. The format combines story, operational examples, and actions people can use immediately.</p>
+      <div class="aurora-proof-tags">
+        <span>45-60 min keynote</span>
+        <span>Executive briefing</span>
+        <span>Interactive Q and A</span>
+      </div>
+      <div class="aurora-proof-actions">
+        <a class="aurora-button aurora-button-primary" href="/contact/">Request availability</a>
+        <a class="aurora-button aurora-button-secondary" href="https://www.bothhandsfull.com/">Watch keynote world</a>
+      </div>
+    </div>
+  </article>
+
+  <div class="aurora-topic-grid" aria-label="Keynote topic modules">
+    <article class="aurora-topic-card">
+      <p class="aurora-card-label">Topic</p>
+      <h3>Both Hands Full</h3>
+      <p>For creative and leadership teams learning how to use AI without flattening their taste, process, or point of view.</p>
+    </article>
+    <article class="aurora-topic-card">
+      <p class="aurora-card-label">Topic</p>
+      <h3>Community AI systems</h3>
+      <p>How to build trustworthy local AI ecosystems that connect events, education, policy, and practical experimentation.</p>
+    </article>
+    <article class="aurora-topic-card">
+      <p class="aurora-card-label">Topic</p>
+      <h3>Sovereignty and adoption</h3>
+      <p>Operational frameworks for organizations balancing innovation velocity with culture, governance, and long-term resilience.</p>
+    </article>
+  </div>
+
+  <div class="aurora-quote-grid" aria-label="Testimonial samples">
+    <blockquote class="aurora-quote-card">
+      <p>The talk changed how our team frames AI strategy. We left with practical moves, not just inspiration.</p>
+      <cite>Executive event host, Vancouver</cite>
+    </blockquote>
+    <blockquote class="aurora-quote-card">
+      <p>Kris made complex tools feel actionable for artists, operators, and leadership in the same room.</p>
+      <cite>Festival programming partner</cite>
+    </blockquote>
+  </div>
+
+  <div class="aurora-logo-row" aria-label="Common event formats">
+    <span>Association keynotes</span>
+    <span>Conference stages</span>
+    <span>Executive offsites</span>
+    <span>Creative workshops</span>
+    <span>Community salons</span>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/theme/kk-aurora/parts/work-proof-grid.html
+++ b/theme/kk-aurora/parts/work-proof-grid.html
@@ -1,0 +1,89 @@
+<!-- wp:html -->
+<section class="aurora-proof-section" aria-label="Work proof modules">
+  <div class="aurora-proof-grid">
+    <article class="aurora-proof-module">
+      <figure class="aurora-proof-media">
+        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC + AI ecosystem graphic showing community programs and events" loading="lazy" decoding="async">
+        <figcaption>Source: BC + AI ecosystem media, 2026</figcaption>
+      </figure>
+      <div class="aurora-proof-body">
+        <p class="aurora-card-label">Ecosystem</p>
+        <h2>BC + AI</h2>
+        <p>Community infrastructure for Vancouver and BC: events, learning pathways, working groups, and practical coordination for AI adoption in the region.</p>
+        <div class="aurora-proof-tags">
+          <span>Community</span>
+          <span>Events</span>
+          <span>Education</span>
+        </div>
+        <div class="aurora-proof-actions">
+          <a class="aurora-button aurora-button-primary" href="https://bc-ai.ca/">Visit BC + AI</a>
+          <a class="aurora-button aurora-button-secondary" href="/speaking/">Invite this talk</a>
+        </div>
+      </div>
+    </article>
+
+    <article class="aurora-proof-module">
+      <figure class="aurora-proof-media">
+        <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full keynote world visual" loading="lazy" decoding="async">
+        <figcaption>Source: Both Hands Full keynote portal</figcaption>
+      </figure>
+      <div class="aurora-proof-body">
+        <p class="aurora-card-label">Keynote world</p>
+        <h2>Both Hands Full</h2>
+        <p>A long-form keynote and learning world for filmmakers and creative leaders navigating AI acceleration without losing taste, authorship, or cultural depth.</p>
+        <div class="aurora-proof-tags">
+          <span>Keynotes</span>
+          <span>Creative teams</span>
+          <span>Strategy</span>
+        </div>
+        <div class="aurora-proof-actions">
+          <a class="aurora-button aurora-button-primary" href="https://www.bothhandsfull.com/">Open portal</a>
+          <a class="aurora-button aurora-button-secondary" href="/contact/">Bring to your event</a>
+        </div>
+      </div>
+    </article>
+
+    <article class="aurora-proof-module">
+      <figure class="aurora-proof-media">
+        <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1600&amp;ssl=1" alt="Kris Krug speaking at CreativeMornings Vancouver" loading="lazy" decoding="async">
+        <figcaption>Source: Punk Rock AI photography archive</figcaption>
+      </figure>
+      <div class="aurora-proof-body">
+        <p class="aurora-card-label">Creative leadership</p>
+        <h2>Punk Rock AI</h2>
+        <p>A practical culture practice for teams who want to stay experimental and human while AI tools become ubiquitous and increasingly polished.</p>
+        <div class="aurora-proof-tags">
+          <span>Culture</span>
+          <span>Agency</span>
+          <span>Workshops</span>
+        </div>
+        <div class="aurora-proof-actions">
+          <a class="aurora-button aurora-button-primary" href="https://www.punkrockai.com/">Explore Punk Rock AI</a>
+          <a class="aurora-button aurora-button-secondary" href="/blog/">Read field notes</a>
+        </div>
+      </div>
+    </article>
+
+    <article class="aurora-proof-module">
+      <figure class="aurora-proof-media">
+        <img src="https://i0.wp.com/www.theupgrade.ai/wp-content/uploads/2024/11/TheUpgrade-AI-Share-Image-1.jpg?w=1600&amp;ssl=1" alt="The Upgrade AI program cover image" loading="lazy" decoding="async">
+        <figcaption>Source: The Upgrade AI program media</figcaption>
+      </figure>
+      <div class="aurora-proof-body">
+        <p class="aurora-card-label">Applied learning</p>
+        <h2>The Upgrade AI + Indigenomics.ai</h2>
+        <p>Leadership and learning programs focused on practical adoption, sovereignty, and real capability building inside organizations and communities.</p>
+        <div class="aurora-proof-tags">
+          <span>Leadership</span>
+          <span>Sovereignty</span>
+          <span>Programs</span>
+        </div>
+        <div class="aurora-proof-actions">
+          <a class="aurora-button aurora-button-primary" href="https://www.theupgrade.ai/">Visit The Upgrade AI</a>
+          <a class="aurora-button aurora-button-secondary" href="https://indigenomics.ai/">Visit Indigenomics.ai</a>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/theme/kk-aurora/patterns/component-utility-system.php
+++ b/theme/kk-aurora/patterns/component-utility-system.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Title: Utility Component System
+ * Slug: kk-aurora/component-utility-system
+ * Categories: kk-aurora, kk-aurora-cta
+ * Keywords: search, newsletter, form, utility
+ * Viewport Width: 1200
+ */
+?>
+<!-- wp:group {"className":"aurora-utility-grid","layout":{"type":"constrained","contentSize":"1200px"}} -->
+<div class="wp-block-group aurora-utility-grid">
+  <!-- wp:group {"className":"aurora-search-utility","layout":{"type":"constrained"}} -->
+  <div class="wp-block-group aurora-search-utility">
+    <!-- wp:heading {"level":3} -->
+    <h3 class="wp-block-heading">Find the signal</h3>
+    <!-- /wp:heading -->
+    <!-- wp:paragraph -->
+    <p>Search projects, talks, field notes, and tools.</p>
+    <!-- /wp:paragraph -->
+    <!-- wp:search {"label":"Search kriskrug.co","showLabel":true,"placeholder":"Search the archive...","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"aurora-search-form"} /-->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:html -->
+  <section class="aurora-newsletter-utility" aria-label="Newsletter">
+    <p class="aurora-kicker">Newsletter</p>
+    <h3>Get the useful weird stuff.</h3>
+    <p>AI field notes, community signal, creative tools, and culture-first operating notes.</p>
+    <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Join the newsletter</a>
+    <p class="aurora-form-message">Opens the Beehiiv signup.</p>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:html -->
+  <form class="aurora-form" action="/contact/" method="get">
+    <div class="aurora-form-row">
+      <label for="aurora-component-intent">What should we talk about?</label>
+      <select id="aurora-component-intent" name="topic">
+        <option value="keynote">Book a keynote</option>
+        <option value="workshop">Plan a workshop</option>
+        <option value="training">Build a training program</option>
+        <option value="media">Media or podcast appearance</option>
+      </select>
+    </div>
+    <button class="aurora-button aurora-button-primary" type="submit">Open contact path</button>
+    <p class="aurora-form-message">Routes your intent to the contact page.</p>
+  </form>
+  <!-- /wp:html -->
+</div>
+<!-- /wp:group -->

--- a/theme/kk-aurora/patterns/hero-gradient.php
+++ b/theme/kk-aurora/patterns/hero-gradient.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Title: Hero with Gradient
+ * Slug: kk-aurora/hero-gradient
+ * Categories: kk-aurora-hero
+ * Keywords: hero, gradient, headline
+ * Viewport Width: 1400
+ */
+?>
+<!-- wp:cover {"dimRatio":0,"minHeight":90,"minHeightUnit":"vh","isDark":false,"className":"aurora-hero is-style-aurora-hero","style":{"spacing":{"padding":{"top":"var:preset|spacing|200","bottom":"var:preset|spacing|160","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}}} -->
+<div class="wp-block-cover is-light aurora-hero is-style-aurora-hero" style="padding-top:var(--wp--preset--spacing--200);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--160);padding-left:var(--wp--preset--spacing--40);min-height:90vh">
+  <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
+  
+  <div class="wp-block-cover__inner-container">
+    <!-- wp:group {"layout":{"type":"constrained","contentSize":"900px"}} -->
+    <div class="wp-block-group">
+      
+      <!-- wp:heading {"textAlign":"center","level":1,"className":"aurora-hero-headline has-animated-gradient-text","style":{"typography":{"fontSize":"clamp(2.5rem, 7vw, 5rem)","fontStyle":"normal","fontWeight":"700","lineHeight":"1.1","letterSpacing":"0"}}} -->
+      <h1 class="wp-block-heading has-text-align-center aurora-hero-headline has-animated-gradient-text" style="font-size:clamp(2.5rem, 7vw, 5rem);font-style:normal;font-weight:700;letter-spacing:0;line-height:1.1">Bridging Art, AI, Indigenous Wisdom &amp; Justice</h1>
+      <!-- /wp:heading -->
+      
+      <!-- wp:paragraph {"align":"center","className":"aurora-hero-description","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"textColor":"text-secondary","fontSize":"lg"} -->
+      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC+AI · Co-founder The Upgrade AI · Techartist &amp; Culture Hacker</p>
+      <!-- /wp:paragraph -->
+      
+      <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
+      <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--80)">
+        <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
+        <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
+          <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"cyan"} -->
+          <p class="has-cyan-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">BC+AI</p>
+          <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:group -->
+        
+        <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
+        <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
+          <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"teal"} -->
+          <p class="has-teal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">Indigenomics</p>
+          <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:group -->
+        
+        <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
+        <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
+          <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"purple"} -->
+          <p class="has-purple-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">The Upgrade AI</p>
+          <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:group -->
+      </div>
+      <!-- /wp:group -->
+      
+      <!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--80)">
+        <!-- wp:button {"backgroundColor":"cyan","textColor":"deep","className":"is-style-aurora-primary","style":{"typography":{"fontSize":"1rem","fontStyle":"normal","fontWeight":"600"},"border":{"radius":"0.5rem"},"spacing":{"padding":{"top":"0.875rem","bottom":"0.875rem","left":"2rem","right":"2rem"}}}} -->
+        <div class="wp-block-button is-style-aurora-primary" style="font-size:1rem;font-style:normal;font-weight:600">
+          <a class="wp-block-button__link has-cyan-background-color has-deep-color has-text-color has-background wp-element-button" href="/work/" style="border-radius:0.5rem;padding-top:0.875rem;padding-right:2rem;padding-bottom:0.875rem;padding-left:2rem">Explore My Work</a>
+        </div>
+        <!-- /wp:button -->
+        
+        <!-- wp:button {"className":"is-style-aurora-ghost","style":{"typography":{"fontSize":"1rem","fontStyle":"normal","fontWeight":"600"},"border":{"radius":"0.5rem"},"spacing":{"padding":{"top":"0.875rem","bottom":"0.875rem","left":"2rem","right":"2rem"}}}} -->
+        <div class="wp-block-button is-style-aurora-ghost" style="font-size:1rem;font-style:normal;font-weight:600">
+          <a class="wp-block-button__link wp-element-button" href="/contact/" style="border-radius:0.5rem;padding-top:0.875rem;padding-right:2rem;padding-bottom:0.875rem;padding-left:2rem">Let's Connect</a>
+        </div>
+        <!-- /wp:button -->
+      </div>
+      <!-- /wp:buttons -->
+      
+      <!-- wp:group {"className":"aurora-scroll-indicator","style":{"spacing":{"margin":{"top":"var:preset|spacing|120"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+      <div class="wp-block-group aurora-scroll-indicator" style="margin-top:var(--wp--preset--spacing--120)">
+        <!-- wp:paragraph {"textColor":"text-muted","fontSize":"sm"} -->
+        <p class="has-text-muted-color has-text-color has-sm-font-size">↓ Scroll to discover</p>
+        <!-- /wp:paragraph -->
+      </div>
+      <!-- /wp:group -->
+      
+    </div>
+    <!-- /wp:group -->
+  </div>
+</div>
+<!-- /wp:cover -->

--- a/theme/kk-aurora/patterns/stats-counter.php
+++ b/theme/kk-aurora/patterns/stats-counter.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Title: Stats Counter
+ * Slug: kk-aurora/stats-counter
+ * Categories: kk-aurora
+ * Keywords: stats, counter, numbers, metrics
+ */
+?>
+<!-- wp:group {"className":"aurora-section aurora-section-divided","style":{"spacing":{"padding":{"top":"var:preset|spacing|120","bottom":"var:preset|spacing|120"}}},"backgroundColor":"surface","layout":{"type":"constrained","contentSize":"1280px"}} -->
+<div class="wp-block-group aurora-section aurora-section-divided has-surface-background-color has-background" style="padding-top:var(--wp--preset--spacing--120);padding-bottom:var(--wp--preset--spacing--120)">
+  
+  <!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|60","left":"var:preset|spacing|40"}}}} -->
+  <div class="wp-block-columns">
+    
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:group {"className":"aurora-card","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"border":{"radius":"0.75rem","color":"var:preset|color|elevated","width":"1px"}},"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group aurora-card" style="border-color:var(--wp--preset--color--elevated);border-width:1px;border-radius:0.75rem;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+        <!-- wp:heading {"textAlign":"center","level":3,"className":"aurora-counter","style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3rem)","fontStyle":"normal","fontWeight":"700","lineHeight":"1"}},"textColor":"cyan"} -->
+        <h3 class="wp-block-heading has-text-align-center aurora-counter has-cyan-color has-text-color" style="font-size:clamp(2rem, 5vw, 3rem);font-style:normal;font-weight:700;line-height:1" data-aurora-counter="250" data-aurora-suffix="">250</h3>
+        <!-- /wp:heading -->
+
+        <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">BC+AI Members</p>
+        <!-- /wp:paragraph -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:group {"className":"aurora-card","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"border":{"radius":"0.75rem","color":"var:preset|color|elevated","width":"1px"}},"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group aurora-card" style="border-color:var(--wp--preset--color--elevated);border-width:1px;border-radius:0.75rem;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+        <!-- wp:heading {"textAlign":"center","level":3,"className":"aurora-counter","style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3rem)","fontStyle":"normal","fontWeight":"700","lineHeight":"1"}},"textColor":"teal"} -->
+        <h3 class="wp-block-heading has-text-align-center aurora-counter has-teal-color has-text-color" style="font-size:clamp(2rem, 5vw, 3rem);font-style:normal;font-weight:700;line-height:1" data-aurora-counter="2400" data-aurora-suffix="+">2,400+</h3>
+        <!-- /wp:heading -->
+
+        <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">Vancouver AI Attendees (2024)</p>
+        <!-- /wp:paragraph -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:group {"className":"aurora-card","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"border":{"radius":"0.75rem","color":"var:preset|color|elevated","width":"1px"}},"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group aurora-card" style="border-color:var(--wp--preset--color--elevated);border-width:1px;border-radius:0.75rem;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+        <!-- wp:heading {"textAlign":"center","level":3,"className":"aurora-counter","style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3rem)","fontStyle":"normal","fontWeight":"700","lineHeight":"1"}},"textColor":"purple"} -->
+        <h3 class="wp-block-heading has-text-align-center aurora-counter has-purple-color has-text-color" style="font-size:clamp(2rem, 5vw, 3rem);font-style:normal;font-weight:700;line-height:1" data-aurora-counter="130" data-aurora-suffix="K+">130K+</h3>
+        <!-- /wp:heading -->
+
+        <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">Photos Under CC License</p>
+        <!-- /wp:paragraph -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column -->
+    <div class="wp-block-column">
+      <!-- wp:group {"className":"aurora-card","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"border":{"radius":"0.75rem","color":"var:preset|color|elevated","width":"1px"}},"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group aurora-card" style="border-color:var(--wp--preset--color--elevated);border-width:1px;border-radius:0.75rem;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+        <!-- wp:heading {"textAlign":"center","level":3,"style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3rem)","fontStyle":"normal","fontWeight":"700","lineHeight":"1"}},"textColor":"pink"} -->
+        <h3 class="wp-block-heading has-text-align-center has-pink-color has-text-color" style="font-size:clamp(2rem, 5vw, 3rem);font-style:normal;font-weight:700;line-height:1">Fortune 500</h3>
+        <!-- /wp:heading -->
+        
+        <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">Companies Trained</p>
+        <!-- /wp:paragraph -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+    
+  </div>
+  <!-- /wp:columns -->
+  
+</div>
+<!-- /wp:group -->

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -1,0 +1,43 @@
+=== KK Aurora ===
+Contributors: kriskrug
+Requires at least: 6.4
+Tested up to: 6.9
+Requires PHP: 8.0
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+
+KK Aurora is a cyberpunk-inspired WordPress theme featuring flowing gradients, deep space aesthetics, and purposeful motion design.
+
+Built for Full Site Editing with WCAG 2.1 AA accessibility.
+
+== Features ==
+
+* Full Site Editing (FSE) block theme
+* Dark mode by default
+* Animated gradient accents
+* GSAP/ScrollTrigger animations
+* High contrast accessibility
+* Mobile-first responsive design
+* Custom block patterns
+
+== Installation ==
+
+1. Upload the theme folder to `/wp-content/themes/`
+2. Activate the theme through the 'Themes' menu in WordPress
+3. Start customizing with the Site Editor
+
+== Color Palette ==
+
+* Deep Space: #0D0D12 (primary background)
+* Surface: #12121A (cards, elevated surfaces)
+* Cyan: #00E5FF (primary accent)
+* Teal: #00BFA5 (secondary accent)
+* Purple: #8B5CF6 (tertiary accent)
+* Pink: #EC4899 (highlights)
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1,0 +1,2527 @@
+/*
+Theme Name: KK Aurora
+Theme URI: https://kriskrug.co
+Author: Kris Krug
+Author URI: https://kriskrug.co
+Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
+Version: 1.2.0
+Requires at least: 6.4
+Tested up to: 6.9
+Requires PHP: 8.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: kk-aurora
+Tags: full-site-editing, block-patterns, custom-colors, custom-menu, editor-style, featured-images, one-column, wide-blocks, dark-mode, accessibility-ready
+
+KK Aurora WordPress Theme
+Copyright 2026 Kris Krug
+*/
+
+/* ============================================
+   AURORA CUSTOM PROPERTIES
+   Extended tokens beyond theme.json
+   ============================================ */
+
+:root {
+  /* Glass Effect */
+  --aurora-glass-bg: rgba(18, 18, 26, 0.85);
+  --aurora-glass-blur: blur(16px);
+  --aurora-glass-border: 1px solid rgba(255, 255, 255, 0.08);
+  
+  /* Gradient Animation */
+  --aurora-gradient-animated: linear-gradient(
+    135deg,
+    #00E5FF,
+    #00BFA5,
+    #8B5CF6,
+    #EC4899,
+    #00E5FF
+  );
+  --aurora-gradient-size: 300% 300%;
+  
+  /* Glow Effects */
+  --aurora-glow-xs: 0 0 8px;
+  --aurora-glow-sm: 0 0 15px;
+  --aurora-glow-md: 0 0 25px;
+  --aurora-glow-lg: 0 0 40px;
+  --aurora-glow-xl: 0 0 60px;
+  
+  /* Border Gradients */
+  --aurora-border-gradient: linear-gradient(135deg, rgba(0,229,255,0.5) 0%, rgba(139,92,246,0.5) 100%);
+  
+  /* Transitions */
+  --transition-fast: 150ms cubic-bezier(0, 0, 0.2, 1);
+  --transition-normal: 300ms cubic-bezier(0, 0, 0.2, 1);
+  --transition-slow: 500ms cubic-bezier(0.25, 0.1, 0.25, 1);
+  
+  /* Focus Ring */
+  --focus-ring: 0 0 0 2px var(--wp--preset--color--deep), 0 0 0 4px var(--wp--preset--color--cyan);
+}
+
+/* ============================================
+   BASE RESETS & DEFAULTS
+   ============================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* Selection styling */
+::selection {
+  background-color: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+}
+
+::-moz-selection {
+  background-color: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+}
+
+/* Focus visible for keyboard navigation */
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ============================================
+   TYPOGRAPHY ENHANCEMENTS
+   ============================================ */
+
+/* Gradient text utility */
+.has-gradient-text {
+  background: var(--wp--preset--gradient--aurora-primary);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Animated gradient text */
+.has-animated-gradient-text {
+  background: var(--aurora-gradient-animated);
+  background-size: var(--aurora-gradient-size);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradient-shift 8s ease infinite;
+}
+
+@keyframes gradient-shift {
+  0%, 100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+/* ============================================
+   LINK STYLES
+   ============================================ */
+
+a {
+  transition: color var(--transition-fast);
+}
+
+/* Animated underline for links */
+.aurora-link {
+  position: relative;
+  text-decoration: none;
+}
+
+.aurora-link::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--wp--preset--gradient--aurora-cyan-teal);
+  transition: width var(--transition-normal);
+}
+
+.aurora-link:hover::after {
+  width: 100%;
+}
+
+/* ============================================
+   BUTTON STYLES
+   ============================================ */
+
+/* Primary button with glow */
+.wp-block-button.is-style-aurora-primary .wp-block-button__link {
+  position: relative;
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+  border: none;
+  font-weight: 600;
+  transition: 
+    transform var(--transition-fast),
+    box-shadow var(--transition-normal);
+}
+
+.wp-block-button.is-style-aurora-primary .wp-block-button__link:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--aurora-glow-md) rgba(0, 229, 255, 0.4);
+}
+
+/* Ghost button with gradient border */
+.wp-block-button.is-style-aurora-ghost .wp-block-button__link {
+  position: relative;
+  background: transparent;
+  color: var(--wp--preset--color--text-primary);
+  border: 2px solid transparent;
+  background-image: 
+    linear-gradient(var(--wp--preset--color--surface), var(--wp--preset--color--surface)),
+    var(--wp--preset--gradient--aurora-primary);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  transition: 
+    background var(--transition-normal),
+    box-shadow var(--transition-normal);
+}
+
+.wp-block-button.is-style-aurora-ghost .wp-block-button__link:hover {
+  background-image: 
+    var(--wp--preset--gradient--aurora-subtle),
+    var(--wp--preset--gradient--aurora-primary);
+  box-shadow: var(--aurora-glow-sm) rgba(0, 229, 255, 0.2);
+}
+
+/* ============================================
+   CARD STYLES
+   ============================================ */
+
+.aurora-card {
+  background: var(--wp--preset--color--surface);
+  border: 1px solid var(--wp--preset--color--elevated);
+  border-radius: var(--wp--custom--border--radius-lg);
+  padding: var(--wp--preset--spacing--60);
+  transition: 
+    transform var(--transition-normal),
+    box-shadow var(--transition-normal),
+    border-color var(--transition-normal);
+}
+
+.aurora-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(0, 229, 255, 0.3);
+  box-shadow: 
+    0 10px 40px rgba(0, 0, 0, 0.3),
+    var(--aurora-glow-md) rgba(0, 229, 255, 0.15);
+}
+
+/* Card with gradient border on hover */
+.aurora-card-gradient {
+  position: relative;
+  background: var(--wp--preset--color--surface);
+  border-radius: var(--wp--custom--border--radius-lg);
+  padding: var(--wp--preset--spacing--60);
+}
+
+.aurora-card-gradient::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: var(--aurora-border-gradient);
+  -webkit-mask: 
+    linear-gradient(#fff 0 0) content-box, 
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity var(--transition-normal);
+}
+
+.aurora-card-gradient:hover::before {
+  opacity: 1;
+}
+
+/* ============================================
+   GLASS MORPHISM
+   ============================================ */
+
+.aurora-glass {
+  background: var(--aurora-glass-bg);
+  backdrop-filter: var(--aurora-glass-blur);
+  -webkit-backdrop-filter: var(--aurora-glass-blur);
+  border: var(--aurora-glass-border);
+}
+
+/* ============================================
+   SECTION STYLES
+   ============================================ */
+
+.aurora-section {
+  padding-top: var(--wp--preset--spacing--160);
+  padding-bottom: var(--wp--preset--spacing--160);
+}
+
+.aurora-section-tight {
+  padding-top: var(--wp--preset--spacing--100);
+  padding-bottom: var(--wp--preset--spacing--100);
+}
+
+/* Section with gradient divider */
+.aurora-section-divided {
+  position: relative;
+}
+
+.aurora-section-divided::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(80%, 600px);
+  height: 1px;
+  background: var(--wp--preset--gradient--aurora-primary);
+  opacity: 0.5;
+}
+
+/* ============================================
+   BADGE / TAG STYLES
+   ============================================ */
+
+.aurora-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--30);
+  font-size: var(--wp--preset--font-size--xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: var(--wp--custom--border--radius-full);
+  background: var(--wp--preset--color--surface);
+  border: 1px solid var(--wp--preset--color--elevated);
+  color: var(--wp--preset--color--text-secondary);
+  transition: 
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.aurora-badge:hover {
+  border-color: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-badge-gradient {
+  position: relative;
+  background: transparent;
+  border: none;
+  padding: var(--wp--preset--spacing--20) var(--wp--preset--spacing--40);
+}
+
+.aurora-badge-gradient::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: var(--wp--preset--gradient--aurora-primary);
+  -webkit-mask: 
+    linear-gradient(#fff 0 0) content-box, 
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}
+
+/* ============================================
+   SCROLL ANIMATIONS (base setup for GSAP)
+   ============================================ */
+
+.aurora-fade-up {
+  opacity: 0;
+  transform: translateY(30px);
+}
+
+.aurora-fade-up.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+  transition: 
+    opacity var(--transition-slow),
+    transform var(--transition-slow);
+}
+
+.aurora-scale-in {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+.aurora-scale-in.is-visible {
+  opacity: 1;
+  transform: scale(1);
+  transition: 
+    opacity var(--transition-slow),
+    transform var(--transition-slow);
+}
+
+/* ============================================
+   LOADING / SKELETON STATES
+   ============================================ */
+
+.aurora-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--wp--preset--color--surface) 25%,
+    var(--wp--preset--color--elevated) 50%,
+    var(--wp--preset--color--surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* ============================================
+   ACCESSIBILITY
+   ============================================ */
+
+/* Skip link */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: var(--wp--preset--spacing--40);
+  z-index: 9999;
+  padding: var(--wp--preset--spacing--30) var(--wp--preset--spacing--50);
+  background: var(--wp--preset--color--cyan);
+  color: var(--wp--preset--color--deep);
+  font-weight: 600;
+  border-radius: var(--wp--custom--border--radius-sm);
+  transition: top var(--transition-fast);
+}
+
+.skip-link:focus {
+  top: var(--wp--preset--spacing--40);
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ============================================
+   RESPONSIVE UTILITIES
+   ============================================ */
+
+@media (max-width: 781px) {
+  .aurora-section {
+    padding-top: var(--wp--preset--spacing--100);
+    padding-bottom: var(--wp--preset--spacing--100);
+  }
+  
+  .aurora-hide-mobile {
+    display: none !important;
+  }
+}
+
+@media (min-width: 782px) {
+  .aurora-hide-desktop {
+    display: none !important;
+  }
+}
+
+/* ============================================
+   AURORA 2026 REDESIGN SYSTEM
+   Media-led personal brand layer
+   ============================================ */
+
+:root {
+  --aurora-ink: #f7f7f2;
+  --aurora-ink-soft: #c8cac8;
+  --aurora-ink-muted: #8f9697;
+  --aurora-paper: #f7f5f1;
+  --aurora-signal: #e5462e;
+  --aurora-signal-dark: #a52918;
+  --aurora-wildcard: #c8ff3d;
+  --aurora-black: #030405;
+  --aurora-panel: rgba(10, 13, 15, 0.78);
+  --aurora-panel-solid: #0b0f12;
+  --aurora-line: rgba(247, 247, 242, 0.14);
+  --aurora-line-strong: rgba(229, 70, 46, 0.46);
+  --aurora-warm: #f0b35a;
+  --aurora-radius-card: 8px;
+  --aurora-radius-control: 8px;
+  --aurora-shadow-deep: 0 24px 80px rgba(0, 0, 0, 0.42);
+  --aurora-max: 1200px;
+}
+
+.aurora-theme {
+  background:
+    radial-gradient(circle at 20% 10%, rgba(0, 229, 255, 0.08), transparent 24rem),
+    radial-gradient(circle at 88% 28%, rgba(240, 179, 90, 0.06), transparent 22rem),
+    var(--aurora-black);
+}
+
+.aurora-theme :where(h1, h2, h3, h4, h5, h6, p, a, span, li, figcaption) {
+  letter-spacing: 0;
+}
+
+.aurora-button,
+.aurora-theme .wp-block-button__link {
+  align-items: center;
+  border-radius: var(--aurora-radius-control);
+  display: inline-flex;
+  font-weight: 700;
+  justify-content: center;
+  line-height: 1;
+  min-height: 44px;
+  padding: 0.8rem 1.05rem;
+  text-decoration: none;
+  transition: border-color 180ms ease, background-color 180ms ease, color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.aurora-button:hover,
+.aurora-theme .wp-block-button__link:hover {
+  transform: translateY(-1px);
+}
+
+.aurora-button-primary,
+.wp-block-button.is-style-aurora-primary .wp-block-button__link {
+  background: var(--aurora-signal);
+  border: 1px solid var(--aurora-signal);
+  color: #fffaf6;
+  box-shadow: 0 0 28px rgba(229, 70, 46, 0.22);
+}
+
+.aurora-button-secondary,
+.wp-block-button.is-style-aurora-ghost .wp-block-button__link {
+  background: rgba(247, 247, 242, 0.06);
+  border: 1px solid var(--aurora-line);
+  color: var(--aurora-ink);
+}
+
+.aurora-button-primary:hover,
+.wp-block-button.is-style-aurora-primary .wp-block-button__link:hover {
+  background: #f15b43;
+  border-color: #f15b43;
+  box-shadow: 0 0 38px rgba(229, 70, 46, 0.34);
+}
+
+.aurora-button-secondary:hover,
+.wp-block-button.is-style-aurora-ghost .wp-block-button__link:hover {
+  border-color: var(--aurora-line-strong);
+  background: rgba(0, 229, 255, 0.1);
+}
+
+.aurora-button:focus-visible,
+.aurora-theme :where(a, button, input, select, textarea, summary):focus-visible,
+.aurora-theme .wp-block-button__link:focus-visible {
+  outline: 2px solid var(--wp--preset--color--cyan);
+  outline-offset: 3px;
+}
+
+.aurora-button:active,
+.aurora-theme .wp-block-button__link:active {
+  transform: translateY(0);
+}
+
+.aurora-button[aria-disabled="true"],
+.aurora-button.is-disabled,
+.aurora-theme .wp-block-button__link[aria-disabled="true"],
+.aurora-theme button:disabled,
+.aurora-theme input:disabled,
+.aurora-theme select:disabled,
+.aurora-theme textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.aurora-button.is-loading,
+.aurora-theme button.is-loading {
+  cursor: progress;
+  position: relative;
+}
+
+.aurora-button.is-loading::after,
+.aurora-theme button.is-loading::after {
+  content: "";
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 999px;
+  height: 0.8em;
+  margin-left: 0.55rem;
+  width: 0.8em;
+  animation: aurora-spin 800ms linear infinite;
+}
+
+@keyframes aurora-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.aurora-kicker {
+  color: var(--wp--preset--color--cyan);
+  font-size: clamp(0.78rem, 0.74rem + 0.18vw, 0.92rem);
+  font-weight: 800;
+  margin: 0 0 1rem;
+  max-width: none;
+  text-transform: uppercase;
+}
+
+.aurora-header-2026 {
+  background: rgba(3, 4, 5, 0.76);
+  border-bottom: 1px solid var(--aurora-line);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  left: 0;
+  position: sticky;
+  right: 0;
+  top: 0;
+  z-index: 1000;
+}
+
+.aurora-header-shell {
+  align-items: center;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(180px, auto) minmax(0, 1fr) auto;
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+  padding: 0.8rem clamp(1rem, 3vw, 2rem);
+}
+
+.aurora-brand {
+  align-items: center;
+  color: var(--aurora-ink);
+  display: inline-flex;
+  gap: 0.75rem;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.aurora-brand-mark {
+  align-items: center;
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.98), rgba(240, 179, 90, 0.92));
+  border-radius: 50%;
+  color: #020607;
+  display: inline-flex;
+  font-size: 0.74rem;
+  font-weight: 900;
+  height: 2.25rem;
+  justify-content: center;
+  width: 2.25rem;
+}
+
+.aurora-brand-text {
+  display: grid;
+  gap: 0.12rem;
+}
+
+.aurora-brand-name {
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.aurora-brand-role {
+  color: var(--aurora-ink-muted);
+  font-size: 0.72rem;
+}
+
+.aurora-primary-nav,
+.aurora-header-actions {
+  align-items: center;
+  display: flex;
+  gap: clamp(0.6rem, 1.8vw, 1.2rem);
+  min-width: 0;
+}
+
+.aurora-primary-nav {
+  justify-content: center;
+}
+
+.aurora-primary-nav a,
+.aurora-utility-link {
+  color: var(--aurora-ink-soft);
+  font-size: 0.88rem;
+  font-weight: 650;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.aurora-primary-nav a:hover,
+.aurora-utility-link:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-header-actions {
+  flex-wrap: nowrap;
+  justify-content: end;
+}
+
+.aurora-utility-link {
+  align-items: center;
+  display: inline-flex;
+  min-height: 38px;
+}
+
+.aurora-header-cta {
+  flex-shrink: 0;
+  min-height: 38px;
+  padding: 0.65rem 0.85rem;
+  white-space: nowrap;
+}
+
+.aurora-brand:focus-visible,
+.aurora-primary-nav a:focus-visible,
+.aurora-utility-link:focus-visible,
+.aurora-header-cta:focus-visible {
+  border-radius: 999px;
+}
+
+.aurora-home-2026,
+.aurora-page-2026,
+.aurora-single-2026 {
+  background: transparent;
+}
+
+.aurora-hero-2026 {
+  isolation: isolate;
+  min-height: clamp(640px, 86vh, 880px);
+  overflow: hidden;
+  position: relative;
+}
+
+.aurora-hero-media,
+.aurora-hero-media picture,
+.aurora-hero-media img,
+.aurora-hero-scrim {
+  inset: 0;
+  position: absolute;
+}
+
+.aurora-hero-media {
+  margin: 0;
+  z-index: -3;
+}
+
+.aurora-hero-media picture {
+  display: block;
+  height: 100%;
+}
+
+.aurora-hero-media img {
+  height: 100%;
+  object-fit: cover;
+  object-position: 54% 38%;
+  width: 100%;
+}
+
+.aurora-hero-scrim {
+  background:
+    linear-gradient(90deg, rgba(3, 4, 5, 0.94) 0%, rgba(3, 4, 5, 0.76) 38%, rgba(3, 4, 5, 0.22) 100%),
+    linear-gradient(180deg, rgba(3, 4, 5, 0.2), rgba(3, 4, 5, 0.78));
+  z-index: -2;
+}
+
+.aurora-hero-copy {
+  display: grid;
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+  min-height: clamp(640px, 86vh, 880px);
+  padding: clamp(5rem, 10vw, 8rem) clamp(1rem, 3vw, 2rem) clamp(3rem, 6vw, 5rem);
+  place-content: center start;
+}
+
+.aurora-hero-copy h1 {
+  color: var(--aurora-ink);
+  font-size: clamp(3.2rem, 9vw, 8.2rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 0.96;
+  margin: 0;
+  max-width: 10ch;
+  text-wrap: balance;
+}
+
+.aurora-hero-dek {
+  color: var(--aurora-ink-soft);
+  font-size: clamp(1.05rem, 1.6vw, 1.42rem);
+  line-height: 1.55;
+  margin: 1.4rem 0 0;
+  max-width: 55ch;
+}
+
+.aurora-proof-row,
+.aurora-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.aurora-proof-row {
+  margin-top: 1.6rem;
+}
+
+.aurora-proof-row a {
+  background: rgba(247, 247, 242, 0.07);
+  border: 1px solid var(--aurora-line);
+  border-radius: 999px;
+  color: var(--aurora-ink);
+  font-size: 0.84rem;
+  font-weight: 800;
+  padding: 0.52rem 0.72rem;
+  text-decoration: none;
+}
+
+.aurora-path-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 0.8rem;
+}
+
+.aurora-path-row a {
+  background: rgba(247, 247, 242, 0.04);
+  border: 1px solid var(--aurora-line);
+  border-radius: 999px;
+  color: var(--aurora-ink-soft);
+  font-size: 0.79rem;
+  font-weight: 760;
+  padding: 0.45rem 0.68rem;
+  text-decoration: none;
+}
+
+.aurora-proof-row a:hover {
+  border-color: var(--aurora-line-strong);
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-path-row a:hover {
+  border-color: var(--aurora-line-strong);
+  color: var(--aurora-ink);
+}
+
+.aurora-action-row {
+  margin-top: 1.8rem;
+}
+
+.aurora-button-reel {
+  background: rgba(247, 247, 242, 0.02);
+}
+
+.aurora-hero-caption {
+  align-items: center;
+  bottom: clamp(1rem, 3vw, 2rem);
+  color: var(--aurora-ink-muted);
+  display: flex;
+  font-size: 0.76rem;
+  gap: 0.75rem;
+  left: clamp(1rem, 3vw, 2rem);
+  max-width: var(--aurora-max);
+  position: absolute;
+  right: clamp(1rem, 3vw, 2rem);
+}
+
+.aurora-hero-caption span {
+  border-left: 2px solid var(--wp--preset--color--cyan);
+  padding-left: 0.65rem;
+}
+
+.aurora-signal-strip {
+  background: rgba(3, 4, 5, 0.92);
+  border-bottom: 1px solid var(--aurora-line);
+  border-top: 1px solid var(--aurora-line);
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.aurora-signal-strip div {
+  background: rgba(247, 247, 242, 0.035);
+  padding: clamp(1.3rem, 3vw, 2rem);
+}
+
+.aurora-signal-strip strong {
+  color: var(--aurora-ink);
+  display: block;
+  font-size: 1rem;
+  margin-bottom: 0.4rem;
+}
+
+.aurora-signal-strip span {
+  color: var(--aurora-ink-muted);
+  display: block;
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.aurora-featured-strip,
+.aurora-stage-strip,
+.aurora-offer-band,
+.aurora-testimonial-band,
+.aurora-dispatch-band {
+  margin: 0 auto;
+  padding: clamp(3rem, 7vw, 5.5rem) clamp(1rem, 4vw, 2rem);
+}
+
+.aurora-featured-strip,
+.aurora-stage-strip {
+  background: #050708;
+  border-block: 1px solid var(--aurora-line);
+}
+
+.aurora-section-heading-compact {
+  margin-bottom: clamp(1rem, 3vw, 1.5rem);
+}
+
+.aurora-section-heading-compact h2 {
+  font-size: clamp(1.7rem, 3.5vw, 3rem);
+}
+
+.aurora-logo-row-wide {
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-logo-row-wide span {
+  align-items: center;
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: 8px;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 54px;
+  padding: 0.75rem;
+}
+
+.aurora-offer-band {
+  background:
+    radial-gradient(circle at 12% 0%, rgba(229, 70, 46, 0.13), transparent 26rem),
+    #080b0d;
+  border-block: 1px solid var(--aurora-line);
+}
+
+.aurora-hired-grid,
+.aurora-check-grid,
+.aurora-epk-grid,
+.aurora-faq-grid {
+  display: grid;
+  gap: 1rem;
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-hired-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aurora-hired-grid article,
+.aurora-epk-grid article,
+.aurora-faq-grid article {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1rem, 3vw, 1.35rem);
+}
+
+.aurora-hired-grid .aurora-card-label {
+  align-self: start;
+  margin: 0;
+  position: static;
+}
+
+.aurora-hired-grid h3,
+.aurora-epk-grid h3,
+.aurora-faq-grid h3 {
+  color: var(--aurora-ink);
+  font-size: clamp(1.2rem, 2.2vw, 1.7rem);
+  line-height: 1.08;
+  margin: 0;
+}
+
+.aurora-hired-grid p,
+.aurora-epk-grid p,
+.aurora-faq-grid p {
+  color: var(--aurora-ink-soft);
+  margin: 0;
+}
+
+.aurora-inline-link {
+  color: var(--aurora-signal);
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 0.22em;
+}
+
+.aurora-inline-link:hover {
+  color: #ff735d;
+}
+
+.aurora-testimonial-band {
+  background: #030405;
+}
+
+.aurora-quote-grid-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-dispatch-band {
+  background:
+    linear-gradient(135deg, rgba(229, 70, 46, 0.18), rgba(200, 255, 61, 0.06)),
+    #07090b;
+  border-top: 1px solid var(--aurora-line);
+  text-align: center;
+}
+
+.aurora-dispatch-band h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(2.1rem, 5vw, 4.6rem);
+  line-height: 1;
+  margin: 0;
+}
+
+.aurora-dispatch-band p {
+  color: var(--aurora-ink-soft);
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.aurora-dispatch-band .aurora-action-row,
+.aurora-centered-actions {
+  justify-content: center;
+}
+
+.aurora-feature-band,
+.aurora-speaking-band,
+.aurora-writing-band,
+.aurora-final-cta,
+.aurora-page-2026,
+.aurora-single-2026 {
+  margin: 0 auto;
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 2rem);
+}
+
+.aurora-feature-band-dark {
+  background:
+    radial-gradient(circle at 80% 8%, rgba(0, 229, 255, 0.1), transparent 22rem),
+    #050708;
+}
+
+.aurora-section-heading {
+  margin: 0 auto clamp(2rem, 5vw, 4rem);
+  max-width: var(--aurora-max);
+}
+
+.aurora-section-heading h2,
+.aurora-speaking-copy h2,
+.aurora-final-cta h2,
+.aurora-writing-title,
+.aurora-page-title,
+.aurora-related h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(2.1rem, 5vw, 4.8rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 1;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.aurora-section-heading p,
+.aurora-speaking-copy p,
+.aurora-final-cta p,
+.aurora-writing-dek {
+  color: var(--aurora-ink-soft);
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  line-height: 1.7;
+  max-width: 62ch;
+}
+
+.aurora-work-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-media-card {
+  background: var(--aurora-panel-solid);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  min-height: 24rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.aurora-media-card-large {
+  grid-column: span 2;
+}
+
+.aurora-media-card a {
+  color: inherit;
+  display: grid;
+  height: 100%;
+  min-height: inherit;
+  text-decoration: none;
+}
+
+.aurora-media-card img {
+  height: 100%;
+  inset: 0;
+  object-fit: cover;
+  position: absolute;
+  transition: transform 500ms ease, filter 500ms ease;
+  width: 100%;
+}
+
+.aurora-media-card::after {
+  background: linear-gradient(180deg, transparent 18%, rgba(3, 4, 5, 0.82) 74%, rgba(3, 4, 5, 0.98));
+  content: '';
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.aurora-media-card:hover img {
+  filter: saturate(1.12);
+  transform: scale(1.035);
+}
+
+.aurora-media-card > a > div {
+  align-self: end;
+  padding: 1.2rem;
+  position: relative;
+  z-index: 1;
+}
+
+.aurora-media-card h3 {
+  color: var(--aurora-ink);
+  font-size: clamp(1.3rem, 2.5vw, 2.2rem);
+  letter-spacing: 0;
+  line-height: 1.05;
+  margin: 0 0 0.5rem;
+}
+
+.aurora-media-card p {
+  color: var(--aurora-ink-soft);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.aurora-card-label {
+  background: rgba(3, 4, 5, 0.72);
+  border: 1px solid var(--aurora-line);
+  border-radius: 999px;
+  color: var(--wp--preset--color--cyan);
+  font-size: 0.74rem;
+  font-weight: 850;
+  justify-self: start;
+  margin: 1rem;
+  padding: 0.45rem 0.62rem;
+  position: relative;
+  text-transform: uppercase;
+  z-index: 1;
+}
+
+.aurora-text-card {
+  background:
+    linear-gradient(135deg, rgba(0, 229, 255, 0.16), transparent 44%),
+    linear-gradient(180deg, rgba(247, 247, 242, 0.08), rgba(247, 247, 242, 0.03));
+}
+
+.aurora-text-card::after {
+  display: none;
+}
+
+.aurora-speaking-band {
+  align-items: center;
+  background: #080b0d;
+  border-block: 1px solid var(--aurora-line);
+  display: grid;
+  gap: clamp(2rem, 6vw, 5rem);
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.72fr);
+  max-width: none;
+}
+
+.aurora-speaking-copy,
+.aurora-speaking-panel {
+  margin-inline: auto;
+  max-width: 620px;
+}
+
+.aurora-speaking-copy {
+  justify-self: end;
+}
+
+.aurora-speaking-panel {
+  background: linear-gradient(180deg, rgba(247, 247, 242, 0.08), rgba(247, 247, 242, 0.035));
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1rem, 3vw, 1.6rem);
+  width: min(100%, 460px);
+}
+
+.aurora-speaking-panel span {
+  border-bottom: 1px solid var(--aurora-line);
+  color: var(--aurora-ink);
+  font-weight: 750;
+  padding: 0.75rem 0;
+}
+
+.aurora-speaking-panel span:last-child {
+  border-bottom: 0;
+}
+
+.aurora-writing-band {
+  background: #030405;
+}
+
+.aurora-writing-title,
+.aurora-writing-dek {
+  text-align: center;
+}
+
+.aurora-writing-dek {
+  margin: 1rem auto 2.5rem;
+}
+
+.aurora-article-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.aurora-article-row {
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  padding: clamp(1rem, 3vw, 1.4rem);
+  transition: border-color 180ms ease, background-color 180ms ease;
+}
+
+.aurora-article-row:hover {
+  background: rgba(247, 247, 242, 0.035);
+  border-color: var(--aurora-line-strong);
+}
+
+.aurora-article-title {
+  margin: 0.45rem 0;
+}
+
+.aurora-article-title a,
+.aurora-related-row a {
+  color: var(--aurora-ink);
+  text-decoration: none;
+}
+
+.aurora-article-title a:hover,
+.aurora-related-row a:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-article-excerpt,
+.aurora-article-excerpt p {
+  color: var(--aurora-ink-soft);
+  margin: 0;
+}
+
+.aurora-article-date,
+.aurora-article-category,
+.aurora-article-meta,
+.aurora-post-tags {
+  color: var(--aurora-ink-muted);
+  font-size: 0.86rem;
+}
+
+.aurora-writing-actions {
+  margin-top: 2rem;
+}
+
+.aurora-final-cta {
+  background:
+    radial-gradient(circle at 50% 0%, rgba(0, 229, 255, 0.12), transparent 24rem),
+    #07090b;
+  border-top: 1px solid var(--aurora-line);
+  text-align: center;
+}
+
+.aurora-final-cta p {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.aurora-final-cta .aurora-action-row {
+  justify-content: center;
+}
+
+.aurora-work-hero,
+.aurora-speaking-hero {
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 2rem) clamp(2rem, 4vw, 3rem);
+}
+
+.aurora-work-hero-copy,
+.aurora-speaking-hero-copy {
+  max-width: 72ch;
+}
+
+.aurora-work-hero h1,
+.aurora-speaking-hero h1 {
+  color: var(--aurora-ink);
+  font-size: clamp(2.4rem, 6.5vw, 5.8rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 0.98;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.aurora-work-hero p,
+.aurora-speaking-hero p {
+  color: var(--aurora-ink-soft);
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  line-height: 1.7;
+  max-width: 62ch;
+}
+
+.aurora-speaking-hero-keynote {
+  max-width: none;
+  min-height: clamp(520px, 70vh, 760px);
+  padding-bottom: clamp(4rem, 9vw, 7rem);
+  padding-top: clamp(6rem, 12vw, 9rem);
+  position: relative;
+}
+
+.aurora-speaking-hero-keynote::before {
+  background:
+    linear-gradient(90deg, rgba(3, 4, 5, 0.95), rgba(3, 4, 5, 0.64)),
+    url("https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=2200&ssl=1") center / cover;
+  content: "";
+  inset: 0;
+  opacity: 0.9;
+  position: absolute;
+  z-index: -1;
+}
+
+.aurora-speaking-hero-keynote .aurora-speaking-hero-copy {
+  margin-inline: auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-human-line {
+  color: var(--aurora-ink-muted);
+  font-size: 0.95rem;
+  margin-top: 1rem;
+}
+
+.aurora-human-line a {
+  color: var(--aurora-ink);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.aurora-topic-grid-keynotes {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.aurora-keynote-card {
+  align-content: start;
+}
+
+.aurora-topic-hook {
+  color: var(--aurora-ink);
+  font-size: 1.04rem;
+  font-weight: 760;
+}
+
+.aurora-topic-meta {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+}
+
+.aurora-topic-meta div {
+  border-top: 1px solid var(--aurora-line);
+  padding-top: 0.65rem;
+}
+
+.aurora-topic-meta dt {
+  color: var(--aurora-ink-muted);
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.aurora-topic-meta dd {
+  color: var(--aurora-ink-soft);
+  margin: 0.18rem 0 0;
+}
+
+.aurora-topic-meta a {
+  color: var(--aurora-signal);
+}
+
+.aurora-speaking-reel-feature {
+  margin: clamp(1rem, 4vw, 2rem) auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-check-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  list-style: none;
+  padding: 0;
+}
+
+.aurora-check-grid li {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  color: var(--aurora-ink-soft);
+  line-height: 1.55;
+  margin: 0;
+  padding: 1rem 1rem 1rem 2.35rem;
+  position: relative;
+}
+
+.aurora-check-grid li::before {
+  background: var(--aurora-signal);
+  border-radius: 999px;
+  color: #fff;
+  content: "✓";
+  display: grid;
+  font-size: 0.78rem;
+  font-weight: 900;
+  height: 1.25rem;
+  left: 0.8rem;
+  place-items: center;
+  position: absolute;
+  top: 1.05rem;
+  width: 1.25rem;
+}
+
+.aurora-form-shell {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+  padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.aurora-speaking-form {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aurora-speaking-form label {
+  color: var(--aurora-ink);
+  display: grid;
+  font-size: 0.82rem;
+  font-weight: 800;
+  gap: 0.35rem;
+}
+
+.aurora-speaking-form input,
+.aurora-speaking-form select,
+.aurora-speaking-form textarea {
+  background: rgba(3, 4, 5, 0.84);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-control);
+  color: var(--aurora-ink);
+  font: inherit;
+  min-height: 44px;
+  padding: 0.72rem 0.85rem;
+  width: 100%;
+}
+
+.aurora-speaking-form textarea {
+  min-height: 130px;
+  resize: vertical;
+}
+
+.aurora-form-wide {
+  grid-column: span 3;
+}
+
+.aurora-speaking-form button {
+  cursor: pointer;
+  grid-column: 1 / span 1;
+}
+
+.aurora-epk-grid,
+.aurora-faq-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.aurora-faq-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aurora-proof-section {
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+  padding: 0 clamp(1rem, 4vw, 2rem) clamp(4rem, 8vw, 7rem);
+}
+
+.aurora-proof-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.aurora-proof-module {
+  background: var(--aurora-panel-solid);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  overflow: clip;
+}
+
+.aurora-proof-media {
+  margin: 0;
+}
+
+.aurora-proof-media img {
+  aspect-ratio: 16 / 9;
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 100%;
+}
+
+.aurora-proof-media figcaption {
+  color: var(--aurora-ink-muted);
+  font-size: 0.76rem;
+  margin: 0;
+  padding: 0.72rem 1rem 0;
+}
+
+.aurora-proof-body {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.aurora-proof-body h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(1.3rem, 2.6vw, 2rem);
+  letter-spacing: 0;
+  line-height: 1.05;
+  margin: 0;
+}
+
+.aurora-proof-body p {
+  color: var(--aurora-ink-soft);
+  margin: 0;
+}
+
+.aurora-proof-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.aurora-proof-tags span {
+  background: rgba(247, 247, 242, 0.05);
+  border: 1px solid var(--aurora-line);
+  border-radius: 999px;
+  color: var(--aurora-ink-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.34rem 0.56rem;
+  white-space: nowrap;
+}
+
+.aurora-proof-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.aurora-media-card a:focus-visible,
+.aurora-proof-module a:focus-visible,
+.aurora-topic-card:focus-within,
+.aurora-quote-card:focus-within,
+.aurora-article-row a:focus-visible {
+  outline: 2px solid var(--wp--preset--color--cyan);
+  outline-offset: 4px;
+}
+
+.aurora-media-card a:active,
+.aurora-proof-module a:active,
+.aurora-article-row a:active {
+  transform: translateY(1px);
+}
+
+.aurora-empty-state,
+.aurora-component-empty {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px dashed var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  color: var(--aurora-ink-muted);
+  padding: 1rem;
+}
+
+.aurora-speaking-reel {
+  align-items: stretch;
+  background: linear-gradient(135deg, rgba(0, 229, 255, 0.07), rgba(247, 247, 242, 0.02));
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  margin-bottom: 1rem;
+  overflow: clip;
+}
+
+.aurora-speaking-reel-media {
+  margin: 0;
+}
+
+.aurora-speaking-reel-media img {
+  display: block;
+  height: 100%;
+  min-height: 280px;
+  object-fit: cover;
+  width: 100%;
+}
+
+.aurora-speaking-reel-media figcaption {
+  color: var(--aurora-ink-muted);
+  font-size: 0.76rem;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.aurora-speaking-reel-copy {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1rem;
+}
+
+.aurora-speaking-reel-copy h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(1.6rem, 3.3vw, 2.6rem);
+  line-height: 1.05;
+  margin: 0;
+}
+
+.aurora-speaking-reel-copy p {
+  margin: 0;
+}
+
+.aurora-topic-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+.aurora-topic-card {
+  background: rgba(247, 247, 242, 0.03);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.7rem;
+  padding: 1rem;
+}
+
+.aurora-topic-card h3 {
+  color: var(--aurora-ink);
+  font-size: 1.22rem;
+  line-height: 1.08;
+  margin: 0;
+}
+
+.aurora-topic-card p {
+  color: var(--aurora-ink-soft);
+  margin: 0;
+}
+
+.aurora-quote-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-bottom: 1rem;
+}
+
+.aurora-quote-card {
+  background: rgba(247, 247, 242, 0.04);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  margin: 0;
+  padding: 1rem;
+}
+
+.aurora-quote-card p {
+  color: var(--aurora-ink);
+  font-size: 1.06rem;
+  font-style: normal;
+  line-height: 1.6;
+  margin: 0;
+  max-width: none;
+}
+
+.aurora-quote-card cite {
+  color: var(--aurora-ink-muted);
+  display: block;
+  font-size: 0.8rem;
+  margin-top: 0.7rem;
+}
+
+.aurora-logo-row {
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  padding: 1rem;
+}
+
+.aurora-logo-row span {
+  color: var(--aurora-ink-muted);
+  font-size: 0.78rem;
+  font-weight: 760;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.aurora-page-header,
+.aurora-article-header {
+  padding-bottom: clamp(2rem, 5vw, 4rem);
+}
+
+.aurora-page-title,
+.aurora-single-title {
+  color: var(--aurora-ink);
+  font-size: clamp(2.8rem, 8vw, 6.2rem);
+  font-weight: 900;
+  letter-spacing: 0;
+  line-height: 0.98;
+  margin: 0;
+  text-wrap: balance;
+}
+
+.aurora-page-content,
+.aurora-prose {
+  color: var(--aurora-ink-soft);
+}
+
+.aurora-page-content :where(h2, h3, h4),
+.aurora-prose :where(h2, h3, h4) {
+  color: var(--aurora-ink);
+  letter-spacing: 0;
+}
+
+.aurora-page-content :where(img, video, iframe),
+.aurora-prose :where(img, video, iframe) {
+  border-radius: var(--aurora-radius-card);
+  height: auto;
+  max-width: 100%;
+}
+
+.aurora-page-content :where(a:has(> img)),
+.aurora-prose :where(a:has(> img)) {
+  display: inline-block;
+  max-width: 100%;
+}
+
+.aurora-article-meta {
+  gap: 0.8rem;
+  margin-top: 1.4rem;
+}
+
+.aurora-article-meta p,
+.aurora-article-meta time,
+.aurora-article-meta span,
+.aurora-article-meta a {
+  color: var(--aurora-ink-muted);
+  font-size: 0.82rem;
+  font-weight: 760;
+  letter-spacing: 0;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.aurora-article-meta p,
+.aurora-article-meta .wp-block-post-author-name {
+  margin: 0;
+}
+
+.aurora-article-meta a:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-meta-divider {
+  color: rgba(247, 247, 242, 0.24);
+}
+
+.aurora-article-proof {
+  color: var(--aurora-ink-soft);
+  font-size: clamp(1rem, 1.3vw, 1.16rem);
+  line-height: 1.65;
+  margin: 1.2rem 0 0;
+  max-width: 62ch;
+}
+
+.aurora-featured-media {
+  margin-bottom: clamp(2rem, 5vw, 4rem);
+}
+
+.aurora-featured-media img {
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-deep);
+  width: 100%;
+}
+
+.aurora-article-map {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  color: var(--aurora-ink-soft);
+  margin: 0 auto clamp(2rem, 5vw, 4rem);
+  max-width: 720px;
+  padding: 1rem;
+}
+
+.aurora-article-map summary {
+  color: var(--aurora-ink);
+  cursor: pointer;
+  font-weight: 820;
+  list-style-position: outside;
+}
+
+.aurora-article-map ol {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0.85rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.aurora-article-map a {
+  color: var(--aurora-ink-soft);
+  text-decoration: none;
+}
+
+.aurora-article-map a:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-article-map .is-subsection {
+  color: var(--aurora-ink-muted);
+  font-size: 0.94em;
+}
+
+.aurora-prose {
+  font-size: clamp(1.04rem, 0.98rem + 0.24vw, 1.16rem);
+  line-height: 1.78;
+}
+
+.aurora-prose > * + * {
+  margin-top: 1.45rem;
+}
+
+.aurora-prose :where(p, li) {
+  line-height: 1.78;
+}
+
+.aurora-prose :where(h2, h3, h4) {
+  scroll-margin-top: 7rem;
+}
+
+.aurora-prose h2 {
+  font-size: clamp(1.9rem, 3.5vw, 3rem);
+  line-height: 1.08;
+  margin-top: clamp(3rem, 6vw, 4.8rem);
+}
+
+.aurora-prose h3 {
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  line-height: 1.18;
+  margin-top: clamp(2rem, 4vw, 3.2rem);
+}
+
+.aurora-prose :where(ul, ol) {
+  display: grid;
+  gap: 0.55rem;
+  margin: 1.6rem 0;
+  padding-left: 1.35rem;
+}
+
+.aurora-prose li::marker {
+  color: var(--wp--preset--color--cyan);
+  font-weight: 800;
+}
+
+.aurora-prose :where(.wp-block-quote, blockquote) {
+  background: rgba(247, 247, 242, 0.035);
+  border-left: 3px solid var(--wp--preset--color--cyan);
+  border-radius: 0 var(--aurora-radius-card) var(--aurora-radius-card) 0;
+  color: var(--aurora-ink);
+  margin: clamp(2rem, 5vw, 3.6rem) 0;
+  padding: clamp(1.2rem, 3vw, 2rem);
+}
+
+.aurora-prose :where(.wp-block-pullquote) {
+  border-bottom: 1px solid var(--aurora-line);
+  border-top: 1px solid var(--aurora-line);
+  color: var(--aurora-ink);
+  margin: clamp(2.4rem, 6vw, 4.5rem) auto;
+  max-width: 860px;
+  padding: clamp(1.8rem, 5vw, 3.5rem) 0;
+}
+
+.aurora-prose :where(.wp-block-pullquote p) {
+  font-size: clamp(1.55rem, 4vw, 3rem);
+  line-height: 1.18;
+}
+
+.aurora-prose :where(figure) {
+  margin: clamp(2rem, 5vw, 3.6rem) auto;
+}
+
+.aurora-prose :where(.wp-block-image, .wp-block-gallery, .wp-block-embed, .wp-block-video) {
+  max-width: min(100%, 920px);
+}
+
+.aurora-prose :where(.alignwide, .wp-block-gallery) {
+  margin-left: calc(50% - min(46vw, 560px));
+  margin-right: calc(50% - min(46vw, 560px));
+  max-width: min(92vw, 1120px);
+}
+
+.aurora-prose :where(.alignfull) {
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  max-width: 100vw;
+}
+
+.aurora-prose :where(.wp-block-gallery) {
+  gap: 0.75rem;
+}
+
+.aurora-prose :where(.wp-block-image img, .wp-block-gallery img, .wp-block-embed iframe, .wp-block-video video) {
+  background: var(--aurora-panel-solid);
+  border: 1px solid var(--aurora-line);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.aurora-prose :where(.wp-block-embed__wrapper) {
+  aspect-ratio: 16 / 9;
+  background: var(--aurora-panel-solid);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  overflow: hidden;
+}
+
+.aurora-prose :where(.wp-block-embed__wrapper iframe) {
+  height: 100%;
+  width: 100%;
+}
+
+.aurora-prose :where(figcaption, .wp-element-caption) {
+  color: var(--aurora-ink-muted);
+  font-size: 0.86rem;
+  font-style: normal;
+  line-height: 1.55;
+  margin: 0.75rem auto 0;
+  max-width: 68ch;
+  text-align: left;
+}
+
+.aurora-author-panel,
+.aurora-tag-panel,
+.aurora-related-row {
+  border-top: 1px solid var(--aurora-line);
+  margin-top: clamp(2rem, 5vw, 4rem);
+  padding-top: clamp(1.4rem, 3vw, 2rem);
+}
+
+.aurora-author-panel {
+  align-items: flex-start;
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  gap: 1rem;
+  padding: clamp(1rem, 3vw, 1.6rem);
+}
+
+.aurora-author-title {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+}
+
+.aurora-tag-panel {
+  gap: 0.75rem;
+}
+
+.aurora-tag-panel p {
+  color: var(--aurora-ink-muted);
+  margin: 0;
+}
+
+.aurora-related {
+  padding-top: clamp(3rem, 7vw, 5rem);
+}
+
+.aurora-related-row {
+  margin-top: 0;
+  padding: 1rem 0;
+}
+
+.aurora-footer-2026 {
+  background: #030405;
+  border-top: 1px solid var(--aurora-line);
+  padding: clamp(3rem, 8vw, 6rem) clamp(1rem, 4vw, 2rem) 2rem;
+}
+
+.aurora-footer-shell {
+  display: grid;
+  gap: clamp(2rem, 6vw, 5rem);
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.9fr);
+  margin: 0 auto;
+  max-width: var(--aurora-max);
+}
+
+.aurora-footer-brand h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(2rem, 5vw, 4.2rem);
+  letter-spacing: 0;
+  line-height: 1.03;
+  margin: 0;
+  max-width: 12ch;
+}
+
+.aurora-footer-brand p {
+  color: var(--aurora-ink-soft);
+  max-width: 58ch;
+}
+
+.aurora-footer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 1.4rem;
+}
+
+.aurora-footer-nav {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aurora-footer-nav h3 {
+  color: var(--aurora-ink);
+  font-size: 0.9rem;
+  margin: 0 0 0.8rem;
+}
+
+.aurora-footer-nav a {
+  color: var(--aurora-ink-muted);
+  display: block;
+  font-size: 0.92rem;
+  margin: 0.6rem 0;
+  text-decoration: none;
+}
+
+.aurora-footer-nav a:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+.aurora-utility-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.aurora-search-utility,
+.aurora-newsletter-utility,
+.aurora-form {
+  background: rgba(247, 247, 242, 0.035);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+}
+
+.aurora-search-utility h2,
+.aurora-search-utility h3,
+.aurora-newsletter-utility h3 {
+  color: var(--aurora-ink);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.aurora-search-utility p,
+.aurora-newsletter-utility p,
+.aurora-form-message {
+  color: var(--aurora-ink-muted);
+  margin: 0;
+}
+
+.aurora-footer-brand .aurora-newsletter-utility {
+  margin-top: 1rem;
+  max-width: 34rem;
+}
+
+.aurora-search-form,
+.aurora-theme .wp-block-search {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.aurora-search-form .wp-block-search__inside-wrapper,
+.aurora-theme .wp-block-search__inside-wrapper {
+  background: rgba(3, 4, 5, 0.6);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-control);
+  display: flex;
+  gap: 0.4rem;
+  padding: 0.35rem;
+}
+
+.aurora-search-form label,
+.aurora-theme .wp-block-search__label,
+.aurora-form label {
+  color: var(--aurora-ink);
+  font-size: 0.82rem;
+  font-weight: 760;
+}
+
+.aurora-search-form input[type="search"],
+.aurora-theme .wp-block-search__input,
+.aurora-form :where(input, select, textarea),
+.aurora-theme :where(.gform_wrapper, .wp-block-jetpack-contact-form) :where(input, select, textarea) {
+  background: rgba(247, 247, 242, 0.06);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-control);
+  color: var(--aurora-ink);
+  min-height: 44px;
+  padding: 0.72rem 0.85rem;
+  width: 100%;
+}
+
+.aurora-search-form input[type="search"]::placeholder,
+.aurora-theme .wp-block-search__input::placeholder,
+.aurora-form :where(input, textarea)::placeholder {
+  color: var(--aurora-ink-muted);
+}
+
+.aurora-search-form .wp-block-search__button,
+.aurora-theme .wp-block-search__button,
+.aurora-form button,
+.aurora-theme :where(.gform_wrapper, .wp-block-jetpack-contact-form) button {
+  align-items: center;
+  background: var(--wp--preset--color--cyan);
+  border: 1px solid var(--wp--preset--color--cyan);
+  border-radius: var(--aurora-radius-control);
+  color: #041013;
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 800;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.72rem 0.95rem;
+}
+
+.aurora-search-form .wp-block-search__button:hover,
+.aurora-theme .wp-block-search__button:hover,
+.aurora-form button:hover {
+  box-shadow: 0 0 28px rgba(0, 229, 255, 0.22);
+}
+
+.aurora-form-row {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.aurora-form-message,
+.aurora-form-error,
+.aurora-form-success {
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.aurora-form-error,
+.aurora-theme :where(.gform_validation_errors, .jetpack-field-error) {
+  color: #ffb4b4;
+}
+
+.aurora-form-success,
+.aurora-theme :where(.gform_confirmation_message, .contact-form-submission) {
+  color: var(--wp--preset--color--teal);
+}
+
+.aurora-footer-bottom {
+  border-top: 1px solid var(--aurora-line);
+  color: var(--aurora-ink-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.82rem;
+  gap: 1rem;
+  justify-content: space-between;
+  margin: clamp(2rem, 6vw, 4rem) auto 0;
+  max-width: var(--aurora-max);
+  padding-top: 1.2rem;
+}
+
+.aurora-footer-bottom p {
+  margin: 0;
+}
+
+.aurora-footer-bottom a {
+  color: var(--aurora-ink-muted);
+  text-decoration: none;
+}
+
+.aurora-footer-bottom a:hover {
+  color: var(--wp--preset--color--cyan);
+}
+
+@media (max-width: 1180px) {
+  .aurora-header-shell {
+    column-gap: 1rem;
+    grid-template-areas:
+      "brand actions"
+      "nav nav";
+    grid-template-columns: minmax(0, 1fr) auto;
+    row-gap: 0.65rem;
+  }
+
+  .aurora-brand {
+    grid-area: brand;
+  }
+
+  .aurora-primary-nav {
+    grid-area: nav;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.95rem;
+    justify-content: start;
+  }
+
+  .aurora-header-actions {
+    grid-area: actions;
+    justify-content: end;
+  }
+
+  .aurora-work-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .aurora-proof-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-topic-grid,
+  .aurora-topic-grid-keynotes,
+  .aurora-logo-row,
+  .aurora-logo-row-wide,
+  .aurora-hired-grid,
+  .aurora-quote-grid-three,
+  .aurora-check-grid,
+  .aurora-epk-grid,
+  .aurora-faq-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .aurora-speaking-band,
+  .aurora-footer-shell,
+  .aurora-utility-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-speaking-reel {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-speaking-copy {
+    justify-self: start;
+  }
+}
+
+@media (max-width: 700px) {
+  .aurora-header-shell {
+    gap: 0.55rem 0.75rem;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 0.6rem 1rem 0.7rem;
+  }
+
+  .aurora-brand-mark {
+    flex: 0 0 auto;
+    font-size: 0.68rem;
+    height: 2rem;
+    width: 2rem;
+  }
+
+  .aurora-brand-role {
+    display: none;
+  }
+
+  .aurora-primary-nav {
+    display: flex;
+    gap: 0.4rem;
+    grid-column: 1 / -1;
+    justify-content: start;
+    overflow-x: auto;
+    padding: 0.05rem 0 0.15rem;
+    scrollbar-width: none;
+    width: 100%;
+  }
+
+  .aurora-primary-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .aurora-primary-nav a {
+    background: rgba(247, 247, 242, 0.05);
+    border: 1px solid var(--aurora-line);
+    border-radius: 999px;
+    flex: 0 0 auto;
+    font-size: 0.76rem;
+    line-height: 1;
+    padding: 0.46rem 0.58rem;
+  }
+
+  .aurora-header-actions {
+    gap: 0.6rem;
+    grid-column: 2;
+    grid-row: 1;
+    justify-content: end;
+    width: auto;
+  }
+
+  .aurora-utility-link {
+    display: inline-flex;
+    font-size: 0.76rem;
+    min-height: 36px;
+    white-space: nowrap;
+  }
+
+  .aurora-header-cta {
+    flex: 0 0 auto;
+    min-height: 40px;
+    padding: 0.62rem 0.78rem;
+    white-space: nowrap;
+  }
+
+  .aurora-hero-copy {
+    justify-content: stretch;
+    min-height: clamp(600px, 82vh, 780px);
+    padding-top: 4rem;
+  }
+
+  .aurora-hero-media img {
+    object-position: 62% 30%;
+  }
+
+  .aurora-hero-copy h1 {
+    font-size: clamp(2.65rem, 12vw, 3.9rem);
+    hyphens: manual;
+    max-width: 12ch;
+    overflow-wrap: normal;
+  }
+
+  .aurora-signal-strip,
+  .aurora-work-grid,
+  .aurora-footer-nav,
+  .aurora-search-form .wp-block-search__inside-wrapper,
+  .aurora-theme .wp-block-search__inside-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-search-form .wp-block-search__inside-wrapper,
+  .aurora-theme .wp-block-search__inside-wrapper {
+    display: grid;
+  }
+
+  .aurora-topic-grid,
+  .aurora-topic-grid-keynotes,
+  .aurora-quote-grid,
+  .aurora-quote-grid-three,
+  .aurora-logo-row,
+  .aurora-logo-row-wide,
+  .aurora-hired-grid,
+  .aurora-check-grid,
+  .aurora-epk-grid,
+  .aurora-faq-grid,
+  .aurora-speaking-form {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-form-wide,
+  .aurora-speaking-form button {
+    grid-column: auto;
+  }
+
+  .aurora-path-row {
+    gap: 0.45rem;
+  }
+
+  .aurora-path-row a {
+    font-size: 0.72rem;
+    padding: 0.4rem 0.56rem;
+  }
+
+  .aurora-media-card-large {
+    grid-column: auto;
+  }
+
+  .aurora-media-card {
+    min-height: 20rem;
+  }
+
+  .aurora-single-title {
+    font-size: clamp(2.45rem, 11vw, 4rem);
+  }
+
+  .aurora-article-meta {
+    gap: 0.45rem 0.6rem;
+  }
+
+  .aurora-article-map {
+    padding: 0.9rem;
+  }
+
+  .aurora-prose {
+    font-size: 1.02rem;
+  }
+
+  .aurora-prose :where(.alignwide, .wp-block-gallery, .alignfull) {
+    margin-left: 0;
+    margin-right: 0;
+    max-width: 100%;
+  }
+
+  .aurora-prose :where(.wp-block-quote, blockquote) {
+    padding: 1rem;
+  }
+
+  .aurora-prose :where(figcaption, .wp-element-caption) {
+    font-size: 0.8rem;
+  }
+
+  .aurora-speaking-panel,
+  .aurora-speaking-copy {
+    max-width: none;
+  }
+
+  .aurora-author-panel {
+    display: block;
+  }
+
+  .aurora-hero-caption {
+    font-size: 0.68rem;
+    gap: 0.45rem;
+    left: 1rem;
+    right: 1rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .aurora-utility-link {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-header-2026 {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .aurora-media-card img,
+  .aurora-button,
+  .aurora-theme .wp-block-button__link,
+  .aurora-article-row,
+  .aurora-reading-progress span,
+  .aurora-button.is-loading::after {
+    animation: none;
+    transition: none;
+  }
+
+  .aurora-media-card:hover img,
+  .aurora-button:hover,
+  .aurora-theme .wp-block-button__link:hover {
+    transform: none;
+  }
+
+  .aurora-reading-progress {
+    display: none;
+  }
+}
+
+/* ============================================
+   PRINT STYLES
+   ============================================ */
+
+@media print {
+  body {
+    background: white;
+    color: black;
+  }
+  
+  .aurora-glass,
+  .aurora-card,
+  .aurora-badge {
+    background: white;
+    border: 1px solid #ccc;
+    box-shadow: none;
+  }
+  
+  a {
+    color: black;
+    text-decoration: underline;
+  }
+  
+  .aurora-fade-up,
+  .aurora-scale-in {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1801,13 +1801,16 @@ a {
   color: rgba(247, 247, 242, 0.24);
 }
 
-.aurora-article-proof {
+.aurora-article-dek {
   color: var(--aurora-ink-soft);
-  font-size: clamp(1rem, 1.3vw, 1.16rem);
-  line-height: 1.65;
-  margin: 1.2rem 0 0;
+  font-size: clamp(1.12rem, 1.6vw, 1.4rem);
+  line-height: 1.55;
+  margin: 1.4rem 0 0;
   max-width: 62ch;
+  font-style: italic;
 }
+.aurora-article-dek .wp-block-post-excerpt__excerpt { margin: 0; }
+.aurora-article-dek .wp-block-post-excerpt__more-text { display: none; }
 
 .aurora-featured-media {
   margin-bottom: clamp(2rem, 5vw, 4rem);

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.2.0
+Version: 1.3.0
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/templates/404.html
+++ b/theme/kk-aurora/templates/404.html
@@ -1,0 +1,51 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|200","bottom":"var:preset|spacing|200"}}},"layout":{"type":"constrained","contentSize":"600px"}} -->
+<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--200);padding-bottom:var(--wp--preset--spacing--200)">
+  
+  <!-- wp:heading {"textAlign":"center","level":1,"className":"has-gradient-text","style":{"typography":{"fontSize":"clamp(6rem, 15vw, 12rem)","fontStyle":"normal","fontWeight":"900","lineHeight":"1"}}} -->
+  <h1 class="wp-block-heading has-text-align-center has-gradient-text" style="font-size:clamp(6rem, 15vw, 12rem);font-style:normal;font-weight:900;line-height:1">404</h1>
+  <!-- /wp:heading -->
+  
+  <!-- wp:heading {"textAlign":"center","level":2,"style":{"typography":{"fontSize":"1.5rem","fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"textColor":"text-primary"} -->
+  <h2 class="wp-block-heading has-text-align-center has-text-primary-color has-text-color" style="margin-top:var(--wp--preset--spacing--60);font-size:1.5rem;font-style:normal;font-weight:600">Page Not Found</h2>
+  <!-- /wp:heading -->
+  
+  <!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"textColor":"text-secondary"} -->
+  <p class="has-text-align-center has-text-secondary-color has-text-color" style="margin-top:var(--wp--preset--spacing--40)">The page you're looking for has drifted into the void. Let's get you back on track.</p>
+  <!-- /wp:paragraph -->
+  
+  <!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"flex","justifyContent":"center"}} -->
+  <div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--60)">
+    <!-- wp:button {"backgroundColor":"cyan","textColor":"deep","className":"is-style-aurora-primary"} -->
+    <div class="wp-block-button is-style-aurora-primary">
+      <a class="wp-block-button__link has-cyan-background-color has-deep-color has-text-color has-background wp-element-button" href="/">Return Home</a>
+    </div>
+    <!-- /wp:button -->
+    
+    <!-- wp:button {"className":"is-style-aurora-ghost"} -->
+    <div class="wp-block-button is-style-aurora-ghost">
+      <a class="wp-block-button__link wp-element-button" href="/contact/">Contact Me</a>
+    </div>
+    <!-- /wp:button -->
+  </div>
+  <!-- /wp:buttons -->
+  
+  <!-- wp:group {"className":"aurora-search-utility","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group aurora-search-utility" style="margin-top:var(--wp--preset--spacing--80)">
+    <!-- wp:heading {"textAlign":"center","level":2} -->
+    <h2 class="wp-block-heading has-text-align-center">Search the field notes</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">Try a topic, project, talk, or person.</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:search {"label":"Search kriskrug.co","showLabel":true,"placeholder":"Search topics, talks, projects...","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"aurora-search-form"} /-->
+  </div>
+  <!-- /wp:group -->
+  
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -1,0 +1,227 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-home-2026 aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-home-2026 aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-hero-2026" aria-labelledby="aurora-home-title">
+    <figure class="aurora-hero-media" aria-label="Kris Krug speaking on stage at CreativeMornings Vancouver">
+      <picture>
+        <source media="(max-width: 700px)" srcset="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=900&amp;ssl=1">
+        <source media="(max-width: 1180px)" srcset="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1400&amp;ssl=1">
+        <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=2200&amp;ssl=1" alt="Kris Krug speaking on stage at CreativeMornings Vancouver" fetchpriority="high" decoding="async">
+      </picture>
+    </figure>
+    <div class="aurora-hero-scrim" aria-hidden="true"></div>
+    <div class="aurora-hero-copy" data-reveal>
+      <p class="aurora-kicker">AI keynote speaker. Creative technologist. Community builder.</p>
+      <h1 id="aurora-home-title">Authored judgment in the age of generative everything.</h1>
+      <p class="aurora-hero-dek">The machines now spill out adequate everything. The scarce thing - and the thing the world will pay for - is taste that can be explained, defended, and taught. I help organizations and creative pros build it.</p>
+      <div class="aurora-proof-row" aria-label="Current proof">
+        <a href="https://bc-ai.ca/">Executive Director, BC + AI</a>
+        <a href="https://www.theupgrade.ai/">Founder, TheUpgrade.ai</a>
+        <a href="/speaking/">20+ years on stage</a>
+        <a href="/work/">Culture, code, community</a>
+      </div>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/speaking/">Book a keynote</a>
+        <a class="aurora-button aurora-button-secondary" href="/work/">See current work</a>
+      </div>
+    </div>
+    <div class="aurora-hero-caption" aria-label="Hero media source">
+      <span>Photo: CreativeMornings Vancouver</span>
+      <span>Source: Punk Rock AI media archive</span>
+    </div>
+  </section>
+
+  <section class="aurora-featured-strip" aria-labelledby="aurora-featured-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Featured in</p>
+      <h2 id="aurora-featured-title">Proof without the logo soup.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Media and publication logos">
+      <span>BBC</span>
+      <span>WIRED</span>
+      <span>Forbes</span>
+      <span>Reuters</span>
+      <span>Time</span>
+      <span>The Guardian</span>
+      <span>Fast Company</span>
+      <span>NPR</span>
+    </div>
+  </section>
+
+  <section class="aurora-feature-band aurora-feature-band-dark" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What I'm building now</p>
+      <h2>Living projects, not dusty credentials.</h2>
+      <p>These are the current rooms, portals, workshops, and communities where the AI conversation becomes something people can use.</p>
+    </div>
+
+    <div class="aurora-work-grid aurora-current-work-grid" data-reveal-stagger>
+      <article class="aurora-media-card aurora-media-card-large">
+        <a href="https://bc-ai.ca/" aria-label="Explore BC + AI Ecosystem">
+          <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC + AI community ecosystem graphic" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Ecosystem</span>
+          <div>
+            <h3>BC + AI Ecosystem</h3>
+            <p>Community infrastructure for a responsible, inclusive, place-rooted AI future in British Columbia.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.theupgrade.ai/" aria-label="Explore TheUpgrade.ai">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/01k7dj5tx212rc55a76ds68rq4-Kris-Krug.png?w=1200&amp;ssl=1" alt="Kris Krug portrait used for AI training and workshop context" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Training</span>
+          <div>
+            <h3>TheUpgrade.ai</h3>
+            <p>Practical workshops and executive briefings that build human capacity alongside machine capacity.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.punkrockai.com/" aria-label="Explore Punk Rock AI">
+          <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1200&amp;ssl=1" alt="Kris Krug speaking at CreativeMornings Vancouver" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Keynote portal</span>
+          <div>
+            <h3>Punk Rock AI</h3>
+            <p>Make culture, not content. A creative rebellion with tools, prompts, and stage receipts.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.bothhandsfull.com/" aria-label="Explore Both Hands Full">
+          <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full keynote portal graphic" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Talk world</span>
+          <div>
+            <h3>Both Hands Full</h3>
+            <p>Critique in one hand. Agency in the other. A portal for filmmakers in the age of synthetic everything.</p>
+          </div>
+        </a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-offer-band" aria-labelledby="aurora-hired-title" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What I get hired for</p>
+      <h2 id="aurora-hired-title">Rooms that need clarity, courage, and a useful next step.</h2>
+    </div>
+    <div class="aurora-hired-grid">
+      <article>
+        <span class="aurora-card-label">Keynotes</span>
+        <h3>Keynotes that move rooms</h3>
+        <p>Plain-English talks on AI, taste, ethics, creativity, and human agency. No hype. No doom sermon. A better frame for the room.</p>
+        <a class="aurora-inline-link" href="/speaking/">Book a keynote</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Workshops</span>
+        <h3>Workshops that change teams</h3>
+        <p>Practical AI learning for creative teams, leadership offsites, associations, and organizations that need shared language fast.</p>
+        <a class="aurora-inline-link" href="/services/">Work with me</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Networks</span>
+        <h3>Ecosystem work that builds durable networks</h3>
+        <p>Community strategy, salons, partner rooms, and public-interest infrastructure for people trying to build with the future, not just talk about it.</p>
+        <a class="aurora-inline-link" href="/work/">See current work</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-stage-strip" aria-labelledby="aurora-stages-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Recent and recurring stages</p>
+      <h2 id="aurora-stages-title">The rooms already know the work.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Stage and event logos">
+      <span>TEDx</span>
+      <span>SXSW</span>
+      <span>Web Summit</span>
+      <span>PopTech</span>
+      <span>CreativeMornings</span>
+      <span>World AI Film Festival</span>
+      <span>UN</span>
+      <span>Microsoft</span>
+      <span>Adobe</span>
+      <span>Grammys</span>
+    </div>
+  </section>
+
+  <section class="aurora-testimonial-band" aria-labelledby="aurora-testimonials-title" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What people say</p>
+      <h2 id="aurora-testimonials-title">Fresh proof belongs here before launch.</h2>
+      <p>The Stewart Butterfield quote can stay as an anchor. This slot is designed for two or three current organizer quotes from 2024-2026 work.</p>
+    </div>
+    <div class="aurora-quote-grid aurora-quote-grid-three">
+      <blockquote class="aurora-quote-card">
+        <p>"Kris brought a rare mix of clarity, cultural fluency, and practical next steps. The room left with language they could actually use."</p>
+        <cite>Event organizer quote - replace with verified 2024-2026 attribution</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"He made the AI conversation feel less abstract, less performative, and much more human."</p>
+        <cite>Workshop host quote - replace with verified attribution</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"The value was not just inspiration. People left with a working frame for what to do next."</p>
+        <cite>Leadership audience quote - replace with verified attribution</cite>
+      </blockquote>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:group {"className":"aurora-writing-band","layout":{"type":"constrained","contentSize":"980px"}} -->
+  <div class="wp-block-group aurora-writing-band">
+    <!-- wp:heading {"level":2,"className":"aurora-writing-title"} -->
+    <h2 class="wp-block-heading aurora-writing-title">Field notes</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph {"className":"aurora-writing-dek"} -->
+    <p class="aurora-writing-dek">Essays from the edge of AI, creativity, community, tools, taste, and what happens after the demo.</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:query {"queryId":2,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"className":"aurora-writing-query"} -->
+    <div class="wp-block-query aurora-writing-query">
+      <!-- wp:post-template {"className":"aurora-article-list","layout":{"type":"default"}} -->
+        <!-- wp:group {"className":"aurora-article-row","layout":{"type":"constrained"}} -->
+        <div class="wp-block-group aurora-article-row">
+          <!-- wp:post-terms {"term":"category","className":"aurora-article-category"} /-->
+          <!-- wp:post-title {"level":3,"isLink":true,"className":"aurora-article-title"} /-->
+          <!-- wp:post-excerpt {"excerptLength":24,"className":"aurora-article-excerpt"} /-->
+          <!-- wp:post-date {"className":"aurora-article-date"} /-->
+        </div>
+        <!-- /wp:group -->
+      <!-- /wp:post-template -->
+    </div>
+    <!-- /wp:query -->
+
+    <!-- wp:buttons {"className":"aurora-writing-actions","layout":{"type":"flex","justifyContent":"center"}} -->
+    <div class="wp-block-buttons aurora-writing-actions">
+      <!-- wp:button {"className":"is-style-aurora-ghost"} -->
+      <div class="wp-block-button is-style-aurora-ghost"><a class="wp-block-button__link wp-element-button" href="/blog/">Read the field notes</a></div>
+      <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:html -->
+  <section class="aurora-dispatch-band" aria-labelledby="aurora-dispatch-title" data-reveal>
+    <p class="aurora-kicker">Get the dispatch</p>
+    <h2 id="aurora-dispatch-title">The dispatch from the edge.</h2>
+    <p>Weekly field notes on AI, creativity, and what's still ours to make. Sharp, useful, and short enough to actually read. Free.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Join the dispatch</a>
+      <a class="aurora-button aurora-button-secondary" href="/blog/">Read the field notes</a>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/home.html
+++ b/theme/kk-aurora/templates/home.html
@@ -1,0 +1,227 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-home-2026 aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-home-2026 aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-hero-2026" aria-labelledby="aurora-home-title">
+    <figure class="aurora-hero-media" aria-label="Kris Krug speaking on stage at CreativeMornings Vancouver">
+      <picture>
+        <source media="(max-width: 700px)" srcset="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=900&amp;ssl=1">
+        <source media="(max-width: 1180px)" srcset="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1400&amp;ssl=1">
+        <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=2200&amp;ssl=1" alt="Kris Krug speaking on stage at CreativeMornings Vancouver" fetchpriority="high" decoding="async">
+      </picture>
+    </figure>
+    <div class="aurora-hero-scrim" aria-hidden="true"></div>
+    <div class="aurora-hero-copy" data-reveal>
+      <p class="aurora-kicker">AI keynote speaker. Creative technologist. Community builder.</p>
+      <h1 id="aurora-home-title">Authored judgment in the age of generative everything.</h1>
+      <p class="aurora-hero-dek">The machines now spill out adequate everything. The scarce thing - and the thing the world will pay for - is taste that can be explained, defended, and taught. I help organizations and creative pros build it.</p>
+      <div class="aurora-proof-row" aria-label="Current proof">
+        <a href="https://bc-ai.ca/">Executive Director, BC + AI</a>
+        <a href="https://www.theupgrade.ai/">Founder, TheUpgrade.ai</a>
+        <a href="/speaking/">20+ years on stage</a>
+        <a href="/work/">Culture, code, community</a>
+      </div>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/speaking/">Book a keynote</a>
+        <a class="aurora-button aurora-button-secondary" href="/work/">See current work</a>
+      </div>
+    </div>
+    <div class="aurora-hero-caption" aria-label="Hero media source">
+      <span>Photo: CreativeMornings Vancouver</span>
+      <span>Source: Punk Rock AI media archive</span>
+    </div>
+  </section>
+
+  <section class="aurora-featured-strip" aria-labelledby="aurora-featured-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Featured in</p>
+      <h2 id="aurora-featured-title">Proof without the logo soup.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Media and publication logos">
+      <span>BBC</span>
+      <span>WIRED</span>
+      <span>Forbes</span>
+      <span>Reuters</span>
+      <span>Time</span>
+      <span>The Guardian</span>
+      <span>Fast Company</span>
+      <span>NPR</span>
+    </div>
+  </section>
+
+  <section class="aurora-feature-band aurora-feature-band-dark" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What I'm building now</p>
+      <h2>Living projects, not dusty credentials.</h2>
+      <p>These are the current rooms, portals, workshops, and communities where the AI conversation becomes something people can use.</p>
+    </div>
+
+    <div class="aurora-work-grid aurora-current-work-grid" data-reveal-stagger>
+      <article class="aurora-media-card aurora-media-card-large">
+        <a href="https://bc-ai.ca/" aria-label="Explore BC + AI Ecosystem">
+          <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC + AI community ecosystem graphic" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Ecosystem</span>
+          <div>
+            <h3>BC + AI Ecosystem</h3>
+            <p>Community infrastructure for a responsible, inclusive, place-rooted AI future in British Columbia.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.theupgrade.ai/" aria-label="Explore TheUpgrade.ai">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/01k7dj5tx212rc55a76ds68rq4-Kris-Krug.png?w=1200&amp;ssl=1" alt="Kris Krug portrait used for AI training and workshop context" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Training</span>
+          <div>
+            <h3>TheUpgrade.ai</h3>
+            <p>Practical workshops and executive briefings that build human capacity alongside machine capacity.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.punkrockai.com/" aria-label="Explore Punk Rock AI">
+          <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1200&amp;ssl=1" alt="Kris Krug speaking at CreativeMornings Vancouver" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Keynote portal</span>
+          <div>
+            <h3>Punk Rock AI</h3>
+            <p>Make culture, not content. A creative rebellion with tools, prompts, and stage receipts.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://www.bothhandsfull.com/" aria-label="Explore Both Hands Full">
+          <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full keynote portal graphic" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Talk world</span>
+          <div>
+            <h3>Both Hands Full</h3>
+            <p>Critique in one hand. Agency in the other. A portal for filmmakers in the age of synthetic everything.</p>
+          </div>
+        </a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-offer-band" aria-labelledby="aurora-hired-title" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What I get hired for</p>
+      <h2 id="aurora-hired-title">Rooms that need clarity, courage, and a useful next step.</h2>
+    </div>
+    <div class="aurora-hired-grid">
+      <article>
+        <span class="aurora-card-label">Keynotes</span>
+        <h3>Keynotes that move rooms</h3>
+        <p>Plain-English talks on AI, taste, ethics, creativity, and human agency. No hype. No doom sermon. A better frame for the room.</p>
+        <a class="aurora-inline-link" href="/speaking/">Book a keynote</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Workshops</span>
+        <h3>Workshops that change teams</h3>
+        <p>Practical AI learning for creative teams, leadership offsites, associations, and organizations that need shared language fast.</p>
+        <a class="aurora-inline-link" href="/services/">Work with me</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Networks</span>
+        <h3>Ecosystem work that builds durable networks</h3>
+        <p>Community strategy, salons, partner rooms, and public-interest infrastructure for people trying to build with the future, not just talk about it.</p>
+        <a class="aurora-inline-link" href="/work/">See current work</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-stage-strip" aria-labelledby="aurora-stages-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Recent and recurring stages</p>
+      <h2 id="aurora-stages-title">The rooms already know the work.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Stage and event logos">
+      <span>TEDx</span>
+      <span>SXSW</span>
+      <span>Web Summit</span>
+      <span>PopTech</span>
+      <span>CreativeMornings</span>
+      <span>World AI Film Festival</span>
+      <span>UN</span>
+      <span>Microsoft</span>
+      <span>Adobe</span>
+      <span>Grammys</span>
+    </div>
+  </section>
+
+  <section class="aurora-testimonial-band" aria-labelledby="aurora-testimonials-title" data-reveal>
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What people say</p>
+      <h2 id="aurora-testimonials-title">Fresh proof belongs here before launch.</h2>
+      <p>The Stewart Butterfield quote can stay as an anchor. This slot is designed for two or three current organizer quotes from 2024-2026 work.</p>
+    </div>
+    <div class="aurora-quote-grid aurora-quote-grid-three">
+      <blockquote class="aurora-quote-card">
+        <p>"Kris brought a rare mix of clarity, cultural fluency, and practical next steps. The room left with language they could actually use."</p>
+        <cite>Event organizer quote - replace with verified 2024-2026 attribution</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"He made the AI conversation feel less abstract, less performative, and much more human."</p>
+        <cite>Workshop host quote - replace with verified attribution</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"The value was not just inspiration. People left with a working frame for what to do next."</p>
+        <cite>Leadership audience quote - replace with verified attribution</cite>
+      </blockquote>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:group {"className":"aurora-writing-band","layout":{"type":"constrained","contentSize":"980px"}} -->
+  <div class="wp-block-group aurora-writing-band">
+    <!-- wp:heading {"level":2,"className":"aurora-writing-title"} -->
+    <h2 class="wp-block-heading aurora-writing-title">Field notes</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:paragraph {"className":"aurora-writing-dek"} -->
+    <p class="aurora-writing-dek">Essays from the edge of AI, creativity, community, tools, taste, and what happens after the demo.</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:query {"queryId":2,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"className":"aurora-writing-query"} -->
+    <div class="wp-block-query aurora-writing-query">
+      <!-- wp:post-template {"className":"aurora-article-list","layout":{"type":"default"}} -->
+        <!-- wp:group {"className":"aurora-article-row","layout":{"type":"constrained"}} -->
+        <div class="wp-block-group aurora-article-row">
+          <!-- wp:post-terms {"term":"category","className":"aurora-article-category"} /-->
+          <!-- wp:post-title {"level":3,"isLink":true,"className":"aurora-article-title"} /-->
+          <!-- wp:post-excerpt {"excerptLength":24,"className":"aurora-article-excerpt"} /-->
+          <!-- wp:post-date {"className":"aurora-article-date"} /-->
+        </div>
+        <!-- /wp:group -->
+      <!-- /wp:post-template -->
+    </div>
+    <!-- /wp:query -->
+
+    <!-- wp:buttons {"className":"aurora-writing-actions","layout":{"type":"flex","justifyContent":"center"}} -->
+    <div class="wp-block-buttons aurora-writing-actions">
+      <!-- wp:button {"className":"is-style-aurora-ghost"} -->
+      <div class="wp-block-button is-style-aurora-ghost"><a class="wp-block-button__link wp-element-button" href="/blog/">Read the field notes</a></div>
+      <!-- /wp:button -->
+    </div>
+    <!-- /wp:buttons -->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:html -->
+  <section class="aurora-dispatch-band" aria-labelledby="aurora-dispatch-title" data-reveal>
+    <p class="aurora-kicker">Get the dispatch</p>
+    <h2 id="aurora-dispatch-title">The dispatch from the edge.</h2>
+    <p>Weekly field notes on AI, creativity, and what's still ours to make. Sharp, useful, and short enough to actually read. Free.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Join the dispatch</a>
+      <a class="aurora-button aurora-button-secondary" href="/blog/">Read the field notes</a>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/index.html
+++ b/theme/kk-aurora/templates/index.html
@@ -1,0 +1,45 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|120","bottom":"var:preset|spacing|120"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
+<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--120);padding-bottom:var(--wp--preset--spacing--120)">
+  
+  <!-- wp:query-title {"type":"archive","textAlign":"center","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} /-->
+  
+  <!-- wp:query {"queryId":1,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"constrained"}} -->
+  <div class="wp-block-query">
+    
+    <!-- wp:post-template {"layout":{"type":"default"}} -->
+      <!-- wp:group {"className":"aurora-card","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"},"margin":{"bottom":"var:preset|spacing|60"}},"border":{"radius":"0.75rem","color":"var:preset|color|elevated","width":"1px"}},"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group aurora-card" style="border-color:var(--wp--preset--color--elevated);border-width:1px;border-radius:0.75rem;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)">
+        
+        <!-- wp:post-terms {"term":"category","style":{"typography":{"fontSize":"0.75rem","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"purple"} /-->
+        
+        <!-- wp:post-title {"level":2,"isLink":true,"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}},"typography":{"fontSize":"1.5rem","fontStyle":"normal","fontWeight":"700"}}} /-->
+        
+        <!-- wp:post-excerpt {"moreText":"Continue reading →","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary"} /-->
+        
+        <!-- wp:post-date {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"textColor":"text-muted","fontSize":"xs"} /-->
+        
+      </div>
+      <!-- /wp:group -->
+    <!-- /wp:post-template -->
+    
+    <!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}}} -->
+      <!-- wp:query-pagination-previous /-->
+      <!-- wp:query-pagination-numbers /-->
+      <!-- wp:query-pagination-next /-->
+    <!-- /wp:query-pagination -->
+    
+    <!-- wp:query-no-results -->
+      <!-- wp:paragraph {"align":"center","textColor":"text-muted"} -->
+      <p class="has-text-align-center has-text-muted-color has-text-color">No posts found.</p>
+      <!-- /wp:paragraph -->
+    <!-- /wp:query-no-results -->
+    
+  </div>
+  <!-- /wp:query -->
+  
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-2672.html
+++ b/theme/kk-aurora/templates/page-2672.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-work-page","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-work-page">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-work-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Work and initiatives</p>
+      <h1 id="aurora-work-title">Project systems that turn AI noise into useful momentum.</h1>
+      <p>This page is a living map of active projects, keynote worlds, and culture-building systems. Every module carries proof media, source labels, and a direct path to deeper context.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/contact/">Start a project conversation</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book a keynote</a>
+      </div>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:template-part {"slug":"work-proof-grid","area":"uncategorized"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-generative-ai-services.html
+++ b/theme/kk-aurora/templates/page-generative-ai-services.html
@@ -1,0 +1,75 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-services-page aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-services-page aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-services-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Services and training</p>
+      <h1 id="aurora-services-title">AI training for teams that want capacity, not party tricks.</h1>
+      <p>Practical workshops, executive briefings, and ecosystem advisory through TheUpgrade.ai. The work is simple to describe: build human capacity - taste, ethics, judgment - alongside machine capacity.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/contact/?intent=training">Start a project</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book a keynote</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-services-offers-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What teams hire Kris for</p>
+      <h2 id="aurora-services-offers-title">Three offers, one job: leave people more capable.</h2>
+    </div>
+    <div class="aurora-hired-grid">
+      <article>
+        <span class="aurora-card-label">Workshop</span>
+        <h3>AI mindset workshops</h3>
+        <p>Hands-on sessions for creative, communications, leadership, and product teams that need a humane on-ramp to AI adoption.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=training">Inquire about a workshop</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Briefing</span>
+        <h3>Executive AI briefings</h3>
+        <p>Plain-English briefings for leadership teams that need strategy, risks, cultural stakes, and near-term decisions in one room.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=briefing">Book a briefing</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Advisory</span>
+        <h3>Ecosystem and community advisory</h3>
+        <p>Support for associations, festivals, public-interest groups, and founders building durable AI networks instead of one-off events.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=advisory">Start a conversation</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-services-outcomes-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Outcomes</p>
+      <h2 id="aurora-services-outcomes-title">What changes after the room.</h2>
+    </div>
+    <ul class="aurora-check-grid">
+      <li>Shared language for AI opportunities, risks, and tradeoffs</li>
+      <li>Practical workflows people can use the same week</li>
+      <li>A clearer line between experimentation and governance</li>
+      <li>Better taste around prompts, outputs, review, and publication</li>
+      <li>Team confidence without flattening craft, ethics, or responsibility</li>
+      <li>A follow-up path into keynotes, cohorts, advisory, or community programming</li>
+    </ul>
+  </section>
+
+  <section class="aurora-dispatch-band" aria-labelledby="aurora-services-cta-title">
+    <p class="aurora-kicker">TheUpgrade.ai</p>
+    <h2 id="aurora-services-cta-title">Build the capacity before the pressure spikes.</h2>
+    <p>Bring Kris in for a workshop, executive briefing, or advisory sprint that gives your team a useful operating frame for the age of generative everything.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="/contact/?intent=training">Start a project</a>
+      <a class="aurora-button aurora-button-secondary" href="https://www.theupgrade.ai/">Visit TheUpgrade.ai</a>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-publications.html
+++ b/theme/kk-aurora/templates/page-publications.html
@@ -1,0 +1,65 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-press-page aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-press-page aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-press-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Press and publications</p>
+      <h1 id="aurora-press-title">Proof, bios, headshots, and the public trail.</h1>
+      <p>A clean press surface for event organizers, journalists, producers, and partners. This replaces the old under-construction publications page with a working press-kit structure.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/speaking/#speaker-kit">Download the EPK</a>
+        <a class="aurora-button aurora-button-secondary" href="/contact/?intent=press">Press inquiry</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-press-logos-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Featured in</p>
+      <h2 id="aurora-press-logos-title">Coverage links get verified before launch.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Media and publication logos">
+      <span>BBC</span>
+      <span>WIRED</span>
+      <span>Forbes</span>
+      <span>Reuters</span>
+      <span>Time</span>
+      <span>The Guardian</span>
+      <span>Fast Company</span>
+      <span>NPR</span>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-bios-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Bios</p>
+      <h2 id="aurora-bios-title">Three lengths for organizers and editors.</h2>
+    </div>
+    <div class="aurora-epk-grid">
+      <article>
+        <h3>Short</h3>
+        <p>Kris Krug is an AI keynote speaker, creative technologist, and Executive Director of BC+AI Ecosystem.</p>
+      </article>
+      <article>
+        <h3>Medium</h3>
+        <p>Kris Krug is an AI keynote speaker, creative technologist, photographer, and community builder. He is the Executive Director of BC+AI Ecosystem and founder of TheUpgrade.ai, where he helps creative professionals and organizations build human capacity - taste, ethics, and judgment - alongside machine capacity.</p>
+      </article>
+      <article>
+        <h3>Long</h3>
+        <p>Kris Krug works at the messy edge where technology, creativity, ethics, and human weirdness collide. Over twenty years, he has been in rooms where the future gets argued about: SXSW, TED, PopTech, Web Summit, the UN Global Youth Summit, COP15, the Grammys, and beyond.</p>
+      </article>
+      <article>
+        <h3>Assets</h3>
+        <p>Headshots, stage photos, logo lockups, topic sheets, and sample intro scripts should live in the downloadable EPK before production launch.</p>
+      </article>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-recent-projects-include.html
+++ b/theme/kk-aurora/templates/page-recent-projects-include.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-work-page","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-work-page">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-work-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Work and initiatives</p>
+      <h1 id="aurora-work-title">Project systems that turn AI noise into useful momentum.</h1>
+      <p>This page is a living map of active projects, keynote worlds, and culture-building systems. Every module carries proof media, source labels, and a direct path to deeper context.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/contact/">Start a project conversation</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book a keynote</a>
+      </div>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:template-part {"slug":"work-proof-grid","area":"uncategorized"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-services.html
+++ b/theme/kk-aurora/templates/page-services.html
@@ -1,0 +1,75 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-services-page aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-services-page aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-services-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Services and training</p>
+      <h1 id="aurora-services-title">AI training for teams that want capacity, not party tricks.</h1>
+      <p>Practical workshops, executive briefings, and ecosystem advisory through TheUpgrade.ai. The work is simple to describe: build human capacity - taste, ethics, judgment - alongside machine capacity.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/contact/?intent=training">Start a project</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book a keynote</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-services-offers-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What teams hire Kris for</p>
+      <h2 id="aurora-services-offers-title">Three offers, one job: leave people more capable.</h2>
+    </div>
+    <div class="aurora-hired-grid">
+      <article>
+        <span class="aurora-card-label">Workshop</span>
+        <h3>AI mindset workshops</h3>
+        <p>Hands-on sessions for creative, communications, leadership, and product teams that need a humane on-ramp to AI adoption.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=training">Inquire about a workshop</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Briefing</span>
+        <h3>Executive AI briefings</h3>
+        <p>Plain-English briefings for leadership teams that need strategy, risks, cultural stakes, and near-term decisions in one room.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=briefing">Book a briefing</a>
+      </article>
+      <article>
+        <span class="aurora-card-label">Advisory</span>
+        <h3>Ecosystem and community advisory</h3>
+        <p>Support for associations, festivals, public-interest groups, and founders building durable AI networks instead of one-off events.</p>
+        <a class="aurora-inline-link" href="/contact/?intent=advisory">Start a conversation</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-services-outcomes-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Outcomes</p>
+      <h2 id="aurora-services-outcomes-title">What changes after the room.</h2>
+    </div>
+    <ul class="aurora-check-grid">
+      <li>Shared language for AI opportunities, risks, and tradeoffs</li>
+      <li>Practical workflows people can use the same week</li>
+      <li>A clearer line between experimentation and governance</li>
+      <li>Better taste around prompts, outputs, review, and publication</li>
+      <li>Team confidence without flattening craft, ethics, or responsibility</li>
+      <li>A follow-up path into keynotes, cohorts, advisory, or community programming</li>
+    </ul>
+  </section>
+
+  <section class="aurora-dispatch-band" aria-labelledby="aurora-services-cta-title">
+    <p class="aurora-kicker">TheUpgrade.ai</p>
+    <h2 id="aurora-services-cta-title">Build the capacity before the pressure spikes.</h2>
+    <p>Bring Kris in for a workshop, executive briefing, or advisory sprint that gives your team a useful operating frame for the age of generative everything.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="/contact/?intent=training">Start a project</a>
+      <a class="aurora-button aurora-button-secondary" href="https://www.theupgrade.ai/">Visit TheUpgrade.ai</a>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-speaking.html
+++ b/theme/kk-aurora/templates/page-speaking.html
@@ -1,0 +1,211 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-speaking-page aurora-keynote-first","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-speaking-page aurora-keynote-first">
+
+  <!-- wp:html -->
+  <section class="aurora-speaking-hero aurora-speaking-hero-keynote" aria-labelledby="aurora-speaking-title">
+    <div class="aurora-speaking-hero-copy">
+      <p class="aurora-kicker">Speaking and workshops</p>
+      <h1 id="aurora-speaking-title">Bring Kris into the room.</h1>
+      <p>AI keynotes and workshops for audiences that need clarity, courage, and a useful next step. Plain English. Real stakes. No hype.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="#speaking-inquiry">Check availability</a>
+        <a class="aurora-button aurora-button-secondary" href="#speaker-kit">Download EPK</a>
+      </div>
+      <p class="aurora-human-line">Talk to a human: <a href="tel:+17788983076">(778) 898-3076</a></p>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section aurora-stage-strip" aria-labelledby="aurora-speaking-proof-title">
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Seen on stages and in rooms</p>
+      <h2 id="aurora-speaking-proof-title">A talk is only useful if it changes what people do next.</h2>
+    </div>
+    <div class="aurora-logo-row aurora-logo-row-wide" aria-label="Speaking proof logos">
+      <span>TED</span>
+      <span>SXSW</span>
+      <span>Web Summit</span>
+      <span>PopTech</span>
+      <span>CreativeMornings</span>
+      <span>World AI Film Festival</span>
+      <span>UN</span>
+      <span>TEDx</span>
+      <span>Microsoft</span>
+      <span>Adobe</span>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-keynote-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Signature keynotes</p>
+      <h2 id="aurora-keynote-title">Three ways to bring the work into your room.</h2>
+    </div>
+    <div class="aurora-topic-grid aurora-topic-grid-keynotes">
+      <article class="aurora-topic-card aurora-keynote-card">
+        <p class="aurora-kicker">01</p>
+        <h3>Authored Judgment</h3>
+        <p class="aurora-topic-hook">In the age of generative everything, taste is the moat.</p>
+        <dl class="aurora-topic-meta">
+          <div><dt>For</dt><dd>Creative directors, agency leadership, CMOs</dd></div>
+          <div><dt>Format</dt><dd>30 / 45 / 60 min. Workshop add-on available.</dd></div>
+        </dl>
+        <a class="aurora-inline-link" href="#speaking-inquiry">Inquire about this talk</a>
+      </article>
+
+      <article class="aurora-topic-card aurora-keynote-card">
+        <p class="aurora-kicker">02</p>
+        <h3>Both Hands Full</h3>
+        <p class="aurora-topic-hook">Critique in one hand. Agency in the other. How to use AI without selling out the people you'd want to be.</p>
+        <dl class="aurora-topic-meta">
+          <div><dt>For</dt><dd>Filmmakers, creatives, media organizations</dd></div>
+          <div><dt>Portal</dt><dd><a href="https://www.bothhandsfull.com/">bothhandsfull.com</a></dd></div>
+        </dl>
+        <a class="aurora-inline-link" href="#speaking-inquiry">Inquire about this talk</a>
+      </article>
+
+      <article class="aurora-topic-card aurora-keynote-card">
+        <p class="aurora-kicker">03</p>
+        <h3>Developing an AI Mindset</h3>
+        <p class="aurora-topic-hook">From vague pressure to practical confidence - the humane on-ramp to AI for teams.</p>
+        <dl class="aurora-topic-meta">
+          <div><dt>For</dt><dd>Corporate L&amp;D, leadership offsites, association keynotes</dd></div>
+          <div><dt>Format</dt><dd>Workshop format strongly recommended.</dd></div>
+        </dl>
+        <a class="aurora-inline-link" href="#speaking-inquiry">Inquire about this talk</a>
+      </article>
+
+      <article class="aurora-topic-card aurora-keynote-card">
+        <p class="aurora-kicker">04</p>
+        <h3>Punk Rock AI</h3>
+        <p class="aurora-topic-hook">Make culture, not content. A creative rebellion for people tired of AI slop and corporate inevitability theater.</p>
+        <dl class="aurora-topic-meta">
+          <div><dt>For</dt><dd>Creators, founders, festival audiences</dd></div>
+          <div><dt>Portal</dt><dd><a href="https://www.punkrockai.com/">punkrockai.com</a></dd></div>
+        </dl>
+        <a class="aurora-inline-link" href="#speaking-inquiry">Inquire about this talk</a>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-speaking-reel aurora-speaking-reel-feature" aria-labelledby="aurora-reel-title">
+    <figure class="aurora-speaking-reel-media">
+      <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=1600&amp;ssl=1" alt="Kris Krug speaking on stage with a large screen behind him" loading="lazy" decoding="async">
+      <figcaption>Poster-first reel slot. Replace with the 60-90 second speaking sizzle once final video hosting is chosen.</figcaption>
+    </figure>
+    <div class="aurora-speaking-reel-copy">
+      <p class="aurora-kicker">Video reel</p>
+      <h2 id="aurora-reel-title">A 90-second cut will do more work than another paragraph.</h2>
+      <p>This module is ready for a poster-first YouTube, Vimeo, or self-hosted reel embed. Keep the default lightweight until someone chooses to play.</p>
+      <a class="aurora-button aurora-button-secondary" href="#speaking-inquiry">Check availability</a>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-organizer-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">What organizers get</p>
+      <h2 id="aurora-organizer-title">Less anxiety before the event. More signal after it.</h2>
+    </div>
+    <ul class="aurora-check-grid">
+      <li>A pre-event call to tailor the talk to your audience</li>
+      <li>Custom slides referencing your industry and attendees</li>
+      <li>A keynote portal so your audience leaves with a working resource</li>
+      <li>On-site Q&amp;A, panel moderation, or fireside add-ons</li>
+      <li>Event photography options from someone who knows the room</li>
+      <li>Post-event recap content for your channels</li>
+    </ul>
+  </section>
+
+  <section class="aurora-testimonial-band" aria-labelledby="aurora-speaking-quotes-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Organizer proof</p>
+      <h2 id="aurora-speaking-quotes-title">Replace these slots with verified 2024-2026 organizer quotes.</h2>
+    </div>
+    <div class="aurora-quote-grid aurora-quote-grid-three">
+      <blockquote class="aurora-quote-card">
+        <p>"Kris gave our audience a frame they were still using weeks later."</p>
+        <cite>Event producer quote - verify before launch</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"The talk was high-energy, but the real value was how practical the room became afterward."</p>
+        <cite>Conference organizer quote - verify before launch</cite>
+      </blockquote>
+      <blockquote class="aurora-quote-card">
+        <p>"He made AI feel less like a vendor demo and more like a human operating question."</p>
+        <cite>Leadership host quote - verify before launch</cite>
+      </blockquote>
+    </div>
+  </section>
+
+  <section id="speaking-inquiry" class="aurora-proof-section aurora-speaking-form-section" aria-labelledby="aurora-inquiry-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Booking form</p>
+      <h2 id="aurora-inquiry-title">Check availability.</h2>
+      <p>This slot is prepared for Fluent Forms or Tally. Route submissions to the CRM with the tag <strong>speaking</strong>.</p>
+    </div>
+    <div class="aurora-form-shell">
+      <form class="aurora-speaking-form" action="/contact/" method="get">
+        <input type="hidden" name="intent" value="speaking">
+        <label>Name <input name="name" autocomplete="name"></label>
+        <label>Email <input name="email" type="email" autocomplete="email"></label>
+        <label>Organization <input name="organization" autocomplete="organization"></label>
+        <label>Event name <input name="event"></label>
+        <label>Date <input name="date" type="date"></label>
+        <label>City <input name="city" autocomplete="address-level2"></label>
+        <label>Audience size <input name="audience_size" inputmode="numeric"></label>
+        <label>Audience type <input name="audience_type"></label>
+        <label>Budget range
+          <select name="budget">
+            <option value="">Choose one</option>
+            <option>&lt;$10k</option>
+            <option>$10-25k</option>
+            <option>$25-50k</option>
+            <option>$50k+</option>
+            <option>Honorarium</option>
+            <option>Pro bono mission-aligned</option>
+          </select>
+        </label>
+        <label class="aurora-form-wide">Topic interest <input name="topic"></label>
+        <label class="aurora-form-wide">Anything else? <textarea name="notes" rows="5"></textarea></label>
+        <button class="aurora-button aurora-button-primary" type="submit">Send</button>
+      </form>
+    </div>
+  </section>
+
+  <section id="speaker-kit" class="aurora-proof-section" aria-labelledby="aurora-kit-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Press kit</p>
+      <h2 id="aurora-kit-title">Everything an organizer needs before they announce.</h2>
+    </div>
+    <div class="aurora-epk-grid">
+      <article><h3>Speaker one-pager</h3><p>Short, medium, and long bios; talk menu; sample audience outcomes.</p></article>
+      <article><h3>Photo pack</h3><p>High-res headshots and stage photos in square, portrait, and landscape crops.</p></article>
+      <article><h3>Intro script</h3><p>A clean emcee intro that does not make the room suffer through a resume recital.</p></article>
+      <article><h3>Topic sheets</h3><p>One-sheet summaries for Authored Judgment, Both Hands Full, and Developing an AI Mindset.</p></article>
+    </div>
+    <div class="aurora-action-row aurora-centered-actions">
+      <a class="aurora-button aurora-button-primary" href="/contact/">Request the EPK</a>
+      <a class="aurora-button aurora-button-secondary" href="#speaking-inquiry">Check availability</a>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-faq-title">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">FAQ</p>
+      <h2 id="aurora-faq-title">Fast answers for organizers.</h2>
+    </div>
+    <div class="aurora-faq-grid">
+      <article><h3>Where are you based?</h3><p>Vancouver, BC and Galiano Island. Available globally.</p></article>
+      <article><h3>Do you travel?</h3><p>Yes. Travel and accommodations are standard for in-person events.</p></article>
+      <article><h3>What's your fee?</h3><p>Tiered by format, travel, audience, and usage. Submit the form for a quote.</p></article>
+      <article><h3>Do you do nonprofit or mission-aligned rates?</h3><p>Often, yes. Ask directly and name the context.</p></article>
+      <article><h3>What are your AV requirements?</h3><p>A simple tech rider should ship with the EPK before launch.</p></article>
+      <article><h3>Can you moderate, MC, or photograph too?</h3><p>Yes. These can be scoped as add-ons when they strengthen the event.</p></article>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page-work.html
+++ b/theme/kk-aurora/templates/page-work.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026 aurora-work-page","layout":{"type":"default"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026 aurora-work-page">
+
+  <!-- wp:html -->
+  <section class="aurora-work-hero" aria-labelledby="aurora-work-title">
+    <div class="aurora-work-hero-copy">
+      <p class="aurora-kicker">Work and initiatives</p>
+      <h1 id="aurora-work-title">Project systems that turn AI noise into useful momentum.</h1>
+      <p>This page is a living map of active projects, keynote worlds, and culture-building systems. Every module carries proof media, source labels, and a direct path to deeper context.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/contact/">Start a project conversation</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book a keynote</a>
+      </div>
+    </div>
+  </section>
+  <!-- /wp:html -->
+
+  <!-- wp:template-part {"slug":"work-proof-grid","area":"uncategorized"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/page.html
+++ b/theme/kk-aurora/templates/page.html
@@ -1,0 +1,15 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"aurora-page-2026","layout":{"type":"constrained","contentSize":"980px"}} -->
+<main id="aurora-main" class="wp-block-group aurora-page-2026">
+  <!-- wp:group {"className":"aurora-page-header","layout":{"type":"constrained","contentSize":"860px"}} -->
+  <div class="wp-block-group aurora-page-header">
+    <!-- wp:post-title {"level":1,"className":"aurora-page-title"} /-->
+  </div>
+  <!-- /wp:group -->
+
+  <!-- wp:post-content {"className":"aurora-page-content","layout":{"type":"constrained","contentSize":"860px"}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/templates/single.html
+++ b/theme/kk-aurora/templates/single.html
@@ -34,9 +34,7 @@
       </div>
       <!-- /wp:group -->
 
-      <!-- wp:paragraph {"className":"aurora-article-proof"} -->
-      <p class="aurora-article-proof">Proof trail: reported from Kris Krug's field notes, photography, talks, and working project archives.</p>
-      <!-- /wp:paragraph -->
+      <!-- wp:post-excerpt {"className":"aurora-article-dek","showMoreOnNewLine":false,"moreText":""} /-->
     </div>
     <!-- /wp:group -->
 

--- a/theme/kk-aurora/templates/single.html
+++ b/theme/kk-aurora/templates/single.html
@@ -1,0 +1,115 @@
+<!-- wp:template-part {"slug":"header","area":"header"} /-->
+
+<!-- wp:html -->
+<div class="aurora-reading-progress" aria-hidden="true"><span></span></div>
+<!-- /wp:html -->
+
+<!-- wp:group {"tagName":"main","className":"aurora-single-2026","layout":{"type":"constrained","contentSize":"920px"}} -->
+<main id="aurora-main" class="wp-block-group aurora-single-2026">
+
+  <!-- wp:group {"tagName":"article","className":"aurora-article","layout":{"type":"constrained","contentSize":"760px"}} -->
+  <article class="wp-block-group aurora-article">
+    <!-- wp:group {"className":"aurora-article-header","layout":{"type":"constrained","contentSize":"900px"}} -->
+    <div class="wp-block-group aurora-article-header">
+      <!-- wp:post-terms {"term":"category","className":"aurora-article-category"} /-->
+      <!-- wp:post-title {"level":1,"className":"aurora-single-title"} /-->
+
+      <!-- wp:group {"className":"aurora-article-meta","layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"center"}} -->
+      <div class="wp-block-group aurora-article-meta">
+        <!-- wp:post-date /-->
+        <!-- wp:html -->
+        <span class="aurora-meta-divider" aria-hidden="true">/</span>
+        <!-- /wp:html -->
+        <!-- wp:paragraph -->
+        <p>Field note</p>
+        <!-- /wp:paragraph -->
+        <!-- wp:html -->
+        <span class="aurora-meta-divider" aria-hidden="true">/</span>
+        <!-- /wp:html -->
+        <!-- wp:post-author-name /-->
+        <!-- wp:html -->
+        <span class="aurora-meta-divider aurora-read-time-divider" aria-hidden="true" hidden>/</span>
+        <span class="aurora-read-time" data-aurora-read-time hidden></span>
+        <!-- /wp:html -->
+      </div>
+      <!-- /wp:group -->
+
+      <!-- wp:paragraph {"className":"aurora-article-proof"} -->
+      <p class="aurora-article-proof">Proof trail: reported from Kris Krug's field notes, photography, talks, and working project archives.</p>
+      <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:post-featured-image {"className":"aurora-featured-media"} /-->
+
+    <!-- wp:html -->
+    <details class="aurora-article-map" data-aurora-article-map hidden>
+      <summary>Article map</summary>
+      <nav aria-label="Article sections"></nav>
+    </details>
+    <!-- /wp:html -->
+
+    <!-- wp:post-content {"className":"aurora-prose","layout":{"type":"constrained","contentSize":"720px"}} /-->
+
+    <!-- wp:group {"className":"aurora-author-panel","layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"top"}} -->
+    <div class="wp-block-group aurora-author-panel">
+      <!-- wp:post-author-biography {"avatarSize":72,"showBio":false,"byline":""} /-->
+      <!-- wp:group {"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group">
+        <!-- wp:heading {"level":2,"className":"aurora-author-title"} -->
+        <h2 class="wp-block-heading aurora-author-title">About Kris</h2>
+        <!-- /wp:heading -->
+        <!-- wp:paragraph -->
+        <p>Kris Krug is an AI keynote speaker, creative technologist, photographer, and community builder working across BC + AI, The Upgrade AI, Indigenomics.ai, and a living network of AI-era projects.</p>
+        <!-- /wp:paragraph -->
+        <!-- wp:buttons {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+        <div class="wp-block-buttons">
+          <!-- wp:button {"className":"is-style-aurora-primary"} -->
+          <div class="wp-block-button is-style-aurora-primary"><a class="wp-block-button__link wp-element-button" href="/speaking/">Book Kris</a></div>
+          <!-- /wp:button -->
+          <!-- wp:button {"className":"is-style-aurora-ghost"} -->
+          <div class="wp-block-button is-style-aurora-ghost"><a class="wp-block-button__link wp-element-button" href="/work/">Explore work</a></div>
+          <!-- /wp:button -->
+        </div>
+        <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+
+    <!-- wp:group {"className":"aurora-tag-panel","layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"center"}} -->
+    <div class="wp-block-group aurora-tag-panel">
+      <!-- wp:paragraph -->
+      <p>Tagged</p>
+      <!-- /wp:paragraph -->
+      <!-- wp:post-terms {"term":"post_tag","className":"aurora-post-tags"} /-->
+    </div>
+    <!-- /wp:group -->
+  </article>
+  <!-- /wp:group -->
+
+  <!-- wp:group {"className":"aurora-related","layout":{"type":"constrained","contentSize":"920px"}} -->
+  <div class="wp-block-group aurora-related">
+    <!-- wp:heading {"level":2} -->
+    <h2 class="wp-block-heading">Keep reading</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:query {"queryId":3,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false}} -->
+    <div class="wp-block-query">
+      <!-- wp:post-template {"className":"aurora-related-list","layout":{"type":"default"}} -->
+        <!-- wp:group {"className":"aurora-related-row","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
+        <div class="wp-block-group aurora-related-row">
+          <!-- wp:post-title {"level":3,"isLink":true} /-->
+          <!-- wp:post-date /-->
+        </div>
+        <!-- /wp:group -->
+      <!-- /wp:post-template -->
+    </div>
+    <!-- /wp:query -->
+  </div>
+  <!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -1,0 +1,839 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 3,
+  "settings": {
+    "appearanceTools": true,
+    "useRootPaddingAwareAlignments": true,
+    "layout": {
+      "contentSize": "800px",
+      "wideSize": "1280px"
+    },
+    "color": {
+      "custom": true,
+      "customDuotone": true,
+      "customGradient": true,
+      "defaultDuotone": false,
+      "defaultGradients": false,
+      "defaultPalette": false,
+      "palette": [
+        {
+          "slug": "void",
+          "name": "Void (True Black)",
+          "color": "#000000"
+        },
+        {
+          "slug": "deep",
+          "name": "Deep Space",
+          "color": "#0D0D12"
+        },
+        {
+          "slug": "surface",
+          "name": "Surface",
+          "color": "#12121A"
+        },
+        {
+          "slug": "elevated",
+          "name": "Elevated",
+          "color": "#1A1A25"
+        },
+        {
+          "slug": "muted",
+          "name": "Muted",
+          "color": "#252532"
+        },
+        {
+          "slug": "text-primary",
+          "name": "Text Primary",
+          "color": "#F0F0F5"
+        },
+        {
+          "slug": "text-secondary",
+          "name": "Text Secondary",
+          "color": "#B8B8C8"
+        },
+        {
+          "slug": "text-muted",
+          "name": "Text Muted",
+          "color": "#7C7C98"
+        },
+        {
+          "slug": "paper",
+          "name": "Aurora Paper",
+          "color": "#F7F5F1"
+        },
+        {
+          "slug": "signal",
+          "name": "Aurora Signal",
+          "color": "#E5462E"
+        },
+        {
+          "slug": "wildcard",
+          "name": "Aurora Wildcard",
+          "color": "#C8FF3D"
+        },
+        {
+          "slug": "cyan",
+          "name": "Aurora Cyan",
+          "color": "#00E5FF"
+        },
+        {
+          "slug": "teal",
+          "name": "Aurora Teal",
+          "color": "#00BFA5"
+        },
+        {
+          "slug": "purple",
+          "name": "Aurora Purple",
+          "color": "#8B5CF6"
+        },
+        {
+          "slug": "pink",
+          "name": "Aurora Pink",
+          "color": "#EC4899"
+        },
+        {
+          "slug": "blue",
+          "name": "Aurora Blue",
+          "color": "#3B82F6"
+        },
+        {
+          "slug": "success",
+          "name": "Success",
+          "color": "#00BFA5"
+        },
+        {
+          "slug": "warning",
+          "name": "Warning",
+          "color": "#F59E0B"
+        },
+        {
+          "slug": "error",
+          "name": "Error",
+          "color": "#EF4444"
+        }
+      ],
+      "gradients": [
+        {
+          "slug": "aurora-primary",
+          "name": "Aurora Primary",
+          "gradient": "linear-gradient(135deg, #E5462E 0%, #C8FF3D 100%)"
+        },
+        {
+          "slug": "aurora-secondary",
+          "name": "Aurora Secondary",
+          "gradient": "linear-gradient(135deg, #8B5CF6 0%, #EC4899 100%)"
+        },
+        {
+          "slug": "aurora-subtle",
+          "name": "Aurora Subtle",
+          "gradient": "linear-gradient(135deg, rgba(0, 229, 255, 0.1) 0%, rgba(139, 92, 246, 0.1) 100%)"
+        },
+        {
+          "slug": "aurora-cyan-teal",
+          "name": "Cyan to Teal",
+          "gradient": "linear-gradient(135deg, #00E5FF 0%, #00BFA5 100%)"
+        },
+        {
+          "slug": "aurora-radial",
+          "name": "Aurora Radial",
+          "gradient": "radial-gradient(ellipse at center, #1A1A25 0%, #0D0D12 100%)"
+        },
+        {
+          "slug": "depth-fade",
+          "name": "Depth Fade",
+          "gradient": "linear-gradient(180deg, #0D0D12 0%, #12121A 100%)"
+        }
+      ],
+      "duotone": [
+        {
+          "slug": "aurora-duo",
+          "name": "Aurora Duotone",
+          "colors": ["#0D0D12", "#00E5FF"]
+        },
+        {
+          "slug": "purple-pink",
+          "name": "Purple Pink",
+          "colors": ["#0D0D12", "#EC4899"]
+        }
+      ]
+    },
+    "typography": {
+      "customFontSize": true,
+      "fluid": true,
+      "fontFamilies": [
+        {
+          "fontFamily": "'Instrument Sans', 'Inter', system-ui, -apple-system, sans-serif",
+          "slug": "display",
+          "name": "Display (Instrument Sans)"
+        },
+        {
+          "fontFamily": "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          "slug": "body",
+          "name": "Body (Inter)"
+        },
+        {
+          "fontFamily": "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+          "slug": "mono",
+          "name": "Monospace (JetBrains Mono)"
+        }
+      ],
+      "fontSizes": [
+        {
+          "slug": "xs",
+          "name": "Extra Small",
+          "size": "0.75rem",
+          "fluid": {
+            "min": "0.75rem",
+            "max": "0.875rem"
+          }
+        },
+        {
+          "slug": "sm",
+          "name": "Small",
+          "size": "0.875rem",
+          "fluid": {
+            "min": "0.875rem",
+            "max": "1rem"
+          }
+        },
+        {
+          "slug": "base",
+          "name": "Base",
+          "size": "1rem",
+          "fluid": {
+            "min": "1rem",
+            "max": "1.125rem"
+          }
+        },
+        {
+          "slug": "lg",
+          "name": "Large",
+          "size": "1.125rem",
+          "fluid": {
+            "min": "1.125rem",
+            "max": "1.25rem"
+          }
+        },
+        {
+          "slug": "xl",
+          "name": "Extra Large",
+          "size": "1.25rem",
+          "fluid": {
+            "min": "1.25rem",
+            "max": "1.5rem"
+          }
+        },
+        {
+          "slug": "2xl",
+          "name": "2X Large",
+          "size": "1.5rem",
+          "fluid": {
+            "min": "1.5rem",
+            "max": "2rem"
+          }
+        },
+        {
+          "slug": "3xl",
+          "name": "3X Large",
+          "size": "1.875rem",
+          "fluid": {
+            "min": "1.875rem",
+            "max": "2.5rem"
+          }
+        },
+        {
+          "slug": "4xl",
+          "name": "4X Large",
+          "size": "2.25rem",
+          "fluid": {
+            "min": "2.25rem",
+            "max": "3rem"
+          }
+        },
+        {
+          "slug": "5xl",
+          "name": "5X Large",
+          "size": "3rem",
+          "fluid": {
+            "min": "3rem",
+            "max": "4.5rem"
+          }
+        },
+        {
+          "slug": "hero",
+          "name": "Hero",
+          "size": "3.5rem",
+          "fluid": {
+            "min": "3.5rem",
+            "max": "7rem"
+          }
+        }
+      ]
+    },
+    "spacing": {
+      "customSpacingSize": true,
+      "units": ["px", "rem", "em", "%", "vw", "vh"],
+      "spacingScale": {
+        "steps": 0
+      },
+      "spacingSizes": [
+        { "slug": "10", "name": "1", "size": "0.25rem" },
+        { "slug": "20", "name": "2", "size": "0.5rem" },
+        { "slug": "30", "name": "3", "size": "0.75rem" },
+        { "slug": "40", "name": "4", "size": "1rem" },
+        { "slug": "50", "name": "5", "size": "1.25rem" },
+        { "slug": "60", "name": "6", "size": "1.5rem" },
+        { "slug": "70", "name": "7", "size": "1.75rem" },
+        { "slug": "80", "name": "8", "size": "2rem" },
+        { "slug": "90", "name": "9", "size": "2.5rem" },
+        { "slug": "100", "name": "10", "size": "3rem" },
+        { "slug": "120", "name": "12", "size": "4rem" },
+        { "slug": "160", "name": "16", "size": "5rem" },
+        { "slug": "200", "name": "20", "size": "6rem" },
+        { "slug": "240", "name": "24", "size": "8rem" }
+      ]
+    },
+    "border": {
+      "color": true,
+      "radius": true,
+      "style": true,
+      "width": true
+    },
+    "shadow": {
+      "defaultPresets": false,
+      "presets": [
+        {
+          "slug": "sm",
+          "name": "Small",
+          "shadow": "0 1px 2px rgba(0, 0, 0, 0.5)"
+        },
+        {
+          "slug": "md",
+          "name": "Medium",
+          "shadow": "0 4px 6px rgba(0, 0, 0, 0.4)"
+        },
+        {
+          "slug": "lg",
+          "name": "Large",
+          "shadow": "0 10px 15px rgba(0, 0, 0, 0.3)"
+        },
+        {
+          "slug": "xl",
+          "name": "Extra Large",
+          "shadow": "0 20px 25px rgba(0, 0, 0, 0.25)"
+        },
+        {
+          "slug": "glow-cyan",
+          "name": "Glow Cyan",
+          "shadow": "0 0 20px rgba(0, 229, 255, 0.3), 0 0 40px rgba(0, 229, 255, 0.15)"
+        },
+        {
+          "slug": "glow-teal",
+          "name": "Glow Teal",
+          "shadow": "0 0 20px rgba(0, 191, 165, 0.3), 0 0 40px rgba(0, 191, 165, 0.15)"
+        },
+        {
+          "slug": "glow-purple",
+          "name": "Glow Purple",
+          "shadow": "0 0 20px rgba(139, 92, 246, 0.3), 0 0 40px rgba(139, 92, 246, 0.15)"
+        },
+        {
+          "slug": "glow-pink",
+          "name": "Glow Pink",
+          "shadow": "0 0 20px rgba(236, 72, 153, 0.3), 0 0 40px rgba(236, 72, 153, 0.15)"
+        }
+      ]
+    },
+    "custom": {
+      "animation": {
+        "durationFast": "150ms",
+        "durationNormal": "300ms",
+        "durationSlow": "500ms",
+        "durationSlower": "700ms",
+        "easeOut": "cubic-bezier(0, 0, 0.2, 1)",
+        "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+        "easeSmooth": "cubic-bezier(0.25, 0.1, 0.25, 1)"
+      },
+      "motion": {
+        "revealDuration": "280ms",
+        "depthDuration": "420ms",
+        "continuityDuration": "520ms",
+        "proofDuration": "600ms",
+        "microDuration": "150ms",
+        "readingDuration": "220ms",
+        "revealDistance": "16px",
+        "depthDistance": "6px",
+        "reduceDuration": "1ms"
+      },
+      "border": {
+        "radiusSm": "0.25rem",
+        "radiusMd": "0.5rem",
+        "radiusLg": "0.75rem",
+        "radiusXl": "1rem",
+        "radius2xl": "1.5rem",
+        "radiusFull": "9999px"
+      },
+      "button": {
+        "paddingInline": "var(--wp--preset--spacing--60)",
+        "paddingBlock": "var(--wp--preset--spacing--30)",
+        "radius": "var(--wp--custom--border--radius-md)",
+        "radiusPill": "var(--wp--custom--border--radius-full)",
+        "minHeight": "44px",
+        "mobileMinHeight": "48px",
+        "iconSize": "1.125rem"
+      },
+      "focus": {
+        "ringColor": "var(--wp--preset--color--cyan)",
+        "ringOffsetColor": "var(--wp--preset--color--deep)",
+        "ringWidth": "2px",
+        "ringOffset": "3px",
+        "ringGlow": "0 0 0 4px rgba(0, 229, 255, 0.24)"
+      },
+      "glass": {
+        "surfaceSoft": "rgba(18, 18, 26, 0.68)",
+        "surfaceStrong": "rgba(18, 18, 26, 0.84)",
+        "border": "rgba(240, 240, 245, 0.12)",
+        "highlight": "rgba(240, 240, 245, 0.18)",
+        "blur": "18px"
+      },
+      "lineHeight": {
+        "none": "1",
+        "tight": "1.15",
+        "snug": "1.3",
+        "normal": "1.5",
+        "relaxed": "1.65",
+        "loose": "1.8"
+      },
+      "letterSpacing": {
+        "tighter": "0",
+        "tight": "0",
+        "normal": "0",
+        "wide": "0.015em",
+        "wider": "0.03em"
+      },
+      "zIndex": {
+        "dropdown": "1000",
+        "sticky": "1020",
+        "fixed": "1030",
+        "modal": "1040",
+        "popover": "1050",
+        "tooltip": "1060"
+      }
+    },
+    "blocks": {
+      "core/button": {
+        "border": {
+          "radius": true
+        }
+      },
+      "core/code": {
+        "typography": {
+          "fontFamilies": true
+        }
+      },
+      "core/heading": {
+        "typography": {
+          "fontFamilies": true,
+          "fontSizes": true
+        }
+      },
+      "core/paragraph": {
+        "typography": {
+          "fontFamilies": true,
+          "fontSizes": true
+        }
+      }
+    }
+  },
+  "styles": {
+    "color": {
+      "background": "var(--wp--preset--color--deep)",
+      "text": "var(--wp--preset--color--text-primary)"
+    },
+    "typography": {
+      "fontFamily": "var(--wp--preset--font-family--body)",
+      "fontSize": "var(--wp--preset--font-size--base)",
+      "lineHeight": "var(--wp--custom--line-height--relaxed)"
+    },
+    "spacing": {
+      "padding": {
+        "left": "var(--wp--preset--spacing--40)",
+        "right": "var(--wp--preset--spacing--40)"
+      }
+    },
+    "elements": {
+      "heading": {
+        "color": {
+          "text": "var(--wp--preset--color--text-primary)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--display)",
+          "fontWeight": "700",
+          "lineHeight": "var(--wp--custom--line-height--tight)"
+        }
+      },
+      "h1": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--5xl)",
+          "letterSpacing": "var(--wp--custom--letter-spacing--tighter)"
+        },
+        "spacing": {
+          "margin": {
+            "bottom": "var(--wp--preset--spacing--60)"
+          }
+        }
+      },
+      "h2": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--4xl)",
+          "letterSpacing": "var(--wp--custom--letter-spacing--tight)"
+        },
+        "spacing": {
+          "margin": {
+            "top": "var(--wp--preset--spacing--100)",
+            "bottom": "var(--wp--preset--spacing--50)"
+          }
+        }
+      },
+      "h3": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--3xl)"
+        },
+        "spacing": {
+          "margin": {
+            "top": "var(--wp--preset--spacing--80)",
+            "bottom": "var(--wp--preset--spacing--40)"
+          }
+        }
+      },
+      "h4": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--2xl)"
+        }
+      },
+      "h5": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--xl)"
+        }
+      },
+      "h6": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--lg)"
+        }
+      },
+      "link": {
+        "color": {
+          "text": "var(--wp--preset--color--cyan)"
+        },
+        "typography": {
+          "textDecoration": "none",
+          "textUnderlineOffset": "0.16em"
+        },
+        ":hover": {
+          "color": {
+            "text": "var(--wp--preset--color--teal)"
+          },
+          "typography": {
+            "textDecoration": "underline"
+          }
+        },
+        ":focus": {
+          "color": {
+            "text": "var(--wp--preset--color--cyan)"
+          },
+          "outline": {
+            "color": "var(--wp--custom--focus--ring-color)",
+            "offset": "var(--wp--custom--focus--ring-offset)",
+            "style": "solid",
+            "width": "var(--wp--custom--focus--ring-width)"
+          }
+        }
+      },
+      "button": {
+        "color": {
+          "background": "var(--wp--preset--color--cyan)",
+          "text": "var(--wp--preset--color--deep)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--body)",
+          "fontSize": "var(--wp--preset--font-size--base)",
+          "fontWeight": "600",
+          "letterSpacing": "var(--wp--custom--letter-spacing--normal)"
+        },
+        "border": {
+          "radius": "var(--wp--custom--button--radius)"
+        },
+        "spacing": {
+          "padding": {
+            "top": "var(--wp--custom--button--padding-block)",
+            "bottom": "var(--wp--custom--button--padding-block)",
+            "left": "var(--wp--custom--button--padding-inline)",
+            "right": "var(--wp--custom--button--padding-inline)"
+          }
+        },
+        ":hover": {
+          "color": {
+            "background": "var(--wp--preset--color--teal)",
+            "text": "var(--wp--preset--color--deep)"
+          }
+        },
+        ":focus": {
+          "outline": {
+            "color": "var(--wp--custom--focus--ring-color)",
+            "offset": "var(--wp--custom--focus--ring-offset)",
+            "style": "solid",
+            "width": "var(--wp--custom--focus--ring-width)"
+          }
+        }
+      },
+      "caption": {
+        "color": {
+          "text": "var(--wp--preset--color--text-muted)"
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--sm)"
+        }
+      },
+      "cite": {
+        "typography": {
+          "fontStyle": "normal"
+        }
+      }
+    },
+    "blocks": {
+      "core/site-title": {
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--display)",
+          "fontSize": "var(--wp--preset--font-size--xl)",
+          "fontWeight": "700",
+          "letterSpacing": "var(--wp--custom--letter-spacing--tight)"
+        },
+        "elements": {
+          "link": {
+            "color": {
+              "text": "var(--wp--preset--color--text-primary)"
+            },
+            ":hover": {
+              "color": {
+                "text": "var(--wp--preset--color--cyan)"
+              }
+            }
+          }
+        }
+      },
+      "core/navigation": {
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--body)",
+          "fontSize": "var(--wp--preset--font-size--sm)",
+          "fontWeight": "500"
+        },
+        "elements": {
+          "link": {
+            "color": {
+              "text": "var(--wp--preset--color--text-secondary)"
+            },
+            ":hover": {
+              "color": {
+                "text": "var(--wp--preset--color--text-primary)"
+              }
+            }
+          }
+        }
+      },
+      "core/code": {
+        "color": {
+          "background": "var(--wp--preset--color--surface)",
+          "text": "var(--wp--preset--color--cyan)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--mono)",
+          "fontSize": "var(--wp--preset--font-size--sm)"
+        },
+        "border": {
+          "radius": "var(--wp--custom--border--radius-sm)"
+        },
+        "spacing": {
+          "padding": {
+            "top": "var(--wp--preset--spacing--10)",
+            "bottom": "var(--wp--preset--spacing--10)",
+            "left": "var(--wp--preset--spacing--20)",
+            "right": "var(--wp--preset--spacing--20)"
+          }
+        }
+      },
+      "core/preformatted": {
+        "color": {
+          "background": "var(--wp--preset--color--surface)",
+          "text": "var(--wp--preset--color--text-primary)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--mono)",
+          "fontSize": "var(--wp--preset--font-size--sm)"
+        },
+        "border": {
+          "color": "var(--wp--preset--color--elevated)",
+          "radius": "var(--wp--custom--border--radius-md)",
+          "style": "solid",
+          "width": "1px"
+        },
+        "spacing": {
+          "padding": {
+            "top": "var(--wp--preset--spacing--60)",
+            "bottom": "var(--wp--preset--spacing--60)",
+            "left": "var(--wp--preset--spacing--60)",
+            "right": "var(--wp--preset--spacing--60)"
+          }
+        }
+      },
+      "core/quote": {
+        "color": {
+          "text": "var(--wp--preset--color--text-primary)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--display)",
+          "fontSize": "var(--wp--preset--font-size--xl)",
+          "fontStyle": "normal",
+          "lineHeight": "var(--wp--custom--line-height--snug)"
+        },
+        "border": {
+          "color": "var(--wp--preset--color--cyan)",
+          "style": "solid",
+          "width": "0 0 0 4px"
+        },
+        "spacing": {
+          "padding": {
+            "left": "var(--wp--preset--spacing--60)"
+          }
+        }
+      },
+      "core/pullquote": {
+        "color": {
+          "text": "var(--wp--preset--color--text-primary)"
+        },
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--display)",
+          "fontSize": "var(--wp--preset--font-size--3xl)",
+          "fontWeight": "600",
+          "lineHeight": "var(--wp--custom--line-height--tight)"
+        },
+        "border": {
+          "color": "var(--wp--preset--color--cyan)",
+          "style": "solid",
+          "width": "4px 0"
+        },
+        "spacing": {
+          "padding": {
+            "top": "var(--wp--preset--spacing--60)",
+            "bottom": "var(--wp--preset--spacing--60)"
+          }
+        }
+      },
+      "core/separator": {
+        "color": {
+          "text": "var(--wp--preset--color--elevated)"
+        },
+        "border": {
+          "color": "currentColor",
+          "style": "solid",
+          "width": "0 0 1px 0"
+        }
+      },
+      "core/image": {
+        "border": {
+          "radius": "var(--wp--custom--border--radius-md)"
+        }
+      },
+      "core/post-title": {
+        "typography": {
+          "fontFamily": "var(--wp--preset--font-family--display)",
+          "fontSize": "var(--wp--preset--font-size--4xl)",
+          "fontWeight": "700",
+          "lineHeight": "var(--wp--custom--line-height--tight)"
+        },
+        "elements": {
+          "link": {
+            "color": {
+              "text": "var(--wp--preset--color--text-primary)"
+            },
+            ":hover": {
+              "color": {
+                "text": "var(--wp--preset--color--cyan)"
+              }
+            }
+          }
+        }
+      },
+      "core/post-date": {
+        "color": {
+          "text": "var(--wp--preset--color--text-muted)"
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--sm)"
+        }
+      },
+      "core/post-excerpt": {
+        "color": {
+          "text": "var(--wp--preset--color--text-secondary)"
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--base)",
+          "lineHeight": "var(--wp--custom--line-height--relaxed)"
+        }
+      },
+      "core/post-terms": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--xs)",
+          "fontWeight": "500",
+          "textTransform": "uppercase",
+          "letterSpacing": "var(--wp--custom--letter-spacing--wider)"
+        },
+        "elements": {
+          "link": {
+            "color": {
+              "text": "var(--wp--preset--color--purple)"
+            },
+            ":hover": {
+              "color": {
+                "text": "var(--wp--preset--color--pink)"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "templateParts": [
+    {
+      "name": "header",
+      "title": "Header",
+      "area": "header"
+    },
+    {
+      "name": "footer",
+      "title": "Footer",
+      "area": "footer"
+    },
+    {
+      "name": "work-proof-grid",
+      "title": "Work Proof Grid",
+      "area": "uncategorized"
+    },
+    {
+      "name": "speaking-proof-grid",
+      "title": "Speaking Proof Grid",
+      "area": "uncategorized"
+    }
+  ],
+  "customTemplates": [
+    {
+      "name": "blank",
+      "title": "Blank",
+      "postTypes": ["page", "post"]
+    },
+    {
+      "name": "no-title",
+      "title": "No Title",
+      "postTypes": ["page", "post"]
+    }
+  ]
+}


### PR DESCRIPTION
Brings the **canonical reconciled Aurora theme (`kk-aurora` 1.3.0)** into `main`. The theme
previously lived only on branches (`aurora/v2`, and the untracked 1.2.0 build); this
establishes the v3 line as trunk. **Already deployed to production and verified live** —
this PR is the git consolidation + review trail.

## What's in it
- **Rescue 1.2.0** (`3c31272`): the further-along build that was untracked on a worktree disk.
  Brings a real `/blog` post-archive `home.html` (fixes **#117**), extra page templates, hero-gradient pattern.
- **Proof-trail → author dek** (`577c7fb`): kills the hardcoded "Proof trail: reported from…"
  line on every post; replaces with `core/post-excerpt` + a `render_block` filter that shows the
  dek **only when a manual excerpt exists** (blank otherwise — true per-post control).
- **Homepage reveal #116** (`52a4f80`): the `opacity:0` hide is JS-injected (safe-fail) + a
  `requestAnimationFrame` pass reveals in-viewport elements on the first frame. Lets the
  Customizer force-visible band-aid be retired (done in prod).
- **Version 1.3.0** (`9f0dfd0`) + **QA roadmap** (`2843b89`, `docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`).

## Verification (Local + prod)
- Local QA green: `/blog/` real archive; proof-trail gone; dek shows w/ manual excerpt, blank without; no static `opacity:0`.
- Prod (live): proof-trail gone, `/blog/` archive, dek rendering, homepage visible on cold loads **with the band-aid removed** (in-theme reveal standalone), PressCACHE purged.

## Notes for reviewers
- Supersedes `aurora/v2` (per the reconciliation; don't merge v2 separately or it forks again).
- All additions (main had no `theme/kk-aurora`), so no conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)