### PR TITLE
Content: polish Work page proof metadata

### DIFF
--- a/backup/20260604-work-page-68/page-snapshots/manifest.md
+++ b/backup/20260604-work-page-68/page-snapshots/manifest.md
@@ -1,0 +1,9 @@
+# Work page issue #68 rollback snapshot
+
+- Page ID: 2672
+- Slug: recent-projects-include
+- Source: authenticated WordPress REST context=edit
+- Modified before: 2026-05-23T08:58:41
+- JSON: page-2672-work-before-proof-metadata.json
+- HTML: page-2672-work-before-proof-metadata.html
+- HTML SHA256: db1f9ceec9a308e29f6d4bb525e99740e3e9a4c9041bad52759ae151ca79cf61

--- a/backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.html
+++ b/backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.html
@@ -1,0 +1,244 @@
+<!-- wp:html -->
+<style>
+.kk-overhaul { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); }
+.kk-overhaul a { font-weight:700; }
+.kk-hero { padding:1.35rem 0 1.4rem; border-bottom:1px solid var(--kk-line); }
+.kk-kicker { margin:0 0 .5rem; text-transform:uppercase; letter-spacing:.08em; font-size:.78rem; color:var(--kk-hot); font-weight:800; }
+.kk-display { margin:.15rem 0 .75rem; font-size:1.9rem; line-height:1.18; max-width:54rem; }
+.kk-lead { font-size:1.14rem; line-height:1.65; max-width:54rem; }
+.kk-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.25rem 0; }
+.kk-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }
+.kk-button.secondary { background:#fff; color:var(--kk-ink) !important; }
+.kk-section { padding:2rem 0; border-bottom:1px solid var(--kk-line); }
+.kk-section-intro { max-width:54rem; margin-bottom:1rem; color:var(--kk-muted); }
+.kk-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(235px,1fr)); gap:1rem; }
+.kk-card { border:1px solid var(--kk-line); border-radius:6px; background:var(--kk-card); overflow:hidden; }
+.kk-card img { display:block; width:100%; aspect-ratio:16/9; object-fit:cover; background:#eee; }
+.kk-card-body { padding:1rem; }
+.kk-card h3 { margin-top:0; margin-bottom:.4rem; font-size:1.12rem; }
+.kk-card p { margin:.45rem 0; color:var(--kk-muted); }
+.kk-tag { display:inline-block; margin:0 0 .55rem; color:var(--kk-hot); font-size:.72rem; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }
+.kk-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }
+.kk-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.75rem; margin-top:1rem; }
+.kk-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }
+.kk-proof strong { display:block; font-size:1.35rem; line-height:1.1; }
+.kk-proof span { display:block; color:var(--kk-muted); margin-top:.25rem; }
+.kk-archive { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; }
+.kk-archive .kk-card img { aspect-ratio:4/3; }
+.kk-archive .kk-card:nth-child(1) { grid-column:span 2; }
+.kk-archive .kk-card:nth-child(1) img { aspect-ratio:16/9; }
+.kk-link-row { display:flex; flex-wrap:wrap; gap:.55rem; margin-top:.75rem; }
+.kk-link-row a { border:1px solid var(--kk-line); border-radius:999px; padding:.28rem .62rem; text-decoration:none; background:#fff; }
+.kk-feature-grid { display:grid; grid-template-columns:minmax(0,1.15fr) minmax(260px,.85fr); gap:1rem; align-items:stretch; }
+.kk-feature-grid .kk-card:first-child img { aspect-ratio:16/10; }
+.kk-stack { display:grid; gap:1rem; }
+.kk-mini-nav { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:.75rem; margin:1.25rem 0 0; }
+.kk-mini-nav a { display:block; border:1px solid var(--kk-line); border-radius:6px; padding:.8rem; background:#fff; text-decoration:none; }
+.kk-mini-nav span { display:block; color:var(--kk-muted); font-weight:400; margin-top:.2rem; }
+.kk-workway img { aspect-ratio:5/3; }
+@media (max-width:760px){ .kk-display{font-size:1.45rem;} .kk-actions{display:block;} .kk-actions a{margin:.35rem 0;} .kk-archive .kk-card:nth-child(1){grid-column:auto;} }
+@media (max-width:860px){ .kk-feature-grid{grid-template-columns:1fr;} }
+</style>
+
+<div class="kk-overhaul">
+  <section class="kk-hero">
+    <p class="kk-kicker">Current work, living systems, and useful experiments</p>
+    <h2 class="kk-display">A portfolio of AI culture, community infrastructure, keynote systems, and long-haul visual storytelling.</h2>
+    <p class="kk-lead">I build things that help people meet the future without losing the plot: public AI communities, practical training, talks that become reusable portals, and story systems that make technology feel human again.</p>
+    <div class="kk-actions">
+      <a class="kk-button" href="/speaking/">Book a keynote</a>
+      <a class="kk-button secondary" href="/services/">Work with me</a>
+    </div>
+    <div class="kk-proof">
+      <div><strong>AI + culture</strong><span>Keynotes, workshops, and field notes.</span></div>
+      <div><strong>Community</strong><span>BC+AI, meetups, associations, and convening.</span></div>
+      <div><strong>Media</strong><span>Photography, documentary, podcast, and broadcast.</span></div>
+    </div>
+    <div class="kk-mini-nav">
+      <a href="#featured-work">Featured work<span>Start with the live initiatives.</span></a>
+      <a href="#public-artifacts">Public artifacts<span>Portals, talks, and reusable resources.</span></a>
+      <a href="#archive-highlights">Archive highlights<span>The photo-heavy backstory.</span></a>
+      <a href="/contact/">Start something<span>Bring me into the room.</span></a>
+    </div>
+  </section>
+
+  <section class="kk-section" id="featured-work">
+    <h2>Featured work</h2>
+    <p class="kk-section-intro">The center of gravity right now: a province-wide AI ecosystem, a brand-new responsible-AI certification, and hands-on training that helps teams build real confidence without flattening the weird human parts.</p>
+    <div class="kk-feature-grid">
+      <article class="kk-card">
+        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC AI ecosystem network graphic" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Ecosystem</span>
+          <h3><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></h3>
+          <p>A province-wide community and industry association for responsible, inclusive, place-rooted AI in British Columbia.</p>
+        </div>
+      </article>
+      <div class="kk-stack">
+        <article class="kk-card">
+          <img src="https://kriskrug.co/wp-content/uploads/2026/05/rap-why-we-built-cover.png" alt="Responsible AI Professional certification cover" loading="lazy" />
+          <div class="kk-card-body">
+            <span class="kk-tag">Certification</span>
+            <h3>Responsible AI Professional</h3>
+            <p>Just launched. A four-week certification that closes the gap between how fast we deploy AI and how slowly we get responsible about it — built with <strong>Martin Lopatka</strong> and <strong>Sarah Downey</strong>. Every grad ships their own ethics assistant.</p>
+            <p><a href="https://lu.ma/ai-ethics">Enroll in the cohort</a></p>
+          </div>
+        </article>
+        <article class="kk-card">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug speaking on stage at LaSalle College Vancouver" loading="lazy" />
+          <div class="kk-card-body">
+            <span class="kk-tag">Speaking</span>
+            <h3>AI Keynotes</h3>
+            <p>Talks and workshops on AI mindset, creative rebellion, human agency, archives, culture, and leadership after the point of no return.</p>
+            <p><a href="/speaking/">See speaking topics</a></p>
+          </div>
+        </article>
+        <article class="kk-card">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1" alt="The Upgrade AI courses workshops and trainings graphic" loading="lazy" />
+          <div class="kk-card-body">
+            <span class="kk-tag">Training</span>
+            <h3>The Upgrade AI</h3>
+            <p>Training, workshops, and applied AI sessions for creative professionals, organizations, community builders, and leadership teams.</p>
+            <p><a href="/services/">Explore services</a></p>
+          </div>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="kk-section" id="public-artifacts">
+    <h2>Public artifacts</h2>
+    <p class="kk-section-intro">Some talks become working websites: scripts, exercises, prompts, resource libraries, and field notes that keep moving after the room empties.</p>
+    <div class="kk-grid">
+      <article class="kk-card">
+        <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full portal graphic" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Synthetic media + soul</span>
+          <h3><a href="https://www.bothhandsfull.com/">Both Hands Full</a></h3>
+          <p>A World AI Film Festival keynote portal for filmmakers and creative workers navigating synthetic media, authorship, taste, and responsibility.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&amp;ssl=1" alt="Punk Rock AI CreativeMornings keynote artwork" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Creative rebellion</span>
+          <h3><a href="https://www.punkrockai.com/">Punk Rock AI</a></h3>
+          <p>A CreativeMornings Vancouver keynote rebuilt as a maker-first portal about agency, taste, and refusing to become a content machine.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/04/AI-Immortality-w-Guy-Kawasaki.png?fit=1200%2C604&amp;ssl=1" alt="Developing an AI Mindset keynote graphic" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">AI adoption</span>
+          <h3><a href="http://developinganaimindset.com/">Developing an AI Mindset</a></h3>
+          <p>A practical AI adoption resource for teams that need shared language, demos, and a humane first step into the tools.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC plus AI ecosystem site graphic" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Home base</span>
+          <h3><a href="https://kriskrug.co/">KrisKrug.co</a></h3>
+          <p>The long-running archive, publishing engine, proof layer, and connective tissue for the work across AI, media, community, and culture.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="kk-section">
+    <h2>How the work shows up</h2>
+    <p class="kk-section-intro">Same operating system, different surfaces: stages, training rooms, associations, media systems, and fieldwork.</p>
+    <div class="kk-grid">
+      <article class="kk-card kk-workway">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug speaking at LaSalle College Vancouver" loading="lazy" />
+        <div class="kk-card-body"><h3>AI education and adoption</h3><p>Workshops, keynotes, demos, and custom sessions that help people build confidence without flattening the ethical and creative questions.</p></div>
+      </article>
+      <article class="kk-card kk-workway">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug hosting a Vancouver AI Community Meetup" loading="lazy" />
+        <div class="kk-card-body"><h3>Community infrastructure</h3><p>Convening, association-building, sponsorship, event design, and systems that help networks become durable instead of merely loud.</p></div>
+      </article>
+      <article class="kk-card kk-workway">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20067931301_e7a16b6f2c_k-1.jpg?w=1200&amp;ssl=1" alt="Kris Krug backstage with Malcolm Gladwell" loading="lazy" />
+        <div class="kk-card-body"><h3>Photography and media</h3><p>Decades of documentary, conference, portrait, festival, and movement storytelling across technology, culture, and social change.</p></div>
+      </article>
+      <article class="kk-card kk-workway">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1" alt="Kris Krug with Daryl Hannah at COP15 in Copenhagen" loading="lazy" />
+        <div class="kk-card-body"><h3>Social impact and culture</h3><p>Work spanning Indigenous-led community projects, youth media, climate gatherings, UN convenings, documentary fieldwork, and civic technology.</p></div>
+      </article>
+    </div>
+  </section>
+
+  <section class="kk-section" id="archive-highlights">
+    <h2>Archive highlights</h2>
+    <p class="kk-section-intro">The back catalog matters. It shows the pattern: cameras, communities, weird rooms, culture, civic technology, and enough miles on the road to know when an idea is real.</p>
+    <div class="kk-archive">
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5637672371_fca291d598_o-1.jpg?w=800&amp;ssl=1" alt="Kris Krug presenting at the UN Global Youth Summit on HIV in Bamako" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">UN + youth media</span>
+          <h3>UN Global Youth Summit on HIV, Bamako</h3>
+          <p>Keynote and youth activist media mentoring work with UNAIDS in Mali, bringing online organizing and movement storytelling into a global room.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1" alt="Kris Krug with Daryl Hannah at COP15 in Copenhagen" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Climate + media</span>
+          <h3>COP15 and climate storytelling</h3>
+          <p>Hosted conversations and produced media around open culture, climate action, and digital community at major international gatherings.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/6283381617_43f79f3848_o.jpg?w=1200&amp;ssl=1" alt="Kris Krug with Mikhail Gorbachev backstage at WE Day" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Backstage culture</span>
+          <h3>WE Day, conferences, and impossible rooms</h3>
+          <p>Photography and video work in rooms where politics, celebrity, activism, and youth culture all collided.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/05/9818127715_416df9a481_o.jpg?w=612&amp;ssl=1" alt="Kris Krug with Jack Dorsey at University of Waterloo" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Tech culture</span>
+          <h3>Founders, networks, and the social web</h3>
+          <p>Years documenting and convening the early social internet, startup communities, conferences, and the people who shaped the platforms.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20190210_170149-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug with Post Malone at the Grammy Awards" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Music + culture</span>
+          <h3>Festivals, artists, and pop-cultural fieldwork</h3>
+          <p>From Grammys corridors to festival fields, the work has always followed the living edge of culture.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/PopTech-2013-Camden-Maine-USA-PopTech_10460205104_o.jpg?w=640&amp;ssl=1" alt="Kris Krug with skateboarder Rodney Mullen at PopTech" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Ideas festivals</span>
+          <h3>PopTech, SXSW, TEDx, and idea circuits</h3>
+          <p>Speaking, hosting, photographing, and learning inside the strange, generative spaces where culture and technology cross-pollinate.</p>
+        </div>
+      </article>
+    </div>
+    <div class="kk-link-row">
+      <a href="/about/">More backstory</a>
+      <a href="/speaking/">Speaking archive</a>
+      <a href="/blog/">Writing</a>
+      <a href="/contact/">Start a project</a>
+    </div>
+  </section>
+
+  <section class="kk-section">
+    <div class="kk-callout">
+      <h2>Need a speaker, strategist, trainer, or weirdly useful AI collaborator?</h2>
+      <p>Start with the lane that fits: keynotes for rooms that need energy and clarity, services for teams that need applied help, or contact if the project is odd and alive and probably worth a conversation.</p>
+      <div class="kk-actions">
+        <a class="kk-button" href="/speaking/">Speaking</a>
+        <a class="kk-button secondary" href="/services/">Services</a>
+        <a class="kk-button secondary" href="/contact/">Contact</a>
+      </div>
+    </div>
+  </section>
+</div>
+<!-- /wp:html -->

--- a/backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.json
+++ b/backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.json
@@ -1,0 +1,288 @@
+{
+  "id": 2672,
+  "date": "2023-08-20T20:09:38",
+  "date_gmt": "2023-08-21T04:09:38",
+  "guid": {
+    "rendered": "https://kriskrug.co/?page_id=2672",
+    "raw": "https://kriskrug.co/?page_id=2672"
+  },
+  "modified": "2026-05-23T08:58:41",
+  "modified_gmt": "2026-05-23T16:58:41",
+  "password": "",
+  "slug": "recent-projects-include",
+  "status": "publish",
+  "type": "page",
+  "link": "https://kriskrug.co/recent-projects-include/",
+  "title": {
+    "raw": "Work",
+    "rendered": "Work"
+  },
+  "content": {
+    "raw": "<!-- wp:html -->\n<style>\n.kk-overhaul { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); }\n.kk-overhaul a { font-weight:700; }\n.kk-hero { padding:1.35rem 0 1.4rem; border-bottom:1px solid var(--kk-line); }\n.kk-kicker { margin:0 0 .5rem; text-transform:uppercase; letter-spacing:.08em; font-size:.78rem; color:var(--kk-hot); font-weight:800; }\n.kk-display { margin:.15rem 0 .75rem; font-size:1.9rem; line-height:1.18; max-width:54rem; }\n.kk-lead { font-size:1.14rem; line-height:1.65; max-width:54rem; }\n.kk-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.25rem 0; }\n.kk-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }\n.kk-button.secondary { background:#fff; color:var(--kk-ink) !important; }\n.kk-section { padding:2rem 0; border-bottom:1px solid var(--kk-line); }\n.kk-section-intro { max-width:54rem; margin-bottom:1rem; color:var(--kk-muted); }\n.kk-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(235px,1fr)); gap:1rem; }\n.kk-card { border:1px solid var(--kk-line); border-radius:6px; background:var(--kk-card); overflow:hidden; }\n.kk-card img { display:block; width:100%; aspect-ratio:16/9; object-fit:cover; background:#eee; }\n.kk-card-body { padding:1rem; }\n.kk-card h3 { margin-top:0; margin-bottom:.4rem; font-size:1.12rem; }\n.kk-card p { margin:.45rem 0; color:var(--kk-muted); }\n.kk-tag { display:inline-block; margin:0 0 .55rem; color:var(--kk-hot); font-size:.72rem; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }\n.kk-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }\n.kk-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.75rem; margin-top:1rem; }\n.kk-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }\n.kk-proof strong { display:block; font-size:1.35rem; line-height:1.1; }\n.kk-proof span { display:block; color:var(--kk-muted); margin-top:.25rem; }\n.kk-archive { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; }\n.kk-archive .kk-card img { aspect-ratio:4/3; }\n.kk-archive .kk-card:nth-child(1) { grid-column:span 2; }\n.kk-archive .kk-card:nth-child(1) img { aspect-ratio:16/9; }\n.kk-link-row { display:flex; flex-wrap:wrap; gap:.55rem; margin-top:.75rem; }\n.kk-link-row a { border:1px solid var(--kk-line); border-radius:999px; padding:.28rem .62rem; text-decoration:none; background:#fff; }\n.kk-feature-grid { display:grid; grid-template-columns:minmax(0,1.15fr) minmax(260px,.85fr); gap:1rem; align-items:stretch; }\n.kk-feature-grid .kk-card:first-child img { aspect-ratio:16/10; }\n.kk-stack { display:grid; gap:1rem; }\n.kk-mini-nav { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:.75rem; margin:1.25rem 0 0; }\n.kk-mini-nav a { display:block; border:1px solid var(--kk-line); border-radius:6px; padding:.8rem; background:#fff; text-decoration:none; }\n.kk-mini-nav span { display:block; color:var(--kk-muted); font-weight:400; margin-top:.2rem; }\n.kk-workway img { aspect-ratio:5/3; }\n@media (max-width:760px){ .kk-display{font-size:1.45rem;} .kk-actions{display:block;} .kk-actions a{margin:.35rem 0;} .kk-archive .kk-card:nth-child(1){grid-column:auto;} }\n@media (max-width:860px){ .kk-feature-grid{grid-template-columns:1fr;} }\n</style>\n\n<div class=\"kk-overhaul\">\n  <section class=\"kk-hero\">\n    <p class=\"kk-kicker\">Current work, living systems, and useful experiments</p>\n    <h2 class=\"kk-display\">A portfolio of AI culture, community infrastructure, keynote systems, and long-haul visual storytelling.</h2>\n    <p class=\"kk-lead\">I build things that help people meet the future without losing the plot: public AI communities, practical training, talks that become reusable portals, and story systems that make technology feel human again.</p>\n    <div class=\"kk-actions\">\n      <a class=\"kk-button\" href=\"/speaking/\">Book a keynote</a>\n      <a class=\"kk-button secondary\" href=\"/services/\">Work with me</a>\n    </div>\n    <div class=\"kk-proof\">\n      <div><strong>AI + culture</strong><span>Keynotes, workshops, and field notes.</span></div>\n      <div><strong>Community</strong><span>BC+AI, meetups, associations, and convening.</span></div>\n      <div><strong>Media</strong><span>Photography, documentary, podcast, and broadcast.</span></div>\n    </div>\n    <div class=\"kk-mini-nav\">\n      <a href=\"#featured-work\">Featured work<span>Start with the live initiatives.</span></a>\n      <a href=\"#public-artifacts\">Public artifacts<span>Portals, talks, and reusable resources.</span></a>\n      <a href=\"#archive-highlights\">Archive highlights<span>The photo-heavy backstory.</span></a>\n      <a href=\"/contact/\">Start something<span>Bring me into the room.</span></a>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"featured-work\">\n    <h2>Featured work</h2>\n    <p class=\"kk-section-intro\">The center of gravity right now: a province-wide AI ecosystem, a brand-new responsible-AI certification, and hands-on training that helps teams build real confidence without flattening the weird human parts.</p>\n    <div class=\"kk-feature-grid\">\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1\" alt=\"BC AI ecosystem network graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Ecosystem</span>\n          <h3><a href=\"https://bc-ai.ca/\">BC + AI Ecosystem</a></h3>\n          <p>A province-wide community and industry association for responsible, inclusive, place-rooted AI in British Columbia.</p>\n        </div>\n      </article>\n      <div class=\"kk-stack\">\n        <article class=\"kk-card\">\n          <img src=\"https://kriskrug.co/wp-content/uploads/2026/05/rap-why-we-built-cover.png\" alt=\"Responsible AI Professional certification cover\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Certification</span>\n            <h3>Responsible AI Professional</h3>\n            <p>Just launched. A four-week certification that closes the gap between how fast we deploy AI and how slowly we get responsible about it — built with <strong>Martin Lopatka</strong> and <strong>Sarah Downey</strong>. Every grad ships their own ethics assistant.</p>\n            <p><a href=\"https://lu.ma/ai-ethics\">Enroll in the cohort</a></p>\n          </div>\n        </article>\n        <article class=\"kk-card\">\n          <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug speaking on stage at LaSalle College Vancouver\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Speaking</span>\n            <h3>AI Keynotes</h3>\n            <p>Talks and workshops on AI mindset, creative rebellion, human agency, archives, culture, and leadership after the point of no return.</p>\n            <p><a href=\"/speaking/\">See speaking topics</a></p>\n          </div>\n        </article>\n        <article class=\"kk-card\">\n          <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1\" alt=\"The Upgrade AI courses workshops and trainings graphic\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Training</span>\n            <h3>The Upgrade AI</h3>\n            <p>Training, workshops, and applied AI sessions for creative professionals, organizations, community builders, and leadership teams.</p>\n            <p><a href=\"/services/\">Explore services</a></p>\n          </div>\n        </article>\n      </div>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"public-artifacts\">\n    <h2>Public artifacts</h2>\n    <p class=\"kk-section-intro\">Some talks become working websites: scripts, exercises, prompts, resource libraries, and field notes that keep moving after the room empties.</p>\n    <div class=\"kk-grid\">\n      <article class=\"kk-card\">\n        <img src=\"https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03\" alt=\"Both Hands Full portal graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Synthetic media + soul</span>\n          <h3><a href=\"https://www.bothhandsfull.com/\">Both Hands Full</a></h3>\n          <p>A World AI Film Festival keynote portal for filmmakers and creative workers navigating synthetic media, authorship, taste, and responsibility.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&amp;ssl=1\" alt=\"Punk Rock AI CreativeMornings keynote artwork\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Creative rebellion</span>\n          <h3><a href=\"https://www.punkrockai.com/\">Punk Rock AI</a></h3>\n          <p>A CreativeMornings Vancouver keynote rebuilt as a maker-first portal about agency, taste, and refusing to become a content machine.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/04/AI-Immortality-w-Guy-Kawasaki.png?fit=1200%2C604&amp;ssl=1\" alt=\"Developing an AI Mindset keynote graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">AI adoption</span>\n          <h3><a href=\"http://developinganaimindset.com/\">Developing an AI Mindset</a></h3>\n          <p>A practical AI adoption resource for teams that need shared language, demos, and a humane first step into the tools.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1\" alt=\"BC plus AI ecosystem site graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Home base</span>\n          <h3><a href=\"https://kriskrug.co/\">KrisKrug.co</a></h3>\n          <p>The long-running archive, publishing engine, proof layer, and connective tissue for the work across AI, media, community, and culture.</p>\n        </div>\n      </article>\n    </div>\n  </section>\n\n  <section class=\"kk-section\">\n    <h2>How the work shows up</h2>\n    <p class=\"kk-section-intro\">Same operating system, different surfaces: stages, training rooms, associations, media systems, and fieldwork.</p>\n    <div class=\"kk-grid\">\n      <article class=\"kk-card kk-workway\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug speaking at LaSalle College Vancouver\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>AI education and adoption</h3><p>Workshops, keynotes, demos, and custom sessions that help people build confidence without flattening the ethical and creative questions.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug hosting a Vancouver AI Community Meetup\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Community infrastructure</h3><p>Convening, association-building, sponsorship, event design, and systems that help networks become durable instead of merely loud.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20067931301_e7a16b6f2c_k-1.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug backstage with Malcolm Gladwell\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Photography and media</h3><p>Decades of documentary, conference, portrait, festival, and movement storytelling across technology, culture, and social change.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Daryl Hannah at COP15 in Copenhagen\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Social impact and culture</h3><p>Work spanning Indigenous-led community projects, youth media, climate gatherings, UN convenings, documentary fieldwork, and civic technology.</p></div>\n      </article>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"archive-highlights\">\n    <h2>Archive highlights</h2>\n    <p class=\"kk-section-intro\">The back catalog matters. It shows the pattern: cameras, communities, weird rooms, culture, civic technology, and enough miles on the road to know when an idea is real.</p>\n    <div class=\"kk-archive\">\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5637672371_fca291d598_o-1.jpg?w=800&amp;ssl=1\" alt=\"Kris Krug presenting at the UN Global Youth Summit on HIV in Bamako\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">UN + youth media</span>\n          <h3>UN Global Youth Summit on HIV, Bamako</h3>\n          <p>Keynote and youth activist media mentoring work with UNAIDS in Mali, bringing online organizing and movement storytelling into a global room.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Daryl Hannah at COP15 in Copenhagen\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Climate + media</span>\n          <h3>COP15 and climate storytelling</h3>\n          <p>Hosted conversations and produced media around open culture, climate action, and digital community at major international gatherings.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/6283381617_43f79f3848_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Mikhail Gorbachev backstage at WE Day\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Backstage culture</span>\n          <h3>WE Day, conferences, and impossible rooms</h3>\n          <p>Photography and video work in rooms where politics, celebrity, activism, and youth culture all collided.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/05/9818127715_416df9a481_o.jpg?w=612&amp;ssl=1\" alt=\"Kris Krug with Jack Dorsey at University of Waterloo\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Tech culture</span>\n          <h3>Founders, networks, and the social web</h3>\n          <p>Years documenting and convening the early social internet, startup communities, conferences, and the people who shaped the platforms.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20190210_170149-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Post Malone at the Grammy Awards\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Music + culture</span>\n          <h3>Festivals, artists, and pop-cultural fieldwork</h3>\n          <p>From Grammys corridors to festival fields, the work has always followed the living edge of culture.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/PopTech-2013-Camden-Maine-USA-PopTech_10460205104_o.jpg?w=640&amp;ssl=1\" alt=\"Kris Krug with skateboarder Rodney Mullen at PopTech\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Ideas festivals</span>\n          <h3>PopTech, SXSW, TEDx, and idea circuits</h3>\n          <p>Speaking, hosting, photographing, and learning inside the strange, generative spaces where culture and technology cross-pollinate.</p>\n        </div>\n      </article>\n    </div>\n    <div class=\"kk-link-row\">\n      <a href=\"/about/\">More backstory</a>\n      <a href=\"/speaking/\">Speaking archive</a>\n      <a href=\"/blog/\">Writing</a>\n      <a href=\"/contact/\">Start a project</a>\n    </div>\n  </section>\n\n  <section class=\"kk-section\">\n    <div class=\"kk-callout\">\n      <h2>Need a speaker, strategist, trainer, or weirdly useful AI collaborator?</h2>\n      <p>Start with the lane that fits: keynotes for rooms that need energy and clarity, services for teams that need applied help, or contact if the project is odd and alive and probably worth a conversation.</p>\n      <div class=\"kk-actions\">\n        <a class=\"kk-button\" href=\"/speaking/\">Speaking</a>\n        <a class=\"kk-button secondary\" href=\"/services/\">Services</a>\n        <a class=\"kk-button secondary\" href=\"/contact/\">Contact</a>\n      </div>\n    </div>\n  </section>\n</div>\n<!-- /wp:html -->\n",
+    "rendered": "\n<style>\n.kk-overhaul { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); }\n.kk-overhaul a { font-weight:700; }\n.kk-hero { padding:1.35rem 0 1.4rem; border-bottom:1px solid var(--kk-line); }\n.kk-kicker { margin:0 0 .5rem; text-transform:uppercase; letter-spacing:.08em; font-size:.78rem; color:var(--kk-hot); font-weight:800; }\n.kk-display { margin:.15rem 0 .75rem; font-size:1.9rem; line-height:1.18; max-width:54rem; }\n.kk-lead { font-size:1.14rem; line-height:1.65; max-width:54rem; }\n.kk-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.25rem 0; }\n.kk-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }\n.kk-button.secondary { background:#fff; color:var(--kk-ink) !important; }\n.kk-section { padding:2rem 0; border-bottom:1px solid var(--kk-line); }\n.kk-section-intro { max-width:54rem; margin-bottom:1rem; color:var(--kk-muted); }\n.kk-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(235px,1fr)); gap:1rem; }\n.kk-card { border:1px solid var(--kk-line); border-radius:6px; background:var(--kk-card); overflow:hidden; }\n.kk-card img { display:block; width:100%; aspect-ratio:16/9; object-fit:cover; background:#eee; }\n.kk-card-body { padding:1rem; }\n.kk-card h3 { margin-top:0; margin-bottom:.4rem; font-size:1.12rem; }\n.kk-card p { margin:.45rem 0; color:var(--kk-muted); }\n.kk-tag { display:inline-block; margin:0 0 .55rem; color:var(--kk-hot); font-size:.72rem; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }\n.kk-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }\n.kk-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); gap:.75rem; margin-top:1rem; }\n.kk-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }\n.kk-proof strong { display:block; font-size:1.35rem; line-height:1.1; }\n.kk-proof span { display:block; color:var(--kk-muted); margin-top:.25rem; }\n.kk-archive { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:1rem; }\n.kk-archive .kk-card img { aspect-ratio:4/3; }\n.kk-archive .kk-card:nth-child(1) { grid-column:span 2; }\n.kk-archive .kk-card:nth-child(1) img { aspect-ratio:16/9; }\n.kk-link-row { display:flex; flex-wrap:wrap; gap:.55rem; margin-top:.75rem; }\n.kk-link-row a { border:1px solid var(--kk-line); border-radius:999px; padding:.28rem .62rem; text-decoration:none; background:#fff; }\n.kk-feature-grid { display:grid; grid-template-columns:minmax(0,1.15fr) minmax(260px,.85fr); gap:1rem; align-items:stretch; }\n.kk-feature-grid .kk-card:first-child img { aspect-ratio:16/10; }\n.kk-stack { display:grid; gap:1rem; }\n.kk-mini-nav { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:.75rem; margin:1.25rem 0 0; }\n.kk-mini-nav a { display:block; border:1px solid var(--kk-line); border-radius:6px; padding:.8rem; background:#fff; text-decoration:none; }\n.kk-mini-nav span { display:block; color:var(--kk-muted); font-weight:400; margin-top:.2rem; }\n.kk-workway img { aspect-ratio:5/3; }\n@media (max-width:760px){ .kk-display{font-size:1.45rem;} .kk-actions{display:block;} .kk-actions a{margin:.35rem 0;} .kk-archive .kk-card:nth-child(1){grid-column:auto;} }\n@media (max-width:860px){ .kk-feature-grid{grid-template-columns:1fr;} }\n</style>\n\n<div class=\"kk-overhaul\">\n  <section class=\"kk-hero\">\n    <p class=\"kk-kicker\">Current work, living systems, and useful experiments</p>\n    <h2 class=\"kk-display\">A portfolio of AI culture, community infrastructure, keynote systems, and long-haul visual storytelling.</h2>\n    <p class=\"kk-lead\">I build things that help people meet the future without losing the plot: public AI communities, practical training, talks that become reusable portals, and story systems that make technology feel human again.</p>\n    <div class=\"kk-actions\">\n      <a class=\"kk-button\" href=\"/speaking/\">Book a keynote</a>\n      <a class=\"kk-button secondary\" href=\"/services/\">Work with me</a>\n    </div>\n    <div class=\"kk-proof\">\n      <div><strong>AI + culture</strong><span>Keynotes, workshops, and field notes.</span></div>\n      <div><strong>Community</strong><span>BC+AI, meetups, associations, and convening.</span></div>\n      <div><strong>Media</strong><span>Photography, documentary, podcast, and broadcast.</span></div>\n    </div>\n    <div class=\"kk-mini-nav\">\n      <a href=\"#featured-work\">Featured work<span>Start with the live initiatives.</span></a>\n      <a href=\"#public-artifacts\">Public artifacts<span>Portals, talks, and reusable resources.</span></a>\n      <a href=\"#archive-highlights\">Archive highlights<span>The photo-heavy backstory.</span></a>\n      <a href=\"/contact/\">Start something<span>Bring me into the room.</span></a>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"featured-work\">\n    <h2>Featured work</h2>\n    <p class=\"kk-section-intro\">The center of gravity right now: a province-wide AI ecosystem, a brand-new responsible-AI certification, and hands-on training that helps teams build real confidence without flattening the weird human parts.</p>\n    <div class=\"kk-feature-grid\">\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1\" alt=\"BC AI ecosystem network graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Ecosystem</span>\n          <h3><a href=\"https://bc-ai.ca/\">BC + AI Ecosystem</a></h3>\n          <p>A province-wide community and industry association for responsible, inclusive, place-rooted AI in British Columbia.</p>\n        </div>\n      </article>\n      <div class=\"kk-stack\">\n        <article class=\"kk-card\">\n          <img data-recalc-dims=\"1\" decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/rap-why-we-built-cover.png?ssl=1\" alt=\"Responsible AI Professional certification cover\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Certification</span>\n            <h3>Responsible AI Professional</h3>\n            <p>Just launched. A four-week certification that closes the gap between how fast we deploy AI and how slowly we get responsible about it — built with <strong>Martin Lopatka</strong> and <strong>Sarah Downey</strong>. Every grad ships their own ethics assistant.</p>\n            <p><a href=\"https://lu.ma/ai-ethics\">Enroll in the cohort</a></p>\n          </div>\n        </article>\n        <article class=\"kk-card\">\n          <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug speaking on stage at LaSalle College Vancouver\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Speaking</span>\n            <h3>AI Keynotes</h3>\n            <p>Talks and workshops on AI mindset, creative rebellion, human agency, archives, culture, and leadership after the point of no return.</p>\n            <p><a href=\"/speaking/\">See speaking topics</a></p>\n          </div>\n        </article>\n        <article class=\"kk-card\">\n          <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1\" alt=\"The Upgrade AI courses workshops and trainings graphic\" loading=\"lazy\" />\n          <div class=\"kk-card-body\">\n            <span class=\"kk-tag\">Training</span>\n            <h3>The Upgrade AI</h3>\n            <p>Training, workshops, and applied AI sessions for creative professionals, organizations, community builders, and leadership teams.</p>\n            <p><a href=\"/services/\">Explore services</a></p>\n          </div>\n        </article>\n      </div>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"public-artifacts\">\n    <h2>Public artifacts</h2>\n    <p class=\"kk-section-intro\">Some talks become working websites: scripts, exercises, prompts, resource libraries, and field notes that keep moving after the room empties.</p>\n    <div class=\"kk-grid\">\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03\" alt=\"Both Hands Full portal graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Synthetic media + soul</span>\n          <h3><a href=\"https://www.bothhandsfull.com/\">Both Hands Full</a></h3>\n          <p>A World AI Film Festival keynote portal for filmmakers and creative workers navigating synthetic media, authorship, taste, and responsibility.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&amp;ssl=1\" alt=\"Punk Rock AI CreativeMornings keynote artwork\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Creative rebellion</span>\n          <h3><a href=\"https://www.punkrockai.com/\">Punk Rock AI</a></h3>\n          <p>A CreativeMornings Vancouver keynote rebuilt as a maker-first portal about agency, taste, and refusing to become a content machine.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/04/AI-Immortality-w-Guy-Kawasaki.png?fit=1200%2C604&amp;ssl=1\" alt=\"Developing an AI Mindset keynote graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">AI adoption</span>\n          <h3><a href=\"http://developinganaimindset.com/\">Developing an AI Mindset</a></h3>\n          <p>A practical AI adoption resource for teams that need shared language, demos, and a humane first step into the tools.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1\" alt=\"BC plus AI ecosystem site graphic\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Home base</span>\n          <h3><a href=\"https://kriskrug.co/\">KrisKrug.co</a></h3>\n          <p>The long-running archive, publishing engine, proof layer, and connective tissue for the work across AI, media, community, and culture.</p>\n        </div>\n      </article>\n    </div>\n  </section>\n\n  <section class=\"kk-section\">\n    <h2>How the work shows up</h2>\n    <p class=\"kk-section-intro\">Same operating system, different surfaces: stages, training rooms, associations, media systems, and fieldwork.</p>\n    <div class=\"kk-grid\">\n      <article class=\"kk-card kk-workway\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-10-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug speaking at LaSalle College Vancouver\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>AI education and adoption</h3><p>Workshops, keynotes, demos, and custom sessions that help people build confidence without flattening the ethical and creative questions.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug hosting a Vancouver AI Community Meetup\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Community infrastructure</h3><p>Convening, association-building, sponsorship, event design, and systems that help networks become durable instead of merely loud.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20067931301_e7a16b6f2c_k-1.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug backstage with Malcolm Gladwell\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Photography and media</h3><p>Decades of documentary, conference, portrait, festival, and movement storytelling across technology, culture, and social change.</p></div>\n      </article>\n      <article class=\"kk-card kk-workway\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Daryl Hannah at COP15 in Copenhagen\" loading=\"lazy\" />\n        <div class=\"kk-card-body\"><h3>Social impact and culture</h3><p>Work spanning Indigenous-led community projects, youth media, climate gatherings, UN convenings, documentary fieldwork, and civic technology.</p></div>\n      </article>\n    </div>\n  </section>\n\n  <section class=\"kk-section\" id=\"archive-highlights\">\n    <h2>Archive highlights</h2>\n    <p class=\"kk-section-intro\">The back catalog matters. It shows the pattern: cameras, communities, weird rooms, culture, civic technology, and enough miles on the road to know when an idea is real.</p>\n    <div class=\"kk-archive\">\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5637672371_fca291d598_o-1.jpg?w=800&amp;ssl=1\" alt=\"Kris Krug presenting at the UN Global Youth Summit on HIV in Bamako\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">UN + youth media</span>\n          <h3>UN Global Youth Summit on HIV, Bamako</h3>\n          <p>Keynote and youth activist media mentoring work with UNAIDS in Mali, bringing online organizing and movement storytelling into a global room.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Daryl Hannah at COP15 in Copenhagen\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Climate + media</span>\n          <h3>COP15 and climate storytelling</h3>\n          <p>Hosted conversations and produced media around open culture, climate action, and digital community at major international gatherings.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/6283381617_43f79f3848_o.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Mikhail Gorbachev backstage at WE Day\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Backstage culture</span>\n          <h3>WE Day, conferences, and impossible rooms</h3>\n          <p>Photography and video work in rooms where politics, celebrity, activism, and youth culture all collided.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/05/9818127715_416df9a481_o.jpg?w=612&amp;ssl=1\" alt=\"Kris Krug with Jack Dorsey at University of Waterloo\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Tech culture</span>\n          <h3>Founders, networks, and the social web</h3>\n          <p>Years documenting and convening the early social internet, startup communities, conferences, and the people who shaped the platforms.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20190210_170149-scaled.jpg?w=1200&amp;ssl=1\" alt=\"Kris Krug with Post Malone at the Grammy Awards\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Music + culture</span>\n          <h3>Festivals, artists, and pop-cultural fieldwork</h3>\n          <p>From Grammys corridors to festival fields, the work has always followed the living edge of culture.</p>\n        </div>\n      </article>\n      <article class=\"kk-card\">\n        <img decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/PopTech-2013-Camden-Maine-USA-PopTech_10460205104_o.jpg?w=640&amp;ssl=1\" alt=\"Kris Krug with skateboarder Rodney Mullen at PopTech\" loading=\"lazy\" />\n        <div class=\"kk-card-body\">\n          <span class=\"kk-tag\">Ideas festivals</span>\n          <h3>PopTech, SXSW, TEDx, and idea circuits</h3>\n          <p>Speaking, hosting, photographing, and learning inside the strange, generative spaces where culture and technology cross-pollinate.</p>\n        </div>\n      </article>\n    </div>\n    <div class=\"kk-link-row\">\n      <a href=\"/about/\">More backstory</a>\n      <a href=\"/speaking/\">Speaking archive</a>\n      <a href=\"/blog/\">Writing</a>\n      <a href=\"/contact/\">Start a project</a>\n    </div>\n  </section>\n\n  <section class=\"kk-section\">\n    <div class=\"kk-callout\">\n      <h2>Need a speaker, strategist, trainer, or weirdly useful AI collaborator?</h2>\n      <p>Start with the lane that fits: keynotes for rooms that need energy and clarity, services for teams that need applied help, or contact if the project is odd and alive and probably worth a conversation.</p>\n      <div class=\"kk-actions\">\n        <a class=\"kk-button\" href=\"/speaking/\">Speaking</a>\n        <a class=\"kk-button secondary\" href=\"/services/\">Services</a>\n        <a class=\"kk-button secondary\" href=\"/contact/\">Contact</a>\n      </div>\n    </div>\n  </section>\n</div>\n\n",
+    "protected": false,
+    "block_version": 1
+  },
+  "excerpt": {
+    "raw": "",
+    "rendered": "<p>Current work, living systems, and useful experiments A portfolio of AI culture, community infrastructure, keynote systems, and long-haul visual storytelling. I build things that help people meet the future without losing the plot: public AI communities, practical training, talks that become reusable portals, and story systems that make technology feel human again. Book a keynote [&hellip;]</p>\n",
+    "protected": false
+  },
+  "author": 18,
+  "featured_media": 0,
+  "parent": 0,
+  "menu_order": 0,
+  "comment_status": "closed",
+  "ping_status": "closed",
+  "template": "",
+  "meta": {
+    "advanced_seo_description": "Explore Kris Krüg's work across BC+AI, AI keynotes, community infrastructure, creative technology, training, and visual storytelling.",
+    "jetpack_seo_html_title": "Work | Kris Krüg",
+    "jetpack_seo_noindex": false,
+    "footnotes": ""
+  },
+  "permalink_template": "https://kriskrug.co/%pagename%/",
+  "generated_slug": "work",
+  "class_list": [
+    "post-2672",
+    "page",
+    "type-page",
+    "status-publish",
+    "hentry"
+  ],
+  "jetpack_sharing_enabled": true,
+  "jetpack_shortlink": "https://wp.me/PaMVFO-H6",
+  "jetpack-related-posts": [
+    {
+      "id": 11914,
+      "url": "https://kriskrug.co/responsible-ai-professional/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 0
+      },
+      "title": "Responsible AI Professional Certification",
+      "author": "Krüg",
+      "date": "May 23, 2026",
+      "format": false,
+      "excerpt": "Responsible AI Professional Everyone’s shipping AI fast. Almost nobody’s doing it responsibly. This fixes that. RAP is a four-week certification that closes the gap between how fast we deploy AI and how slowly we get responsible about it. Built by BC + AI with The Upgrade — cohort-based, framework-driven, and…",
+      "rel": "",
+      "context": "Similar post",
+      "block_context": {
+        "text": "Similar post",
+        "link": ""
+      },
+      "img": {
+        "alt_text": "",
+        "src": "",
+        "width": 0,
+        "height": 0
+      },
+      "classes": []
+    },
+    {
+      "id": 3609,
+      "url": "https://kriskrug.co/podcast-guesting-page-epk/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 1
+      },
+      "title": "Podcast Guest, AI Commentator, Event Host",
+      "author": "Krüg",
+      "date": "November 3, 2023",
+      "format": false,
+      "excerpt": "Podcasts, broadcast, produced interviews, panels, hosting Bring me in when your audience needs AI to sound human, useful, and alive. I am an AI keynote speaker, creative technologist, photographer, community builder, podcast guest, broadcast commentator, host, moderator, and emcee. I help audiences understand generative AI without sanding off the weird,…",
+      "rel": "",
+      "context": "Similar post",
+      "block_context": {
+        "text": "Similar post",
+        "link": ""
+      },
+      "img": {
+        "alt_text": "",
+        "src": "",
+        "width": 0,
+        "height": 0
+      },
+      "classes": []
+    },
+    {
+      "id": 1887,
+      "url": "https://kriskrug.co/speaking/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 2
+      },
+      "title": "AI Keynote Speaker Kris Krüg",
+      "author": "Kris Krüg",
+      "date": "February 1, 2011",
+      "format": false,
+      "excerpt": "AI keynotes, workshops, and culture-shifting rooms I help audiences meet AI with courage, taste, and usable imagination. I am an AI keynote speaker, creative technologist, photographer, and community builder. My talks mix live demos, field stories, creative rebellion, practical workflows, and the hard questions about power, taste, trust, memory, and…",
+      "rel": "",
+      "context": "Similar post",
+      "block_context": {
+        "text": "Similar post",
+        "link": ""
+      },
+      "img": {
+        "alt_text": "",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5156893053_e4e246abb4_k.jpg?fit=1200%2C800&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5156893053_e4e246abb4_k.jpg?fit=1200%2C800&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5156893053_e4e246abb4_k.jpg?fit=1200%2C800&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5156893053_e4e246abb4_k.jpg?fit=1200%2C800&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/5156893053_e4e246abb4_k.jpg?fit=1200%2C800&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 1208,
+      "url": "https://kriskrug.co/about/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 3
+      },
+      "title": "About Kris Krüg",
+      "author": "Kris Krüg",
+      "date": "April 10, 2007",
+      "format": false,
+      "excerpt": "My name is Kris Krug – a boundary-pushing Creative Explorer, an intuitive Tech Whisperer, and a tenacious Culture Hacker. In the fabric of the digital era, where technology often overshadows humanity, I've taken it upon myself to chart a different course. I’m on a relentless mission to humanize technology, to…",
+      "rel": "",
+      "context": "In \"Misc\"",
+      "block_context": {
+        "text": "Misc",
+        "link": "https://kriskrug.co/tag/misc/"
+      },
+      "img": {
+        "alt_text": "",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/Copy-of-landback-scaled.jpg?fit=1200%2C450&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/Copy-of-landback-scaled.jpg?fit=1200%2C450&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/Copy-of-landback-scaled.jpg?fit=1200%2C450&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/Copy-of-landback-scaled.jpg?fit=1200%2C450&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/Copy-of-landback-scaled.jpg?fit=1200%2C450&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 1895,
+      "url": "https://kriskrug.co/publications/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 4
+      },
+      "title": "Publications",
+      "author": "Kris Krüg",
+      "date": "February 1, 2011",
+      "format": false,
+      "excerpt": "Publications, interviews, citations, and source trail The public record behind the rooms, photos, essays, interviews, and weird internet artifacts. This page restores the useful part of the old Publications archive: the links, media appearances, and publication trail that show how the work has moved through journalism, technology, culture, activism, and…",
+      "rel": "",
+      "context": "Similar post",
+      "block_context": {
+        "text": "Similar post",
+        "link": ""
+      },
+      "img": {
+        "alt_text": "",
+        "src": "",
+        "width": 0,
+        "height": 0
+      },
+      "classes": []
+    },
+    {
+      "id": 2666,
+      "url": "https://kriskrug.co/generative-ai-services/",
+      "url_meta": {
+        "origin": 2672,
+        "position": 5
+      },
+      "title": "Generative AI Creative Services &amp; Strategy",
+      "author": "Krüg",
+      "date": "July 7, 2023",
+      "format": false,
+      "excerpt": "AI strategy, training, community, and keynote work Build AI capacity that serves people, communities, and culture. I help organizations move from AI pressure to practical fluency: responsible strategy, community systems, custom training, Indigenous-tech advisory, and talks that make complicated technology feel usable without sanding off the weird, human, and political…",
+      "rel": "",
+      "context": "Similar post",
+      "block_context": {
+        "text": "Similar post",
+        "link": ""
+      },
+      "img": {
+        "alt_text": "Empowering Events & Organizations for the AI Age",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/image-2.png?fit=1200%2C416&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/image-2.png?fit=1200%2C416&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/image-2.png?fit=1200%2C416&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/image-2.png?fit=1200%2C416&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/11/image-2.png?fit=1200%2C416&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    }
+  ],
+  "jetpack_likes_enabled": true,
+  "_links": {
+    "self": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages/2672",
+        "targetHints": {
+          "allow": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
+        }
+      }
+    ],
+    "collection": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages"
+      }
+    ],
+    "about": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/types/page"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/users/18"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/comments?post=2672"
+      }
+    ],
+    "version-history": [
+      {
+        "count": 0,
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages/2672/revisions"
+      }
+    ],
+    "wp:attachment": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/media?parent=2672"
+      }
+    ],
+    "wp:action-publish": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages/2672"
+      }
+    ],
+    "wp:action-unfiltered-html": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages/2672"
+      }
+    ],
+    "wp:action-assign-author": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/pages/2672"
+      }
+    ],
+    "curies": [
+      {
+        "name": "wp",
+        "href": "https://api.w.org/{rel}",
+        "templated": true
+      }
+    ]
+  }
+}

--- a/content/source-packs/keynotes-2026/wp-payloads/work.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/work.html
@@ -52,6 +52,8 @@
 .kk-card h3 { margin:0 0 .4rem; font-size:1.1rem; line-height:1.25; color:var(--kk-ink-2); }
 .kk-card h3 a { color:var(--kk-ink-2); }
 .kk-card p { margin:.4rem 0 0; color:var(--kk-muted); font-size:.96rem; line-height:1.5; }
+.kk-proof-meta { display:flex; flex-wrap:wrap; gap:.35rem; margin-top:.85rem; }
+.kk-proof-meta span { border:1px solid var(--kk-line); background:var(--kk-paper); border-radius:999px; padding:.26rem .55rem; color:var(--kk-ink); font-size:.76rem; line-height:1.25; font-weight:700; }
 
 .kk-photo-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:1.1rem; }
 
@@ -141,6 +143,12 @@
           <span class="kk-tag">Ecosystem</span>
           <h3><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></h3>
           <p>A province-wide community and industry association for responsible, inclusive, place-rooted AI in British Columbia.</p>
+          <div class="kk-proof-meta" aria-label="BC + AI proof metadata">
+            <span>Role: Executive Director</span>
+            <span>Year: 2026</span>
+            <span>Community: Vancouver AI and BC + AI</span>
+            <span>Outcome: regional AI convening</span>
+          </div>
         </div>
       </article>
       <div class="kk-stack">
@@ -150,6 +158,12 @@
             <span class="kk-tag">Certification</span>
             <h3>Responsible AI Professional</h3>
             <p>Just launched. A four-week certification that closes the gap between how fast we deploy AI and how slowly we get responsible about it — built with <strong>Martin Lopatka</strong> and <strong>Sarah Downey</strong>. Every grad ships their own ethics assistant.</p>
+            <div class="kk-proof-meta" aria-label="Responsible AI Professional proof metadata">
+              <span>Role: Co-builder</span>
+              <span>Year: 2026</span>
+              <span>Artifact: certification cohort</span>
+              <span>Outcome: ethics assistant</span>
+            </div>
             <p><a href="https://lu.ma/ai-ethics">Enroll in the cohort</a></p>
           </div>
         </article>
@@ -159,7 +173,27 @@
             <span class="kk-tag">Speaking</span>
             <h3>AI Keynotes</h3>
             <p>Talks and workshops on AI mindset, creative rebellion, human agency, archives, culture, and leadership after the point of no return.</p>
+            <div class="kk-proof-meta" aria-label="AI keynotes proof metadata">
+              <span>Role: Keynote speaker</span>
+              <span>Year: 2026</span>
+              <span>Community: creative workers</span>
+              <span>Artifact: speaking page</span>
+            </div>
             <p><a href="/speaking/">See speaking topics</a></p>
+          </div>
+        </article>
+        <article class="kk-card">
+          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&amp;ssl=1" alt="Indigenomics AI visual from Kris Krug's public writing" loading="lazy" />
+          <div class="kk-card-body">
+            <span class="kk-tag">Indigenous tech</span>
+            <h3><a href="https://indigenomics.ai/">Indigenomics.ai</a></h3>
+            <p>CTO work supporting Indigenous economic sovereignty, data governance, and tools grounded in the Indigenomics framework.</p>
+            <div class="kk-proof-meta" aria-label="Indigenomics.ai proof metadata">
+              <span>Role: CTO</span>
+              <span>Year: 2026</span>
+              <span>Community: Indigenous economy</span>
+              <span>Outcome: sovereignty tooling</span>
+            </div>
           </div>
         </article>
         <article class="kk-card">
@@ -168,6 +202,12 @@
             <span class="kk-tag">Training</span>
             <h3>The Upgrade AI</h3>
             <p>Training, workshops, and applied AI sessions for creative professionals, organizations, community builders, and leadership teams.</p>
+            <div class="kk-proof-meta" aria-label="The Upgrade AI proof metadata">
+              <span>Role: Co-founder</span>
+              <span>Year: 2026</span>
+              <span>Community: creative teams</span>
+              <span>Outcome: applied AI training</span>
+            </div>
             <p><a href="/services/">Explore services</a></p>
           </div>
         </article>
@@ -185,6 +225,12 @@
           <span class="kk-tag">Synthetic media + soul</span>
           <h3><a href="https://www.bothhandsfull.com/">Both Hands Full</a></h3>
           <p>A World AI Film Festival keynote portal for filmmakers and creative workers navigating synthetic media, authorship, taste, and responsibility.</p>
+          <div class="kk-proof-meta" aria-label="Both Hands Full proof metadata">
+            <span>Role: Keynote author</span>
+            <span>Year: 2026</span>
+            <span>Community: film and creative workers</span>
+            <span>Artifact: keynote portal</span>
+          </div>
         </div>
       </article>
       <article class="kk-card">
@@ -224,11 +270,11 @@
       </article>
       <article class="kk-card kk-workway">
         <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?w=1200&amp;ssl=1" alt="Kris Krug hosting a Vancouver AI Community Meetup" loading="lazy" />
-        <div class="kk-card-body"><h3>Community infrastructure</h3><p>Convening, association-building, sponsorship, event design, and systems that help networks become durable instead of merely loud.</p></div>
+        <div class="kk-card-body"><h3>Vancouver AI and community infrastructure</h3><p>Convening, association-building, sponsorship, event design, and systems that help networks become durable instead of merely loud.</p><div class="kk-proof-meta" aria-label="Vancouver AI proof metadata"><span>Role: Convenor</span><span>Year: 2024-2026</span><span>Community: Vancouver AI</span><span>Outcome: durable network</span></div></div>
       </article>
       <article class="kk-card kk-workway">
         <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20067931301_e7a16b6f2c_k-1.jpg?w=1200&amp;ssl=1" alt="Kris Krug backstage with Malcolm Gladwell" loading="lazy" />
-        <div class="kk-card-body"><h3>Photography and media</h3><p>Decades of documentary, conference, portrait, festival, and movement storytelling across technology, culture, and social change.</p></div>
+        <div class="kk-card-body"><h3>Photography and media</h3><p>Decades of documentary, conference, portrait, festival, and movement storytelling across technology, culture, and social change.</p><div class="kk-proof-meta" aria-label="Photography proof metadata"><span>Role: Photographer</span><span>Year: 2005-2026</span><span>Artifact: visual archive</span><span>Outcome: cultural documentation</span></div></div>
       </article>
       <article class="kk-card kk-workway">
         <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/4190423843_069037fecb_o.jpg?w=1200&amp;ssl=1" alt="Kris Krug with Daryl Hannah at COP15 in Copenhagen" loading="lazy" />

--- a/docs/current-state/WORK-PAGE-METADATA-68-2026-06-04.md
+++ b/docs/current-state/WORK-PAGE-METADATA-68-2026-06-04.md
@@ -1,0 +1,62 @@
+# Work Page Metadata #68 Closeout - 2026-06-04
+
+## Scope
+
+Track A content/SEO closeout for GitHub issue #68, "[CONTENT] Polish Work page canonical, OG, and proof metadata."
+
+No Aurora theme files were edited.
+
+## Rollback
+
+Authenticated WordPress REST snapshot saved before the live write:
+
+- `backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.json`
+- `backup/20260604-work-page-68/page-snapshots/page-2672-work-before-proof-metadata.html`
+- SHA256: `db1f9ceec9a308e29f6d4bb525e99740e3e9a4c9041bad52759ae151ca79cf61`
+
+## Live Update
+
+Updated WordPress page `2672` via REST:
+
+- status remained `publish`
+- slug remained `recent-projects-include`
+- title remained `Work`
+- excerpt/meta description set to `Explore Kris Krüg's work across BC+AI, AI keynotes, community infrastructure, creative technology, training, and visual storytelling.`
+- SEO title remained `Work | Kris Krüg`
+- `jetpack_seo_noindex` remained `false`
+
+Body additions:
+
+- added proof metadata chips for role, year, community, artifact, and outcome where available
+- added a visible Indigenomics.ai card using supportable CTO/sovereignty/data-governance framing
+- changed the community card heading to include `Vancouver AI`
+- kept canonical page URL as `/recent-projects-include/`, matching the existing redirect strategy
+
+## Verification
+
+Authenticated readback after update:
+
+- `id`: `2672`
+- `status`: `publish`
+- `slug`: `recent-projects-include`
+- `excerpt_raw`: planned meta description
+- `advanced_seo_description`: planned meta description
+- `jetpack_seo_html_title`: `Work | Kris Krüg`
+- body markers present: `Indigenomics.ai`, `Role: CTO`, `Role: Executive Director`, `Role: Co-founder`, `Vancouver AI and community infrastructure`, `Role: Photographer`, `Both Hands Full proof metadata`, `Outcome: applied AI training`
+
+Public cache-busted checks:
+
+- `https://kriskrug.co/recent-projects-include/?proof=68-20260604` returned `200`
+- `https://kriskrug.co/work/?proof=68-20260604` resolved to `https://kriskrug.co/recent-projects-include/?proof=68-20260604`
+- `https://kriskrug.co/projects/?proof=68-20260604` resolved to `https://kriskrug.co/recent-projects-include/`
+- title: `Work | Kris Krüg`
+- canonical: `https://kriskrug.co/recent-projects-include/`
+- `og:url`: `https://kriskrug.co/recent-projects-include/`
+- description: planned meta description
+- `og:image`: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&ssl=1`
+- visible markers present on canonical and aliases: `Indigenomics.ai`, `Role: CTO`, `Role: Executive Director`, `Role: Co-founder`, `Vancouver AI and community infrastructure`, `Role: Photographer`, `Both Hands Full`, `Outcome: applied AI training`
+
+Redirect header checks:
+
+- `/work/?proof=68-headers`: `301`, `x-redirect-by: redirection`, `location: /recent-projects-include/?proof=68-headers`
+- `/projects/?proof=68-headers`: `301`, `x-redirect-by: KK Hotfix`, `location: https://kriskrug.co/recent-projects-include/`

--- a/docs/current-state/reports/morning-truth-20260604-055806Z.md
+++ b/docs/current-state/reports/morning-truth-20260604-055806Z.md
@@ -1,0 +1,494 @@
+# Morning Truth Report - 2026-06-04 05:58:06 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `1`
+- Open issues: `65`
+- WordPress version (smoke): `6.9.4`
+- Draft queue: future posts `0`, draft posts `71`, draft pages `5`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `yes`
+
+## Issue Label Signals
+
+- `priority:high`: `25`
+- `aurora-v2`: `18`
+- `track-b`: `13`
+- `swarm-ready`: `13`
+- `swarm-parked`: `13`
+- `needs-human-review`: `4`
+- `auto-implement`: `43`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 1 | YES |
+| Open Issues | 66 | 65 | YES |
+| WordPress Version | 6.9.4 | 6.9.4 | no |
+| Scheduled Posts | 0 | 0 | no |
+| Draft Posts | 71 | 71 | no |
+| Draft Pages | 5 | 5 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` vs `origin/aurora/v2`: `50	38`
+- Local `aurora/v2` status: `## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip`
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## codex/work-page-metadata-68...origin/main
+ M content/source-packs/keynotes-2026/wp-payloads/work.html
+?? backup/20260604-work-page-68/
+?? docs/current-state/WORK-PAGE-METADATA-68-2026-06-04.md
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+45f1863 theme: polish article and writing surfaces
+e7fa867 docs: close aurora logo deploy
+3ce45a2 docs: record aurora logo closeout
+8530a10 theme: add Aurora header wordmark
+a4bc9f4 docs: clarify Aurora side worktree status
+d6a449c docs: refresh track a restart truth
+80a1ebc ops: close out mcp shutdown handoff
+35d5efb Merge pull request #144 from WalksWithASwagger/codex/142-align-aurora-docs
+0126946 docs: align Aurora branch model
+740ec6d Merge pull request #143 from WalksWithASwagger/codex/track-a-swarm-safety-75-95-128
+0d8d548 ops: harden track a swarm safety checks
+74655d4 Merge pull request #141 from WalksWithASwagger/codex/cotton-draft-image-link-polish
+856a1b5 Merge pull request #140 from WalksWithASwagger/codex/aurora-font-404-cleanup-137
+4813890 content: polish cotton draft media
+0eb63ae theme: remove stale font asset URLs
+4aa6b20 Merge pull request #139 from WalksWithASwagger/codex/homepage-first-screen-proof-136
+9edd1dd theme: fit homepage proof above fold
+02ab8c4 Merge pull request #138 from WalksWithASwagger/codex/homepage-role-proof-polish
+01bec58 theme: polish homepage role proof
+0c929bf Merge pull request #137 from WalksWithASwagger/codex/queue-merge-cleanup-closeout
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+```text
+147	Docs: Aurora 1.3.10 deploy audit and workplan	codex/aurora-lux-deploy-workplan	DRAFT	2026-06-04T05:53:10Z
+```
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+128	OPEN	Triage Jetpack contact-form submissions + fix notification routing	priority:high, marketing, platform, needs-human-review, swarm-parked	2026-05-29T19:01:33Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, accessibility, aurora-v2	2026-05-26T16:41:34Z
+126	OPEN	[AURORA P2] Work page OG image is blank	bug, priority:medium, seo, aurora-v2	2026-05-26T16:41:34Z
+125	OPEN	[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration	enhancement, priority:medium, performance, aurora-v2	2026-05-23T19:43:14Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+120	OPEN	[AURORA P1] Both Hands Full proof card has text/image overlap	bug, priority:medium, aurora-v2	2026-05-26T16:41:34Z
+95	OPEN	[CONTENT P0] Review media appearances draft before publish/backlinks	enhancement, priority:high, content, needs-human-review, swarm-parked	2026-05-29T19:01:33Z
+86	OPEN	[AURORA P2] Run performance and accessibility QA on real staging	bug, enhancement, priority:high, mobile, accessibility, performance, track-b, aurora-v2, swarm-ready, swarm-wave-3	2026-05-26T16:41:34Z
+75	OPEN	[P0] Lock down Notion-to-WordPress publishing after overwrite incident	bug, priority:high, needs-human-review, swarm-parked	2026-05-29T19:27:05Z
+68	OPEN	[CONTENT] Polish Work page canonical, OG, and proof metadata	enhancement, priority:high, mobile, content, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-26T16:41:34Z
+64	OPEN	[PORTAL] Unified Search Across All 6 Projects	enhancement, priority:high, platform, auto-implement, swarm-parked	2026-05-19T22:27:46Z
+63	OPEN	[PORTAL] Beautiful Constellation Navigation Design	enhancement, priority:medium, mobile, content, accessibility, ux, auto-implement, swarm-parked	2026-05-19T22:27:47Z
+62	OPEN	[PORTAL] Unified Event Calendar - Luma API Integration	enhancement, priority:high, platform, mobile, seo, auto-implement, swarm-parked	2026-05-19T22:27:48Z
+61	OPEN	[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words	enhancement, priority:high, content, auto-implement, swarm-parked	2026-05-19T22:27:45Z
+60	OPEN	[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts	enhancement, priority:medium, content, auto-implement	2026-01-03T04:10:42Z
+59	OPEN	[ARCHIVE] Create Photography Archive - Decades of Work	enhancement, priority:high, mobile, content, auto-implement	2026-01-03T04:10:44Z
+58	OPEN	[MARKETING] User-Generated Content Collection System	enhancement, priority:low, marketing, community, content, auto-implement	2026-01-03T04:08:57Z
+57	OPEN	[MARKETING] Cross-Promotion Framework with BC+AI	enhancement, priority:medium, marketing, auto-implement	2026-01-03T04:08:53Z
+56	OPEN	[MARKETING] Social Media Amplification System	enhancement, priority:medium, marketing, auto-implement, swarm-parked	2026-05-19T22:27:55Z
+55	OPEN	[MARKETING] Formalize Speaking Circuit Strategy	enhancement, priority:high, marketing, content, auto-implement	2026-01-03T04:09:05Z
+54	OPEN	[MARKETING] Create Community Advocate Program	enhancement, priority:medium, marketing, community, auto-implement, swarm-parked	2026-05-19T22:27:54Z
+53	OPEN	[MARKETING] Build Community Referral Program	enhancement, priority:medium, marketing, community, content, auto-implement, swarm-parked	2026-05-19T22:27:53Z
+52	OPEN	[MARKETING] Create Content Syndication Strategy	enhancement, priority:medium, marketing, content, auto-implement, swarm-parked	2026-05-19T22:27:52Z
+51	OPEN	[MARKETING] Implement Email Onboarding Sequences	enhancement, priority:high, marketing, auto-implement, swarm-parked	2026-05-19T22:27:50Z
+50	OPEN	[MARKETING] Launch Podcast Guesting Tour Strategy	enhancement, priority:high, marketing, auto-implement	2026-01-03T04:08:46Z
+49	OPEN	[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides	enhancement, priority:high, marketing, content, auto-implement, swarm-parked	2026-05-19T22:27:51Z
+48	OPEN	[A11Y] Create Accessibility Statement	enhancement, priority:high, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:16Z
+47	OPEN	[A11Y] Keyboard Navigation Improvements	enhancement, priority:high, content, accessibility, auto-implement	2026-01-03T04:00:49Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility, auto-implement	2026-01-03T04:00:36Z
+45	OPEN	[SEO] Add RSS Feeds for Blog Categories	enhancement, priority:low, seo, auto-implement	2026-01-03T04:00:38Z
+44	OPEN	[CONTENT] Create Glossary Page for AI Terminology	enhancement, priority:low, mobile, content, accessibility, auto-implement, swarm-ready, swarm-wave-3	2026-05-19T22:27:39Z
+43	OPEN	[SEO] Add Twitter Card Tags	enhancement, priority:medium, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:15Z
+42	OPEN	[PERFORMANCE] Implement Lazy Loading for Images	enhancement, priority:medium, mobile, performance, auto-implement	2026-01-03T04:00:36Z
+41	OPEN	[PERFORMANCE] Reduce Plugin Bloat	enhancement, priority:medium, mobile, performance, auto-implement	2026-01-03T04:00:31Z
+40	OPEN	[SEO] Optimize Images for Performance and SEO	enhancement, priority:medium, mobile, seo, performance, auto-implement	2026-01-03T04:00:34Z
+38	OPEN	[SEO] Implement Internal Linking Strategy	enhancement, priority:medium, seo, auto-implement	2026-05-19T05:44:48Z
+36	OPEN	[SEO] Add Unique Meta Descriptions	enhancement, priority:high, priority:medium, seo, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:14Z
+35	OPEN	[DESIGN] CTA Button Design System	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:58Z
+34	OPEN	[DESIGN] Hero Section Visual Treatment	enhancement, priority:high, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:57Z
+33	OPEN	[DESIGN] Mobile-First Responsive System	enhancement, priority:high, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:56Z
+32	OPEN	[DESIGN] Form Design Updates	enhancement, priority:medium, mobile, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:54Z
+31	OPEN	[DESIGN] Project Card Design Pattern	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:53Z
+30	OPEN	[DESIGN] Photography Showcase Component	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:52Z
+29	OPEN	[DESIGN] Footer Redesign	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:51Z
+28	OPEN	[DESIGN] Navigation Redesign - Modern Mobile-First	enhancement, priority:high, priority:medium, mobile, content, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:49Z
+27	OPEN	[DESIGN] Color Palette Refinement	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:48Z
+26	OPEN	[DESIGN] Typography System Update	enhancement, priority:medium, accessibility, ux, track-b, aurora-v2	2026-05-24T21:12:47Z
+25	OPEN	[DESIGN] Create Modern Component Library	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:46Z
+24	OPEN	[DESIGN] Full Homepage Redesign - Modern Full-Width Layout	enhancement, priority:medium, mobile, accessibility, ux, performance, track-b, aurora-v2	2026-05-24T21:12:44Z
+23	OPEN	[CONTENT] Reorganize Blog Categories	enhancement, priority:medium, mobile, content, needs-human-review	2026-05-18T17:09:21Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T04:08:28Z
+21	OPEN	[CONTENT] Create Photography Portfolio as Credential Section	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T04:08:30Z
+20	OPEN	[CONTENT] Update Voice/Tone to Professional but Warm	enhancement, priority:medium, content, auto-implement	2026-01-03T04:08:24Z
+19	OPEN	[CONTENT] Add Community Impact Metrics Throughout Site	enhancement, priority:medium, mobile, content, accessibility, performance, auto-implement	2026-01-03T04:08:24Z
+18	OPEN	[CONTENT] Create Vancouver AI Community Page	enhancement, priority:medium, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:30Z
+15	OPEN	[CONTENT] Create The Upgrade AI Co-Founder Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:29Z
+14	OPEN	[CONTENT] Create Indigenomics.ai CTO Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:28Z
+13	OPEN	[CONTENT] Create BC+AI Leadership Section	enhancement, priority:high, mobile, content, auto-implement, swarm-ready, swarm-wave-2	2026-05-19T22:27:27Z
+11	OPEN	[UX] Create Membership Benefits Comparison Matrix	enhancement, priority:medium, mobile, content, ux, auto-implement	2026-01-03T04:00:22Z
+10	OPEN	[UX] Add Hover States to CTA Buttons	enhancement, priority:medium, mobile, content, accessibility, ux, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:13Z
+9	OPEN	[A11Y] Fix Search Field Accessibility	bug, priority:medium, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:12Z
+8	OPEN	[A11Y] Add ARIA Labels to Icon Buttons	bug, enhancement, priority:medium, accessibility, auto-implement, swarm-ready, swarm-wave-1	2026-05-19T22:27:11Z
+7	OPEN	[CONTENT] Add Pricing Information to Services	enhancement, priority:medium, mobile, content, auto-implement	2026-01-03T03:58:41Z
+5	OPEN	[BUG] Fix Color Contrast for WCAG Compliance	bug, priority:high, accessibility, auto-implement	2026-01-03T03:58:39Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo, auto-implement	2026-01-03T04:00:19Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD 45f18635e8368b5dda4126d64e17f56299e0f6d3
+branch refs/heads/codex/work-page-metadata-68
+
+worktree /private/tmp/docs-reliability-fix-20260602/kriskrug-wp
+HEAD 7776f971380a037a6ea15ea55c754d1c0e5186b5
+branch refs/heads/codex/docs-reliability-branch-model-20260602
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-keynote
+HEAD 5a6f50364dbd76797e702d6f0326b76b66f2d885
+branch refs/heads/codex/aurora-keynote-redesign
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-reconcile
+HEAD f3c4edc04c360ee9adfc2bb6ac42ed10452b7268
+branch refs/heads/aurora/v3-reconcile
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80
+HEAD 81a62abfa2693ae41220cc5acfa21d4161100347
+branch refs/heads/aurora/v2
+locked claude agent agent-aec50fddbd7207f80 (pid 73140)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `0`
+
+```text
+18	164
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":128,"title":"Triage Jetpack contact-form submissions + fix notification routing","updatedAt":"2026-05-29T19:01:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":126,"title":"[AURORA P2] Work page OG image is blank","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":125,"title":"[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration","updatedAt":"2026-05-23T19:43:14Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":120,"title":"[AURORA P1] Both Hands Full proof card has text/image overlap","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":95,"title":"[CONTENT P0] Review media appearances draft before publish/backlinks","updatedAt":"2026-05-29T19:01:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":86,"title":"[AURORA P2] Run performance and accessibility QA on real staging","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":75,"title":"[P0] Lock down Notion-to-WordPress publishing after overwrite incident","updatedAt":"2026-05-29T19:27:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":68,"title":"[CONTENT] Polish Work page canonical, OG, and proof metadata","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":64,"title":"[PORTAL] Unified Search Across All 6 Projects","updatedAt":"2026-05-19T22:27:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":63,"title":"[PORTAL] Beautiful Constellation Navigation Design","updatedAt":"2026-05-19T22:27:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":62,"title":"[PORTAL] Unified Event Calendar - Luma API Integration","updatedAt":"2026-05-19T22:27:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":61,"title":"[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words","updatedAt":"2026-05-19T22:27:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":60,"title":"[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts","updatedAt":"2026-01-03T04:10:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":59,"title":"[ARCHIVE] Create Photography Archive - Decades of Work","updatedAt":"2026-01-03T04:10:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":58,"title":"[MARKETING] User-Generated Content Collection System","updatedAt":"2026-01-03T04:08:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":57,"title":"[MARKETING] Cross-Promotion Framework with BC+AI","updatedAt":"2026-01-03T04:08:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":56,"title":"[MARKETING] Social Media Amplification System","updatedAt":"2026-05-19T22:27:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":55,"title":"[MARKETING] Formalize Speaking Circuit Strategy","updatedAt":"2026-01-03T04:09:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":54,"title":"[MARKETING] Create Community Advocate Program","updatedAt":"2026-05-19T22:27:54Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":53,"title":"[MARKETING] Build Community Referral Program","updatedAt":"2026-05-19T22:27:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":52,"title":"[MARKETING] Create Content Syndication Strategy","updatedAt":"2026-05-19T22:27:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":51,"title":"[MARKETING] Implement Email Onboarding Sequences","updatedAt":"2026-05-19T22:27:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":50,"title":"[MARKETING] Launch Podcast Guesting Tour Strategy","updatedAt":"2026-01-03T04:08:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":49,"title":"[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides","updatedAt":"2026-05-19T22:27:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":48,"title":"[A11Y] Create Accessibility Statement","updatedAt":"2026-05-19T22:27:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":47,"title":"[A11Y] Keyboard Navigation Improvements","updatedAt":"2026-01-03T04:00:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-01-03T04:00:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":45,"title":"[SEO] Add RSS Feeds for Blog Categories","updatedAt":"2026-01-03T04:00:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":44,"title":"[CONTENT] Create Glossary Page for AI Terminology","updatedAt":"2026-05-19T22:27:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":43,"title":"[SEO] Add Twitter Card Tags","updatedAt":"2026-05-19T22:27:15Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":42,"title":"[PERFORMANCE] Implement Lazy Loading for Images","updatedAt":"2026-01-03T04:00:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":41,"title":"[PERFORMANCE] Reduce Plugin Bloat","updatedAt":"2026-01-03T04:00:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":40,"title":"[SEO] Optimize Images for Performance and SEO","updatedAt":"2026-01-03T04:00:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":38,"title":"[SEO] Implement Internal Linking Strategy","updatedAt":"2026-05-19T05:44:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":36,"title":"[SEO] Add Unique Meta Descriptions","updatedAt":"2026-05-19T22:27:14Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":35,"title":"[DESIGN] CTA Button Design System","updatedAt":"2026-05-24T21:12:58Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":34,"title":"[DESIGN] Hero Section Visual Treatment","updatedAt":"2026-05-24T21:12:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":33,"title":"[DESIGN] Mobile-First Responsive System","updatedAt":"2026-05-24T21:12:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":32,"title":"[DESIGN] Form Design Updates","updatedAt":"2026-05-24T21:12:54Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":31,"title":"[DESIGN] Project Card Design Pattern","updatedAt":"2026-05-24T21:12:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":30,"title":"[DESIGN] Photography Showcase Component","updatedAt":"2026-05-24T21:12:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":29,"title":"[DESIGN] Footer Redesign","updatedAt":"2026-05-24T21:12:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":28,"title":"[DESIGN] Navigation Redesign - Modern Mobile-First","updatedAt":"2026-05-24T21:12:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":27,"title":"[DESIGN] Color Palette Refinement","updatedAt":"2026-05-24T21:12:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":26,"title":"[DESIGN] Typography System Update","updatedAt":"2026-05-24T21:12:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":25,"title":"[DESIGN] Create Modern Component Library","updatedAt":"2026-05-24T21:12:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":24,"title":"[DESIGN] Full Homepage Redesign - Modern Full-Width Layout","updatedAt":"2026-05-24T21:12:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":23,"title":"[CONTENT] Reorganize Blog Categories","updatedAt":"2026-05-18T17:09:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-01-03T04:08:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":21,"title":"[CONTENT] Create Photography Portfolio as Credential Section","updatedAt":"2026-01-03T04:08:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":20,"title":"[CONTENT] Update Voice/Tone to Professional but Warm","updatedAt":"2026-01-03T04:08:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":19,"title":"[CONTENT] Add Community Impact Metrics Throughout Site","updatedAt":"2026-01-03T04:08:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":18,"title":"[CONTENT] Create Vancouver AI Community Page","updatedAt":"2026-05-19T22:27:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":15,"title":"[CONTENT] Create The Upgrade AI Co-Founder Section","updatedAt":"2026-05-19T22:27:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":14,"title":"[CONTENT] Create Indigenomics.ai CTO Section","updatedAt":"2026-05-19T22:27:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":13,"title":"[CONTENT] Create BC+AI Leadership Section","updatedAt":"2026-05-19T22:27:27Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":11,"title":"[UX] Create Membership Benefits Comparison Matrix","updatedAt":"2026-01-03T04:00:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":10,"title":"[UX] Add Hover States to CTA Buttons","updatedAt":"2026-05-19T22:27:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":9,"title":"[A11Y] Fix Search Field Accessibility","updatedAt":"2026-05-19T22:27:12Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":8,"title":"[A11Y] Add ARIA Labels to Icon Buttons","updatedAt":"2026-05-19T22:27:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":7,"title":"[CONTENT] Add Pricing Information to Services","updatedAt":"2026-01-03T03:58:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":5,"title":"[BUG] Fix Color Contrast for WCAG Compliance","updatedAt":"2026-01-03T03:58:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlRA","name":"auto-implement","description":"Ready for agent automation","color":"ff6b6b"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-01-03T04:00:19Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[{"number":147,"title":"Docs: Aurora 1.3.10 deploy audit and workplan","updatedAt":"2026-06-04T05:54:01Z"}]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=0, draft_posts=71, draft_pages=5
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 6.9.4 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.180.0",
+          "jetpack": "52dbe7cc70e522fe47c0",
+          "popup-maker": "1.22.0",
+          "zero-bs-crm": "5ba5dddc04be2306aaf0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "6.9.4"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/recent-projects-include/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/blaze",
+          "jetpack/v4/blaze-app",
+          "jetpack/v4/explat",
+          "jetpack/v4/import",
+          "jetpack/v4/stats-app",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "wpcom/v2",
+          "wpcom/v3",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "6.9.4",
+  "started_at": "2026-06-04T05:58:15Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/WORK-PLAN-2026-05-23.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": true,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 1
+    },
+    {
+      "declared": 66,
+      "drift": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 65
+    },
+    {
+      "declared": "6.9.4",
+      "drift": false,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "6.9.4"
+    },
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 0
+    },
+    {
+      "declared": 71,
+      "drift": false,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 71
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 5
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/WORK-PLAN-2026-05-23.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301
+date: Thu, 04 Jun 2026 05:58:40 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+location: https://kriskrug.co/recent-projects-include/
+server: Pagely-ARES/1.22.2
+x-gateway-request-id: 103f4a7d5fa294db6e32198f6ff131b6
+x-jetpack-boost-cache: miss
+vary: accept,content-type
+expires: Thu, 04 Jun 2026 06:58:40 GMT
+cache-control: max-age=3600
+x-redirect-by: KK Hotfix
+x-gateway-cache-key: 1780548197.237|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: MISS
+x-gateway-skip-cache: 0
+```
+
+### Aurora Local vs Origin Divergence
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2`
+- Exit code: `0`
+
+```text
+50	38
+```
+
+### Aurora Local Status
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 status --short --branch`
+- Exit code: `0`
+
+```text
+## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip
+```


### PR DESCRIPTION
## Summary
- added Work page proof metadata chips for role, year, community, artifact, and outcome
- added a visible Indigenomics.ai Work card with supportable CTO/sovereignty framing
- saved an authenticated rollback snapshot and documented live WordPress REST/public verification

## Verification
- make morning-truth
- git diff --check
- make verify
- authenticated WP REST readback for page 2672
- public checks for /recent-projects-include/, /work/, and /projects/ metadata and visible markers

Refs #68