### PR TITLE
Add version-controlled Shopify Buy Button pattern for the Shop page (#158)

### DIFF
--- a/fixes/issue-158-shopify-embed.php
+++ b/fixes/issue-158-shopify-embed.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Issue #158: Shopify Buy Button embed for the kriskrug.co Shop page.
+ *
+ * What it does:
+ * Loads the Shopify BuyButton.js Storefront SDK and mounts one product
+ * component per ID into the `#kk-shop` container rendered by the
+ * `kk-aurora/shop-buy-button` Gutenberg pattern. Config (domain, token,
+ * product IDs) is single-sourced from `window.kkShop`, which the pattern
+ * emits — so KK fills the placeholders in ONE place (the page), not here.
+ * This snippet only runs the wiring.
+ *
+ * Placeholders to replace (in the pattern, via window.kkShop):
+ *   SHOPIFY_DOMAIN    -> Store A domain, e.g. kriskrug.myshopify.com
+ *   STOREFRONT_TOKEN  -> publishable Storefront access token (public by design;
+ *                        BuyButton.js is client-side — never an Admin API key)
+ *   PRODUCT_ID_1...   -> numeric Shopify product IDs in the `kriskrug` collection
+ *
+ * Graceful no-op: if `#kk-shop` is absent, or any value is still a literal
+ * placeholder / empty, the init script does nothing and the pattern's
+ * "Shop opening soon" fallback stays visible. No console errors, no half-mount.
+ *
+ * How to install:
+ * Add this file as a Code Snippets (Pro) PHP snippet set to run "only on the
+ * front end", or drop it in `wp-content/mu-plugins/` as a must-use plugin.
+ * It enqueues only on the page whose slug matches KK_ISSUE_158_SHOP_SLUG, so it
+ * adds nothing to the rest of the site. After the /shop page is published, set
+ * KK_ISSUE_158_SHOP_SLUG to its slug if it differs from `shop`.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'KK_ISSUE_158_SHOP_SLUG', 'shop' );
+define( 'KK_ISSUE_158_SDK_HANDLE', 'shopify-buy-button-storefront' );
+define( 'KK_ISSUE_158_SDK_SRC', 'https://sdks.shopifycdn.com/buy-button/latest/buy-button-storefront.min.js' );
+
+add_action( 'wp_enqueue_scripts', 'kk_issue_158_enqueue_shop_embed' );
+
+function kk_issue_158_enqueue_shop_embed() {
+	if ( ! kk_issue_158_is_shop_surface() ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		KK_ISSUE_158_SDK_HANDLE,
+		KK_ISSUE_158_SDK_SRC,
+		[],
+		null,
+		true
+	);
+
+	wp_add_inline_script( KK_ISSUE_158_SDK_HANDLE, kk_issue_158_init_script() );
+}
+
+function kk_issue_158_is_shop_surface() {
+	return is_page( KK_ISSUE_158_SHOP_SLUG );
+}
+
+function kk_issue_158_init_script() {
+	return <<<'JS'
+(function () {
+	var node = document.getElementById('kk-shop');
+	var cfg = window.kkShop || {};
+	var ids = Array.isArray(cfg.productIds) ? cfg.productIds : [];
+
+	function unset(value) {
+		return !value || /^(SHOPIFY_DOMAIN|STOREFRONT_TOKEN|PRODUCT_ID_)/.test(value);
+	}
+
+	var ready = ids.filter(function (id) { return !unset(id); });
+
+	if (!node || unset(cfg.domain) || unset(cfg.storefrontAccessToken) || !ready.length) {
+		return;
+	}
+
+	var options = {
+		product: {
+			buttonDestination: 'cart',
+			contents: { img: true, title: true, price: true, options: true },
+			text: { button: 'Add to cart' },
+			styles: {
+				product: { 'max-width': '100%', 'margin-bottom': '1.5rem' },
+				button: {
+					'background-color': '#111418',
+					color: '#f5f5f4',
+					'border-radius': '0.375rem',
+					'font-weight': '600',
+					':hover': { 'background-color': '#2a2f37' },
+					':focus': { 'background-color': '#2a2f37' }
+				}
+			}
+		},
+		cart: {
+			text: { title: 'Cart', total: 'Subtotal', button: 'Checkout' },
+			styles: {
+				button: {
+					'background-color': '#111418',
+					color: '#f5f5f4',
+					':hover': { 'background-color': '#2a2f37' },
+					':focus': { 'background-color': '#2a2f37' }
+				}
+			}
+		},
+		toggle: {
+			styles: {
+				toggle: {
+					'background-color': '#111418',
+					':hover': { 'background-color': '#2a2f37' },
+					':focus': { 'background-color': '#2a2f37' }
+				}
+			}
+		}
+	};
+
+	function mount() {
+		var client = window.ShopifyBuy.buildClient({
+			domain: cfg.domain,
+			storefrontAccessToken: cfg.storefrontAccessToken
+		});
+		window.ShopifyBuy.UI.onReady(client).then(function (ui) {
+			node.innerHTML = '';
+			ready.forEach(function (id) {
+				ui.createComponent('product', {
+					id: id,
+					node: node,
+					moneyFormat: '%24%7B%7Bamount%7D%7D',
+					options: options
+				});
+			});
+		});
+	}
+
+	if (window.ShopifyBuy && window.ShopifyBuy.UI) {
+		mount();
+	} else {
+		var poll = setInterval(function () {
+			if (window.ShopifyBuy && window.ShopifyBuy.UI) {
+				clearInterval(poll);
+				mount();
+			}
+		}, 100);
+	}
+})();
+JS;
+}

--- a/theme/kk-aurora/patterns/shop-buy-button.php
+++ b/theme/kk-aurora/patterns/shop-buy-button.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Title: Shop Buy Button
+ * Slug: kk-aurora/shop-buy-button
+ * Categories: kk-aurora
+ * Keywords: shop, store, shopify, buy button, merch
+ * Viewport Width: 1100
+ */
+?>
+<!-- wp:group {"tagName":"section","layout":{"type":"constrained","contentSize":"900px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|120","bottom":"var:preset|spacing|120"}}}} -->
+<section class="wp-block-group" style="padding-top:var(--wp--preset--spacing--120);padding-bottom:var(--wp--preset--spacing--120)">
+  <!-- wp:heading {"level":2,"className":"aurora-shop-heading","style":{"typography":{"fontSize":"clamp(2rem, 5vw, 3rem)","fontWeight":"700","lineHeight":"1.1"}}} -->
+  <h2 class="wp-block-heading aurora-shop-heading" style="font-size:clamp(2rem, 5vw, 3rem);font-weight:700;line-height:1.1">Shop</h2>
+  <!-- /wp:heading -->
+
+  <!-- wp:paragraph {"className":"aurora-shop-intro","style":{"spacing":{"margin":{"top":"var:preset|spacing|40"}}},"textColor":"text-secondary","fontSize":"lg"} -->
+  <p class="aurora-shop-intro has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--40)">A small, evolving collection of prints, merch, and experiments. Checkout is handled securely by Shopify.</p>
+  <!-- /wp:paragraph -->
+
+  <!-- wp:html -->
+  <div id="kk-shop" class="aurora-shop-mount" style="margin-top:2.5rem;">
+    <p class="aurora-shop-fallback" style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:0.75rem;text-transform:uppercase;letter-spacing:0.18em;color:#6b7280;">Shop opening soon</p>
+  </div>
+  <!--
+    Shop config for the kriskrug.co Store A `kriskrug` collection.
+    BuyButton.js runs client-side, so the Storefront token is public by design
+    (publishable Storefront access token only — never an Admin API key).
+
+    The companion snippet `fixes/issue-158-shopify-embed.php` reads window.kkShop,
+    loads the Shopify SDK, and mounts the listed products into #kk-shop. Replace
+    the PLACEHOLDER strings below with Store A's real values. While any value is
+    still a literal placeholder, the snippet no-ops and the fallback stays visible.
+  -->
+  <script>
+    window.kkShop = window.kkShop || {
+      domain: 'SHOPIFY_DOMAIN',
+      storefrontAccessToken: 'STOREFRONT_TOKEN',
+      collection: 'kriskrug',
+      productIds: ['PRODUCT_ID_1', 'PRODUCT_ID_2', 'PRODUCT_ID_3']
+    };
+  </script>
+  <!-- /wp:html -->
+</section>
+<!-- /wp:group -->


### PR DESCRIPTION
Closes #158
Epic: WalksWithASwagger/kk-kb#2071

## What & how

Adds two version-controlled files so a human can later build the kriskrug.co `/shop` page from a tracked pattern instead of pasting embed code into the dashboard.

**`theme/kk-aurora/patterns/shop-buy-button.php`** — Gutenberg pattern (mirrors `article-field-note.php`'s header shape: Title/Slug/Categories/Keywords/Viewport, then block markup). Renders a Shop section: heading + intro and a `<div id="kk-shop">` with a "Shop opening soon" fallback. Carries a **config-only** inline `window.kkShop` block (domain / Storefront token / `kriskrug` collection / product IDs) using clearly-marked PLACEHOLDERS. Category is `kk-aurora` (the registered catch-all), so no `functions.php` change is needed.

**`fixes/issue-158-shopify-embed.php`** — Snippet (mirrors `issue-43-twitter-cards.php`: top doc block, `ABSPATH` guard, `define()` config, install notes). Enqueues `buy-button-storefront.min.js` only on the `/shop` page and adds an inline init that reads `window.kkShop`, then mounts one BuyButton product component per ID into `#kk-shop`. Uses the same publishable-Storefront-token model as the BC+AI site (`ShopifyBuyButton.tsx`). Neutral/dark accent (`#111418`) for KK's personal brand.

### Division of responsibility (intentional, to avoid double-mounting)
- **Pattern = content + config.** Emits `window.kkShop` and the fallback. No mount logic.
- **Snippet = behavior.** Loads the SDK and mounts once, reading that config.
- Result: placeholders live in **one place** (the page), mounted once.

### Graceful no-op
The init does nothing — leaving the "Shop opening soon" fallback visible, no console errors — unless `#kk-shop` exists AND the domain, token, and at least one product ID are real (not still literal `SHOPIFY_DOMAIN` / `STOREFRONT_TOKEN` / `PRODUCT_ID_*`). The fallback is cleared before mounting so it never stacks above the buttons.

## Verification
```
php -l theme/kk-aurora/patterns/shop-buy-button.php  -> No syntax errors detected
php -l fixes/issue-158-shopify-embed.php             -> No syntax errors detected
```
No real tokens or product IDs committed — placeholders only.

## HITL / dashboard steps for KK
1. **Create the page in WP** from the `Shop Buy Button` pattern (KK Aurora category). Set the permalink/slug to `shop` and publish.
2. **Fill the placeholders** in the page's `window.kkShop` block with Store A's real values:
   - `SHOPIFY_DOMAIN` -> Store A domain (e.g. `kriskrug.myshopify.com`)
   - `STOREFRONT_TOKEN` -> publishable Storefront access token (NOT an Admin API key)
   - `PRODUCT_ID_1...` -> numeric product IDs from the `kriskrug` collection (add/remove entries as needed)
3. **Install the snippet** — add `fixes/issue-158-shopify-embed.php` as a Code Snippets (Pro) PHP snippet (front-end only) or drop it in `wp-content/mu-plugins/`.
4. If the page slug isn't `shop`, update `KK_ISSUE_158_SHOP_SLUG` in the snippet to match.
5. Purge Pagely/Jetpack cache, then load `/shop` and confirm the Add-to-cart buttons render and checkout opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)