### PR TITLE
ops: harden Track A swarm safety checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth docs-truth-check clean
+.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth docs-truth-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -137,6 +137,13 @@ draft-queue-audit: ## Run read-only draft queue audit (LOCAL_ONLY=1 FORMAT=json)
 		python3 scripts/notion-to-wp/draft_queue_audit.py --local-only --format "$${FORMAT:-markdown}"; \
 	else \
 		scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --format "$${FORMAT:-markdown}"; \
+	fi
+
+jetpack-feedback-audit: ## Run PII-safe read-only Jetpack Forms feedback counts/routing audit (FORMAT=json)
+	@if [ "$${FORMAT:-human}" = "json" ]; then \
+		python3 scripts/jetpack_feedback_audit.py --env-file "$${ENV_FILE:-scripts/notion-to-wp/.env}" --json; \
+	else \
+		python3 scripts/jetpack_feedback_audit.py --env-file "$${ENV_FILE:-scripts/notion-to-wp/.env}"; \
 	fi
 
 wp7-smoke: ## Run read-only public WP 7 rollout smoke checks (BASE_URL=https://kriskrug.co EXPECT_VERSION=6.9.4)

--- a/content/drafts/2026-05-19-ai-media-appearances-podcast-guesting/publish-gate.md
+++ b/content/drafts/2026-05-19-ai-media-appearances-podcast-guesting/publish-gate.md
@@ -7,6 +7,8 @@ Status: private WordPress draft created as a standalone support post; do not pub
 - WP draft ID: `11879`
 - Edit URL: <https://kriskrug.co/wp-admin/post.php?post=11879&action=edit>
 - Verified readback: status `draft`, slug `ai-media-appearances-podcast-guesting`
+- 2026-05-29 authenticated read-only readback: category `1677`, `5` tags, `featured_media=0`, `647` words, `19` links, `0` images, `0` Gutenberg block comments.
+- Rollback/delete note: while it remains unpublished, rollback is simply leaving draft `11879` untouched or moving it to trash from wp-admin after KK approval. Do not publish, backfill backlinks, or import a featured image until the review items below are complete.
 
 ## WP draft attempt - 2026-05-19
 
@@ -32,8 +34,8 @@ Status: the earlier backup blocker is retired. See `../../source-packs/keynotes-
 - [ ] Choose final featured image or embed-only treatment.
 - [ ] Check every public source link before live use.
 - [ ] Confirm no third-party endorsement is implied beyond the public appearances.
-- [ ] If creating a WP draft, check the target slug before any live WordPress write.
-- [ ] If publishing publicly, add backlinks from `/speaking/`, `/about/`, and `/podcast-guesting-page-epk/` after the post URL exists.
+- [ ] If publishing publicly, confirm the draft still has the intended slug/status/category before any live WordPress write.
+- [ ] If publishing publicly, add backlinks from `/speaking/`, `/about/`, and `/podcast-guesting-page-epk/` only after the post URL exists.
 
 ## Safety notes
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -12,11 +12,12 @@ Read these first for current execution context:
 1. [AURORA-CONTENT-RECOVERY-2026-05-25.md](AURORA-CONTENT-RECOVERY-2026-05-25.md)
 2. [AURORA-LIVE-QA-2026-05-25.md](AURORA-LIVE-QA-2026-05-25.md)
 3. [QUEUE-MERGE-CLEANUP-2026-05-26.md](QUEUE-MERGE-CLEANUP-2026-05-26.md)
-4. [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md)
-5. [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md)
-6. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) plus `reports/morning-truth-20260525-220258Z.md`
-7. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
-8. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
+4. [TRACK-A-SWARM-75-95-128-2026-05-29.md](TRACK-A-SWARM-75-95-128-2026-05-29.md)
+5. [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md)
+6. [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md)
+7. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) plus `reports/morning-truth-20260525-220258Z.md`
+8. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
+9. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
 
 Then use historical plans for context:
 
@@ -42,6 +43,7 @@ Then use historical plans for context:
 | [AURORA-CONTENT-RECOVERY-2026-05-25.md](AURORA-CONTENT-RECOVERY-2026-05-25.md) | Recovery note for stale Aurora 1.3.0 production templates masking rich page content, plus the 1.3.3/1.3.4 deploy artifacts and verification markers. |
 | [AURORA-LIVE-QA-2026-05-25.md](AURORA-LIVE-QA-2026-05-25.md) | Live QA closeout for the 1.3.3 recovery deploy and 1.3.4 polish pass, including desktop/mobile screenshot artifact paths and residual CDN notes. |
 | [QUEUE-MERGE-CLEANUP-2026-05-26.md](QUEUE-MERGE-CLEANUP-2026-05-26.md) | GitHub PR, branch, worktree, and issue-comment closeout after merging the Aurora recovery, Cotton draft, modernization guardrails, and v3 IA rollout salvage lanes. |
+| [TRACK-A-SWARM-75-95-128-2026-05-29.md](TRACK-A-SWARM-75-95-128-2026-05-29.md) | Public-safe closeout for issues #75, #95, and #128, including dependency-aware Notion tests, draft `11879` readback, and PII-safe Jetpack feedback audit guidance. |
 | [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md) | Track A/Track B lane handoff with ownership boundaries and public-surface updates. |
 | [AURORA-V3-QA-ROADMAP-2026-05-24.md](AURORA-V3-QA-ROADMAP-2026-05-24.md) | Reconciled Aurora v1.3.0 line, local QA evidence, and post-merge rollout priorities. |
 | [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) | Read-only truth memo with live evidence, drift flags, and verification matrix for safe next-session startup. |

--- a/docs/current-state/TRACK-A-SWARM-75-95-128-2026-05-29.md
+++ b/docs/current-state/TRACK-A-SWARM-75-95-128-2026-05-29.md
@@ -1,0 +1,65 @@
+# Track A Issue Swarm - 2026-05-29
+
+**Scope:** GitHub issues `#75`, `#95`, and `#128`.
+**Mode:** read-only production checks, repo-owned safety tooling, and public-safe handoff notes.
+**Production writes:** none.
+
+## Summary
+
+This swarm split the three issues by what can safely happen in the public repo versus what must stay private or admin-gated.
+
+| Issue | Current disposition | Safe repo-owned action taken |
+|---|---|---|
+| `#75` | Open; `needs-human-review` remains correct. | Reconfirmed tracked-file secret scan and connector safety tests; made `make test` dependency-aware for Notion publisher tests when the local venv is absent. |
+| `#95` | Open and parked for KK review. | Refreshed authenticated read-only draft `11879` metrics and updated the local publish gate with rollback/delete notes. |
+| `#128` | Open; now labeled `priority:high`, `platform`, `marketing`, `needs-human-review`, `swarm-parked`. | Added a PII-safe Jetpack feedback audit command that reports counts and sanitized routing signals without fetching names, emails, message bodies, attachments, or CSV exports. |
+
+## Verified Signals
+
+- Live GitHub queue at swarm start: `0` open PRs.
+- `make morning-truth` generated `docs/current-state/reports/morning-truth-20260529-183305Z.md`.
+- Tracked-file secret scan: `gitleaks dir <clean git archive> --redact --no-banner` returned no leaks found.
+- Notion publisher tests in an ephemeral venv: `21` tests passed.
+- Jetpack feedback endpoint, authenticated read-only: `538` inbox, `96` spam, `0` trash.
+- PII-safe page form scan: `41` pages scanned, one block-managed contact form on `/contact/` (page `2418`); routing values redacted, routing keys present for `to` and `subject`.
+- Media appearances draft `11879`, authenticated read-only: status `draft`, category `1677`, `5` tags, `featured_media=0`, `647` words, `19` links, `0` images, `0` Gutenberg block comments.
+
+## New Commands
+
+```bash
+make test
+make jetpack-feedback-audit
+FORMAT=json make jetpack-feedback-audit
+```
+
+`make test` now uses `scripts/notion-to-wp/.venv/bin/python` when available, otherwise a Python with the Notion publisher dependencies installed, otherwise a temporary venv installed from `scripts/notion-to-wp/requirements.txt`.
+
+`make jetpack-feedback-audit` is intentionally narrow. It requests feedback counts, a meta-only sample with `id/date/status/type`, sanitized Jetpack Forms configuration booleans, and a redacted scan for block-managed form pages. It does not request private response bodies or export respondent data.
+
+## Remaining Human/Admin Work
+
+### `#75`
+
+- Treat credential rotation as historically done, but leave any destructive proof that the old credential no longer works to an admin-controlled session.
+- Do not rewrite git history without explicit KK approval and a coordinated force-push window.
+- Keep any live connector work draft-only unless KK approves the exact target and rollback path.
+
+### `#95`
+
+- KK reviews wp-admin draft `11879`.
+- Decide featured image versus embed-only treatment.
+- Rebuild block-clean if the draft becomes a publish candidate.
+- Run preview QA before schedule/publish.
+- Add backlinks only after the public URL exists and KK has approved publication.
+
+### `#128`
+
+- Triage Jetpack feedback privately in wp-admin or a private export; do not commit names, emails, messages, or CSV data to this repo.
+- Reply from Gmail where needed, in KK's voice.
+- Set a monitored recipient/alias and Gmail filter/label.
+- Verify routing with a test submission.
+- Invite newsletter opt-in only; do not bulk-add inquiry contacts without consent.
+
+## Privacy Rule For `#128`
+
+This repository and GitHub issues are public. It is safe to record counts, endpoint availability, routing keys, and redacted operational steps here. It is not safe to record submitter names, emails, message bodies, attachments, CSV exports, or reply drafts containing personal data.

--- a/scripts/jetpack_feedback_audit.py
+++ b/scripts/jetpack_feedback_audit.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""PII-safe, read-only Jetpack Forms feedback audit."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+from dataclasses import dataclass
+from html import unescape
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+DEFAULT_ENV_FILE = Path("scripts/notion-to-wp/.env")
+
+
+@dataclass
+class Config:
+    base_url: str
+    user: str
+    app_password: str
+
+
+def load_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def load_config(env_file: Path, base_url: str | None) -> Config:
+    values = load_env(env_file)
+    resolved_base_url = (base_url or values.get("WP_BASE_URL") or "https://kriskrug.co").rstrip("/")
+    user = values.get("WP_USER")
+    app_password = (values.get("WP_APP_PASSWORD") or "").replace(" ", "")
+    if not user or not app_password:
+        raise SystemExit(f"Missing WP_USER/WP_APP_PASSWORD in {env_file}")
+    return Config(base_url=resolved_base_url, user=user, app_password=app_password)
+
+
+def auth_header(config: Config) -> str:
+    token = base64.b64encode(f"{config.user}:{config.app_password}".encode()).decode()
+    return f"Basic {token}"
+
+
+def get_json(config: Config, path: str, timeout: int, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = config.base_url + path
+    if params:
+        url += "?" + urlencode(params, doseq=True)
+    request = Request(
+        url,
+        headers={
+            "Authorization": auth_header(config),
+            "Accept": "application/json",
+            "User-Agent": "kriskrug-jetpack-feedback-audit/1.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            body = response.read(2_000_000).decode(response.headers.get_content_charset() or "utf-8", "replace")
+            return {
+                "http_status": response.status,
+                "headers": {
+                    "x_wp_total": response.headers.get("X-WP-Total"),
+                    "x_wp_total_pages": response.headers.get("X-WP-TotalPages"),
+                },
+                "payload": json.loads(body),
+            }
+    except HTTPError as exc:
+        body = exc.read(500_000).decode("utf-8", "replace")
+        try:
+            payload: Any = json.loads(body)
+        except json.JSONDecodeError:
+            payload = body[:1000]
+        return {"http_status": exc.code, "headers": {}, "payload": payload}
+    except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+        return {"http_status": None, "headers": {}, "payload": str(exc)}
+
+
+def strip_html(value: str | None) -> str:
+    if not value:
+        return ""
+    text = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", unescape(text)).strip()
+
+
+def summarize_config(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {"available": False, "raw_type": type(payload).__name__}
+    return {
+        "available": True,
+        "has_classic_forms": bool(payload.get("hasClassicForms")),
+        "has_feedback": bool(payload.get("hasFeedback")),
+        "central_form_management_enabled": bool(payload.get("isCentralFormManagementEnabled")),
+        "integrations_enabled": bool(payload.get("isIntegrationsEnabled")),
+        "mailpoet_enabled": bool(payload.get("isMailPoetEnabled")),
+        "notes_enabled": bool(payload.get("isNotesEnabled")),
+        "webhooks_enabled": bool(payload.get("isWebhooksEnabled")),
+        "dashboard_available": bool(payload.get("formsResponsesUrl") or payload.get("dashboardURL")),
+    }
+
+
+def find_form_blocks(page: dict[str, Any]) -> dict[str, Any] | None:
+    raw_content = page.get("content", {}).get("raw") or ""
+    if not re.search(r"jetpack/(contact-form|field)|contact-form|wpforms|gravityform|formidable", raw_content, re.I):
+        return None
+
+    jetpack_forms = []
+    for match in re.finditer(r"<!--\s+wp:jetpack/contact-form\s+(\{.*?\})\s+-->", raw_content):
+        try:
+            attrs = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            attrs = {}
+        routing_keys = sorted(key for key in attrs if re.search(r"email|recipient|subject|to", key, re.I))
+        jetpack_forms.append({"routing_attr_keys": routing_keys})
+
+    title = page.get("title", {}).get("rendered")
+    return {
+        "id": page.get("id"),
+        "slug": page.get("slug"),
+        "status": page.get("status"),
+        "title": strip_html(title),
+        "jetpack_contact_form_blocks": len(jetpack_forms),
+        "routing_attrs_redacted": jetpack_forms,
+    }
+
+
+def scan_pages_for_forms(config: Config, timeout: int) -> dict[str, Any]:
+    result = get_json(
+        config,
+        "/wp-json/wp/v2/pages",
+        timeout,
+        {
+            "context": "edit",
+            "status": "publish,draft,private",
+            "per_page": 100,
+            "_fields": "id,slug,status,title,content.raw",
+        },
+    )
+    payload = result.get("payload")
+    pages = payload if isinstance(payload, list) else []
+    form_pages = [summary for page in pages if (summary := find_form_blocks(page))]
+    return {
+        "http_status": result.get("http_status"),
+        "pages_scanned": len(pages),
+        "form_pages": form_pages,
+    }
+
+
+def collect(config: Config, timeout: int) -> dict[str, Any]:
+    counts = get_json(config, "/wp-json/wp/v2/feedback/counts", timeout)
+    sample = get_json(
+        config,
+        "/wp-json/wp/v2/feedback",
+        timeout,
+        {"per_page": 1, "_fields": "id,date,status,type"},
+    )
+    forms_config = get_json(config, "/wp-json/wp/v2/feedback/config", timeout)
+    jetpack_forms = get_json(
+        config,
+        "/wp-json/wp/v2/jetpack-forms",
+        timeout,
+        {"per_page": 1, "_fields": "id,date,status,slug,title"},
+    )
+    return {
+        "base_url": config.base_url,
+        "privacy": {
+            "message_bodies_requested": False,
+            "names_or_emails_requested": False,
+            "attachments_requested": False,
+            "csv_export_requested": False,
+        },
+        "feedback_counts": {
+            "http_status": counts.get("http_status"),
+            "payload": counts.get("payload"),
+        },
+        "feedback_meta_only_sample": {
+            "http_status": sample.get("http_status"),
+            "total": sample.get("headers", {}).get("x_wp_total"),
+            "fields_requested": ["id", "date", "status", "type"],
+            "sample_count": len(sample.get("payload") or []) if isinstance(sample.get("payload"), list) else None,
+        },
+        "feedback_config": {
+            "http_status": forms_config.get("http_status"),
+            "payload": summarize_config(forms_config.get("payload")),
+        },
+        "jetpack_forms": {
+            "http_status": jetpack_forms.get("http_status"),
+            "total": jetpack_forms.get("headers", {}).get("x_wp_total"),
+        },
+        "page_form_scan": scan_pages_for_forms(config, timeout),
+    }
+
+
+def has_failure(report: dict[str, Any]) -> bool:
+    checks = [
+        report["feedback_counts"]["http_status"],
+        report["feedback_meta_only_sample"]["http_status"],
+        report["feedback_config"]["http_status"],
+        report["jetpack_forms"]["http_status"],
+        report["page_form_scan"]["http_status"],
+    ]
+    return any(status != 200 for status in checks)
+
+
+def print_human(report: dict[str, Any]) -> None:
+    print(f"Jetpack feedback audit: {report['base_url']}")
+    counts = report["feedback_counts"]["payload"]
+    if isinstance(counts, dict):
+        print(
+            "Feedback counts: "
+            f"inbox {counts.get('inbox', 0)}, spam {counts.get('spam', 0)}, trash {counts.get('trash', 0)}"
+        )
+    else:
+        print(f"Feedback counts unavailable: {counts}")
+    print(f"Feedback endpoint total: {report['feedback_meta_only_sample']['total']}")
+    print(f"Jetpack form records total: {report['jetpack_forms']['total']}")
+    config = report["feedback_config"]["payload"]
+    print(f"Forms config: {json.dumps(config, sort_keys=True)}")
+    scan = report["page_form_scan"]
+    print(f"Page form scan: {scan['pages_scanned']} pages scanned, {len(scan['form_pages'])} form pages found")
+    for page in scan["form_pages"]:
+        print(f"  - {page['slug']} ({page['id']}): routing keys redacted {page['routing_attrs_redacted']}")
+    print("")
+    print("Privacy guard: did not request names, emails, message bodies, attachments, or CSV exports.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a PII-safe, read-only Jetpack Forms feedback audit.")
+    parser.add_argument("--env-file", default=str(DEFAULT_ENV_FILE), help="Path to gitignored WordPress connector .env.")
+    parser.add_argument("--base-url", help="Override WP_BASE_URL from the env file.")
+    parser.add_argument("--timeout", type=int, default=30, help="Request timeout in seconds.")
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of human-readable output.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config(Path(args.env_file), args.base_url)
+    report = collect(config, args.timeout)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_human(report)
+    return 1 if has_failure(report) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/github-workflow-automation/scripts/run_tests.sh
+++ b/skills/github-workflow-automation/scripts/run_tests.sh
@@ -14,6 +14,14 @@ NC='\033[0m' # No Color
 
 VERBOSE=false
 TESTS_DETECTED=false
+TEMP_DIRS=""
+
+cleanup() {
+    for dir in $TEMP_DIRS; do
+        rm -rf "$dir"
+    done
+}
+trap cleanup EXIT
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -32,6 +40,46 @@ done
 
 echo "=== Test Runner ==="
 echo
+
+python_has_notion_deps() {
+    "$1" - <<'PY' >/dev/null 2>&1
+import dotenv
+import requests
+import yaml
+PY
+}
+
+select_notion_python() {
+    if [ -x "scripts/notion-to-wp/.venv/bin/python" ]; then
+        echo "scripts/notion-to-wp/.venv/bin/python"
+        return 0
+    fi
+
+    local candidate
+    local python_bin
+    for candidate in python3 python; do
+        if ! command -v "$candidate" >/dev/null 2>&1; then
+            continue
+        fi
+        python_bin="$(command -v "$candidate")"
+        if python_has_notion_deps "$python_bin"; then
+            echo "$python_bin"
+            return 0
+        fi
+    done
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "No python3 found for Notion publisher tests" >&2
+        return 1
+    fi
+
+    local temp_venv
+    temp_venv="$(mktemp -d /tmp/kriskrug-notion-tests.XXXXXX)"
+    TEMP_DIRS="$TEMP_DIRS $temp_venv"
+    python3 -m venv "$temp_venv"
+    PIP_DISABLE_PIP_VERSION_CHECK=1 "$temp_venv/bin/python" -m pip install -q -r scripts/notion-to-wp/requirements.txt
+    echo "$temp_venv/bin/python"
+}
 
 # Detect and run PHPUnit
 if [ -f "phpunit.xml" ] || [ -f "phpunit.xml.dist" ]; then
@@ -113,12 +161,7 @@ if [ -d "scripts/notion-to-wp/tests" ]; then
     TESTS_DETECTED=true
     echo "Detected: Notion publisher tests"
 
-    PYTHON_BIN="python3"
-    if [ -x "scripts/notion-to-wp/.venv/bin/python" ]; then
-        PYTHON_BIN="scripts/notion-to-wp/.venv/bin/python"
-    elif command -v python &> /dev/null; then
-        PYTHON_BIN="python"
-    fi
+    PYTHON_BIN="$(select_notion_python)"
 
     echo "Running unittest for scripts/notion-to-wp/tests..."
     if [ "$VERBOSE" = true ]; then


### PR DESCRIPTION
## Summary

- Makes `make test` reproduce the Notion publisher safety tests even when `scripts/notion-to-wp/.venv` is absent by selecting a dependency-ready Python or a temporary venv.
- Adds `make jetpack-feedback-audit`, a PII-safe authenticated read-only Jetpack feedback audit that reports counts and redacted form routing signals only.
- Records the public-safe #75/#95/#128 swarm handoff and updates draft `11879` publish-gate notes with current readback plus rollback/delete guidance.

Refs #75
Refs #95
Refs #128

## Verification

- `make test`
- `make docs-truth-check`
- `python3 -m py_compile scripts/jetpack_feedback_audit.py`
- `ENV_FILE=/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env make jetpack-feedback-audit`
- `ENV_FILE=/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env FORMAT=json make jetpack-feedback-audit > /tmp/kriskrug-feedback-audit.json && python3 -m json.tool /tmp/kriskrug-feedback-audit.json >/dev/null && python3 -m py_compile scripts/jetpack_feedback_audit.py`
- `git diff --check`
- `gitleaks dir <working copy snapshot> --redact --no-banner`

## Privacy / Production Notes

No WordPress writes, no message bodies, no respondent names/emails, no attachments, and no CSV exports were requested. #128 remains private/admin-gated for actual triage and replies.
