### PR TITLE
Theme: stabilize article map active state

### DIFF
--- a/theme/kk-aurora/assets/js/theme.js
+++ b/theme/kk-aurora/assets/js/theme.js
@@ -331,9 +331,25 @@
         .map((heading) => [heading.id, heading])
     );
 
+    function getLinkHashId(link) {
+      const rawId = link.hash.slice(1);
+
+      try {
+        return decodeURIComponent(rawId);
+      } catch (error) {
+        return rawId;
+      }
+    }
+
+    const mapHeadings = mapLinks
+      .map((link) => headingsById.get(getLinkHashId(link)))
+      .filter(Boolean);
+
+    if (mapHeadings.length === 0) return;
+
     function setActiveMapLink(id) {
       mapLinks.forEach((link) => {
-        const isActive = link.hash === `#${id}`;
+        const isActive = getLinkHashId(link) === id;
         link.classList.toggle('is-active', isActive);
 
         if (isActive) {
@@ -344,34 +360,63 @@
       });
     }
 
-    const firstHeading = headingsById.values().next().value;
+    const firstHeading = mapHeadings[0];
     if (firstHeading) {
       setActiveMapLink(firstHeading.id);
     }
 
+    let pendingMapTargetId = '';
+    let pendingMapTargetUntil = 0;
+
     mapLinks.forEach((link) => {
       link.addEventListener('click', () => {
-        const id = link.hash.slice(1);
+        const id = getLinkHashId(link);
         if (id) {
+          pendingMapTargetId = id;
+          pendingMapTargetUntil = Date.now() + 3000;
           setActiveMapLink(id);
         }
       });
     });
 
-    if (!('IntersectionObserver' in window)) return;
+    const getActiveHeadingId = () => {
+      const anchor = Math.min(window.innerHeight * 0.35, 280);
 
-    const mapObserver = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setActiveMapLink(entry.target.id);
+      if (pendingMapTargetId && Date.now() < pendingMapTargetUntil) {
+        const pendingHeading = headingsById.get(pendingMapTargetId);
+
+        if (pendingHeading && pendingHeading.getBoundingClientRect().top > anchor) {
+          return pendingMapTargetId;
+        }
+
+        pendingMapTargetId = '';
+      }
+
+      let activeHeading = mapHeadings[0];
+
+      mapHeadings.forEach((heading) => {
+        if (heading.getBoundingClientRect().top <= anchor) {
+          activeHeading = heading;
         }
       });
-    }, {
-      rootMargin: '-24% 0px -62% 0px',
-      threshold: 0,
-    });
 
-    headingsById.forEach((heading) => mapObserver.observe(heading));
+      return activeHeading.id;
+    };
+
+    let activeMapFrame = null;
+    const updateActiveMapLink = () => {
+      activeMapFrame = null;
+      setActiveMapLink(getActiveHeadingId());
+    };
+    const scheduleActiveMapUpdate = () => {
+      if (activeMapFrame) return;
+      activeMapFrame = window.requestAnimationFrame(updateActiveMapLink);
+    };
+
+    window.addEventListener('scroll', scheduleActiveMapUpdate, { passive: true });
+    window.addEventListener('resize', scheduleActiveMapUpdate);
+    window.addEventListener('load', scheduleActiveMapUpdate, { once: true });
+    scheduleActiveMapUpdate();
   }
 
   // ============================================

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.11');
+define('KK_AURORA_VERSION', '1.3.12');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.12 =
+* Stabilized Article Map active-section tracking during mobile and scripted scroll.
+
 = 1.3.11 =
 * Wrapped long Article Modules bookmark/source-trail links at narrow widths.
 * Softened the GSAP/ScrollTrigger boot guard so optimized script timing does not emit a false warning.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.11
+Version: 1.3.12
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary
- Replace the Article Map active-section IntersectionObserver band with viewport-anchor tracking scoped to headings that actually appear in the map.
- Keep clicked map links active during smooth scroll so early scroll events do not bounce `aria-current` back to an earlier section.
- Bump Aurora to `1.3.12` for cache-busting.
- Built package: `/Users/kk/Desktop/kk-aurora-article-map-active-state-1.3.12.zip`.

## Verification
- `make morning-truth`
- `node --check theme/kk-aurora/assets/js/theme.js`
- `php -l theme/kk-aurora/functions.php`
- `git diff --check`
- `make wp7-smoke EXPECT_VERSION=6.9.4`
- Local WP active theme readback: `kk-aurora 1.3.12 active`
- Local WP browser assertions at 390px for `/2026/05/16/make-culture-not-content/` and `/2026/05/04/punk-rock-ai/`:
  - direct final-position scroll set `aria-current` to the targeted Article Map heading on both posts;
  - Article Map link click kept the clicked heading active during smooth scroll on both posts.
- `unzip -t /Users/kk/Desktop/kk-aurora-article-map-active-state-1.3.12.zip`

## Deployment Gate
- No production WordPress writes, uploads, activation, Jetpack Boost changes, or cache purges were performed.
- Deployment remains human-gated through KK wp-admin theme upload and Pagely/Boost cache flow.

## Notes
- This addresses the Article Map active-state blocker from #127.
- #127 still has non-code/local-state blockers: Local `/work/` route mismatch and missing Local media 404s.
- #125 remains the Boost/performance/cache follow-up.

Refs #127.
