### PR TITLE
Docs: Aurora 1.3.10 deploy audit and workplan

### DIFF
--- a/docs/current-state/AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md
+++ b/docs/current-state/AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md
@@ -1,0 +1,64 @@
+# Aurora Article Lux Composition 1.3.10 Closeout + Workplan
+
+**Date:** 2026-06-03 PDT / 2026-06-04 UTC
+**Lane:** Track B theme, with deployment/cache closeout
+**Branch:** `codex/aurora-article-lux-composition-1.3.10`
+**Theme package:** `/Users/kk/Desktop/kk-aurora-article-lux-composition-1.3.10.zip`
+
+## Shipped State
+
+Aurora `1.3.10` is live on `kriskrug.co`. The wp-admin upload replaced installed `1.3.9` with uploaded `1.3.10`, and WordPress reported `Theme updated successfully.`
+
+The deployed pass is scoped to single posts and `/blog/`: calmer article hierarchy, gallery-grade featured media framing, richer archive cards and no-image plates, Article Modules patterns/styles, subtle reveal polish, and active article-map behavior.
+
+Rollback packages found locally:
+
+- `/Users/kk/Desktop/kk-aurora-header-logo-1.3.9-20260603.zip`
+- `/Users/kk/Desktop/kk-aurora-article-lux-1.3.9.zip`
+
+## Audit Evidence
+
+- Live theme asset readback: `https://kriskrug.co/wp-content/themes/kk-aurora/style.css` reports `Version: 1.3.10`.
+- Public smoke passed with `make wp7-smoke EXPECT_VERSION=6.9.4` after deployment and cache work.
+- PressCACHE purge completed in wp-admin with `Cache Purge: Success`.
+- Jetpack Boost Critical CSS regeneration completed; Boost reported `6 files generated 34 minutes ago`, and the Boost site page cache reported `Cache already cleared`.
+- Live article HTML includes both Jetpack's broader baseline critical CSS and the new scoped `1.3.10` article rules, including `.aurora-single-2026 .aurora-single-title`.
+- Desktop Chrome QA covered `/blog/`, `Agent Orchestrators, Creative Insurgents & The New Stack`, and `The Long Road to Futureproof`: one visible H1, no horizontal overflow, visible keyboard focus, article-map active state on posts, related posts did not repeat the current post, and no `KK` fallback art was visible.
+- The only console warning observed during QA was `KK Aurora: GSAP or ScrollTrigger not loaded`; no console errors were observed.
+
+## Findings
+
+The deploy is healthy enough to keep live. The most important remaining risk is not the theme package; it is the performance/cache layer around Jetpack Boost and its generated critical CSS. Boost did finish regeneration, but this area already maps to issue #125 and should stay a near-term follow-up because it can affect first paint, motion timing, and stale critical CSS after future theme changes.
+
+The second real gap is device coverage. Static fallback QA covered mobile during build, but post-deploy live QA was limited to the available Chrome desktop viewport. Issue #127 should be treated as the next visual confidence gate for `/blog/` and article pages.
+
+The third blocker is local environment reliability. Local WordPress at `127.0.0.1:10003` was unavailable during the 1.3.10 pass, forcing fixture fallback for full browser evidence. Fixing that will make future Track B releases much less squishy.
+
+## Workplan
+
+1. Close the performance/cache loop.
+   - Re-check issue #125 against the live 1.3.10 deployment.
+   - Confirm Boost critical CSS remains fresh after a logged-out/cold read of `/blog/` and two posts.
+   - Decide whether the `KK Aurora: GSAP or ScrollTrigger not loaded` warning is expected optional infrastructure or a real cleanup item.
+
+2. Run live responsive QA.
+   - Use issue #127 as the home for the pass.
+   - Validate `/blog/`, latest post, and one media-heavy post at `1440x1000`, `390x844`, and `320x700`.
+   - Acceptance: one H1, no horizontal overflow, readable callouts, visible focus, reduced-motion behavior, active article map, no current-post repeat, and no `KK` fallback art.
+
+3. Repair Local WP QA.
+   - Restore or document the `127.0.0.1:10003` + `kriskrug-local.local` workflow.
+   - Add a small repeatable smoke note so future Track B browser QA can prefer real Local WP before static fixtures.
+
+4. Tune real content.
+   - Review the newest authored posts using the Article Modules vocabulary.
+   - Adjust spacing/contrast only where real Notion/WP output exposes awkward module rhythm.
+   - Keep connector-compatible class names and existing pattern slugs unchanged.
+
+5. Defer broader IA.
+   - Do not reorganize categories, tags, permalink structure, or generic content pages in the immediate follow-up.
+   - Revisit generic content pages under issue #122 as a separate planning lane after article/blog confidence is stable.
+
+## Next Default
+
+The next Track B slice should be: `Aurora post-deploy QA hardening`, focused on issues #125 and #127 first. Treat Local WP repair as the enabling task if live-only browser QA keeps slowing the loop.


### PR DESCRIPTION
## Summary
- Records the Aurora 1.3.10 live deployment closeout for the article/blog lux composition pass.
- Captures post-deploy verification, PressCACHE purge, Jetpack Boost Critical CSS regeneration, and desktop live QA evidence.
- Defines the next workplan around issue #125, issue #127, Local WP QA repair, and real-content article-module tuning.

## Verification
- `curl https://kriskrug.co/wp-content/themes/kk-aurora/style.css` reports `Version: 1.3.10`.
- `make wp7-smoke EXPECT_VERSION=6.9.4` passed after deployment/cache work.
- `git diff --check origin/main..HEAD` passed.

## Notes
- This PR is docs-only and intentionally avoids the mixed-history Aurora closeout branch.
- No additional production writes are part of this PR.