### PR TITLE
Align Aurora v3 reconcile docs with branch model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,14 +179,14 @@ phpcbf --standard=WordPress-Extra path/to/file.php
 Day-to-day work happens through Claude Code / Cursor agent sessions, not via the dormant GitHub Actions agent swarm. Two modes:
 
 - **Publisher mode (Track A):** Notion → kriskrug.co publishing, content enrichment, schema/SEO tweaks. Operates on `main`.
-- **Architect mode (Track B):** Aurora v2 theme migration. Operates on `aurora/v2`.
+- **Architect mode (Track B):** Aurora theme maintenance. Start from `main` on a lane-scoped `codex/...` branch; use `aurora/v3-reconcile` and `aurora/v2` only as historical/evidence branches unless a dated handoff explicitly revives one.
 
 See [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) for the decision rule.
 
 **Safety rules every agent must follow** (post 2026-05-15 incident):
 - Backup before destructive operations
 - Slug-based idempotency for the Notion → WP connector (never PATCH without verified target)
-- No theme file changes on `main` — that's Track B's branch only
+- Theme file changes happen in focused Track B PR branches from `main`; do not mix them with Track A content publishing changes.
 
 ## Development Workflow
 
@@ -245,7 +245,7 @@ Manual validation:
 
 - **Content publishing:** dry-run the connector first (`--dry-run`), eyeball the rendered post on staging or with the WP REST API, then publish for real.
 - **PHP snippets in `fixes/`:** paste into Code Snippets on prod, save as inactive, toggle on, watch Query Monitor / front-end behavior.
-- **Aurora theme (Track B):** stand up on Cloudways or Local by Flywheel, render every post type (Make Culture and Your Taste are the stress tests per [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md)).
+- **Aurora theme (Track B):** stand up on Cloudways or Local by Flywheel when a change needs rendered proof, then render every post type (Make Culture and Your Taste are the stress tests per [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md)).
 
 If broader automated coverage is added (for example PHPUnit, Playwright, or end-to-end staging checks), extend this section with exact run commands.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository is used for:
 1. **Site audits + state snapshots** of the live kriskrug.co WordPress install (see [`docs/current-state/`](docs/current-state/))
 2. **Content pipeline** — Notion → kriskrug.co publisher with safety guards (see [`scripts/notion-to-wp/`](scripts/notion-to-wp/))
 3. **Custom WordPress code** — schema markup, theme tweaks, helper plugins (see [`fixes/`](fixes/), [`inc/`](inc/), and [`plugins/`](plugins/))
-4. **Aurora v2 theme work** — separate `aurora/v2` branch, paced sprints (see [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md))
+4. **Aurora theme work** — canonical theme source now lives on `main`; this `aurora/v3-reconcile` line is preserved as deferred evidence for specific theme-polish files, not as a wholesale merge target
 5. **Issue tracking + project management** for fixes, content, and theme work
 
 ### Why a Separate Repo?
@@ -115,10 +115,15 @@ Notion → kriskrug.co publishing, post-publish enrichment, schema maintenance, 
 - Active backlog: [`docs/current-state/FIX_QUEUE.md`](docs/current-state/FIX_QUEUE.md), [`docs/current-state/SITE-AUDIT-2026-05-16.md`](docs/current-state/SITE-AUDIT-2026-05-16.md)
 - Deployed schema: [`fixes/schema-snippets-deployed.php`](fixes/schema-snippets-deployed.php)
 
-### Track B — Aurora v2 theme migration (on `aurora/v2`, paced sprints)
+### Track B — Aurora theme
 
-FSE theme rebuild on a separate branch. Touches `theme/`, FSE templates, theme.json. Never touches post content.
+FSE theme maintenance and polish. Touches `theme/`, FSE templates, theme.json. Never touches post content.
 
+- Current branch model (2026-05-29): start Track B work from `main` on a
+  lane-scoped `codex/...` branch. Use this `aurora/v3-reconcile` branch only
+  as deferred evidence for specific theme-polish files, and keep `aurora/v2`
+  references as historical context unless a dated handoff explicitly revives
+  one.
 - Migration plan: [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md)
 
 ### Which track am I in?

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,7 +13,7 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 | File | What it covers |
 |---|---|
 | [`current-state/README.md`](current-state/README.md) | Index of the baseline snapshot |
-| [`current-state/TWO-TRACK-MODEL.md`](current-state/TWO-TRACK-MODEL.md) | Active operating model — Track A (content/SEO) vs Track B (Aurora theme) |
+| [`current-state/TWO-TRACK-MODEL.md`](current-state/TWO-TRACK-MODEL.md) | Active Track A / Track B decision rule, with the 2026-05-29 branch-model update marking `aurora/v2` as historical and `aurora/v3-reconcile` as evidence only |
 | [`current-state/REPO_STATE.md`](current-state/REPO_STATE.md) | What's actually checked in vs. just documented |
 | [`current-state/SITE_INVENTORY.md`](current-state/SITE_INVENTORY.md) | Live-site fingerprint: host, theme, plugins, content shape |
 | [`current-state/ACCESS_CHANNELS.md`](current-state/ACCESS_CHANNELS.md) | MCP / REST / Chrome / SSH — what works today |

--- a/docs/current-state/TWO-TRACK-MODEL.md
+++ b/docs/current-state/TWO-TRACK-MODEL.md
@@ -2,6 +2,13 @@
 
 **Decided 2026-05-16 with KK.** Captures how the kriskrug.co work splits so each stream can move at its own pace without blocking the other.
 
+**Branch model updated 2026-05-29:** the track split is still current, but the
+old `aurora/v2` branch instruction is historical. Canonical Aurora source is now
+on `main`; Track B theme changes should start from `main` on focused
+`codex/...` branches. `aurora/v2` remains preserved historical evidence, and
+`aurora/v3-reconcile` remains deferred reconcile evidence for specific
+theme-polish files. Do not merge either branch wholesale.
+
 ---
 
 ## The problem this solves
@@ -45,11 +52,11 @@ So we split them.
 
 ---
 
-## Track B — Aurora v2 redesign
+## Track B — Aurora theme
 
 | | |
 |---|---|
-| **Branch** | `aurora/v2` (new — rebased onto current `main`) |
+| **Branch** | Current model: `main` plus focused `codex/...` PR branches. Historical model: `aurora/v2`; preserved reconcile evidence: `aurora/v3-reconcile`. |
 | **Cadence** | Paced sprints, not weekly |
 | **Owner** | Architect-mode Claude sessions (separate context) |
 | **Touches** | `theme/kk-aurora/` (theme.json, templates, patterns, assets), FSE Site Editor on staging, theme settings on production at cutover |
@@ -58,7 +65,7 @@ So we split them.
 
 ### What Track B does
 
-- **Rebase first** — the old branch (`origin/claude/setup-wordpress-rebuild-KVLxh`, last touched 2026-01-18) deletes Track A's work. Track B's first step is creating `aurora/v2` from current `main` and cherry-picking `theme/` + `demo/` from the old branch.
+- **Start from current `main`** — the old branch (`origin/claude/setup-wordpress-rebuild-KVLxh`, last touched 2026-01-18) and the later `aurora/v2` line are historical. Pull specific evidence from `aurora/v3-reconcile` only when the dated handoff names the file or commit to salvage.
 - **Stand up staging** — install on Cloudways dev (`24.144.80.107`) or Local by Flywheel
 - **Iterate** via WP Site Editor on staging; push tweaks back to the branch
 - **Smoke-test** all post types (long-form, image-heavy, embed-heavy — Make Culture and Your Taste are the stress tests)
@@ -99,7 +106,7 @@ If you're doing both in the same session, you've probably scope-crept; finish on
 
 - **Sequencing big calls between tracks.** Example: if Track A's reader audit suggests a homepage hero rewrite, should that rewrite happen on the current theme (Track A) or wait for Aurora (Track B)? Default: ship on current theme if the fix is ≤ a few hours; defer to Aurora if it's a layout-level decision. KK has final call on close ones.
 - **Coordination cadence.** No standing weekly sync between tracks because there's currently one human (KK) reviewing both. Revisit if/when that changes.
-- **Branch hygiene** for Track B. Once `aurora/v2` exists, keeping it in sync with `main` (via rebase, not merge) is the architect-session's responsibility. Stale-branch risk is real — the 4-month gap on the current Aurora branch is exactly what this section is trying to prevent recurring.
+- **Branch hygiene** for Track B. Keep theme PRs short-lived and based on `main`; treat `aurora/v2` and `aurora/v3-reconcile` as evidence branches unless a dated handoff explicitly revives them. Stale-branch risk is real — the 4-month gap on the original Aurora branch is exactly what this section is trying to prevent recurring.
 
 ---
 


### PR DESCRIPTION
## Summary
- Updates the `aurora/v3-reconcile` branch README, CONTRIBUTING, docs index, and two-track model to stop pointing agents at `aurora/v2` as current work.
- States that canonical Aurora source lives on `main`, while this v3 branch is deferred evidence for specific theme-polish files.
- Mirrors the branch-model language from the main-branch docs PR.

## Verification
- `git diff --check`
- `rg -n 'aurora/v2|aurora/v3-reconcile|No theme file changes|Operates on \`aurora|Track B — Aurora' README.md CONTRIBUTING.md docs/current-state/TWO-TRACK-MODEL.md docs/INDEX.md`
- `make docs-truth-check` is unavailable on this historical branch: `No rule to make target docs-truth-check`.

Refs #142
Companion main-branch PR: https://github.com/WalksWithASwagger/kriskrug-wp/pull/144