### PR TITLE
theme: polish homepage role proof

### DIFF
--- a/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
+++ b/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
@@ -1,0 +1,51 @@
+# Aurora Homepage Role-Proof Polish - 2026-05-26
+
+## Scope
+
+Issue #12 needed the homepage hero to stop underselling the current work. Aurora `1.3.4` already fixed the old empty/duplicate H1 problem, so this pass stays surgical: preserve the keynote-first homepage and add the explicit role proof, metrics, and initiative links the issue asked for.
+
+No WordPress REST writes were made in this pass. The homepage is theme-owned.
+
+## Live Baseline
+
+Public fetch of `https://kriskrug.co/?issue12=20260526` before edits returned:
+
+- Status `200`.
+- One H1: `Authored judgment in the age of generative everything.`
+- Homepage markers included Indigenomics, The Upgrade, Vancouver AI, keynote, and photographer.
+- Exact `BC+AI` marker was absent because the live page used `BC + AI`.
+- The visible homepage did not yet carry the full issue #12 metric spine: `2,000+ members`, `$200B`, and `Fortune 500 training`.
+
+The only missing image alt detected was a hidden Facebook tracking pixel, not a visible homepage image.
+
+## Aurora 1.3.5 Changes
+
+- Bumped `theme/kk-aurora/style.css` and `theme/kk-aurora/functions.php` from `1.3.4` to `1.3.5`.
+- Updated `theme/kk-aurora/templates/front-page.html` hero copy to foreground:
+  - Executive Director, BC+AI.
+  - CTO, Indigenomics.ai.
+  - Co-founder, The Upgrade AI.
+  - 2,000+ BC+AI members.
+  - $200B Indigenous economy work.
+  - Fortune 500 training.
+- Added Indigenomics.ai to the current-work card set with a direct CTA.
+- Changed The Upgrade card copy/image to carry the co-founder and training proof more clearly.
+
+## Verification
+
+- `git diff --check` passed.
+- Visible homepage card image URLs returned `200` image responses.
+- Local template marker check found one `<h1>`, all new role/metric markers, and no visible `<img>` missing `alt`.
+- `make wp7-smoke EXPECT_VERSION=6.9.4` passed against the currently live Aurora site before the `1.3.5` upload.
+- Built `/Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip`.
+- `unzip -t /Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip` passed.
+
+## Remaining Live Gate
+
+Issue #12 should close only after Aurora `1.3.5` is uploaded, caches are purged, and the public homepage is checked for:
+
+- One visible H1.
+- Hero proof links to BC+AI, Indigenomics.ai, and The Upgrade AI.
+- Metrics visible in rendered source/text.
+- Desktop and mobile layout without overflow.
+- No broken visible images.

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.4');
+define('KK_AURORA_VERSION', '1.3.5');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.4
+Version: 1.3.5
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -14,13 +14,13 @@
     </figure>
     <div class="aurora-hero-scrim" aria-hidden="true"></div>
     <div class="aurora-hero-copy" data-reveal>
-      <p class="aurora-kicker">AI keynote speaker. Creative technologist. Community builder.</p>
+      <p class="aurora-kicker">AI keynote speaker. Community builder. Technology-for-justice operator.</p>
       <h1 id="aurora-home-title">Authored judgment in the age of generative everything.</h1>
-      <p class="aurora-hero-dek">The machines now spill out adequate everything. The scarce thing - and the thing the world will pay for - is taste that can be explained, defended, and taught. I help organizations and creative pros build it.</p>
+      <p class="aurora-hero-dek">Bridging art, AI, Indigenous wisdom, and justice through BC+AI's 2,000+ member ecosystem, Indigenomics.ai's $200B Indigenous economy work, and The Upgrade AI's practical training for enterprise and creative teams.</p>
       <div class="aurora-proof-row" aria-label="Current proof">
-        <a href="https://bc-ai.ca/">Executive Director, BC + AI</a>
-        <a href="https://www.theupgrade.ai/">Founder, TheUpgrade.ai</a>
-        <a href="/speaking/">20+ years on stage</a>
+        <a href="https://bc-ai.ca/">Executive Director, BC+AI</a>
+        <a href="https://indigenomics.ai/">CTO, Indigenomics.ai</a>
+        <a href="https://www.theupgrade.ai/">Co-founder, The Upgrade AI</a>
         <a href="/work/">Culture, code, community</a>
       </div>
       <div class="aurora-action-row">
@@ -65,18 +65,29 @@
           <span class="aurora-card-label">Ecosystem</span>
           <div>
             <h3>BC + AI Ecosystem</h3>
-            <p>Community infrastructure for a responsible, inclusive, place-rooted AI future in British Columbia.</p>
+            <p>Community infrastructure for a responsible, inclusive, place-rooted AI future in British Columbia, now connecting 2,000+ members.</p>
+          </div>
+        </a>
+      </article>
+
+      <article class="aurora-media-card">
+        <a href="https://indigenomics.ai/" aria-label="Explore Indigenomics.ai">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&amp;ssl=1" alt="Indigenomics AI visual from Kris Krug's public writing" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Sovereignty tech</span>
+          <div>
+            <h3>Indigenomics.ai</h3>
+            <p>CTO work supporting Indigenous economic sovereignty, evidence systems, and the $200B Indigenous economy frame.</p>
           </div>
         </a>
       </article>
 
       <article class="aurora-media-card">
         <a href="https://www.theupgrade.ai/" aria-label="Explore TheUpgrade.ai">
-          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/01k7dj5tx212rc55a76ds68rq4-Kris-Krug.png?w=1200&amp;ssl=1" alt="Kris Krug portrait used for AI training and workshop context" loading="lazy" decoding="async">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1" alt="The Upgrade AI courses workshops and trainings graphic" loading="lazy" decoding="async">
           <span class="aurora-card-label">Training</span>
           <div>
-            <h3>TheUpgrade.ai</h3>
-            <p>Practical workshops and executive briefings that build human capacity alongside machine capacity.</p>
+            <h3>The Upgrade AI</h3>
+            <p>Co-founded with Peter Bittner to bring useful AI training to Fortune 500 teams, creative pros, and community builders.</p>
           </div>
         </a>
       </article>


### PR DESCRIPTION
## Summary

- Bump Aurora to `1.3.5` for a tiny homepage role-proof patch.
- Update the homepage hero and current-work cards to explicitly feature BC+AI, Indigenomics.ai, and The Upgrade AI.
- Add the requested issue #12 proof markers: `2,000+`, `$200B`, and `Fortune 500`.
- Document the live baseline, verification, package path, and remaining live upload gate.

Refs #12

## Verification

- `git diff --check`
- staged `gitleaks protect --staged --redact`
- local template marker check: one `<h1>`, role/metric markers present, visible images have alt text
- visible card image URL checks returned `200` image responses
- `make wp7-smoke EXPECT_VERSION=6.9.4`
- built `/Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip`
- `unzip -t /Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip`

## Live Gate

Issue #12 remains open until Aurora `1.3.5` is uploaded, caches are purged, and the public homepage is checked for one visible H1, role/metric markers, responsive layout, and no broken visible images.