### PR TITLE
theme: fit homepage proof above fold

### DIFF
--- a/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
+++ b/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
@@ -40,9 +40,29 @@ The only missing image alt detected was a hidden Facebook tracking pixel, not a 
 - Built `/Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip`.
 - `unzip -t /Users/kk/Desktop/kk-aurora-homepage-role-proof-1.3.5.zip` passed.
 
+## Aurora 1.3.6 Follow-Up
+
+After `1.3.5` was uploaded and purged, live browser QA confirmed the content markers were present but the desktop hero type was still so large that the role-proof row started below a 1440 by 1000 first viewport.
+
+Aurora `1.3.6` tightens only the homepage hero rhythm:
+
+- Reduces the desktop hero H1 scale while keeping it canonical and visually strong.
+- Expands the H1 measure so it wraps less aggressively.
+- Reduces hero deck/proof/action spacing.
+- Keeps the role-proof row visible in a normal mobile first viewport and preserves 320px no-overflow behavior.
+
+Injected-CSS browser probe before committing showed:
+
+- Desktop 1440 by 1000: H1, deck, role-proof row, and CTAs visible by `838px`; no horizontal overflow.
+- Mobile 390 by 844: H1, deck, and role-proof row visible by `824px`; no horizontal overflow.
+- Small 320 by 700: no horizontal overflow; content remains stacked and readable.
+- Built `/Users/kk/Desktop/kk-aurora-homepage-first-screen-proof-1.3.6.zip`.
+- `unzip -t /Users/kk/Desktop/kk-aurora-homepage-first-screen-proof-1.3.6.zip` passed.
+- `make wp7-smoke EXPECT_VERSION=6.9.4` passed against the live site after the `1.3.5` upload and before the `1.3.6` upload.
+
 ## Remaining Live Gate
 
-Issue #12 should close only after Aurora `1.3.5` is uploaded, caches are purged, and the public homepage is checked for:
+Issue #12 should close only after Aurora `1.3.6` is uploaded, caches are purged, and the public homepage is checked for:
 
 - One visible H1.
 - Hero proof links to BC+AI, Indigenomics.ai, and The Upgrade AI.

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.5');
+define('KK_AURORA_VERSION', '1.3.6');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.5
+Version: 1.3.6
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -725,7 +725,7 @@ a {
 
 .aurora-hero-2026 {
   isolation: isolate;
-  min-height: clamp(640px, 86vh, 880px);
+  min-height: clamp(600px, 80vh, 800px);
   overflow: hidden;
   position: relative;
 }
@@ -766,28 +766,28 @@ a {
   display: grid;
   margin: 0 auto;
   max-width: var(--aurora-max);
-  min-height: clamp(640px, 86vh, 880px);
-  padding: clamp(5rem, 10vw, 8rem) clamp(1rem, 3vw, 2rem) clamp(3rem, 6vw, 5rem);
+  min-height: clamp(600px, 80vh, 800px);
+  padding: clamp(4rem, 8vw, 6rem) clamp(1rem, 3vw, 2rem) clamp(2rem, 4vw, 3rem);
   place-content: center start;
 }
 
 .aurora-hero-copy h1 {
   color: var(--aurora-ink);
-  font-size: clamp(3.2rem, 9vw, 8.2rem);
+  font-size: clamp(3rem, 6.4vw, 6rem);
   font-weight: 900;
   letter-spacing: 0;
-  line-height: 0.96;
+  line-height: 0.98;
   margin: 0;
-  max-width: 10ch;
+  max-width: 13.5ch;
   text-wrap: balance;
 }
 
 .aurora-hero-dek {
   color: var(--aurora-ink-soft);
-  font-size: clamp(1.05rem, 1.6vw, 1.42rem);
+  font-size: clamp(1rem, 1.35vw, 1.25rem);
   line-height: 1.55;
-  margin: 1.4rem 0 0;
-  max-width: 55ch;
+  margin: 1rem 0 0;
+  max-width: 62ch;
 }
 
 .aurora-proof-row,
@@ -798,7 +798,7 @@ a {
 }
 
 .aurora-proof-row {
-  margin-top: 1.6rem;
+  margin-top: 1.1rem;
 }
 
 .aurora-proof-row a {
@@ -842,6 +842,10 @@ a {
 
 .aurora-action-row {
   margin-top: 1.8rem;
+}
+
+.aurora-hero-copy .aurora-action-row {
+  margin-top: 1.25rem;
 }
 
 .aurora-button-reel {
@@ -2695,10 +2699,16 @@ a {
   }
 
   .aurora-hero-copy h1 {
-    font-size: clamp(2.65rem, 12vw, 3.9rem);
+    font-size: clamp(2.35rem, 10.5vw, 3.45rem);
     hyphens: manual;
-    max-width: 12ch;
+    line-height: 1;
+    max-width: 13ch;
     overflow-wrap: normal;
+  }
+
+  .aurora-hero-dek {
+    font-size: 1rem;
+    margin-top: 1rem;
   }
 
   .aurora-writing-archive {
@@ -2801,6 +2811,14 @@ a {
 
   .aurora-path-row {
     gap: 0.45rem;
+  }
+
+  .aurora-proof-row {
+    margin-top: 1rem;
+  }
+
+  .aurora-hero-copy .aurora-action-row {
+    margin-top: 1.1rem;
   }
 
   .aurora-path-row a {


### PR DESCRIPTION
## Summary

- Bump Aurora to `1.3.6` for a follow-up homepage rhythm polish.
- Tighten the homepage hero type scale, measure, and hero-only spacing so the role-proof row lands in the first desktop viewport.
- Keep the change scoped to the homepage hero and update the issue #12 closeout doc with the post-upload finding and package path.

Refs #12

## Verification

- Live `1.3.5` source check after upload/purge: one H1, BC+AI / Indigenomics.ai / The Upgrade AI role markers, `2,000+`, `$200B`, `Fortune 500`, initiative links, 6 visible images with alt, visible images returned `200`.
- `make wp7-smoke EXPECT_VERSION=6.9.4`
- Playwright desktop/mobile browser pass on live `1.3.5` found no horizontal overflow or broken visible images, but desktop role proof sat below a 1440x1000 first viewport.
- Injected `1.3.6` CSS probe: desktop role proof + CTAs visible by 838px; mobile role proof visible by 824px; 320px viewport had no horizontal overflow.
- `git diff --check`
- `gitleaks protect --staged --redact`
- built `/Users/kk/Desktop/kk-aurora-homepage-first-screen-proof-1.3.6.zip`
- `unzip -t /Users/kk/Desktop/kk-aurora-homepage-first-screen-proof-1.3.6.zip`

## Live Gate

Issue #12 remains open until Aurora `1.3.6` is uploaded, caches are purged, and the public homepage is checked live again.