### PR TITLE
ops+theme: reconcile main-canonical docs, nav a11y, and Work OG fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the entry point for any AI agent (Claude Code, Cursor, Codex, etc.)
 
 ## What this repo is
 
-The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site currently running the Aurora theme (`kk-aurora`) in production as of 2026-05-24. The repo is **adjacent to** the live site, not a mirror of it. `main` does not contain a full production theme/database/media mirror; Track B theme code lives on `aurora/v2`, and curated source-pack media/proofs are tracked. Custom repo-side WP code now includes `inc/digital-composting.php` (merged, not yet deployed to prod) and `plugins/kk-sidebar-promos/` (packaged helper plugin, deploy only with an explicit rollback path and KK approval).
+The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site running the Aurora theme (`kk-aurora`) as of 2026-05-24. The repo is **adjacent to** the live site, not a mirror of it. `main` now contains the canonical tracked theme line (merged via PR #129), plus content/ops tooling and docs. Custom repo-side WP code includes `inc/digital-composting.php` (merged, not yet deployed to prod) and `plugins/kk-sidebar-promos/` (packaged helper plugin, deploy only with an explicit rollback path and KK approval).
 
 ## Read this in order (top of repo, top of context)
 
@@ -12,33 +12,34 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 2. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 3. [`docs/current-state/REPO_STATE.md`](docs/current-state/REPO_STATE.md) — what's actually built vs. just documented
 4. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
-5. [`docs/current-state/HANDOFF-2026-05-24.md`](docs/current-state/HANDOFF-2026-05-24.md) — authoritative cross-track state as of 2026-05-24
-6. [`docs/current-state/SESSION-HANDOFF-2026-05-24.md`](docs/current-state/SESSION-HANDOFF-2026-05-24.md) — Track A/Track B ownership and latest lane handoff
-7. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — latest read-only truth memo and verification matrix
-8. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical Track A baseline; keep for context, not for current counts
+5. [`docs/current-state/HANDOFF-2026-05-24.md`](docs/current-state/HANDOFF-2026-05-24.md) — 2026-05-24 Aurora/theme/content handoff
+6. [`docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) — reconciled Aurora v1.3.0 QA + rollout status
+7. [`docs/current-state/SESSION-HANDOFF-2026-05-24.md`](docs/current-state/SESSION-HANDOFF-2026-05-24.md) — Track A/Track B ownership and latest lane handoff
+8. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — latest startup truth snapshot
+9. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
 
 For the detailed diagnostic behind that plan, read [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md).
 
 After those five, the rest of the repo will make sense.
 
-## Two tracks — pick one per session
+## Two lanes — pick one per commit
 
-| | Track A — Content + SEO | Track B — Aurora v2 theme |
+| | Track A — Content + SEO | Track B — Aurora theme |
 |---|---|---|
-| Branch | `main` | `aurora/v2` |
+| Branch | `main` (or feature branch from `main`) | `main` (or feature branch from `main`) |
 | Touches | Posts, pages, media, taxonomies, Code Snippets (PHP/CSS), schema JSON-LD, redirects, alt text | `theme/kk-aurora/`, FSE templates, theme.json |
-| Lives in | `content/drafts/`, `fixes/`, `scripts/notion-to-wp/`, `docs/current-state/` | `theme/`, `demo/`, `docs/current-state/AURORA-*` |
+| Lives in | `content/drafts/`, `fixes/`, `scripts/notion-to-wp/`, `docs/current-state/` | `theme/kk-aurora/`, `docs/current-state/AURORA-*` |
 | Owner | Publisher-mode session | Architect-mode session |
 
 **Decision rule:** Editing a post / page / media / category / schema / redirect → Track A. Editing theme files / FSE templates / theme.json → Track B. If you're doing both in one session, you've scope-crept — finish one, commit, then start the other in a fresh session.
 
-Full decision tree: [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md#how-to-know-which-track-youre-in).
+Legacy branch split context is in [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md). Treat branch-specific rules there as historical unless reconfirmed by a newer handoff.
 
 ## Hard safety rules (post 2026-05-15 incident)
 
 1. **Rollback path before destructive operations.** The strict backup/restore proof gate was retired on 2026-05-22. Use dry-runs, slug/ID checks, page/post snapshots, reversible deploy steps, and KK approval for risky live changes. Use a full backup when the blast radius justifies it, but do not block ordinary publish/review work solely on restore-drill proof.
 2. **Slug-based idempotency** for the Notion → WP connector. Never PATCH a WP post without first verifying that the slug match is the intended target. See [`INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md).
-3. **No theme file changes on `main`.** Theme work belongs on `aurora/v2`.
+3. **Keep commits lane-scoped.** `main` is now canonical for both content and theme truth; do not mix unrelated Track A + Track B edits in one commit.
 4. **Don't run the connector on production without `--dry-run` first.**
 
 ## What's historical or parked (don't get distracted)
@@ -48,8 +49,7 @@ Full decision tree: [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md
 - **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. The current execution roadmap is [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md); the longer-range reference roadmap is [`docs/current-state/ROADMAP.md`](docs/current-state/ROADMAP.md).
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. The current front door is the 2026-05-24 handoff set in `docs/current-state/`; `WORK-PLAN-2026-05-23.md` is now historical context.
+- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use the 2026-05-24 handoff set first (`HANDOFF`, `AURORA-V3-QA-ROADMAP`, `TRACK-A-MORNING-TRUTH`) and keep `WORK-PLAN-2026-05-23.md` as historical context.
 
 Anything banner-tagged `STATUS: Historical` at the top is reference-only.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Building a Responsible & Inclusive AI Future for British Columbia
 
-**Live site:** [kriskrug.co](https://kriskrug.co/) (Pagely-hosted WordPress, Catch Responsive theme)
+**Live site:** [kriskrug.co](https://kriskrug.co/) (Pagely-hosted WordPress, Aurora `kk-aurora` theme)
 **Repo:** [WalksWithASwagger/kriskrug-wp](https://github.com/WalksWithASwagger/kriskrug-wp)
 **Operating model:** Two tracks — see [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md)
 
@@ -35,7 +35,7 @@ This repository is used for:
 1. **Site audits + state snapshots** of the live kriskrug.co WordPress install (see [`docs/current-state/`](docs/current-state/))
 2. **Content pipeline** — Notion → kriskrug.co publisher with safety guards (see [`scripts/notion-to-wp/`](scripts/notion-to-wp/))
 3. **Custom WordPress code** — schema markup, theme tweaks, helper plugins (see [`fixes/`](fixes/), [`inc/`](inc/), and [`plugins/`](plugins/))
-4. **Aurora v2 theme work** — separate `aurora/v2` branch, paced sprints (see [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md))
+4. **Aurora theme work** — canonical theme source now tracked on `main` (merged via PR #129), with lane-scoped feature branches for larger slices
 5. **Issue tracking + project management** for fixes, content, and theme work
 
 ### Why a Separate Repo?
@@ -95,7 +95,8 @@ skills/                          # Claude Code skills used in this repo
 ### Where to start
 
 - **Reading the site state:** `docs/current-state/README.md`
-- **Planning next work:** `docs/current-state/WORK-PLAN-2026-05-23.md`
+- **Planning next work:** `docs/current-state/HANDOFF-2026-05-24.md` and `docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`
+- **Latest startup truth:** `docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`
 - **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
 - **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
@@ -104,7 +105,7 @@ skills/                          # Claude Code skills used in this repo
 
 ## How work happens here
 
-Two parallel tracks. Pick one per session — don't mix.
+Two parallel lanes. Keep one lane per commit — don't mix unrelated theme/content changes in the same commit.
 
 ### Track A — Content + SEO (on `main`, weekly cadence)
 
@@ -115,15 +116,15 @@ Notion → kriskrug.co publishing, post-publish enrichment, schema maintenance, 
 - Active backlog: [`docs/current-state/FIX_QUEUE.md`](docs/current-state/FIX_QUEUE.md), [`docs/current-state/SITE-AUDIT-2026-05-16.md`](docs/current-state/SITE-AUDIT-2026-05-16.md)
 - Deployed schema: [`fixes/schema-snippets-deployed.php`](fixes/schema-snippets-deployed.php)
 
-### Track B — Aurora v2 theme migration (on `aurora/v2`, paced sprints)
+### Track B — Aurora theme (on `main` via lane-scoped branches)
 
-FSE theme rebuild on a separate branch. Touches `theme/`, FSE templates, theme.json. Never touches post content.
+FSE theme rebuild and polish. Touches `theme/kk-aurora/`, FSE templates, theme.json. Avoid bundling theme edits with content publishing changes in the same commit.
 
 - Migration plan: [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md)
 
 ### Which track am I in?
 
-See the decision rule in [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md#how-to-know-which-track-youre-in). If you're editing a post, page, schema, redirect, or category → Track A. If you're editing theme files or FSE templates → Track B.
+If you're editing a post, page, schema, redirect, or category → Track A. If you're editing theme files or FSE templates → Track B. Use the two-track model doc for historical context, but prefer the 2026-05-24 handoff docs for current branch/layout truth.
 
 ## Getting Started
 
@@ -141,7 +142,7 @@ Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](do
 
 ## Technology Stack
 
-- **Platform:** WordPress 6.9+ on Pagely (production), Catch Responsive theme
+- **Platform:** WordPress 6.9+ on Pagely (production), Aurora `kk-aurora` theme
 - **Content pipeline:** Python (Notion API → WordPress REST API)
 - **Custom code:** PHP snippets (Code Snippets plugin on prod), `inc/digital-composting.php`, and packaged helper plugins such as `plugins/kk-sidebar-promos/`
 - **CLI Tools:** GitHub CLI (`gh`), Claude Code / Cursor agents

--- a/docs/current-state/HANDOFF-2026-05-24.md
+++ b/docs/current-state/HANDOFF-2026-05-24.md
@@ -6,7 +6,7 @@ WORK-PLAN / state docs where they conflict.
 ## TL;DR
 
 The **Aurora redesign theme (`kk-aurora`) is LIVE on production** kriskrug.co (active
-version **1.1.2**, WordPress 6.9.4, Pagely host). The launch blockers are fixed and several
+version **1.3.0**, WordPress 6.9.4, Pagely host). The launch blockers are fixed and several
 pages are rebuilt. **WordPress 7.0 is NOT installed** (Pagely pins the channel; not
 self-serviceable — parked).
 
@@ -16,7 +16,7 @@ There are **two different ways to change the site. Use the right one:**
 
 | Change type | How | Deploy? | Editable by KK? |
 |---|---|---|---|
-| **Global** — header, footer, homepage, single post, blog archive, design CSS/JS, the reveal fix | Edit theme files in the `aurora/v2` worktree → build zip → KK uploads in wp-admin (Replace) → purge Pagely cache | Yes (theme upload) | No |
+| **Global** — header, footer, homepage, single post, blog archive, design CSS/JS, the reveal fix | Edit theme files from `main` (or a feature branch from `main`) → package zip as needed → KK uploads in wp-admin (Replace) → purge Pagely cache | Yes (theme upload) | No |
 | **Individual content pages** — Events, Services, the ~25 marketing/authority/multilingual pages | Write page **content via REST** (`POST /wp/v2/pages/{id}`), reusing the live theme's Aurora CSS classes | **No deploy** | Yes (wp-admin) |
 
 **Decision (KK, 2026-05-24): content pages = DB content via REST, NOT theme templates.**
@@ -44,7 +44,7 @@ Do NOT build per-page theme templates anymore. Reuse live Aurora classes:
   treatment (do them via REST, per the rule above). Services + Events are done.
 - **#120 (P1)** — Both Hands Full proof card text/image overlap.
 - **#125/#126/#127 (P2)** — Boost Critical CSS/perf (auto-regenerating), Work OG image
-  (needs KK to pick a featured image), mobile/responsive QA.
+  fallback and verification, mobile/responsive QA.
 - **#119 caveat** — broken image fixed, but full **media-library migration** (stop
   hotlinking from punkrockai/bc-ai/etc.) still pending. See `AURORA-MEDIA-GAPS-2026-05-23.md`.
 - Older design issues #24–#35, #86 — legacy backlog; reconcile against what's already shipped.
@@ -62,22 +62,14 @@ Do NOT build per-page theme templates anymore. Reuse live Aurora classes:
   no hands-off file deploys.
 - **WordPress 7.0:** wp-admin Updates offers no 7.0 (Pagely-pinned at 6.9.4). Needs Pagely support.
 
-## 🔴 aurora/v2 branch has DIVERGED — reconcile before any theme push (top regroup item)
+## Historical note — aurora/v2 divergence (superseded by PR #129)
 
-The local worktree at `.claude/worktrees/agent-aec50fddbd7207f80/` (branch `aurora/v2`,
-tip `81a62ab`) is **38 commits ahead but 50 behind `origin/aurora/v2`.** Two lines of theme
-work split apart:
+This section documented pre-merge divergence before PR #129 landed. Theme source of truth is
+now `main` (Aurora v1.3.0 merged as `eaf1182`), so do not use this section as current
+deployment guidance.
 
-- **Local / deployed-to-prod (this session):** launch-blocker fixes (v1.1.1) + Services
-  template (v1.1.2) — *what's actually live on kriskrug.co right now.*
-- **origin/aurora/v2 (other agents):** PRs #102–#106 — inventory/harden aurora components,
-  upgrade longform posts, add work & speaking media templates, aurora QA gate — *NOT in
-  production.*
-
-**Do NOT force-push** the local branch — it would destroy #102–#106. Reconciling needs a
-careful **merge** of the two lines (and a re-deploy of the merged theme), done deliberately,
-not at shutdown. This divergence is the likely source of cross-agent confusion. **Resolve
-this first when regrouping.** The local theme commits are NOT pushed.
+- Keep `aurora/v2` references as historical context only.
+- New theme fixes should branch from `main`.
 
 Also uncommitted (NOT mine, left untouched): a working-tree change to
 `content/source-packs/keynotes-2026/wp-payloads/photography.html` — appears to be in-flight
@@ -85,9 +77,7 @@ Photography-page work from another agent; verify its intent before committing.
 
 ## Where things are
 
-- **Theme source:** `aurora/v2` branch, worktree at
-  `.claude/worktrees/agent-aec50fddbd7207f80/theme/kk-aurora/` (local tip `81a62ab`;
-  see divergence warning above). `main` has NO theme files (two-track model).
+- **Theme source:** `main` (or feature branches from `main`) at `theme/kk-aurora/`.
 - **Page snapshots / content sources:** `backup/page-snapshots/`.
 - **Key docs:** `AURORA-LAUNCH-AUDIT-2026-05-23.md`, `AURORA-MEDIA-GAPS-2026-05-23.md`, this file.
 - **Auth REST creds:** `scripts/notion-to-wp/.env` (`WP_USER`/`WP_APP_PASSWORD`).

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -37,6 +37,7 @@ Then use historical plans for context:
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
 | [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md) | Authoritative cross-track state as of 2026-05-24 (Aurora live, branch divergence warning, deploy mechanics). |
 | [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md) | Track A/Track B lane handoff with ownership boundaries and public-surface updates. |
+| [AURORA-V3-QA-ROADMAP-2026-05-24.md](AURORA-V3-QA-ROADMAP-2026-05-24.md) | Reconciled Aurora v1.3.0 line, local QA evidence, and post-merge rollout priorities. |
 | [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) | Read-only truth memo with live evidence, drift flags, and verification matrix for safe next-session startup. |
 | `reports/` | Timestamped outputs from `make morning-truth` (read-only startup truth reports). |
 | [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) | Historical Track A baseline after the Sovereign AI draft pipeline closeout. Counts and queue state have drifted; verify live before acting. |
@@ -99,7 +100,7 @@ Then use historical plans for context:
 - **Site is on Pagely** (managed WP host), publicly reporting **WordPress 6.9.4** with **`kk-aurora` active** as of 2026-05-24.
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
-- **Current addendum:** use the 2026-05-24 handoff set first ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
+- **Current addendum:** use the 2026-05-24 handoff set first ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
 - **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-05-22 19:46 PDT / 2026-05-23 02:46 UTC. Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
 - **Draft queue addendum:** use [`DRAFT-QUEUE-AUDIT-2026-05-22.md`](DRAFT-QUEUE-AUDIT-2026-05-22.md) before touching the publishing queue; `sovereign-ai-for-whom` is already WP draft `11905`.
 - **Issue queue addendum:** use [`ISSUE-QUEUE-AUDIT-2026-05-22.md`](ISSUE-QUEUE-AUDIT-2026-05-22.md) as context only; refresh live counts before action (`gh issue list --state open --limit 200`).

--- a/docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md
+++ b/docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md
@@ -1,16 +1,18 @@
 # Track A Morning Truth - 2026-05-24
 
-**Scope:** Track A on `main`, read-only verification and repo-side stabilization only.
+**Scope:** startup truth refresh after PR #129 merged Aurora into `main`.
 **Snapshot window:** 2026-05-24 (America/Vancouver and UTC checks)
 **Production writes:** none
 
 ## Why this exists
 
-This memo captures the exact live and repo evidence needed to avoid startup drift. It supersedes older "current count" claims where they conflict with live command output.
+This memo captures the exact live and repo evidence needed to avoid startup drift.
+It supersedes stale count/branch claims in older work-plan docs.
 
 ## Verified Startup Truth
 
-- `main` vs `origin/main`: `0 0` (in sync).
+- Canonical theme/content branch is `origin/main` at `5c5e11c`.
+- Clean execution worktree: `/Users/kk/Code/kriskrug-wp-main-canonical-20260524` on `codex/main-canonical-truth-20260524`.
 - Open PRs: `0`.
 - Open issues: `67`.
 - Draft queue (WordPress): `1` scheduled post, `43` draft posts, `5` draft pages.
@@ -19,63 +21,46 @@ This memo captures the exact live and repo evidence needed to avoid startup drif
 Command evidence:
 
 ```bash
-git rev-list --left-right --count origin/main...main
-gh pr list --state open --limit 50 | wc -l
-gh issue list --state open --limit 200 | wc -l
-make draft-queue-audit
-make wp7-smoke EXPECT_VERSION=6.9.4
+git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 fetch --prune
+git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 status --short --branch
+git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 log --oneline -n 20
+gh pr list --repo WalksWithASwagger/kriskrug-wp --state open --limit 50
+gh issue list --repo WalksWithASwagger/kriskrug-wp --state open --limit 200 | wc -l
+git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 worktree list --porcelain
+/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --repo-root /Users/kk/Code/kriskrug-wp-main-canonical-20260524 --format markdown
+make -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 wp7-smoke EXPECT_VERSION=6.9.4
+/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
 ```
 
 ## Verified Live Surface Truth
 
 - `/projects/` still returns `404`.
 - `/recent-projects-include/` still emits `og:image=https://s0.wp.com/i/blank.jpg`.
-- Homepage visibility still depends on an inline "Aurora reveal safety net" override.
-- GSAP and ScrollTrigger are loaded from jsDelivr CDN.
+- Homepage source still includes GSAP + ScrollTrigger from jsDelivr CDN.
 
 Command evidence:
 
 ```bash
 curl -sI https://kriskrug.co/projects/
-curl -sL https://kriskrug.co/recent-projects-include/ | rg -n "og:image"
-curl -sL https://kriskrug.co/ | rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"
+curl -sL https://kriskrug.co/recent-projects-include/ | rg -n "canonical|og:image|twitter:image"
+curl -sL https://kriskrug.co/ | rg -n "gsap.min.js|ScrollTrigger.min.js|data-reveal"
 ```
 
-## Aurora Divergence Risk (Read-Only)
+## Tooling Baseline
 
-- `origin/aurora/v2...origin/main`: `18 112`.
-- Local locked `aurora/v2` worktree vs `origin/aurora/v2`: `50 38`.
-- Locked worktree has a dirty artifact (`theme/kk-aurora.zip`).
+- `make health`: pass.
+- `make validate`: fails because `phpcs` is not installed locally.
 
-Command evidence:
+## Drift vs historical docs
 
-```bash
-git rev-list --left-right --count origin/aurora/v2...origin/main
-git -C .claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2
-git -C .claude/worktrees/agent-aec50fddbd7207f80 status --short --branch
-```
+The following are now historical/stale and must not be used as startup truth without refresh:
 
-## Drift vs `WORK-PLAN-2026-05-23.md`
-
-The following fields have drifted and must be treated as historical snapshot values:
-
-- Open issues (`61` declared vs `67` observed).
-- Scheduled posts (`0` declared vs `1` observed).
-- Cross-track reality (Aurora is now live; 2026-05-24 handoffs are authoritative).
-
-Run this before execution to detect drift automatically:
-
-```bash
-make current-state-drift-check
-```
-
-## Startup Command Surface (Track A)
-
-- `make morning-truth` writes a timestamped read-only report to `docs/current-state/reports/`.
-- `make current-state-drift-check` compares declared snapshot values vs live checks.
+- `WORK-PLAN-2026-05-23.md` counts and branch assumptions.
+- Any instruction that says "no theme files on `main`".
+- Any claim that `aurora/v2` is the canonical production source line.
 
 ## Stop Rules Reaffirmed
 
-- No production WordPress writes in this stabilization slice.
-- No theme changes on `main`.
-- No Aurora branch reconciliation/deploy in the locked worktree during Track A startup truth work.
+- No production write without rollback notes and explicit approval for risky mutations.
+- Keep Track A and Track B edits lane-scoped per commit.
+- Do not use stale counts without re-running startup truth checks.

--- a/docs/current-state/WORK-PLAN-2026-05-23.md
+++ b/docs/current-state/WORK-PLAN-2026-05-23.md
@@ -1,8 +1,9 @@
 # Work Plan - 2026-05-23
 
-> STATUS: Historical snapshot (superseded as front door on 2026-05-24).
-> Use `HANDOFF-2026-05-24.md`, `SESSION-HANDOFF-2026-05-24.md`, and
-> `TRACK-A-MORNING-TRUTH-2026-05-24.md` for current startup truth.
+> **Status:** historical baseline after PR #129 (2026-05-24).
+> Use `HANDOFF-2026-05-24.md`, `AURORA-V3-QA-ROADMAP-2026-05-24.md`, and
+> `TRACK-A-MORNING-TRUTH-2026-05-24.md` for current execution truth.
+> Counts and branch assumptions below are preserved for history.
 
 **Purpose:** current roadmap and execution front door after the Sovereign AI draft pipeline closeout.
 **Snapshot time:** 2026-05-22 19:43 PDT / 2026-05-23 02:43 UTC.

--- a/theme/kk-aurora/assets/js/micro-interactions.js
+++ b/theme/kk-aurora/assets/js/micro-interactions.js
@@ -477,14 +477,17 @@
   // ============================================
   
   function init() {
-    initCursorGlow();
-    initCardSpotlight();
     initScrollReveal();
     initButtonRipple();
-    initTextSplit();
     initCounters();
     initHeaderTransform();
     initImageReveal();
+    const motionProfile = document.body?.dataset?.auroraMotionProfile;
+    if (motionProfile === 'enhanced') {
+      initCursorGlow();
+      initCardSpotlight();
+      initTextSplit();
+    }
     // initLinkPreview(); // Disabled - too distracting
   }
   

--- a/theme/kk-aurora/assets/js/theme.js
+++ b/theme/kk-aurora/assets/js/theme.js
@@ -39,6 +39,37 @@
     });
   }
 
+  function initPrimaryNavKeyboard() {
+    const nav = document.querySelector('.aurora-primary-nav');
+    if (!nav) return;
+
+    const links = Array.from(nav.querySelectorAll('a[href]'));
+    if (links.length < 2) return;
+
+    links.forEach((link, index) => {
+      link.addEventListener('keydown', (event) => {
+        let targetIndex = index;
+
+        if (event.key === 'ArrowRight') {
+          targetIndex = index + 1 >= links.length ? 0 : index + 1;
+        } else if (event.key === 'ArrowLeft') {
+          targetIndex = index - 1 < 0 ? links.length - 1 : index - 1;
+        } else if (event.key === 'Home') {
+          targetIndex = 0;
+        } else if (event.key === 'End') {
+          targetIndex = links.length - 1;
+        } else {
+          return;
+        }
+
+        event.preventDefault();
+        const target = links[targetIndex];
+        target.focus();
+        target.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      });
+    });
+  }
+
   // ============================================
   // SMOOTH SCROLL FOR ANCHOR LINKS
   // ============================================
@@ -276,6 +307,7 @@
 
   function init() {
     initMobileMenu();
+    initPrimaryNavKeyboard();
     initSmoothScroll();
     initExternalLinks();
     initCodeCopy();

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.0');
+define('KK_AURORA_VERSION', '1.3.1');
 
 /**
  * Theme setup
@@ -336,3 +336,28 @@ function manual_excerpt_dek_only(string $block_content, array $block): string {
     return $block_content;
 }
 add_filter('render_block', __NAMESPACE__ . '\\manual_excerpt_dek_only', 10, 2);
+
+/**
+ * Set a real social fallback image on Work when Jetpack emits a blank og:image.
+ *
+ * @param array<string, string> $tags Existing Open Graph tags.
+ * @return array<string, string>
+ */
+function work_page_open_graph_fallback(array $tags): array {
+    if (!is_page(['recent-projects-include', 'work'])) {
+        return $tags;
+    }
+
+    $image = 'https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&ssl=1';
+
+    $tags['og:image'] = $image;
+    $tags['og:image:secure_url'] = $image;
+    $tags['og:image:width'] = '1200';
+    $tags['og:image:height'] = '630';
+    $tags['og:image:alt'] = 'BC + AI ecosystem graphic showing community programs and events';
+    $tags['twitter:image'] = $image;
+    $tags['twitter:image:alt'] = 'BC + AI ecosystem graphic showing community programs and events';
+
+    return $tags;
+}
+add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\work_page_open_graph_fallback');

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -338,6 +338,47 @@ function manual_excerpt_dek_only(string $block_content, array $block): string {
 add_filter('render_block', __NAMESPACE__ . '\\manual_excerpt_dek_only', 10, 2);
 
 /**
+ * Redirect the legacy /projects path to the canonical Work page permalink.
+ */
+function redirect_legacy_projects_path(): void {
+    if (is_admin() || wp_doing_ajax() || wp_doing_cron()) {
+        return;
+    }
+
+    if (defined('REST_REQUEST') && REST_REQUEST) {
+        return;
+    }
+
+    $request_uri = isset($_SERVER['REQUEST_URI']) ? wp_unslash((string) $_SERVER['REQUEST_URI']) : '';
+    $request_path = trim((string) wp_parse_url($request_uri, PHP_URL_PATH), '/');
+    if ($request_path !== 'projects') {
+        return;
+    }
+
+    $method = isset($_SERVER['REQUEST_METHOD']) ? strtoupper((string) $_SERVER['REQUEST_METHOD']) : 'GET';
+    if (!in_array($method, ['GET', 'HEAD'], true)) {
+        return;
+    }
+
+    $target_url = home_url('/recent-projects-include/');
+    $work_page = get_page_by_path('recent-projects-include');
+    if (!$work_page instanceof \WP_Post) {
+        $work_page = get_page_by_path('work');
+    }
+
+    if ($work_page instanceof \WP_Post) {
+        $permalink = get_permalink($work_page);
+        if ($permalink !== false) {
+            $target_url = $permalink;
+        }
+    }
+
+    wp_safe_redirect($target_url, 301, 'KK Aurora');
+    exit;
+}
+add_action('template_redirect', __NAMESPACE__ . '\\redirect_legacy_projects_path', 1);
+
+/**
  * Set a real social fallback image on Work when Jetpack emits a blank og:image.
  *
  * @param array<string, string> $tags Existing Open Graph tags.

--- a/theme/kk-aurora/parts/work-proof-grid.html
+++ b/theme/kk-aurora/parts/work-proof-grid.html
@@ -1,7 +1,7 @@
 <!-- wp:html -->
 <section class="aurora-proof-section" aria-label="Work proof modules">
   <div class="aurora-proof-grid">
-    <article class="aurora-proof-module">
+    <article class="aurora-proof-module aurora-proof-module-bhf">
       <figure class="aurora-proof-media">
         <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC + AI ecosystem graphic showing community programs and events" loading="lazy" decoding="async">
         <figcaption>Source: BC + AI ecosystem media, 2026</figcaption>

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.0
+Version: 1.3.1
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -1525,6 +1525,8 @@ a {
 
 .aurora-proof-media {
   margin: 0;
+  overflow: hidden;
+  position: relative;
 }
 
 .aurora-proof-media img {
@@ -1536,16 +1538,27 @@ a {
 }
 
 .aurora-proof-media figcaption {
+  display: block;
   color: var(--aurora-ink-muted);
   font-size: 0.76rem;
+  line-height: 1.35;
   margin: 0;
   padding: 0.72rem 1rem 0;
 }
 
 .aurora-proof-body {
+  align-content: start;
   display: grid;
   gap: 0.8rem;
   padding: 1rem;
+}
+
+.aurora-proof-module-bhf .aurora-proof-media {
+  background: #050607;
+}
+
+.aurora-proof-module-bhf .aurora-proof-media img {
+  object-position: center top;
 }
 
 .aurora-proof-body h2 {


### PR DESCRIPTION
## Summary
- reconcile agent/operator docs to post-PR-129 reality (`main` as canonical theme+content branch)
- refresh 2026-05-24 startup truth docs and mark older plan assumptions as historical
- add Work-page Jetpack OG/Twitter image fallback to avoid blank social image output
- add a surgical 301 redirect for legacy `/projects/` requests to the canonical Work permalink (`recent-projects-include` / `work` fallback)
- harden Work proof-card media layout for BHF overlap edge case
- add keyboard navigation support for horizontal primary nav (`ArrowLeft/Right`, `Home/End`)
- reduce default motion load by gating enhanced interaction stack behind `data-aurora-motion-profile="enhanced"`
- reconcile stale issue contracts/comments to merged-main reality

## Verification
- `php -l theme/kk-aurora/functions.php`
- `node --check theme/kk-aurora/assets/js/theme.js`
- `node --check theme/kk-aurora/assets/js/micro-interactions.js`
- `make wp7-smoke EXPECT_VERSION=6.9.4`
- `/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python -m unittest discover -s scripts/notion-to-wp/tests -p 'test_*.py'`
- `make validate` *(fails pre-existing: `phpcs` missing locally)*

## Notes
- Work OG fallback and `/projects/` redirect are implemented in code but require theme deploy + cache purge to be visible on production.
- Issue #127 acceptance criteria were rewritten to match current horizontal-nav contract.

Refs #3
Refs #120
Refs #126
Refs #127
Refs #86
Refs #24
Refs #25
Refs #26
Refs #27
Refs #28
Refs #29
Refs #30
Refs #31
Refs #32
Refs #33
Refs #34
Refs #35
