### PR TITLE
theme: remove stale font asset URLs

### DIFF
--- a/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
+++ b/docs/current-state/AURORA-HOMEPAGE-ROLE-PROOF-2026-05-26.md
@@ -60,9 +60,20 @@ Injected-CSS browser probe before committing showed:
 - `unzip -t /Users/kk/Desktop/kk-aurora-homepage-first-screen-proof-1.3.6.zip` passed.
 - `make wp7-smoke EXPECT_VERSION=6.9.4` passed against the live site after the `1.3.5` upload and before the `1.3.6` upload.
 
+## Aurora 1.3.7 Follow-Up
+
+After `1.3.6` was uploaded and purged, live browser QA confirmed the homepage role-proof layout was fixed. The remaining browser console error came from two hardcoded, stale `fonts.gstatic.com` font file URLs in `assets/css/typography-refined.css`.
+
+Aurora `1.3.7` removes those hardcoded font-file URLs and relies on the Google Fonts stylesheet already preloaded in `functions.php`, with normal system fallbacks.
+
+- Google Fonts stylesheet font assets returned `200`.
+- Built `/Users/kk/Desktop/kk-aurora-font-404-cleanup-1.3.7.zip`.
+- `unzip -t /Users/kk/Desktop/kk-aurora-font-404-cleanup-1.3.7.zip` passed.
+- `make wp7-smoke EXPECT_VERSION=6.9.4` passed against the live site after the `1.3.6` upload and before the `1.3.7` upload.
+
 ## Remaining Live Gate
 
-Issue #12 should close only after Aurora `1.3.6` is uploaded, caches are purged, and the public homepage is checked for:
+Issue #12 should close only after Aurora `1.3.7` is uploaded, caches are purged, and the public homepage is checked for:
 
 - One visible H1.
 - Hero proof links to BC+AI, Indigenomics.ai, and The Upgrade AI.

--- a/theme/kk-aurora/assets/css/bleeding-edge.css
+++ b/theme/kk-aurora/assets/css/bleeding-edge.css
@@ -293,7 +293,7 @@
 
 @supports (font-variation-settings: normal) {
   .aurora-hero-headline {
-    font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+    font-family: 'Inter', system-ui, sans-serif;
     font-variation-settings: 'wght' 700;
     transition: font-variation-settings 0.3s ease;
   }

--- a/theme/kk-aurora/assets/css/typography-refined.css
+++ b/theme/kk-aurora/assets/css/typography-refined.css
@@ -10,24 +10,7 @@
    Performance meets beauty
    ============================================ */
 
-/* Primary display font - Inter with variable font support */
-@font-face {
-  font-family: 'Inter Variable';
-  src: url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZ9hjp-Ek-_EeA.woff2') format('woff2');
-  font-weight: 100 900;
-  font-style: normal;
-  font-display: swap;
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* Monospace for code */
-@font-face {
-  font-family: 'JetBrains Mono';
-  src: url('https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.woff2') format('woff2');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
+/* Inter and JetBrains Mono load through the Google Fonts stylesheet preloaded in functions.php. */
 
 /* ============================================
    BASE TYPOGRAPHY
@@ -41,7 +24,7 @@ html {
 }
 
 body {
-  font-family: 'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
   font-feature-settings: 
     'kern' 1,      /* Kerning */
     'liga' 1,      /* Ligatures */
@@ -61,7 +44,7 @@ body {
 
 h1, h2, h3, h4, h5, h6,
 .wp-block-heading {
-  font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
   font-weight: 700;
   letter-spacing: 0;
   text-wrap: balance; /* Prevent orphans */

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.6');
+define('KK_AURORA_VERSION', '1.3.7');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.6
+Version: 1.3.7
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary

- Bump Aurora to `1.3.7` for a final live-QA cleanup.
- Remove stale hardcoded `fonts.gstatic.com` font-file URLs from `typography-refined.css`; the site already preloads the Google Fonts stylesheet in `functions.php`.
- Update the homepage role-proof closeout doc with the `1.3.7` font-console follow-up and package path.

Refs #12

## Verification

- Live `1.3.6` direct style check returned `Version: 1.3.6` with homepage rhythm CSS present.
- Live source check: one H1, role/metric markers present, initiative links present, six visible images with alt text, visible images returned `200`.
- Live browser check: desktop proof row at `y=732`, CTAs end at `838px`, no horizontal overflow; mobile 390 proof row ends at `824px`, no horizontal overflow; small 320 has no horizontal overflow.
- Remaining console 404 traced to stale hardcoded font URLs in theme CSS.
- Google Fonts stylesheet font assets returned `200`.
- `git diff --check`
- `gitleaks protect --staged --redact`
- built `/Users/kk/Desktop/kk-aurora-font-404-cleanup-1.3.7.zip`
- `unzip -t /Users/kk/Desktop/kk-aurora-font-404-cleanup-1.3.7.zip`
- `make wp7-smoke EXPECT_VERSION=6.9.4`

## Live Gate

Issue #12 remains open until Aurora `1.3.7` is uploaded, caches are purged, and the public homepage is checked live again for layout, markers, visible images, and a clean theme-owned console.