### PR TITLE
Docs: restore Local WP QA path

### DIFF
--- a/docs/current-state/LOCAL-WP-QA-2026-06-04.md
+++ b/docs/current-state/LOCAL-WP-QA-2026-06-04.md
@@ -1,0 +1,130 @@
+# Local WP QA Path - 2026-06-04
+
+## Summary
+
+Issue #149 is unblocked for Track B QA. The Local site `kriskrug-local`
+now serves real WordPress pages at `127.0.0.1:10003` using the host
+`kriskrug-local.local`, and the Local theme copy was synced from canonical
+`origin/main` so it serves `kk-aurora` 1.3.11 instead of stale 1.3.3.
+
+Use Local WP as the preferred Track B browser QA surface before static
+fixtures, but verify the theme version before trusting release evidence.
+
+## Startup And Sync
+
+Local site metadata:
+
+- Site ID: `T6GsFbHbA`
+- Site name: `kriskrug-local`
+- Domain: `kriskrug-local.local`
+- Web port: `10003`
+- PHP CGI port: `10002`
+- MySQL port: `10004`
+- Path: `/Users/kk/Local Sites/kriskrug-local/app/public`
+
+Start the Local app:
+
+```bash
+open -a Local
+```
+
+If Local says the site is running but nothing is listening on `10003`, use the
+Local GraphQL endpoint recorded by Local itself:
+
+```bash
+python3 - <<'PY'
+import json
+import pathlib
+import urllib.request
+
+info = json.loads(
+    (pathlib.Path.home() / "Library/Application Support/Local/graphql-connection-info.json").read_text()
+)
+body = {
+    "query": "mutation startSite($siteId: ID!) { startSite(id: $siteId) { id name status } }",
+    "variables": {"siteId": "T6GsFbHbA"},
+}
+req = urllib.request.Request(
+    info["url"],
+    data=json.dumps(body).encode(),
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + info["authToken"],
+    },
+)
+with urllib.request.urlopen(req, timeout=30) as response:
+    print(response.read().decode())
+PY
+```
+
+Before syncing a repo theme into Local, preserve the previous Local copy:
+
+```bash
+cp -a "$HOME/Local Sites/kriskrug-local/app/public/wp-content/themes/kk-aurora" \
+  "$HOME/Local Sites/kriskrug-local/app/public/wp-content/themes/kk-aurora.backup-20260604-152304Z"
+rsync -a --delete theme/kk-aurora/ \
+  "$HOME/Local Sites/kriskrug-local/app/public/wp-content/themes/kk-aurora/"
+```
+
+The backup created during this pass is:
+
+```text
+/Users/kk/Local Sites/kriskrug-local/app/public/wp-content/themes/kk-aurora.backup-20260604-152304Z
+```
+
+## Verification
+
+Listener proof:
+
+```bash
+lsof -nP -iTCP:10003 -sTCP:LISTEN
+lsof -nP -iTCP:10004 -sTCP:LISTEN
+```
+
+Observed result after the GraphQL start:
+
+```text
+nginx listening on 127.0.0.1:10003 and [::1]:10003
+mysqld listening on 127.0.0.1:10004 and [::1]:10004
+```
+
+Theme proof:
+
+```bash
+php /Applications/Local.app/Contents/Resources/extraResources/bin/wp-cli/wp-cli.phar \
+  --path="$HOME/Local Sites/kriskrug-local/app/public" \
+  --allow-root theme list --status=active --fields=name,version,status
+```
+
+Observed result:
+
+```text
+name        version  status
+kk-aurora  1.3.11   active
+```
+
+Public route proof:
+
+```bash
+curl -sSL --max-time 15 \
+  --resolve kriskrug-local.local:10003:127.0.0.1 \
+  http://kriskrug-local.local:10003/blog/
+
+curl -sSL --max-time 15 \
+  --resolve kriskrug-local.local:10003:127.0.0.1 \
+  http://kriskrug-local.local:10003/2026/05/16/make-culture-not-content/
+```
+
+Observed results:
+
+- `/blog/` returned `200`, loaded `kk-aurora` assets with `ver=1.3.11`, rendered one archive H1, and included `kriskrug-wordmark.png`.
+- `/2026/05/16/make-culture-not-content/` returned `200`, loaded `kk-aurora` assets with `ver=1.3.11`, rendered `.aurora-single-2026`, and rendered the post H1 `Make Culture, Not Content`.
+
+## Troubleshooting Notes
+
+- Do not trust `~/Library/Application Support/Local/site-statuses.json` by itself. It reported `T6GsFbHbA: running` while no nginx/mysql processes were listening.
+- Use `lsof` and `curl` as the truth source for whether the Local route is actually alive.
+- Local redirects direct `127.0.0.1:10003` requests to `kriskrug-local.local:10003`; use `--resolve kriskrug-local.local:10003:127.0.0.1` for repeatable shell checks.
+- WP-CLI currently emits a PHP deprecation warning from the bundled phar under PHP 8.2, but the command still returns useful output.
+- Local's database/content snapshot is older than production. For article QA, pick posts that exist locally or sync a fresh content snapshot in a separate, explicit lane.
+- When testing a feature branch, sync that branch's `theme/kk-aurora/` into Local before taking browser evidence, and record the theme version in the issue or PR.

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -10,20 +10,21 @@ This folder is the source of truth for "what was true on May 14, 2026" and for d
 Read these first for current execution context:
 
 1. [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) plus `reports/morning-truth-20260604-062927Z.md`
-2. [AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md](AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md)
-3. [WORK-PAGE-METADATA-68-2026-06-04.md](WORK-PAGE-METADATA-68-2026-06-04.md)
-4. [AURORA-HEADER-LOGO-CLOSEOUT-2026-06-03.md](AURORA-HEADER-LOGO-CLOSEOUT-2026-06-03.md)
-5. [TRACK-A-RESTART-2026-05-31.md](TRACK-A-RESTART-2026-05-31.md)
-6. [SHUTDOWN-2026-05-30.md](SHUTDOWN-2026-05-30.md)
-7. [AURORA-CONTENT-RECOVERY-2026-05-25.md](AURORA-CONTENT-RECOVERY-2026-05-25.md)
-8. [AURORA-LIVE-QA-2026-05-25.md](AURORA-LIVE-QA-2026-05-25.md)
-9. [QUEUE-MERGE-CLEANUP-2026-05-26.md](QUEUE-MERGE-CLEANUP-2026-05-26.md)
-10. [TRACK-A-SWARM-75-95-128-2026-05-29.md](TRACK-A-SWARM-75-95-128-2026-05-29.md)
-11. [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md)
-12. [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md)
-13. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md)
-14. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
-15. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
+2. [LOCAL-WP-QA-2026-06-04.md](LOCAL-WP-QA-2026-06-04.md)
+3. [AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md](AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md)
+4. [WORK-PAGE-METADATA-68-2026-06-04.md](WORK-PAGE-METADATA-68-2026-06-04.md)
+5. [AURORA-HEADER-LOGO-CLOSEOUT-2026-06-03.md](AURORA-HEADER-LOGO-CLOSEOUT-2026-06-03.md)
+6. [TRACK-A-RESTART-2026-05-31.md](TRACK-A-RESTART-2026-05-31.md)
+7. [SHUTDOWN-2026-05-30.md](SHUTDOWN-2026-05-30.md)
+8. [AURORA-CONTENT-RECOVERY-2026-05-25.md](AURORA-CONTENT-RECOVERY-2026-05-25.md)
+9. [AURORA-LIVE-QA-2026-05-25.md](AURORA-LIVE-QA-2026-05-25.md)
+10. [QUEUE-MERGE-CLEANUP-2026-05-26.md](QUEUE-MERGE-CLEANUP-2026-05-26.md)
+11. [TRACK-A-SWARM-75-95-128-2026-05-29.md](TRACK-A-SWARM-75-95-128-2026-05-29.md)
+12. [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md)
+13. [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md)
+14. [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md)
+15. [TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)
+16. [INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)
 
 Side-worktree safety refresh (2026-06-02): canonical new work should start from
 `main` in a fresh lane-scoped branch. Do not edit
@@ -55,6 +56,7 @@ Then use historical plans for context:
 | [ROADMAP.md](ROADMAP.md) | Six-phase, 3-month plan that synthesizes FIX_QUEUE + postmortem follow-ups + content pipeline next steps. Use as longer-range reference after the latest work plan. |
 | [FULL-AUDIT-ROADMAP-2026-05-18.md](FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit of repo, GitHub queue, Track A, Track B, and human decisions. |
 | [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) | Current post-ship audit and workplan after Aurora 1.3.10, Work metadata #68, open queue, draft audit, and ready/agent/block buckets. |
+| [LOCAL-WP-QA-2026-06-04.md](LOCAL-WP-QA-2026-06-04.md) | Local WP QA path for Track B: `kriskrug-local.local:10003`, GraphQL startup, Local theme sync, and proof that `/blog/` plus a real article load with Aurora 1.3.11. |
 | [HANDOFF-2026-05-24.md](HANDOFF-2026-05-24.md) | Authoritative cross-track state as of 2026-05-24 (Aurora live, branch divergence warning, deploy mechanics). |
 | [AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md](AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md) | Aurora 1.3.10 article/blog composition closeout and next QA path. |
 | [WORK-PAGE-METADATA-68-2026-06-04.md](WORK-PAGE-METADATA-68-2026-06-04.md) | Work page metadata and OG image closeout for issue #68, with remaining #126 social-debugger follow-up. |
@@ -129,7 +131,7 @@ Then use historical plans for context:
 - **Site is on Pagely** (managed WP host), publicly reporting **WordPress 6.9.4** with **`kk-aurora` 1.3.10 active** as of the 2026-06-04 post-ship audit.
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
-- **Current addendum:** start with the post-ship audit/workplan and newest morning-truth report, then use the Aurora 1.3.10 workplan, Work metadata closeout, Aurora logo closeout, and the 2026-05-24 handoff set ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
+- **Current addendum:** start with the post-ship audit/workplan and newest morning-truth report, then use the Local WP QA note, Aurora 1.3.10 workplan, Work metadata closeout, Aurora logo closeout, and the 2026-05-24 handoff set ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
 - **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-06-04 06:29 UTC (`make morning-truth` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
 - **Draft queue addendum:** `make morning-truth` reported `0` future posts, `71` draft posts, and `5` draft pages on 2026-06-04 06:29 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
 - **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #147 merged, and `gh issue list --state open --limit 200` returned `66` open issues on 2026-06-04 06:31 UTC.


### PR DESCRIPTION
## Summary
- documents the working Local WP QA path for `kriskrug-local.local:10003`
- records the Local GraphQL `startSite` fallback when Local claims running but nginx/mysql are not listening
- records the repo-to-Local theme sync path and verifies Local now serves `kk-aurora` 1.3.11 from current `origin/main`
- links the new note from `docs/current-state/README.md`

Closes #149

## Verification
- `lsof -nP -iTCP:10003 -sTCP:LISTEN` shows nginx listening on `127.0.0.1:10003` and `[::1]:10003`
- `curl -sSI -H 'Host: kriskrug-local.local' http://127.0.0.1:10003/blog/` returns the expected WordPress redirect to `kriskrug-local.local:10003`
- Local `/blog/` with `--resolve kriskrug-local.local:10003:127.0.0.1` returns `kk-aurora` assets with `ver=1.3.11`, `.aurora-writing-archive`, and `kriskrug-wordmark.png`
- Local `/2026/05/16/make-culture-not-content/` returns `kk-aurora` assets with `ver=1.3.11`, `.aurora-single-2026`, and H1 `Make Culture, Not Content`
- `php -l theme/kk-aurora/functions.php` passes
- `make wp7-smoke EXPECT_VERSION=6.9.4` passes against production

## Notes
- `vendor/bin/phpcs --standard=phpcs.xml.dist` was requested in the lane plan but `vendor/bin/phpcs` is not installed in this checkout.
- Local's database snapshot is older than production. The production article `/2026/06/03/agent-orchestrators-creative-insurgents-the-new-stack/` is not available locally yet, so use locally-present posts or run a separate explicit content sync before relying on that URL for Local article evidence.