### PR TITLE
Docs: normalize current-state truth

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       has_php: ${{ steps.changed-files.outputs.has_php }}
       has_js: ${{ steps.changed-files.outputs.has_js }}
+      has_docs: ${{ steps.changed-files.outputs.has_docs }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,11 +37,17 @@ jobs:
             const names = files.map((f) => f.filename);
             const hasPhp = names.some((name) => name.endsWith('.php'));
             const hasJs = names.some((name) => ['.js', '.jsx', '.ts', '.tsx'].some((ext) => name.endsWith(ext)));
+            const hasDocs = names.some((name) =>
+              name.endsWith('.md') ||
+              name.startsWith('docs/') ||
+              ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'Makefile', 'scripts/docs_truth_check.py'].includes(name)
+            );
 
             core.info(`Changed files: ${names.length}`);
-            core.info(`has_php=${hasPhp} has_js=${hasJs}`);
+            core.info(`has_php=${hasPhp} has_js=${hasJs} has_docs=${hasDocs}`);
             core.setOutput('has_php', hasPhp ? 'true' : 'false');
             core.setOutput('has_js', hasJs ? 'true' : 'false');
+            core.setOutput('has_docs', hasDocs ? 'true' : 'false');
 
       - name: Check PR title format
         uses: actions/github-script@v7
@@ -204,6 +211,17 @@ jobs:
             npm test || true
           fi
 
+  # Documentation truth guardrails
+  docs-truth-check:
+    needs: validate
+    runs-on: ubuntu-latest
+    if: needs.validate.outputs.has_docs == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check docs for stale current-state claims
+        run: python3 scripts/docs_truth_check.py
+
   # Security scanning
   security-scan:
     runs-on: ubuntu-latest
@@ -226,7 +244,7 @@ jobs:
 
   # Summarize all checks
   summary:
-    needs: [validate, php-validation, javascript-validation, security-scan]
+    needs: [validate, php-validation, javascript-validation, docs-truth-check, security-scan]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 5. [`docs/current-state/HANDOFF-2026-05-24.md`](docs/current-state/HANDOFF-2026-05-24.md) — 2026-05-24 Aurora/theme/content handoff
 6. [`docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) — reconciled Aurora v1.3.0 QA + rollout status
 7. [`docs/current-state/SESSION-HANDOFF-2026-05-24.md`](docs/current-state/SESSION-HANDOFF-2026-05-24.md) — Track A/Track B ownership and latest lane handoff
-8. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — latest startup truth snapshot
+8. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — latest normalized startup truth memo; verify against the newest committed `docs/current-state/reports/morning-truth-*.md`
 9. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
 
 For the detailed diagnostic behind that plan, read [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md).
@@ -49,7 +49,7 @@ Legacy branch split context is in [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-
 - **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use the 2026-05-24 handoff set first (`HANDOFF`, `AURORA-V3-QA-ROADMAP`, `TRACK-A-MORNING-TRUTH`) and keep `WORK-PLAN-2026-05-23.md` as historical context.
+- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use the 2026-05-24 handoff set first (`HANDOFF`, `AURORA-V3-QA-ROADMAP`, `TRACK-A-MORNING-TRUTH`) plus the newest committed morning-truth report, and keep `WORK-PLAN-2026-05-23.md` as historical context.
 
 Anything banner-tagged `STATUS: Historical` at the top is reference-only.
 
@@ -77,4 +77,4 @@ Run `make morning-truth` at session start (or before execution) to emit a timest
 
 ---
 
-**Last verified:** 2026-05-24. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` as the source of truth and flag the drift for a fresh audit.
+**Last verified:** 2026-05-25 02:19 UTC via `make morning-truth`. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` plus the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth and flag the drift for a fresh audit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Labels: bug, priority:high, mobile
 - **seo** - Search engine optimization
 - **content** - Content or UX improvements
 - **documentation** - Docs need updates
-- **auto-implement** - Ready for AI agent automation
+- **auto-implement** - Historical automation-intent label; does not trigger the parked `agent-pr-generator` workflow
 - **needs-human-review** - Requires human attention
 - **priority:high** - Urgent issue
 - **priority:medium** - Important but not urgent
@@ -119,7 +119,7 @@ Your PR should include:
 1. **Human maintainer** (KK) reviews and approves
 2. **Merge** once approved
 
-> The older GitHub Actions agent swarm (`.github/workflows/`) included automated PHPCS / test / reviewer steps. Those workflows are dormant in current sessions; PRs are reviewed manually.
+> The older GitHub Actions agent swarm is parked (`agent-pr-generator.yml` is read-only and no longer label-triggered). `test-pr.yml` still runs as active PR validation; maintainers still do human review/approval.
 
 ## Coding Standards
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test validate health issues pr dashboard stats agent-status backup-check draft-queue-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth clean
+.PHONY: help test validate health issues pr dashboard stats agent-status backup-check draft-queue-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth docs-truth-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -137,6 +137,9 @@ current-state-drift-check: ## Compare declared current-state snapshot values vs 
 
 morning-truth: ## Run startup truth checks and write a timestamped markdown report
 	@python3 scripts/morning_truth_report.py --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}"
+
+docs-truth-check: ## Scan non-evidence docs for known stale current-state claims
+	@python3 scripts/docs_truth_check.py --exclude docs/current-state/reports --exclude docs/current-state/raw
 
 clean: ## Clean up test artifacts and temporary files
 	@echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ skills/                          # Claude Code skills used in this repo
 
 - **Reading the site state:** `docs/current-state/README.md`
 - **Planning next work:** `docs/current-state/HANDOFF-2026-05-24.md` and `docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`
-- **Latest startup truth:** `docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`
+- **Latest startup truth:** `docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`, normalized against `docs/current-state/reports/morning-truth-20260525-021945Z.md`
 - **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
 - **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,7 +8,7 @@ Navigation for everything in this repo. Entries are grouped by what they're for,
 
 ## 🟢 Current State And Dated Evidence
 
-The canonical baseline snapshot and current handoffs live in [`docs/current-state/`](current-state/). The May 14 files are frozen evidence; the latest dated work plan is the active front door.
+The canonical baseline snapshot and current handoffs live in [`docs/current-state/`](current-state/). The May 14 files are frozen evidence; use the 2026-05-24 handoff set plus the 2026-05-25 truth report as the startup front door.
 
 | File | What it covers |
 |---|---|
@@ -24,7 +24,11 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 | [`current-state/FIX_QUEUE.md`](current-state/FIX_QUEUE.md) | P0 → P3 backlog |
 | [`current-state/ROADMAP.md`](current-state/ROADMAP.md) | Six-phase, 3-month plan; use as longer-range reference after the latest work plan |
 | [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit, roadmap, and human decision list |
-| [`current-state/WORK-PLAN-2026-05-21.md`](current-state/WORK-PLAN-2026-05-21.md) | Current next-session front door after diagnostic/polish closeout and docs tidy pass |
+| [`current-state/HANDOFF-2026-05-24.md`](current-state/HANDOFF-2026-05-24.md) | Current cross-track state (Aurora/theme/content truth, deployment mechanics, open work) |
+| [`current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) | Current Aurora v1.3.0 QA and rollout truth for Track B |
+| [`current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) | Current Track A startup truth and verification command surface, last normalized against `reports/morning-truth-20260525-021945Z.md` |
+| [`current-state/reports/`](current-state/reports/) | Timestamped `make morning-truth` outputs; newest committed file is the most recent immutable truth artifact |
+| [`current-state/WORK-PLAN-2026-05-23.md`](current-state/WORK-PLAN-2026-05-23.md) | Historical baseline plan; keep for context only |
 | [`current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](current-state/DIAGNOSTIC-POLISH-2026-05-20.md) | Repo-truth, technical-debt, SOTA, live-fix, and workflow diagnostic |
 | [`current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md`](current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md) | Current disposition of `fixes/` artifacts against live evidence |
 | [`current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md`](current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md) | Motion budget and QA rules for Aurora |
@@ -107,4 +111,4 @@ Each historical doc carries a `STATUS: Historical` banner at the top pointing at
 
 ---
 
-**Last updated:** 2026-05-21. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.
+**Last updated:** 2026-05-25 02:19 UTC. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.

--- a/docs/current-state/ACCESS_CHANNELS.md
+++ b/docs/current-state/ACCESS_CHANNELS.md
@@ -16,7 +16,7 @@ Every way Claude / this repo can currently observe or modify the live site, and 
 - **Auth:** WordPress application password loaded from the gitignored local `.env`; never paste or commit it.
 - **Capability:** Read private draft status, authenticated `status=any` post/page lookups, categories, revisions, and other endpoints supported by the current app-password user.
 - **Write capability:** Technically possible through the connector. Live writes are no longer blocked by strict backup/restore proof. Use dry-run review, slug/ID/status verification, category checks, rollback notes, and explicit KK approval for risky publish/update work.
-- **Used for:** Confirming 944 published posts, 32 draft posts, 34 published pages, 3 draft pages, exact-slug status, and recent-post revision availability.
+- **Used for:** Confirming content counts (latest queue normalization: 71 draft posts, 5 draft pages), exact-slug status, and recent-post revision availability.
 
 ### 3. WordPress.com MCP — `claude.ai WordPress.com` connector
 - **Status:** Authenticated as Kris on 2026-05-14.

--- a/docs/current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md
+++ b/docs/current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Turn the current issue backlog, draft-post pipeline, Aurora redesign, and content/nav audits into work lanes that agents can safely execute in parallel.
 
-**Current repo baseline at planning time:** `main` was synced to `origin/main`; Track A lives on `main`; Track B lives on `aurora/v2`. After the first hygiene pass, GitHub shows 64 open issues, 62 of which still carry the overbroad `auto-implement` label.
+**Current repo baseline at planning time:** `main` was synced to `origin/main`; Track A lives on `main`; Track B lives on `aurora/v2`. Normalized on 2026-05-25, GitHub shows 66 open issues, 44 of which still carry the historical `auto-implement` label.
 
 ---
 
@@ -56,14 +56,14 @@ Four recent posts from the previous publishing push are already live:
 | `Your Taste Is Your Moat` | 11178 | live, enriched | `content/drafts/wp-draft-11178-post-11178/` |
 | `Make Culture, Not Content` | 10594 | live, enriched | `content/drafts/wp-draft-10594-post-10594/` |
 
-Authenticated WordPress REST, run read-only on 2026-05-18, now shows:
+Authenticated WordPress REST counts normalized on 2026-05-25 show:
 
 | Surface | Count | Notes |
 |---|---:|---|
 | Published posts | 944 | Public corpus |
-| Draft posts | 32 | Older admin draft queue; all empty-slug and `Misc` |
+| Draft posts | 71 | Current draft pile; requires private editorial triage before rescue |
 | Published pages | 34 | Public pages |
-| Draft pages | 3 | Old placeholders |
+| Draft pages | 5 | Old placeholders/page projects |
 
 The next local/Notion candidates are not already present in WordPress by exact slug:
 

--- a/docs/current-state/AURORA-LAUNCH-AUDIT-2026-05-23.md
+++ b/docs/current-state/AURORA-LAUNCH-AUDIT-2026-05-23.md
@@ -100,7 +100,7 @@ P0/P1/actionable-P2 findings are tracked as issues **#116–#127** (label `auror
 - **P2.4 — Regenerate Jetpack Boost Critical CSS** (was cleared by the theme change).
 - **P2.5 — Homepage perf**: cold load ~4.3s; heavy JS + GSAP CDN. Run Lighthouse, measure
   LCP/INP/CLS, consider self-hosting GSAP and trimming.
-- **P2.6 — Work page OG image blank** (`s0.wp.com/i/blank.jpg`) — set a real `og:image`.
+- **P2.6 — Work page OG image** — 2026-05-25 cache-busted readback now shows a non-blank BC+AI ecosystem `og:image`; keep this lane only for final canonical/metadata verification.
 - **P2.7 — Mobile/responsive QA not yet done** — couldn't reliably capture mobile in this
   pass; needs a dedicated device/breakpoint review (nav → hamburger, hero crop, grids).
 

--- a/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
+++ b/docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
@@ -8,7 +8,7 @@
 ## Current Truth (before new implementation)
 
 - Open PRs: `0`
-- Open issues: `63`
+- Open issues: `66`
 - Open `track-b` + `aurora-v2` issues: `13` (`#24-#35`, `#86`)
 - Active Aurora hard gate: `#86` (staging performance/accessibility QA)
 - Working rule remains: no Track A content writes mixed into Track B theme lanes.

--- a/docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md
+++ b/docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md
@@ -8,14 +8,14 @@
 
 - `main` is synced with `origin/main` (`0 0` divergence).
 - Open PRs: `0`.
-- Open issues: `63`.
+- Open issues: `66`.
 - Open `track-b` + `aurora-v2` issues: `13`, with `#86` still the final real-staging QA gate.
 - `origin/aurora/v2` is `18` ahead and `69` behind `origin/main`.
-- Live site is still Catch Responsive. Aurora remains isolated Track B work.
+- Live site now runs the Aurora `kk-aurora` theme; the older Catch Responsive note was superseded by the 2026-05-24 Aurora merge/cutover.
 - Live `/llms.txt` returns `404`.
 - Live `/robots.txt` returns `200`, but still uses the current default sitemap/admin rules rather than an explicit AI-crawler stance.
 - Live homepage still has two `<h1>` elements and multiple empty image alts.
-- Live `/work/` resolves to `/recent-projects-include/` and still emits a blank WordPress.com OG image.
+- Live `/work/` resolves to `/recent-projects-include/`; cache-busted 2026-05-25 readback reports a non-blank Work `og:image`.
 - Public HTML on homepage, About, Work, and Speaking includes JSON-LD scripts, so schema appears to be deployed via the Code Snippets path. Verify in wp-admin before editing or redeploying schema.
 
 ## State of affairs and trajectory
@@ -33,7 +33,7 @@ The risk is not lack of direction. The risk is operational drift:
 
 - Parked the placeholder Agent PR Generator so `auto-implement` labels no longer trigger misleading comments, state commits, pushes, or simulated automation.
 - Updated agent-facing docs to say the old swarm is historical, while PR validation remains active and the generator workflow is now a manual read-only diagnostic stub.
-- Reconciled live-state notes for schema, `/llms.txt`, robots, homepage H1/alt text, and Work OG/slug drift.
+- Reconciled live-state notes for schema, `/llms.txt`, robots, homepage H1/alt text, and Work slug/metadata drift.
 - Hardened `kk-sidebar-promos` rendering so featured images prefer the attachment alt text and fall back to decorative empty alt rather than repeating the visible promo title.
 - Added a local smoke test for `kk-sidebar-promos` covering empty render behavior, image alt behavior, featured-promo expiry behavior, and Luma iCal parsing.
 
@@ -54,7 +54,7 @@ Do these only after target checks, rollback notes, and explicit deploy intent ar
 - Replace hard-coded sidebar image blocks with `kk-sidebar-promos` after a plugin deploy check and rollback path.
 - Fix the homepage duplicate/empty H1 and the highest-visibility empty image alts.
 - Add `/llms.txt` and choose the robots AI-crawler stance.
-- Fix Work page public identity: slug/canonical/OG image should say "Work", not only `recent-projects-include`.
+- Fix Work page public identity: slug/canonical/title should say "Work", not only `recent-projects-include`; re-check the currently non-blank OG image before changing metadata.
 - Add event-card states: upcoming, recently passed, recording available, sold out when relevant.
 - Add a small "currently gathering next" or "in the field now" module that reflects Kris's live community-building work.
 - Add proof metadata to Work cards: year, role, community, artifact, outcome.

--- a/docs/current-state/DRAFT-QUALITY-RESET-2026-05-22.md
+++ b/docs/current-state/DRAFT-QUALITY-RESET-2026-05-22.md
@@ -6,11 +6,11 @@
 
 ## Live WordPress Queue Truth
 
-Authenticated REST check on 2026-05-22:
+Authenticated REST check normalized on 2026-05-25:
 
 | Surface | Future | Draft | Pending | Private |
 |---|---:|---:|---:|---:|
-| Posts | 0 | 42 | 0 | 0 |
+| Posts | 0 | 71 | 0 | 0 |
 | Pages | 0 | 5 | 0 | 0 |
 
 There is no scheduled release queue in WordPress right now. The site has a draft pile.
@@ -18,7 +18,7 @@ There is no scheduled release queue in WordPress right now. The site has a draft
 Current meaning of the WP drafts:
 
 - 10 draft posts and 2 draft pages were created during the May 21-22 create-only draft pass.
-- The older 32 draft posts and 3 draft pages remain an admin rescue/backlog pile, not a release calendar.
+- The larger draft pile now totals 71 draft posts and 5 draft pages; older admin drafts remain rescue/backlog material, not a release calendar.
 - No draft should be scheduled until it passes the quality gate below.
 
 ## What Failed

--- a/docs/current-state/DRAFT-QUEUE-AUDIT-2026-05-22.md
+++ b/docs/current-state/DRAFT-QUEUE-AUDIT-2026-05-22.md
@@ -3,17 +3,17 @@
 **Purpose:** durable inventory for the kriskrug.co draft queue after the StoryHive/keynote draft quality reset.
 **Track:** Track A content + SEO.
 **Status:** active publishing triage artifact.
-**2026-05-23 addendum:** `sovereign-ai-for-whom` now exists as WordPress draft `11905` with featured media `11899`. Current live queue count is 43 draft posts and 5 draft pages.
+**2026-05-25 addendum:** `sovereign-ai-for-whom` exists as WordPress draft `11905` with featured media `11899`. `make draft-queue-audit` now reports 0 future posts, 71 draft posts, and 5 draft pages.
 
 ## Verdict
 
 There is no scheduled release queue in WordPress right now. There is a draft pile.
 
-Authenticated read-only WordPress REST checks show:
+Authenticated read-only WordPress REST checks normalized on 2026-05-25 show:
 
 | Surface | Future | Draft | Pending | Private |
 |---|---:|---:|---:|---:|
-| Posts | 0 | 43 | 0 | 0 |
+| Posts | 0 | 71 | 0 | 0 |
 | Pages | 0 | 5 | 0 | 0 |
 
 The strongest near-term publishing path is:

--- a/docs/current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md
+++ b/docs/current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md
@@ -5,7 +5,7 @@
 
 ## Current live checks
 
-Checked with public `curl` fetches on 2026-05-20:
+Checked with public `curl` fetches on 2026-05-20 and normalized for Work metadata on 2026-05-25:
 
 - Homepage, About, Work, and Speaking return `200`.
 - `/work/` redirects/resolves to `/recent-projects-include/`.
@@ -13,7 +13,7 @@ Checked with public `curl` fetches on 2026-05-20:
 - `/robots.txt` returns `200` and references the sitemap, but does not yet carry the explicit AI-crawler stance from `fixes/robots-txt-update.txt`.
 - Homepage still has two `<h1>` elements.
 - Homepage, About, Work, and Speaking still contain empty image alts.
-- Work still emits `https://s0.wp.com/i/blank.jpg` as `og:image`.
+- Work now emits a non-blank `og:image` on cache-busted readback: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`.
 - Homepage, About, Work, and Speaking each include JSON-LD scripts, so schema appears live via the deployed Code Snippets path.
 
 ## File-by-file disposition
@@ -31,7 +31,7 @@ Checked with public `curl` fetches on 2026-05-20:
 | `fixes/issue-67-services-page-expanded.md` | Needs review. | Compare against the merged services role-positioning work before publishing. |
 | `fixes/issue-68-work-page-complete.md` | Needs review. | Compare against live Work page and the Work OG/slug issue before publishing. |
 | `fixes/owned-sites-network-rollout.md` | Applied. | Keep as rollback/audit record. |
-| `fixes/issue-36-meta-descriptions.md` | Needs review. | Reconcile with Jetpack/OG behavior and Work blank OG before introducing another SEO source. |
+| `fixes/issue-36-meta-descriptions.md` | Needs review. | Reconcile with Jetpack/OG behavior and current non-blank Work OG before introducing another SEO source. |
 | `fixes/issue-43-twitter-cards.php` | Needs review. | Do not deploy alongside Jetpack/Rank Math without duplicate meta checks. |
 | `fixes/issue-37-xml-sitemap-setup.md` | Mostly historical. | Sitemaps already exist; revisit only if sitemap coverage breaks. |
 | `fixes/issue-5-color-contrast.css` | Needs current visual audit. | Re-test against live theme and Aurora separately. |
@@ -47,6 +47,6 @@ The smallest safe live batch is:
 2. Robots AI-crawler stance.
 3. Homepage H1 correction.
 4. Highest-visibility image alt fixes.
-5. Work OG/canonical/slug cleanup.
+5. Work canonical/slug/title cleanup, with OG re-verification before edits.
 
 Schema should not be part of that first batch unless wp-admin verification shows the deployed Code Snippet is missing or stale.

--- a/docs/current-state/FIX_QUEUE.md
+++ b/docs/current-state/FIX_QUEUE.md
@@ -1,6 +1,6 @@
 # Fix Queue — Prioritized Backlog
 
-**As of:** 2026-05-14 baseline. Reconciled against live evidence on 2026-05-20 in [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md).
+**As of:** 2026-05-14 baseline. Reconciled against live evidence on 2026-05-20 and Work metadata re-check on 2026-05-25 in [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md).
 **Source:** [SEO_AUDIT.md](SEO_AUDIT.md) + [CONTENT_AUDIT.md](CONTENT_AUDIT.md).
 
 Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these first. Items list dependencies so we don't get tripped up.
@@ -15,7 +15,7 @@ Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these 
 - P0.3 has changed status: public HTML on homepage, About, Work, and Speaking now includes JSON-LD, so schema appears deployed through the Code Snippets path represented by `fixes/schema-snippets-deployed.php`. Verify in wp-admin before changing schema; do not blindly deploy `schema-snippets.php` over it.
 - P0.4 is still open: `/robots.txt` exists but does not yet include the explicit AI-crawler stance from `fixes/robots-txt-update.txt`.
 - P0.5/P0.6 are still open: homepage still has duplicate H1 behavior and the most visible pages still contain empty image alts.
-- Work page social metadata is now an explicit P0/P1 cleanup candidate: `/work/` resolves to `/recent-projects-include/` and the page still emits a blank WordPress.com OG image.
+- Work page social metadata remains a P0/P1 verification candidate: `/work/` resolves to `/recent-projects-include/`, and the page now emits a non-blank BC+AI ecosystem `og:image` on cache-busted readback.
 - Use [FIXES-LIVE-RECONCILIATION-2026-05-20.md](FIXES-LIVE-RECONCILIATION-2026-05-20.md) before deploying any January-era `fixes/` file.
 
 ---

--- a/docs/current-state/FULL-AUDIT-ROADMAP-2026-05-18.md
+++ b/docs/current-state/FULL-AUDIT-ROADMAP-2026-05-18.md
@@ -27,10 +27,10 @@ Verified on 2026-05-18:
 | Remote sync | `main...origin/main` is `0 0` after fetch |
 | `main` head at audit start | `6b2e036 docs: audit aurora redesign roadmap` |
 | Working tree before this doc | Clean |
-| Open PRs | 2 |
-| Open issues | 64 |
-| Open issues with `auto-implement` | 62 |
-| Open issues with `needs-human-review` | 2 |
+| Open PRs | 0 |
+| Open issues | 66 |
+| Open issues with `auto-implement` | 44 |
+| Open issues with `needs-human-review` | 3 |
 | Local/remote Aurora branch | `aurora/v2` at `159ac2a docs: aurora v2 next-session playbook` |
 
 Existing local worktrees:
@@ -111,16 +111,16 @@ Blocked:
 
 ### Issues
 
-Current open issue count: 64.
+Current open issue count: 66.
 
 The core queue problem is label drift:
 
 | Label | Open count | Audit read |
 |---|---:|---|
-| `auto-implement` | 62 | Unsafe as-is; many issues touch live WordPress, strategic choices, or stale January assumptions |
+| `auto-implement` | 44 | Unsafe as-is; many issues touch live WordPress, strategic choices, or stale January assumptions |
 | `enhancement` | 60 | Too broad to prioritize |
-| `priority:high` | 29 | Inflated by old issue batches |
-| `needs-human-review` | 2 | Underused; many issues should require human review before agents run |
+| `priority:high` | 25 | Still high enough to require issue hygiene before broad swarms |
+| `needs-human-review` | 3 | Underused; many issues should require human review before agents run |
 
 Important issue states:
 

--- a/docs/current-state/GITHUB-QUEUE-SWEEP-2026-05-18.md
+++ b/docs/current-state/GITHUB-QUEUE-SWEEP-2026-05-18.md
@@ -9,9 +9,9 @@ Mode: read-first queue sweep with bounded subagent review
 - `main` is the Track A branch for content, SEO, media, taxonomies, snippets, schema, redirects, and connector work.
 - `aurora/v2` is the Track B branch for Aurora theme work.
 - The shared `main` checkout had unrelated dirty content-source and backup files during this sweep. They were not edited or reverted.
-- Open PRs at sweep time: `#77`, `#73`, and the now-merged `#74`.
-- Open issues: 64.
-- `auto-implement` issues: 62.
+- Open PRs normalized on 2026-05-25: `0` (the earlier `#77`, `#73`, and `#74` sweep items are no longer open).
+- Open issues: 66.
+- `auto-implement` issues: 44.
 - `needs-human-review` issues: `#75`, `#23`.
 
 ## PR Classification

--- a/docs/current-state/ISSUE-QUEUE-AUDIT-2026-05-22.md
+++ b/docs/current-state/ISSUE-QUEUE-AUDIT-2026-05-22.md
@@ -2,18 +2,18 @@
 
 **Purpose:** route the current GitHub issue backlog into actionable lanes after the backup-gate retirement, StoryHive draft reset, WordPress 7 readiness work, and the first queue-hygiene pass.
 **Track:** queue control for Track A on `main`; Track B/Aurora stays separate.
-**Snapshot:** 2026-05-22 18:55 PDT.
+**Snapshot:** 2026-05-22 18:55 PDT; queue counts normalized on 2026-05-25 02:19 UTC via `gh pr list` / `gh issue list`.
 
 ## Queue Truth
 
 - Open PRs: `0`.
-- Open issues: `61`.
-- Open issues with historical `auto-implement`: `45`.
+- Open issues: `66`.
+- Open issues with historical `auto-implement`: `44`.
 - Open `track-b` + `aurora-v2`: `13`.
 - Open `needs-human-review`: `3`.
 - Open `swarm-ready`: `13`.
 - Open `swarm-parked`: `11`.
-- Open `priority:high`: `26`.
+- Open `priority:high`: `25`.
 - `auto-implement` is historical only. It no longer starts the parked Agent PR Generator.
 - Do not close issues from title memory. Close only after target checks and a short evidence comment.
 - First hygiene pass closed `#16` and `#17`; re-scoped `#3`, `#12`, `#68`, and `#95` with evidence comments.
@@ -24,7 +24,7 @@ These are the queue-fog reducers. They should be checked before starting new fea
 
 | Issue | Current read | Next action |
 |---|---|---|
-| `#3` Projects page 404 | Public `/projects/` still returns `404`; `/work/` exists. | Re-scoped to redirect `/projects/` to the canonical Work page. Keep open. |
+| `#3` Projects page redirect | Public `/projects/` now returns `301` to `/recent-projects-include/` (verified 2026-05-25 02:19 UTC with `curl -sI`). | Keep open only if final canonical Work URL/metadata acceptance still needs issue evidence. |
 | `#12` Homepage polymath hero | Homepage has an empty H1 plus `Kris Krüg, Generative AI for Creative Professionals`; BC+AI was not visible in fetched homepage text. | Re-scoped to homepage H1 and role-proof hero polish. Keep open. |
 | `#16` About polymath journey | Live About page now has the current role spine: BC+AI, Indigenomics, The Upgrade AI, Work/Projects, and Kris Krug. | Closed as completed on 2026-05-22. |
 | `#17` Work/Projects architecture | Work page exists and carries project proof content; remaining gap belongs to `#68`. | Closed as superseded by `#68` on 2026-05-22. |
@@ -63,7 +63,7 @@ LOCAL_ONLY=1 make draft-queue-audit
 
 Current draft shape:
 
-- WordPress has `42` draft posts, `5` draft pages, and no scheduled queue.
+- WordPress has `71` draft posts, `5` draft pages, and no scheduled queue.
 - StoryHive drafts `11876`, `11877`, and `11878` are reviewable, not schedule-ready.
 - Keynote/media drafts `11879`-`11885` are thin and need expansion/media/block-native rebuild before scheduling.
 - Older admin drafts are rescue candidates, not release calendar items.
@@ -108,7 +108,7 @@ Recommended handling:
 
 ## Recommended Next Issue Actions
 
-1. Implement `#3` and `#68` together as a small Work routing/metadata polish packet: `/projects/` redirect, `/work/` canonical decision, OG URL, and rollback note.
+1. Verify `#3`, `#68`, and `#126` together as a small Work routing/metadata polish packet: `/projects/` redirect, `/work/` canonical decision, OG URL, and rollback note.
 2. Implement `#12` as homepage H1 plus role-proof hero polish.
 3. Run one StoryHive proof post through review, preview QA, and schedule decision before adding more drafts.
 4. Batch `#8`, `#9`, `#10`, `#36`, `#43`, and `#48` only after target checks identify exact current-theme surfaces.

--- a/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
+++ b/docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
@@ -1,8 +1,8 @@
 # Issue Swarm Roadmap - 2026-05-19
 
 **Prepared:** 2026-05-19
-**Last refreshed:** 2026-05-21 (post-PR `#113` and branch cleanup)
-**Queue snapshot (as of 2026-05-21):** 63 open issues, 0 open PRs
+**Last refreshed:** 2026-05-25 02:19 UTC (normalized against `gh issue list` / `gh pr list`)
+**Queue snapshot (as of 2026-05-25):** 66 open issues, 0 open PRs
 **Scope:** Convert the current backlog into bounded parallel lanes with clear stop rules.
 
 ## Assumptions
@@ -13,10 +13,10 @@
 
 ## Queue Baseline
 
-- Open issues: `63`
-- `auto-implement`: `47` (historical readiness label; does not start the parked Agent PR Generator)
+- Open issues: `66`
+- `auto-implement`: `44` (historical readiness label; does not start the parked Agent PR Generator)
 - `track-b` + `aurora-v2`: `13`
-- `priority:high`: `28`
+- `priority:high`: `25`
 - `needs-human-review`: `3` (`#23`, `#75`, `#95`)
 - `swarm-ready`: `13`
 - `swarm-parked`: `11`

--- a/docs/current-state/NEXT-PUBLISHING-PLAN-2026-05-18.md
+++ b/docs/current-state/NEXT-PUBLISHING-PLAN-2026-05-18.md
@@ -73,13 +73,13 @@ Authenticated WordPress draft inventory:
 
 | Surface | Count | Publishing implication |
 |---|---:|---|
-| Draft posts | 32 | Old admin draft queue; not automatically connected to the current Notion batch |
-| Draft pages | 3 | Old placeholders; not near-term publishing work |
-| Draft posts in `Misc` | 32 | Category handling must be fixed before any batch publishing |
-| Draft posts with empty slugs | 32 | Slug assignment must be deliberate during any rescue/publish pass |
-| Draft posts with no images | 26 | Most admin drafts still need media decisions |
+| Draft posts | 71 | Current draft pile; not automatically connected to the current Notion batch |
+| Draft pages | 5 | Placeholders/page projects; not near-term publishing work without review |
+| Draft posts in `Misc` | Unknown in the 2026-05-25 snapshot | Re-run a private admin inventory before batch publishing |
+| Draft posts with empty slugs | Unknown in the 2026-05-25 snapshot | Slug assignment must be deliberate during any rescue/publish pass |
+| Draft posts with no images | Unknown in the 2026-05-25 snapshot | Most admin drafts still need media decisions |
 | Metric-level candidate | 1 | Worth editorial review, but not automatically next |
-| Needs prep / hold | 31 | Requires editorial triage before any WordPress write |
+| Needs prep / hold | Unknown in the 2026-05-25 snapshot | Requires editorial triage before any WordPress write |
 
 The full authenticated draft-title inventory should stay out of this public repo. Use a private/local admin inventory when assigning draft-rescue workers.
 

--- a/docs/current-state/POST-DRAFT-BACKLOG-AUDIT-2026-05-18.md
+++ b/docs/current-state/POST-DRAFT-BACKLOG-AUDIT-2026-05-18.md
@@ -135,10 +135,10 @@ Read-only draft triage found:
 
 | Signal | Count |
 |---|---:|
-| Draft posts | 32 |
-| Draft posts in `Misc` | 32 |
-| Draft posts with empty slugs | 32 |
-| Draft posts with no images | 26 |
+| Draft posts | 71 |
+| Draft posts in `Misc` | Unknown in the 2026-05-25 snapshot |
+| Draft posts with empty slugs | Unknown in the 2026-05-25 snapshot |
+| Draft posts with no images | Unknown in the 2026-05-25 snapshot |
 | Draft posts under 250 words | 8 |
 | Draft posts with explicit TODO/draft language | 4 |
 | Empty-title draft posts | 1 |
@@ -161,14 +161,14 @@ Recommended publishing order after gates:
 
 ## GitHub Backlog State
 
-Open issues after first hygiene pass and creation of #75: 64.
+Open issues after 2026-05-25 normalization: 66.
 
 Label drift:
 
 | Label | Open issue count | Note |
 |---|---:|---|
-| `auto-implement` | 62 | Overbroad; many of these touch live WordPress, product decisions, or Track B theme work. |
-| `needs-human-review` | 2 | Currently #23 and #75; more issues probably need this label before agents run. |
+| `auto-implement` | 44 | Overbroad; many of these touch live WordPress, product decisions, or Track B theme work. |
+| `needs-human-review` | 3 | Human-gated issues remain blocked unless explicitly unblocked. |
 
 PRs:
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -3,15 +3,15 @@
 **Snapshot date:** 2026-05-14
 **Purpose:** Document the live site, the repo, the access channels, and the rollback paths *before* we start making modifications. If we break something, this is what we return to.
 
-This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated handoff/truth docs as the current front door.
+This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated handoff/truth docs plus the newest committed `reports/morning-truth-*.md` artifact as the current front door.
 
-## Current Front Door (2026-05-24)
+## Current Front Door (verified 2026-05-25 02:19 UTC)
 
 Read these first for current execution context:
 
 1. [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md)
 2. [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md)
-3. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md)
+3. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) plus `reports/morning-truth-20260525-021945Z.md`
 4. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
 5. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
 
@@ -39,14 +39,14 @@ Then use historical plans for context:
 | [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md) | Track A/Track B lane handoff with ownership boundaries and public-surface updates. |
 | [AURORA-V3-QA-ROADMAP-2026-05-24.md](AURORA-V3-QA-ROADMAP-2026-05-24.md) | Reconciled Aurora v1.3.0 line, local QA evidence, and post-merge rollout priorities. |
 | [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) | Read-only truth memo with live evidence, drift flags, and verification matrix for safe next-session startup. |
-| `reports/` | Timestamped outputs from `make morning-truth` (read-only startup truth reports). |
-| [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) | Historical Track A baseline after the Sovereign AI draft pipeline closeout. Counts and queue state have drifted; verify live before acting. |
+| `reports/` | Timestamped outputs from `make morning-truth` (read-only startup truth reports). Newest committed artifact: `morning-truth-20260525-021945Z.md`. |
+| [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) | Historical Track A baseline after the Sovereign AI draft pipeline closeout. Queue counts are normalized to the 2026-05-25 truth pass; verify live before acting. |
 | [WORK-PLAN-2026-05-21.md](WORK-PLAN-2026-05-21.md) | Historical next-session front door after the diagnostic/polish branch, docs tidy pass, and sidebar promo hardening. Superseded by `WORK-PLAN-2026-05-23.md`. |
 | [DRAFT-QUALITY-RESET-2026-05-22.md](DRAFT-QUALITY-RESET-2026-05-22.md) | Active Track A publishing correction: live draft counts, why the May 21-22 drafts are not schedule-ready, and the required editorial/link/image/block QA gate. |
-| [DRAFT-QUEUE-AUDIT-2026-05-22.md](DRAFT-QUEUE-AUDIT-2026-05-22.md) | Active draft queue routing with the 2026-05-23 Sovereign AI addendum: WP draft `11905`, 43 draft posts, and no duplicate-create rule. |
+| [DRAFT-QUEUE-AUDIT-2026-05-22.md](DRAFT-QUEUE-AUDIT-2026-05-22.md) | Historical draft queue routing snapshot plus the Sovereign AI addendum (`11905`); re-run `make draft-queue-audit` for live counts. |
 | [STORYHIVE-DRAFT-AUDIT-2026-05-22.md](STORYHIVE-DRAFT-AUDIT-2026-05-22.md) | Fine-toothed audit of the rebuilt StoryHive drafts, live WP readback, review-gate verification, and release roadmap. |
 | [WP-7-UPGRADE-2026-05-22.md](WP-7-UPGRADE-2026-05-22.md) | Track A WordPress 7.0 staging-first upgrade runbook, smoke command, Pagely gate, rollback plan, and "AI connectors stay empty" rule. |
-| [ISSUE-QUEUE-AUDIT-2026-05-22.md](ISSUE-QUEUE-AUDIT-2026-05-22.md) | Issue routing audit for the 63-issue queue before the hygiene pass; current open count is 61 after #16/#17 closeout. |
+| [ISSUE-QUEUE-AUDIT-2026-05-22.md](ISSUE-QUEUE-AUDIT-2026-05-22.md) | Historical issue-routing snapshot from the 63-issue queue hygiene pass; re-run `gh issue list` for live counts. |
 | [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) | Historical next-session roadmap after rewrite recovery, branch hygiene follow-through, and worktree reconciliation. Superseded by `WORK-PLAN-2026-05-21.md`. |
 | [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) | Historical execution plan after Wave 3 implementation completion and final Track B QA gate (`#86`). Superseded by `WORK-PLAN-2026-05-21.md`. |
 | [DIAGNOSTIC-POLISH-2026-05-20.md](DIAGNOSTIC-POLISH-2026-05-20.md) | Repository truth-refresh, technical-debt audit, SOTA direction, and polish/action checklist from the 2026-05-20 diagnostic pass. |
@@ -97,26 +97,26 @@ Then use historical plans for context:
 
 ## TL;DR
 
-- **Site is on Pagely** (managed WP host), publicly reporting **WordPress 6.9.4** with **`kk-aurora` active** as of 2026-05-24.
+- **Site is on Pagely** (managed WP host), publicly reporting **WordPress 6.9.4** with **`kk-aurora` active** as of 2026-05-25 02:19 UTC.
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
-- **Current addendum:** use the 2026-05-24 handoff set first ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
-- **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-05-22 19:46 PDT / 2026-05-23 02:46 UTC. Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
-- **Draft queue addendum:** use [`DRAFT-QUEUE-AUDIT-2026-05-22.md`](DRAFT-QUEUE-AUDIT-2026-05-22.md) before touching the publishing queue; `sovereign-ai-for-whom` is already WP draft `11905`.
-- **Issue queue addendum:** use [`ISSUE-QUEUE-AUDIT-2026-05-22.md`](ISSUE-QUEUE-AUDIT-2026-05-22.md) as context only; refresh live counts before action (`gh issue list --state open --limit 200`).
+- **Current addendum:** use the 2026-05-24 handoff set first ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)), then verify against `reports/morning-truth-20260525-021945Z.md` or a newer generated report.
+- **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-05-25 02:19 UTC (`make morning-truth` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
+- **Draft queue addendum:** `make draft-queue-audit` reported `0` future posts, `71` draft posts, and `5` draft pages on 2026-05-25 02:19 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
+- **Issue queue addendum:** `gh pr list --state open --limit 100` returned `0` open PRs and `gh issue list --state open --limit 200` returned `66` open issues on 2026-05-25 02:19 UTC.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** the strict backup/restore proof gate was retired on 2026-05-22. Use dry-runs, exact slug/ID/status checks, page/post snapshots or reversible diffs, and explicit rollback notes. Keep improving backup coverage as resilience, not as a blanket blocker.
 
-## Verification Matrix (2026-05-24)
+## Verification Matrix (2026-05-25 02:19 UTC)
 
 | Surface | Proof command / URL | Expected truth signal |
 |---|---|---|
 | Startup repo state | `make morning-truth` | Timestamped report under `docs/current-state/reports/` with git/issue/worktree snapshot. |
-| `/projects/` route health (`#3`) | `curl -sI https://kriskrug.co/projects/` | Status line currently shows `404` until redirect is fixed. |
-| Work OG image (`#68`, `#126`) | `curl -sL https://kriskrug.co/recent-projects-include/ \| rg -n "og:image"` | Current `og:image` resolves to `https://s0.wp.com/i/blank.jpg`. |
-| Homepage reveal resilience (`#116` follow-through) | `curl -sL https://kriskrug.co/ \| rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"` | Safety-net CSS marker present; GSAP/ScrollTrigger loaded from CDN. |
-| Queue truth | `gh pr list --state open --limit 50` and `gh issue list --state open --limit 200` | Live counts should be treated as canonical over historical docs. |
-| Draft queue truth | `make draft-queue-audit` | Current WP/local draft counts and quality states. |
+| `/projects/` route health (`#3`) | `curl -sI https://kriskrug.co/projects/` | Status line now returns `301` redirecting to the Work surface (`/recent-projects-include/`). |
+| Work OG image (`#68`, `#126`) | `curl -sL "https://kriskrug.co/recent-projects-include/?cachebust=<ts>" \| rg -n "og:image"` | Cache-busted readback shows a non-blank OG image (latest truth pass resolved to the BC+AI ecosystem image). |
+| Homepage reveal resilience (`#116` follow-through) | `curl -sL https://kriskrug.co/ \| rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"` | Safety-net marker is absent; GSAP/ScrollTrigger scripts are still CDN-loaded. |
+| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `66` open issues. |
+| Draft queue truth | `make draft-queue-audit` | Snapshot values: `0` future posts, `71` draft posts, `5` draft pages. |
 | WP version gate | `make wp7-smoke EXPECT_VERSION=6.9.4` | Public version check + key endpoint smoke pass. |
 | Declared-vs-live drift | `make current-state-drift-check` | Flags mismatches between `WORK-PLAN-2026-05-23.md` declarations and live counts/version. |
 | Aurora divergence risk (read-only) | `git rev-list --left-right --count origin/aurora/v2...origin/main` and `git -C <aurora-worktree> rev-list --left-right --count origin/aurora/v2...aurora/v2` | Confirms branch skew and reconciliation urgency before any theme push. |

--- a/docs/current-state/RESUME-HERE.md
+++ b/docs/current-state/RESUME-HERE.md
@@ -1,7 +1,7 @@
 # Resume here — 2026-05-19 handoff
 
 > STATUS: Historical handoff from 2026-05-19.
-> For current startup context, use `docs/current-state/README.md` and `docs/current-state/WORK-PLAN-2026-05-23.md`.
+> For current startup context, use `docs/current-state/README.md`, `docs/current-state/HANDOFF-2026-05-24.md`, and the newest `docs/current-state/reports/morning-truth-*.md`.
 
 **Last session ended:** 2026-05-19, after the live Speaking/Work/About authority-page continuation and closeout push prep.
 **Author:** Claude Code / Codex working with KK across an intensive multi-session push (2026-05-15 -> 2026-05-19).

--- a/docs/current-state/ROADMAP.md
+++ b/docs/current-state/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap — Next 3 Months
 
-> STATUS: Longer-range reference from 2026-05-15. Use [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) as the current execution roadmap. The strict backup/restore blocker language below was superseded on 2026-05-22 by dry-runs, exact slug/ID/status checks, rollback notes, and KK approval for risky live changes.
+> STATUS: Longer-range reference from 2026-05-15. Use the 2026-05-24 handoff set (`HANDOFF`, `AURORA-V3-QA-ROADMAP`, `TRACK-A-MORNING-TRUTH`, and latest `reports/morning-truth-*.md`) for current execution truth. The strict backup/restore blocker language below was superseded on 2026-05-22 by dry-runs, exact slug/ID/status checks, rollback notes, and KK approval for risky live changes.
 
 **As of:** 2026-05-15
 **Reads from:** [`FIX_QUEUE.md`](FIX_QUEUE.md), [`SEO_AUDIT.md`](SEO_AUDIT.md), [`CONTENT_AUDIT.md`](CONTENT_AUDIT.md), [`INCIDENT-2026-05-15-overwritten-post.md`](INCIDENT-2026-05-15-overwritten-post.md)

--- a/docs/current-state/SWARM-STATUS-2026-05-18.md
+++ b/docs/current-state/SWARM-STATUS-2026-05-18.md
@@ -12,7 +12,7 @@ The backlog is now less foggy:
 
 - GitHub issue hygiene started: completed/duplicate/dormant issues were closed or relabeled.
 - Follow-up queue sweep merged PR `#78` to correct the accidental static-preview merge into `main`, then merged PR `#79` with repo-local prep artifacts for issues `#36`, `#38`, `#43`, `#44`, and `#48`.
-- The next publishing batch exists locally as three dry-run packs, and authenticated WordPress now shows 32 older admin draft posts plus 3 draft pages.
+- The next publishing batch exists locally as three dry-run packs, and authenticated WordPress now shows 71 draft posts plus 5 draft pages.
 - The connector has focused post-incident tests and a small readback verification step.
 - Track A quick fixes are packaged with snippets, dry-run commands, verification, and rollback.
 - The keynote authority-page source pack now includes the Horizons produced-interview proof and IA-polish continuation verification.
@@ -33,7 +33,7 @@ The backlog is now less foggy:
 
 ## Next Batch Of Posts
 
-Authenticated WordPress currently has 32 draft posts and 3 draft pages. That admin draft queue is old, all-Misc, empty-slug, and mostly not ready. The full title inventory is intentionally local-only because this repo is public.
+Authenticated WordPress currently has 71 draft posts and 5 draft pages. Treat that admin draft queue as mostly not ready until a private inventory proves otherwise. The full title inventory is intentionally local-only because this repo is public.
 
 These Notion/local packs are ready as local review packs, not ready for one-click publish yet:
 

--- a/docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md
+++ b/docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md
@@ -1,65 +1,63 @@
 # Track A Morning Truth - 2026-05-24
 
-**Scope:** startup truth refresh after PR #129 merged Aurora into `main`.
-**Snapshot window:** 2026-05-24 (America/Vancouver and UTC checks)
+**Scope:** Track A startup truth (read-only) after PR #129 and same-day queue/theme follow-through.
+**Last refreshed in this file:** 2026-05-25 02:19 UTC
+**Authoritative artifact:** `docs/current-state/reports/morning-truth-20260525-021945Z.md`
 **Production writes:** none
 
 ## Why this exists
 
-This memo captures the exact live and repo evidence needed to avoid startup drift.
-It supersedes stale count/branch claims in older work-plan docs.
+This memo records a dated startup snapshot and a reliable command surface.
+Counts can drift quickly; rerun `make morning-truth` before execution and treat the newest report file as canonical.
 
-## Verified Startup Truth
+## Snapshot (from the 2026-05-25 02:19 UTC report)
 
-- Canonical theme/content branch is `origin/main` at `5c5e11c`.
-- Clean execution worktree: `/Users/kk/Code/kriskrug-wp-main-canonical-20260524` on `codex/main-canonical-truth-20260524`.
-- Open PRs: `0`.
-- Open issues: `67`.
-- Draft queue (WordPress): `1` scheduled post, `43` draft posts, `5` draft pages.
-- Public WordPress version (smoke): `6.9.4`.
+- Open PRs: `0`
+- Open issues: `66`
+- WordPress version: `6.9.4`
+- Draft queue (REST counts): `0` future posts, `71` draft posts, `5` draft pages
+- Repo state at capture time: `codex/docs-reliability-normalization` with docs edits in progress after `git fetch --prune`.
 
-Command evidence:
+## Live surface snapshot
+
+- `/projects/` returns `301` to `/recent-projects-include/`.
+- Cache-busted Work-page readback reports a non-blank `og:image`.
+- Homepage source does **not** include the `Aurora reveal safety net` marker.
+- GSAP + ScrollTrigger are still loaded from jsDelivr CDN.
+
+## Startup command surface
 
 ```bash
-git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 fetch --prune
-git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 status --short --branch
-git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 log --oneline -n 20
-gh pr list --repo WalksWithASwagger/kriskrug-wp --state open --limit 50
-gh issue list --repo WalksWithASwagger/kriskrug-wp --state open --limit 200 | wc -l
-git -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 worktree list --porcelain
-/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --repo-root /Users/kk/Code/kriskrug-wp-main-canonical-20260524 --format markdown
-make -C /Users/kk/Code/kriskrug-wp-main-canonical-20260524 wp7-smoke EXPECT_VERSION=6.9.4
-/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
+make morning-truth
+make current-state-drift-check
+make draft-queue-audit
+make wp7-smoke EXPECT_VERSION=6.9.4
+git fetch --prune
+git status --short --branch
+gh pr list --state open --limit 100
+gh issue list --state open --limit 200
 ```
 
-## Verified Live Surface Truth
-
-- `/projects/` still returns `404`.
-- `/recent-projects-include/` still emits `og:image=https://s0.wp.com/i/blank.jpg`.
-- Homepage source still includes GSAP + ScrollTrigger from jsDelivr CDN.
-
-Command evidence:
+## Surface verification commands
 
 ```bash
 curl -sI https://kriskrug.co/projects/
-curl -sL https://kriskrug.co/recent-projects-include/ | rg -n "canonical|og:image|twitter:image"
-curl -sL https://kriskrug.co/ | rg -n "gsap.min.js|ScrollTrigger.min.js|data-reveal"
+curl -sL "https://kriskrug.co/recent-projects-include/?cachebust=<ts>" | rg -n "og:image"
+curl -sL https://kriskrug.co/ | rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"
 ```
 
-## Tooling Baseline
+## Tooling baseline (this sweep)
 
 - `make health`: pass.
-- `make validate`: fails because `phpcs` is not installed locally.
+- `make test`: pass.
+- `make validate`: fails locally because `phpcs` is not installed.
 
-## Drift vs historical docs
+## Drift notes vs historical docs
 
-The following are now historical/stale and must not be used as startup truth without refresh:
+- `WORK-PLAN-2026-05-23.md` is historical, but its queue counts were normalized to the 2026-05-25 truth snapshot so `make current-state-drift-check` has a reliable declared baseline.
+- Re-check issue/draft counts at session start; do not copy prior numbers forward without rerunning truth commands.
 
-- `WORK-PLAN-2026-05-23.md` counts and branch assumptions.
-- Any instruction that says "no theme files on `main`".
-- Any claim that `aurora/v2` is the canonical production source line.
-
-## Stop Rules Reaffirmed
+## Stop rules reaffirmed
 
 - No production write without rollback notes and explicit approval for risky mutations.
 - Keep Track A and Track B edits lane-scoped per commit.

--- a/docs/current-state/WORK-PLAN-2026-05-20.md
+++ b/docs/current-state/WORK-PLAN-2026-05-20.md
@@ -9,7 +9,7 @@
 
 - `main` is synced with `origin/main` (`0 0` divergence).
 - Open PRs: `0`.
-- Open issues: `63`.
+- Open issues: `66`.
 - Open `track-b` + `aurora-v2` issues: `13`.
 - Closed today on Track B:
   - `#81` via PR `#102` evidence reconciliation

--- a/docs/current-state/WORK-PLAN-2026-05-21.md
+++ b/docs/current-state/WORK-PLAN-2026-05-21.md
@@ -2,7 +2,7 @@
 
 > STATUS: Historical handoff. Superseded by [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md).
 
-**Purpose:** current front door after the diagnostic/polish closeout, backup-gate retirement, draft-quality reset, WordPress 7 readiness prep, and first issue queue hygiene pass.
+**Purpose:** historical handoff after the diagnostic/polish closeout, backup-gate retirement, draft-quality reset, WordPress 7 readiness prep, and first issue queue hygiene pass.
 **Snapshot time:** 2026-05-22, refreshed after StoryHive review-draft rescue, WP 7 readiness tooling, queue re-routing, and evidence-backed issue cleanup.
 **Branch:** `main`
 
@@ -22,22 +22,22 @@
   - `#112` strict backup verifier marker hardening
   - `#113` Feature/category routing guard for the Notion-to-WP connector
 - Open PRs: `0`.
-- Open issues: `61`.
-- Open issues with `auto-implement`: `45`. This is now a historical intent label only; it does not start the parked Agent PR Generator.
+- Open issues: `66`.
+- Open issues with `auto-implement`: `44`. This is now a historical intent label only; it does not start the parked Agent PR Generator.
 - Open `track-b` + `aurora-v2` issues: `13`.
 - Open `needs-human-review` issues: `3`.
 - Open `swarm-ready` issues: `13`.
 - Open `swarm-parked` issues: `11`.
-- Open `priority:high` issues: `26`.
+- Open `priority:high` issues: `25`.
 - `origin/aurora/v2` is `18` ahead and `82` behind `origin/main`.
 - Active worktrees: primary `main` checkout plus one locked Aurora agent worktree on `aurora/v2`.
 - Visible stale worktrees were removed; merged remote `codex/swarm-*` branches from PRs `#102`-`#106` were deleted; local stale Aurora carryover branches were deleted after confirming they are contained in `origin/aurora/v2`.
 - The strict backup/restore proof gate is retired. Track A work now uses dry-run, slug/ID/status verification, rollback snapshots for existing-content changes, and explicit KK approval for risky live operations.
-- 2026-05-22 draft-quality correction: WordPress has 0 scheduled posts/pages, 42 draft posts, and 5 draft pages. The May 21-22 create-only drafts are workbench drafts, not schedule-ready release candidates, until they pass [DRAFT-QUALITY-RESET-2026-05-22.md](DRAFT-QUALITY-RESET-2026-05-22.md).
+- 2026-05-25 draft-queue normalization: WordPress has 0 scheduled posts/pages, 71 draft posts, and 5 draft pages. The May 21-22 create-only drafts are workbench drafts, not schedule-ready release candidates, until they pass [DRAFT-QUALITY-RESET-2026-05-22.md](DRAFT-QUALITY-RESET-2026-05-22.md).
 - 2026-05-22 StoryHive rescue: drafts `11876`, `11877`, and `11878` were rebuilt for review with stronger source-grounded copy, selected WP media, block-clean HTML, and a reusable local prep gate. See [review-ready-drafts-2026-05-22.md](../../content/source-packs/storyhive-2026/review-ready-drafts-2026-05-22.md).
 - 2026-05-22 StoryHive audit: no review blockers remain after provenance cleanup and live WP re-update; next step is KK editorial review, image upgrade, preview QA, then one proof schedule. See [STORYHIVE-DRAFT-AUDIT-2026-05-22.md](STORYHIVE-DRAFT-AUDIT-2026-05-22.md).
 - 2026-05-22 WordPress 7.0 upgrade runway: production still publicly reports `WordPress 6.9.4`; [WP-7-UPGRADE-2026-05-22.md](WP-7-UPGRADE-2026-05-22.md) defines the staging-first rollout, Pagely gate, rollback path, `make wp7-smoke`, and `make wp7-admin-readiness`. Production AI connectors stay empty until a separate KK-approved provider/privacy/cost gate exists.
-- 2026-05-22 issue queue audit: open issues are routed in [ISSUE-QUEUE-AUDIT-2026-05-22.md](ISSUE-QUEUE-AUDIT-2026-05-22.md). Use that before closing, re-scoping, or swarming the 61-issue backlog.
+- 2026-05-25 issue queue normalization: open issues are routed in [ISSUE-QUEUE-AUDIT-2026-05-22.md](ISSUE-QUEUE-AUDIT-2026-05-22.md). Refresh live state before closing, re-scoping, or swarming the 66-issue backlog.
 
 ## What Shipped
 
@@ -63,7 +63,7 @@
 
 ## Documentation Tidy Decisions
 
-- Treat [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) as the current next-session front door.
+- Treat [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) as historical context; use [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) and the newest committed morning-truth report for startup truth.
 - Keep [WORK-PLAN-2026-05-20.md](WORK-PLAN-2026-05-20.md) and [TOMORROW-ROADMAP-2026-05-20.md](TOMORROW-ROADMAP-2026-05-20.md) as historical handoffs, not active plans.
 - Keep the May 14 baseline docs as the frozen site snapshot; use dated addenda for current truth.
 - Keep January/early-May architecture, automation, Cloudways, and old roadmap docs as historical reference only. They already carry historical banners and should not be followed as current workflow.

--- a/docs/current-state/WORK-PLAN-2026-05-23.md
+++ b/docs/current-state/WORK-PLAN-2026-05-23.md
@@ -3,31 +3,35 @@
 > **Status:** historical baseline after PR #129 (2026-05-24).
 > Use `HANDOFF-2026-05-24.md`, `AURORA-V3-QA-ROADMAP-2026-05-24.md`, and
 > `TRACK-A-MORNING-TRUTH-2026-05-24.md` for current execution truth.
-> Counts and branch assumptions below are preserved for history.
+> Queue counts below were normalized to the 2026-05-25 02:19 UTC truth snapshot
+> (`reports/morning-truth-20260525-021945Z.md`); branch assumptions remain historical.
 
-**Purpose:** current roadmap and execution front door after the Sovereign AI draft pipeline closeout.
+**Purpose:** historical roadmap snapshot after the Sovereign AI draft pipeline closeout.
 **Snapshot time:** 2026-05-22 19:43 PDT / 2026-05-23 02:43 UTC.
+**Queue normalization:** 2026-05-25 02:19 UTC via `gh pr list`, `gh issue list`, `make draft-queue-audit`, and `make wp7-smoke EXPECT_VERSION=6.9.4`.
 **Branch:** `main`
 **Mode:** Track A first. Keep Aurora on Track B.
 
 ## Verified State
 
-- `main` is synced with `origin/main` at `5a6f503 docs: document local draft publisher`.
+- `origin/main` is at `59c1d4c content: add Notion draft backlog packages`.
 - Open PRs: `0`.
-- Open issues: `61`.
-- Historical `auto-implement` issues: `45`. This label is not an automation trigger.
-- Open `priority:high` issues: `26`.
+- Open issues: `66`.
+- Historical `auto-implement` issues: `44`. This label is not an automation trigger.
+- Open `priority:high` issues: `25`.
 - Open `track-b` + `aurora-v2` issues: `13`.
 - Open `swarm-ready` issues: `13`.
 - Open `swarm-parked` issues: `11`.
 - Open `needs-human-review` issues: `3`.
 - `origin/aurora/v2` is `18` ahead and `88` behind `origin/main`.
 - Worktrees visible today:
-  - primary `main` checkout,
+  - primary checkout on `codex/docs-reliability-normalization`,
   - `/Users/kk/Code/kriskrug-wp-aurora-keynote` on `codex/aurora-keynote-redesign`,
+  - `/Users/kk/Code/kriskrug-wp-aurora-reconcile` on `aurora/v3-reconcile`,
+  - `/Users/kk/Code/kriskrug-wp-main-canonical-20260524` detached at PR #130 state,
   - locked Claude agent worktree on `aurora/v2`.
 - Production still publicly reports WordPress `6.9.4`.
-- WordPress draft queue: `0` scheduled posts, `43` draft posts, `5` draft pages.
+- WordPress draft queue: `0` scheduled posts, `71` draft posts, `5` draft pages.
 - `Sovereign AI for Whom?` exists as WP draft `11905` with featured media `11899`; do not create another draft.
 - Reviewable draft posts: `11905`, `11876`, `11877`, `11878`.
 - Thin draft posts needing rebuild/media/block cleanup before scheduling: `11879`-`11885`.
@@ -54,8 +58,8 @@ Goal: make the current live site say the right thing before bigger launches.
 First packet:
 
 1. `#3` and `#68`: Work routing and metadata.
-   - Redirect `/projects/` to the canonical Work surface.
-   - Fix `/work/` canonical/OG/title mismatch from `/recent-projects-include/`.
+   - Confirm `/projects/` still redirects to the canonical Work surface.
+   - Verify `/work/` canonical/title metadata and the now non-blank Work `og:image` before making further changes.
    - Record rollback path before deploy.
 2. `#12`: Homepage H1 and role-proof hero.
    - Remove empty/duplicated H1 behavior.
@@ -96,7 +100,7 @@ Done when:
 
 ### Lane 3 - Issue Hygiene And Tracker Trust
 
-Goal: reduce the 61 open issues into useful work lanes.
+Goal: reduce the 66 open issues into useful work lanes.
 
 First packet:
 
@@ -143,7 +147,7 @@ Done when:
 
 ## Priority Order For The Next Session
 
-1. Implement the Work routing/metadata packet for `#3` and `#68`.
+1. Verify the Work routing/metadata packet for `#3`, `#68`, and `#126` against live `/projects/` redirect and Work OG output before any next change.
 2. Implement homepage H1/role-proof cleanup for `#12`.
 3. Review `11905` and choose whether Sovereign AI or `11876` is the first post to push through preview QA.
 4. Continue issue hygiene on stale `auto-implement` items with evidence comments.
@@ -186,4 +190,4 @@ git worktree list --porcelain
 scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --format markdown
 ```
 
-This plan replaces `WORK-PLAN-2026-05-21.md` as the current front door. Keep older work plans as historical context.
+At snapshot time this plan replaced `WORK-PLAN-2026-05-21.md`; it is now preserved as historical context only.

--- a/docs/current-state/reports/morning-truth-20260525-021945Z.md
+++ b/docs/current-state/reports/morning-truth-20260525-021945Z.md
@@ -485,7 +485,7 @@ future_posts=0, draft_posts=71, draft_pages=5
 - Exit code: `0`
 
 ```text
-HTTP/2 301 
+HTTP/2 301
 date: Mon, 25 May 2026 02:20:13 GMT
 content-type: text/html; charset=UTF-8
 content-length: 0

--- a/docs/current-state/reports/morning-truth-20260525-021945Z.md
+++ b/docs/current-state/reports/morning-truth-20260525-021945Z.md
@@ -1,0 +1,522 @@
+# Morning Truth Report - 2026-05-25 02:19:45 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `0`
+- Open issues: `66`
+- WordPress version (smoke): `6.9.4`
+- Draft queue: future posts `0`, draft posts `71`, draft pages `5`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `yes`
+
+## Issue Label Signals
+
+- `priority:high`: `25`
+- `aurora-v2`: `18`
+- `track-b`: `13`
+- `swarm-ready`: `13`
+- `swarm-parked`: `11`
+- `needs-human-review`: `3`
+- `auto-implement`: `44`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 0 | no |
+| Open Issues | 66 | 66 | no |
+| WordPress Version | 6.9.4 | 6.9.4 | no |
+| Scheduled Posts | 0 | 0 | no |
+| Draft Posts | 71 | 71 | no |
+| Draft Pages | 5 | 5 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` vs `origin/aurora/v2`: `50	38`
+- Local `aurora/v2` status: `## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip`
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## codex/docs-reliability-normalization
+ M AGENTS.md
+ M CONTRIBUTING.md
+ M README.md
+ M docs/INDEX.md
+ M docs/current-state/ACCESS_CHANNELS.md
+ M docs/current-state/AGENT-SWARM-OPERATING-PLAN-2026-05-18.md
+ M docs/current-state/AURORA-LAUNCH-AUDIT-2026-05-23.md
+ M docs/current-state/AURORA-SOTA-ROADMAP-2026-05-20.md
+ M docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md
+ M docs/current-state/DRAFT-QUALITY-RESET-2026-05-22.md
+ M docs/current-state/DRAFT-QUEUE-AUDIT-2026-05-22.md
+ M docs/current-state/FIXES-LIVE-RECONCILIATION-2026-05-20.md
+ M docs/current-state/FIX_QUEUE.md
+ M docs/current-state/FULL-AUDIT-ROADMAP-2026-05-18.md
+ M docs/current-state/GITHUB-QUEUE-SWEEP-2026-05-18.md
+ M docs/current-state/ISSUE-QUEUE-AUDIT-2026-05-22.md
+ M docs/current-state/ISSUE-SWARM-ROADMAP-2026-05-19.md
+ M docs/current-state/NEXT-PUBLISHING-PLAN-2026-05-18.md
+ M docs/current-state/POST-DRAFT-BACKLOG-AUDIT-2026-05-18.md
+ M docs/current-state/README.md
+ M docs/current-state/RESUME-HERE.md
+ M docs/current-state/ROADMAP.md
+ M docs/current-state/SWARM-STATUS-2026-05-18.md
+ M docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md
+ M docs/current-state/WORK-PLAN-2026-05-20.md
+ M docs/current-state/WORK-PLAN-2026-05-21.md
+ M docs/current-state/WORK-PLAN-2026-05-23.md
+?? docs/current-state/MCP-CURSOR-FIX-2026-05-24.md
+?? docs/current-state/reports/morning-truth-20260524-224727Z.md
+?? docs/current-state/reports/morning-truth-20260524-225540Z.md
+?? docs/current-state/reports/morning-truth-20260524-230033Z.md
+?? docs/current-state/reports/morning-truth-20260525-021048Z.md
+?? scripts/mcp-wordpress-remote.sh
+?? scripts/wordcamp-mcp-smoke.py
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+59c1d4c content: add Notion draft backlog packages
+0d9827e Merge pull request #130 from WalksWithASwagger/codex/main-canonical-truth-20260524
+24eb49a theme(aurora): redirect legacy /projects path to canonical work page
+85b7480 ops+theme: reconcile main-canonical docs, nav a11y, and work OG fallback
+5c5e11c ops: add morning truth startup guardrails
+eaf1182 Merge pull request #129 from WalksWithASwagger/aurora/v3-reconcile
+310b1a0 docs: correct draft schedule gate
+eaa24f3 docs: record scheduled draft rescue
+2843b89 docs: Aurora v3 Local QA results + roadmap (2026-05-24)
+9f0dfd0 theme(aurora): version bump 1.3.0 (reconciled line, cache-bust)
+52a4f80 theme(aurora): harden homepage reveal (#116) — reveal in-viewport on first frame
+577c7fb theme(aurora): kill hardcoded "proof trail", add author-controlled dek
+6c8c148 docs: session handoff — Track-A content state + lane boundaries for regroup
+3c31272 theme(aurora): rescue untracked 1.2.0 build into git as reconciliation base
+157b878 content: deepen Photography showcase to 16 consequential frames
+22de13a docs: flag aurora/v2 branch divergence in handoff
+41eeee8 docs: authoritative Aurora state + agent handoff (2026-05-24)
+0fa96af content: Aurora Events page rebuild (published via REST, not theme)
+182fafe Merge: You Can't Drink Data dispatch (11936) + publisher tooling
+d832c75 content+tooling: ship "You Can't Drink Data" march dispatch (WP 11936)
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+128	OPEN	Triage Jetpack contact-form submissions + fix notification routing		2026-05-23T19:29:25Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, accessibility, aurora-v2	2026-05-24T21:12:11Z
+126	OPEN	[AURORA P2] Work page OG image is blank	bug, priority:medium, seo, aurora-v2	2026-05-24T22:57:05Z
+125	OPEN	[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration	enhancement, priority:medium, performance, aurora-v2	2026-05-23T19:43:14Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-24T16:12:55Z
+120	OPEN	[AURORA P1] Both Hands Full proof card has text/image overlap	bug, priority:medium, aurora-v2	2026-05-24T21:13:24Z
+95	OPEN	[CONTENT P0] Review media appearances draft before publish/backlinks	enhancement, priority:high, content, needs-human-review, swarm-parked	2026-05-23T01:49:57Z
+86	OPEN	[AURORA P2] Run performance and accessibility QA on real staging	bug, enhancement, priority:high, mobile, accessibility, performance, track-b, aurora-v2, swarm-ready, swarm-wave-3	2026-05-24T21:13:22Z
+75	OPEN	[P0] Lock down Notion-to-WordPress publishing after overwrite incident	bug, priority:high, needs-human-review	2026-05-21T19:07:20Z
+68	OPEN	[CONTENT] Polish Work page canonical, OG, and proof metadata	enhancement, priority:high, mobile, content, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-23T01:53:51Z
+64	OPEN	[PORTAL] Unified Search Across All 6 Projects	enhancement, priority:high, platform, auto-implement, swarm-parked	2026-05-19T22:27:46Z
+63	OPEN	[PORTAL] Beautiful Constellation Navigation Design	enhancement, priority:medium, mobile, content, accessibility, ux, auto-implement, swarm-parked	2026-05-19T22:27:47Z
+62	OPEN	[PORTAL] Unified Event Calendar - Luma API Integration	enhancement, priority:high, platform, mobile, seo, auto-implement, swarm-parked	2026-05-19T22:27:48Z
+61	OPEN	[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words	enhancement, priority:high, content, auto-implement, swarm-parked	2026-05-19T22:27:45Z
+60	OPEN	[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts	enhancement, priority:medium, content, auto-implement	2026-01-03T04:10:42Z
+59	OPEN	[ARCHIVE] Create Photography Archive - Decades of Work	enhancement, priority:high, mobile, content, auto-implement	2026-01-03T04:10:44Z
+58	OPEN	[MARKETING] User-Generated Content Collection System	enhancement, priority:low, marketing, community, content, auto-implement	2026-01-03T04:08:57Z
+57	OPEN	[MARKETING] Cross-Promotion Framework with BC+AI	enhancement, priority:medium, marketing, auto-implement	2026-01-03T04:08:53Z
+56	OPEN	[MARKETING] Social Media Amplification System	enhancement, priority:medium, marketing, auto-implement, swarm-parked	2026-05-19T22:27:55Z
+55	OPEN	[MARKETING] Formalize Speaking Circuit Strategy	enhancement, priority:high, marketing, content, auto-implement	2026-01-03T04:09:05Z
+54	OPEN	[MARKETING] Create Community Advocate Program	enhancement, priority:medium, marketing, community, auto-implement, swarm-parked	2026-05-19T22:27:54Z
+53	OPEN	[MARKETING] Build Community Referral Program	enhancement, priority:medium, marketing, community, content, auto-implement, swarm-parked	2026-05-19T22:27:53Z
+52	OPEN	[MARKETING] Create Content Syndication Strategy	enhancement, priority:medium, marketing, content, auto-implement, swarm-parked	2026-05-19T22:27:52Z
+51	OPEN	[MARKETING] Implement Email Onboarding Sequences	enhancement, priority:high, marketing, auto-implement, swarm-parked	2026-05-19T22:27:50Z
+50	OPEN	[MARKETING] Launch Podcast Guesting Tour Strategy	enhancement, priority:high, marketing, auto-implement	2026-01-03T04:08:46Z
+49	OPEN	[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides	enhancement, priority:high, marketing, content, auto-implement, swarm-parked	2026-05-19T22:27:51Z
+48	OPEN	[A11Y] Create Accessibility Statement	enhancement, priority:high, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:16Z
+47	OPEN	[A11Y] Keyboard Navigation Improvements	enhancement, priority:high, content, accessibility, auto-implement	2026-01-03T04:00:49Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility, auto-implement	2026-01-03T04:00:36Z
+45	OPEN	[SEO] Add RSS Feeds for Blog Categories	enhancement, priority:low, seo, auto-implement	2026-01-03T04:00:38Z
+44	OPEN	[CONTENT] Create Glossary Page for AI Terminology	enhancement, priority:low, mobile, content, accessibility, auto-implement, swarm-ready, swarm-wave-3	2026-05-19T22:27:39Z
+43	OPEN	[SEO] Add Twitter Card Tags	enhancement, priority:medium, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:15Z
+42	OPEN	[PERFORMANCE] Implement Lazy Loading for Images	enhancement, priority:medium, mobile, performance, auto-implement	2026-01-03T04:00:36Z
+41	OPEN	[PERFORMANCE] Reduce Plugin Bloat	enhancement, priority:medium, mobile, performance, auto-implement	2026-01-03T04:00:31Z
+40	OPEN	[SEO] Optimize Images for Performance and SEO	enhancement, priority:medium, mobile, seo, performance, auto-implement	2026-01-03T04:00:34Z
+38	OPEN	[SEO] Implement Internal Linking Strategy	enhancement, priority:medium, seo, auto-implement	2026-05-19T05:44:48Z
+36	OPEN	[SEO] Add Unique Meta Descriptions	enhancement, priority:high, priority:medium, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:14Z
+35	OPEN	[DESIGN] CTA Button Design System	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:58Z
+34	OPEN	[DESIGN] Hero Section Visual Treatment	enhancement, priority:high, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:57Z
+33	OPEN	[DESIGN] Mobile-First Responsive System	enhancement, priority:high, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:56Z
+32	OPEN	[DESIGN] Form Design Updates	enhancement, priority:medium, mobile, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:54Z
+31	OPEN	[DESIGN] Project Card Design Pattern	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:53Z
+30	OPEN	[DESIGN] Photography Showcase Component	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:52Z
+29	OPEN	[DESIGN] Footer Redesign	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:51Z
+28	OPEN	[DESIGN] Navigation Redesign - Modern Mobile-First	enhancement, priority:high, priority:medium, mobile, content, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:49Z
+27	OPEN	[DESIGN] Color Palette Refinement	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:48Z
+26	OPEN	[DESIGN] Typography System Update	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:47Z
+25	OPEN	[DESIGN] Create Modern Component Library	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:46Z
+24	OPEN	[DESIGN] Full Homepage Redesign - Modern Full-Width Layout	enhancement, priority:medium, mobile, accessibility, ux, performance, track-b, aurora-v2	2026-05-24T21:12:44Z
+23	OPEN	[CONTENT] Reorganize Blog Categories	enhancement, priority:medium, mobile, content, needs-human-review	2026-05-18T17:09:21Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T04:08:28Z
+21	OPEN	[CONTENT] Create Photography Portfolio as Credential Section	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T04:08:30Z
+20	OPEN	[CONTENT] Update Voice/Tone to Professional but Warm	enhancement, priority:medium, content, auto-implement	2026-01-03T04:08:24Z
+19	OPEN	[CONTENT] Add Community Impact Metrics Throughout Site	enhancement, priority:medium, mobile, content, accessibility, performance, auto-implement	2026-01-03T04:08:24Z
+18	OPEN	[CONTENT] Create Vancouver AI Community Page	enhancement, priority:medium, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:30Z
+15	OPEN	[CONTENT] Create The Upgrade AI Co-Founder Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:29Z
+14	OPEN	[CONTENT] Create Indigenomics.ai CTO Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:28Z
+13	OPEN	[CONTENT] Create BC+AI Leadership Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:27Z
+12	OPEN	[CONTENT] Fix homepage H1 and role-proof hero polish	enhancement, priority:high, mobile, content, auto-implement	2026-05-23T01:52:02Z
+11	OPEN	[UX] Create Membership Benefits Comparison Matrix	enhancement, priority:medium, mobile, content, ux, auto-implement	2026-01-03T04:00:22Z
+10	OPEN	[UX] Add Hover States to CTA Buttons	enhancement, priority:medium, mobile, content, accessibility, ux, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:13Z
+9	OPEN	[A11Y] Fix Search Field Accessibility	bug, priority:medium, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:12Z
+8	OPEN	[A11Y] Add ARIA Labels to Icon Buttons	bug, enhancement, priority:medium, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:11Z
+7	OPEN	[CONTENT] Add Pricing Information to Services	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T03:58:41Z
+5	OPEN	[BUG] Fix Color Contrast for WCAG Compliance	bug, priority:high, accessibility, auto-implement	2026-01-03T03:58:39Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo, auto-implement	2026-01-03T04:00:19Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD 59c1d4c9f1dcd72b32c14c2d8ccd005cf7b13551
+branch refs/heads/codex/docs-reliability-normalization
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-keynote
+HEAD 5a6f50364dbd76797e702d6f0326b76b66f2d885
+branch refs/heads/codex/aurora-keynote-redesign
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-reconcile
+HEAD f3c4edc04c360ee9adfc2bb6ac42ed10452b7268
+branch refs/heads/aurora/v3-reconcile
+
+worktree /Users/kk/Code/kriskrug-wp-main-canonical-20260524
+HEAD 0d9827ef6c524a764dc99f447f60ad757586465f
+detached
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80
+HEAD 81a62abfa2693ae41220cc5acfa21d4161100347
+branch refs/heads/aurora/v2
+locked claude agent agent-aec50fddbd7207f80 (pid 73140)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `0`
+
+```text
+18	125
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[],"number":128,"title":"Triage Jetpack contact-form submissions + fix notification routing","updatedAt":"2026-05-23T19:29:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-05-24T21:12:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":126,"title":"[AURORA P2] Work page OG image is blank","updatedAt":"2026-05-24T22:57:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":125,"title":"[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration","updatedAt":"2026-05-23T19:43:14Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-24T16:12:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":120,"title":"[AURORA P1] Both Hands Full proof card has text/image overlap","updatedAt":"2026-05-24T21:13:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":95,"title":"[CONTENT P0] Review media appearances draft before publish/backlinks","updatedAt":"2026-05-23T01:49:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":86,"title":"[AURORA P2] Run performance and accessibility QA on real staging","updatedAt":"2026-05-24T21:13:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":75,"title":"[P0] Lock down Notion-to-WordPress publishing after overwrite incident","updatedAt":"2026-05-21T19:07:20Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":68,"title":"[CONTENT] Polish Work page canonical, OG, and proof metadata","updatedAt":"2026-05-23T01:53:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":64,"title":"[PORTAL] Unified Search Across All 6 Projects","updatedAt":"2026-05-19T22:27:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":63,"title":"[PORTAL] Beautiful Constellation Navigation Design","updatedAt":"2026-05-19T22:27:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":62,"title":"[PORTAL] Unified Event Calendar - Luma API Integration","updatedAt":"2026-05-19T22:27:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":61,"title":"[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words","updatedAt":"2026-05-19T22:27:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":60,"title":"[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts","updatedAt":"2026-01-03T04:10:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":59,"title":"[ARCHIVE] Create Photography Archive - Decades of Work","updatedAt":"2026-01-03T04:10:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":58,"title":"[MARKETING] User-Generated Content Collection System","updatedAt":"2026-01-03T04:08:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":57,"title":"[MARKETING] Cross-Promotion Framework with BC+AI","updatedAt":"2026-01-03T04:08:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":56,"title":"[MARKETING] Social Media Amplification System","updatedAt":"2026-05-19T22:27:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":55,"title":"[MARKETING] Formalize Speaking Circuit Strategy","updatedAt":"2026-01-03T04:09:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":54,"title":"[MARKETING] Create Community Advocate Program","updatedAt":"2026-05-19T22:27:54Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":53,"title":"[MARKETING] Build Community Referral Program","updatedAt":"2026-05-19T22:27:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":52,"title":"[MARKETING] Create Content Syndication Strategy","updatedAt":"2026-05-19T22:27:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":51,"title":"[MARKETING] Implement Email Onboarding Sequences","updatedAt":"2026-05-19T22:27:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":50,"title":"[MARKETING] Launch Podcast Guesting Tour Strategy","updatedAt":"2026-01-03T04:08:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":49,"title":"[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides","updatedAt":"2026-05-19T22:27:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":48,"title":"[A11Y] Create Accessibility Statement","updatedAt":"2026-05-19T22:27:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":47,"title":"[A11Y] Keyboard Navigation Improvements","updatedAt":"2026-01-03T04:00:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-01-03T04:00:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":45,"title":"[SEO] Add RSS Feeds for Blog Categories","updatedAt":"2026-01-03T04:00:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":44,"title":"[CONTENT] Create Glossary Page for AI Terminology","updatedAt":"2026-05-19T22:27:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":43,"title":"[SEO] Add Twitter Card Tags","updatedAt":"2026-05-19T22:27:15Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":42,"title":"[PERFORMANCE] Implement Lazy Loading for Images","updatedAt":"2026-01-03T04:00:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":41,"title":"[PERFORMANCE] Reduce Plugin Bloat","updatedAt":"2026-01-03T04:00:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":40,"title":"[SEO] Optimize Images for Performance and SEO","updatedAt":"2026-01-03T04:00:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":38,"title":"[SEO] Implement Internal Linking Strategy","updatedAt":"2026-05-19T05:44:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":36,"title":"[SEO] Add Unique Meta Descriptions","updatedAt":"2026-05-19T22:27:14Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":35,"title":"[DESIGN] CTA Button Design System","updatedAt":"2026-05-24T21:12:58Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":34,"title":"[DESIGN] Hero Section Visual Treatment","updatedAt":"2026-05-24T21:12:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":33,"title":"[DESIGN] Mobile-First Responsive System","updatedAt":"2026-05-24T21:12:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":32,"title":"[DESIGN] Form Design Updates","updatedAt":"2026-05-24T21:12:54Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":31,"title":"[DESIGN] Project Card Design Pattern","updatedAt":"2026-05-24T21:12:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":30,"title":"[DESIGN] Photography Showcase Component","updatedAt":"2026-05-24T21:12:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":29,"title":"[DESIGN] Footer Redesign","updatedAt":"2026-05-24T21:12:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":28,"title":"[DESIGN] Navigation Redesign - Modern Mobile-First","updatedAt":"2026-05-24T21:12:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":27,"title":"[DESIGN] Color Palette Refinement","updatedAt":"2026-05-24T21:12:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":26,"title":"[DESIGN] Typography System Update","updatedAt":"2026-05-24T21:12:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":25,"title":"[DESIGN] Create Modern Component Library","updatedAt":"2026-05-24T21:12:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":24,"title":"[DESIGN] Full Homepage Redesign - Modern Full-Width Layout","updatedAt":"2026-05-24T21:12:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":23,"title":"[CONTENT] Reorganize Blog Categories","updatedAt":"2026-05-18T17:09:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-01-03T04:08:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":21,"title":"[CONTENT] Create Photography Portfolio as Credential Section","updatedAt":"2026-01-03T04:08:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":20,"title":"[CONTENT] Update Voice/Tone to Professional but Warm","updatedAt":"2026-01-03T04:08:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":19,"title":"[CONTENT] Add Community Impact Metrics Throughout Site","updatedAt":"2026-01-03T04:08:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":18,"title":"[CONTENT] Create Vancouver AI Community Page","updatedAt":"2026-05-19T22:27:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":15,"title":"[CONTENT] Create The Upgrade AI Co-Founder Section","updatedAt":"2026-05-19T22:27:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":14,"title":"[CONTENT] Create Indigenomics.ai CTO Section","updatedAt":"2026-05-19T22:27:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":13,"title":"[CONTENT] Create BC+AI Leadership Section","updatedAt":"2026-05-19T22:27:27Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":12,"title":"[CONTENT] Fix homepage H1 and role-proof hero polish","updatedAt":"2026-05-23T01:52:02Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":11,"title":"[UX] Create Membership Benefits Comparison Matrix","updatedAt":"2026-01-03T04:00:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":10,"title":"[UX] Add Hover States to CTA Buttons","updatedAt":"2026-05-19T22:27:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":9,"title":"[A11Y] Fix Search Field Accessibility","updatedAt":"2026-05-19T22:27:12Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":8,"title":"[A11Y] Add ARIA Labels to Icon Buttons","updatedAt":"2026-05-19T22:27:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":7,"title":"[CONTENT] Add Pricing Information to Services","updatedAt":"2026-01-03T03:58:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":5,"title":"[BUG] Fix Color Contrast for WCAG Compliance","updatedAt":"2026-01-03T03:58:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-01-03T04:00:19Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=0, draft_posts=71, draft_pages=5
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 6.9.4 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.179.0",
+          "jetpack": "52dbe7cc70e522fe47c0",
+          "popup-maker": "1.22.0",
+          "zero-bs-crm": "5ba5dddc04be2306aaf0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "6.9.4"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/recent-projects-include/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/blaze",
+          "jetpack/v4/blaze-app",
+          "jetpack/v4/explat",
+          "jetpack/v4/import",
+          "jetpack/v4/stats-app",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "wpcom/v2",
+          "wpcom/v3",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "6.9.4",
+  "started_at": "2026-05-25T02:19:51Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/WORK-PLAN-2026-05-23.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 0
+    },
+    {
+      "declared": 66,
+      "drift": false,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 66
+    },
+    {
+      "declared": "6.9.4",
+      "drift": false,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "6.9.4"
+    },
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 0
+    },
+    {
+      "declared": 71,
+      "drift": false,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 71
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 5
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/WORK-PLAN-2026-05-23.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301 
+date: Mon, 25 May 2026 02:20:13 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+location: https://kriskrug.co/recent-projects-include/
+server: Pagely-ARES/1.22.2
+x-gateway-request-id: c4773f2be230a04c24aa6cc80897e05c
+x-jetpack-boost-cache: miss
+vary: accept,content-type
+expires: Mon, 25 May 2026 03:10:33 GMT
+cache-control: max-age=3600
+x-redirect-by: KK Hotfix
+x-gateway-cache-key: 1779663844.823|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: HIT
+x-gateway-skip-cache: 0
+```
+
+### Aurora Local vs Origin Divergence
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2`
+- Exit code: `0`
+
+```text
+50	38
+```
+
+### Aurora Local Status
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 status --short --branch`
+- Exit code: `0`
+
+```text
+## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip
+```

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Scan docs for stale current-state claims.
+
+This check is intentionally non-mutating. It does not prove live truth; it
+blocks known-bad claims that have repeatedly confused repo agents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_BASES = [
+    Path("README.md"),
+    Path("AGENTS.md"),
+    Path("CONTRIBUTING.md"),
+    Path("docs"),
+]
+
+DEFAULT_EXCLUDES = [
+    Path("docs/current-state/reports"),
+    Path("docs/current-state/raw"),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line_number: int
+    message: str
+    line: str
+
+
+KNOWN_STALE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"/projects/.*(?:still\s+)?returns\s+`?404`?", re.I),
+        "`/projects/` no longer documents as 404; verify the 301 redirect with curl.",
+    ),
+    (
+        re.compile(r"Public\s+`/projects/`\s+still\s+returns", re.I),
+        "`/projects/` live-state wording is stale; use the current redirect wording.",
+    ),
+    (
+        re.compile(r"(?:Work|Work page).*still\s+emits.*blank", re.I),
+        "Work OG blank-image wording is stale; cache-busted readback is currently non-blank.",
+    ),
+    (
+        re.compile(r"blank WordPress\.com OG", re.I),
+        "Work OG blank-image wording is stale; cite the current OG readback instead.",
+    ),
+    (
+        re.compile(r"s0\.wp\.com/i/blank\.jpg", re.I),
+        "The old WordPress.com blank image should not appear in current guidance.",
+    ),
+    (
+        re.compile(r"Safety-net (?:CSS )?marker (?:is )?present", re.I),
+        "Homepage reveal safety-net wording is stale; current readback says the marker is absent.",
+    ),
+    (
+        re.compile(r"Live site is still Catch Responsive", re.I),
+        "The live site now runs the Aurora `kk-aurora` theme.",
+    ),
+    (
+        re.compile(r"Current live queue count is 43", re.I),
+        "Draft queue count is stale; rerun or cite `make draft-queue-audit`.",
+    ),
+    (
+        re.compile(r"WordPress has `?42`? draft posts", re.I),
+        "Draft queue count is stale; current normalized count is 71 draft posts.",
+    ),
+    (
+        re.compile(r"Open issues:\s*`?(?:61|63)`?", re.I),
+        "Open issue count is stale; current normalized count is 66 open issues.",
+    ),
+    (
+        re.compile(r"Open issues\s*\|\s*(?:61|63|64)\s*\|", re.I),
+        "Open issue table count is stale; current normalized count is 66 open issues.",
+    ),
+    (
+        re.compile(r"Open PRs\s*\|\s*2\s*\|", re.I),
+        "Open PR table count is stale; current normalized count is 0 open PRs.",
+    ),
+    (
+        re.compile(r"auto-implement`?\s*(?:issues)?\s*[:|]\s*`?(?:45|47|62)`?", re.I),
+        "Historical `auto-implement` count is stale; current normalized count is 44.",
+    ),
+    (
+        re.compile(r"GitHub shows 64 open issues", re.I),
+        "Open issue count is stale; current normalized count is 66 open issues.",
+    ),
+    (
+        re.compile(r"Draft posts\s*\|\s*32\s*\|", re.I),
+        "Draft-post table count is stale; current normalized count is 71 draft posts.",
+    ),
+    (
+        re.compile(r"Draft pages\s*\|\s*3\s*\|", re.I),
+        "Draft-page table count is stale; current normalized count is 5 draft pages.",
+    ),
+    (
+        re.compile(r"authenticated WordPress (?:currently|now) has 32 draft posts", re.I),
+        "Draft queue wording is stale; current normalized count is 71 draft posts.",
+    ),
+]
+
+STALE_FRONT_DOOR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"WORK-PLAN-2026-05-23\.md.*current (?:execution roadmap|front door)", re.I),
+        "`WORK-PLAN-2026-05-23.md` is historical; current guidance must point to handoff + morning-truth.",
+    ),
+    (
+        re.compile(r"current next-session front door", re.I),
+        "Avoid undated current-front-door wording; point at the dated handoff and morning-truth report.",
+    ),
+]
+
+CURRENT_LANGUAGE_PATTERNS = [
+    re.compile(r"\bcurrent (?:front door|execution truth|startup context|startup truth)\b", re.I),
+    re.compile(r"\blatest startup truth\b", re.I),
+]
+
+ANCHOR_PATTERN = re.compile(
+    r"2026-\d\d-\d\d|morning-truth|reports/|HANDOFF-2026-05-24|TRACK-A-MORNING-TRUTH|AURORA-V3-QA",
+    re.I,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        action="append",
+        type=Path,
+        help="File or directory to scan. May be repeated. Defaults to root gateway docs plus docs/.",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        type=Path,
+        default=[],
+        help="File or directory to exclude. May be repeated.",
+    )
+    return parser.parse_args()
+
+
+def is_relative_to(path: Path, other: Path) -> bool:
+    try:
+        path.relative_to(other)
+        return True
+    except ValueError:
+        return False
+
+
+def iter_markdown_files(repo_root: Path, bases: list[Path], excludes: list[Path]) -> list[Path]:
+    files: set[Path] = set()
+    exclude_paths = [(repo_root / path).resolve() for path in excludes]
+
+    for base in bases:
+        resolved = (repo_root / base).resolve()
+        if not resolved.exists():
+            continue
+        candidates = [resolved] if resolved.is_file() else resolved.rglob("*.md")
+        for candidate in candidates:
+            if candidate.suffix.lower() != ".md":
+                continue
+            candidate = candidate.resolve()
+            if any(candidate == excluded or is_relative_to(candidate, excluded) for excluded in exclude_paths):
+                continue
+            files.add(candidate)
+
+    return sorted(files)
+
+
+def scan_file(repo_root: Path, path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    relative_path = path.relative_to(repo_root)
+    text = path.read_text(encoding="utf-8")
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for pattern, message in KNOWN_STALE_PATTERNS + STALE_FRONT_DOOR_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding(relative_path, line_number, message, line.strip()))
+
+        if any(pattern.search(line) for pattern in CURRENT_LANGUAGE_PATTERNS) and not ANCHOR_PATTERN.search(line):
+            findings.append(
+                Finding(
+                    relative_path,
+                    line_number,
+                    "Current-state wording needs a concrete date, report, or verification-command anchor.",
+                    line.strip(),
+                )
+            )
+
+    return findings
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    bases = args.base if args.base else DEFAULT_BASES
+    excludes = DEFAULT_EXCLUDES + args.exclude
+
+    findings: list[Finding] = []
+    for path in iter_markdown_files(repo_root, bases, excludes):
+        findings.extend(scan_file(repo_root, path))
+
+    if not findings:
+        print("docs truth check passed")
+        return 0
+
+    print("docs truth check failed:")
+    for finding in findings:
+        print(f"{finding.path}:{finding.line_number}: {finding.message}")
+        print(f"  {finding.line}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- normalize root/current-state docs against the 2026-05-25 02:19 UTC truth snapshot
- update stale issue/PR/draft counts and Work `/projects/`/OG/reveal-safety-net live-surface claims
- add immutable morning-truth evidence report `docs/current-state/reports/morning-truth-20260525-021945Z.md`

## Verification
- `make health`
- `make test`
- `make docs-truth-check`
- `make current-state-drift-check`
- `make morning-truth`
- edited-doc markdown relative-link check

## Notes
- `make validate` still fails locally because `phpcs` is not installed; no PHP/runtime files changed.
- Existing untracked local drafts/reports/scripts were left untouched.