### PR TITLE
docs: clarify Aurora side worktree status

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ FSE theme rebuild and polish. Touches `theme/kk-aurora/`, FSE templates, theme.j
   lane-scoped `codex/...` branch. Use `aurora/v3-reconcile` only as deferred
   evidence for specific theme-polish files, and keep `aurora/v2` references as
   historical context unless a dated handoff says otherwise.
+- Side-worktree safety refresh (2026-06-02): do not edit
+  `/Users/kk/Code/kriskrug-wp-aurora-keynote`
+  (`codex/aurora-keynote-redesign`), `/Users/kk/Code/kriskrug-wp-aurora-reconcile`
+  (`aurora/v3-reconcile`), or the locked
+  `/Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80`
+  (`aurora/v2`) directly. Treat them as evidence or historical side branches
+  unless a maintainer explicitly resumes one.
 - Migration plan: [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/AURORA-MIGRATION-PLAN.md)
 
 ### Which track am I in?

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -21,6 +21,15 @@ Read these first for current execution context:
 10. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
 11. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
 
+Side-worktree safety refresh (2026-06-02): canonical new work should start from
+`main` in a fresh lane-scoped branch. Do not edit
+`/Users/kk/Code/kriskrug-wp-aurora-keynote`
+(`codex/aurora-keynote-redesign`),
+`/Users/kk/Code/kriskrug-wp-aurora-reconcile` (`aurora/v3-reconcile`), or the
+locked `/Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80`
+(`aurora/v2`) directly. Treat those side worktrees as evidence or historical
+branches unless a maintainer explicitly resumes one.
+
 Then use historical plans for context:
 
 - [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md)


### PR DESCRIPTION
## Summary
- clarify that Aurora side worktrees are evidence/historical unless explicitly resumed
- warn against direct edits in `kriskrug-wp-aurora-keynote`, `aurora/v3-reconcile`, and locked `aurora/v2` side worktrees
- keep canonical main docs aligned with the current branch model

## Verification
- PASS: `git fetch --prune`
- PASS: `git diff --check`
- PASS: `make docs-truth-check`
- PASS: final live refresh: no open PRs in `WalksWithASwagger/kriskrug-wp`

## Notes
Docs-only. No deploys, branch deletion, issue closure, WordPress writes, or live-site mutations performed.