### PR TITLE
Add: photography showcase gallery pattern (Refs #30)

### DIFF
--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -192,6 +192,11 @@ function register_block_patterns(): void {
         'kk-aurora-article',
         ['label' => __('Article Modules', 'kk-aurora')]
     );
+
+    register_block_pattern_category(
+        'kk-aurora-media',
+        ['label' => __('Media & Galleries', 'kk-aurora')]
+    );
 }
 add_action('init', __NAMESPACE__ . '\\register_block_patterns');
 

--- a/theme/kk-aurora/patterns/photo-gallery.php
+++ b/theme/kk-aurora/patterns/photo-gallery.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Title: Photography Showcase
+ * Slug: kk-aurora/photo-gallery
+ * Categories: kk-aurora-media, kk-aurora
+ * Keywords: photography, gallery, portfolio, images, lightbox
+ * Viewport Width: 1200
+ *
+ * Responsive photography grid that positions the photo archive as a credential.
+ * Each tile is a core Image block, so it gets the native WordPress lightbox
+ * (keyboard-operable click-to-zoom) and lazy-loading for free. Replace the
+ * placeholder image sources, alt text, and captions on insertion — every image
+ * must have meaningful alt text (WCAG 2.1 AA).
+ */
+
+$kk_placeholder = get_theme_file_uri( 'assets/img/kriskrug-wordmark.png' );
+$kk_tiles       = array(
+	array( 'cat' => 'Climate', 'caption' => 'Environmental expeditions and the people doing the work.' ),
+	array( 'cat' => 'Movements', 'caption' => 'On the ground with the communities shaping change.' ),
+	array( 'cat' => 'Music', 'caption' => 'Two decades in the pit, with a camera.' ),
+	array( 'cat' => 'Sport', 'caption' => 'Motion, grit, and the moment before it breaks.' ),
+	array( 'cat' => 'Power', 'caption' => 'Rooms where decisions get made.' ),
+	array( 'cat' => 'Film', 'caption' => 'Sets, festivals, and the craft behind the frame.' ),
+);
+?>
+<!-- wp:group {"className":"aurora-photo-section","layout":{"type":"constrained","contentSize":"1200px"}} -->
+<div class="wp-block-group aurora-photo-section">
+	<!-- wp:paragraph {"className":"aurora-kicker"} -->
+	<p class="aurora-kicker">Photography</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:heading {"level":2} -->
+	<h2 class="wp-block-heading">Two decades in the room, with a camera.</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"className":"aurora-photo-lede"} -->
+	<p class="aurora-photo-lede">Documentary work across climate, culture, music, and power — 144,000+ exposures and counting. A practiced habit of paying attention, brought to the AI conversation.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:group {"className":"aurora-photo-gallery","layout":{"type":"default"}} -->
+	<div class="wp-block-group aurora-photo-gallery">
+<?php foreach ( $kk_tiles as $kk_tile ) : ?>
+		<!-- wp:group {"className":"aurora-photo-tile","layout":{"type":"default"}} -->
+		<div class="wp-block-group aurora-photo-tile">
+			<!-- wp:paragraph {"className":"aurora-photo-cat"} -->
+			<p class="aurora-photo-cat"><?php echo esc_html( $kk_tile['cat'] ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:image {"lightbox":{"enabled":true},"sizeSlug":"large","className":"aurora-photo-image"} -->
+			<figure class="wp-block-image size-large aurora-photo-image"><img src="<?php echo esc_url( $kk_placeholder ); ?>" alt="<?php echo esc_attr( sprintf( '%s — replace with photograph and descriptive alt text', $kk_tile['cat'] ) ); ?>"/><figcaption class="wp-element-caption"><?php echo esc_html( $kk_tile['caption'] ); ?></figcaption></figure>
+			<!-- /wp:image -->
+		</div>
+		<!-- /wp:group -->
+<?php endforeach; ?>
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:paragraph {"className":"aurora-photo-note","fontSize":"sm"} -->
+	<p class="aurora-photo-note has-sm-font-size">Replace each placeholder with your own photograph (click-to-zoom lightbox is on by default). The full archive lives on <a href="https://www.flickr.com/photos/kk">Flickr</a>.</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1887,6 +1887,83 @@ a {
   transform: translateY(1px);
 }
 
+/* Photography showcase — kk-aurora/photo-gallery pattern */
+.aurora-photo-lede {
+  color: var(--aurora-ink-soft);
+  max-width: 60ch;
+}
+
+.aurora-photo-gallery {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 16rem), 1fr));
+  margin-top: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.aurora-photo-tile {
+  background: var(--aurora-panel-solid);
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-card);
+  display: grid;
+  gap: 0.6rem;
+  overflow: clip;
+  padding: 0.75rem;
+  transition: transform 150ms ease, border-color 150ms ease;
+}
+
+.aurora-photo-tile:hover,
+.aurora-photo-tile:focus-within {
+  border-color: var(--aurora-line-strong);
+  transform: translateY(-2px);
+}
+
+.aurora-photo-cat {
+  background: rgba(247, 247, 242, 0.05);
+  border: 1px solid var(--aurora-line);
+  border-radius: 999px;
+  color: var(--aurora-ink-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  justify-self: start;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding: 0.3rem 0.6rem;
+  text-transform: uppercase;
+}
+
+.aurora-photo-image {
+  margin: 0;
+}
+
+.aurora-photo-image img {
+  aspect-ratio: 4 / 3;
+  border-radius: var(--aurora-radius-control);
+  cursor: zoom-in;
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 100%;
+}
+
+.aurora-photo-image figcaption {
+  color: var(--aurora-ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  margin: 0.5rem 0 0;
+  text-align: left;
+}
+
+.aurora-photo-image img:focus-visible,
+.aurora-photo-tile:focus-within {
+  outline: 2px solid var(--wp--preset--color--cyan);
+  outline-offset: 3px;
+}
+
+.aurora-photo-note {
+  color: var(--aurora-ink-muted);
+  margin-top: 1rem;
+}
+
 .aurora-empty-state,
 .aurora-component-empty {
   background: rgba(247, 247, 242, 0.035);

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -426,6 +426,11 @@
           "radius": true
         }
       },
+      "core/image": {
+        "lightbox": {
+          "allowEditing": true
+        }
+      },
       "core/code": {
         "typography": {
           "fontFamilies": true


### PR DESCRIPTION
## What

Adds the **Photography Showcase** block pattern (`kk-aurora/photo-gallery`) — the genuine gap identified during the aurora-v2 triage (#30): the theme had zero gallery/photography component (`aurora-photo`/`aurora-gallery` = 0 CSS rules), while the live `/photography/` page renders plain inline images with no grid or lightbox.

### Changes (4 files, +148)
- **`patterns/photo-gallery.php`** *(new)* — responsive grid of 6 `core/image` tiles (Climate / Movements / Music / Sport / Power / Film) with per-image **native lightbox**, category chips, captions, and "two decades in the room" credential framing. Ships with alt-text guidance.
- **`style.css`** — `.aurora-photo-*` grid (auto-fill `minmax`, aspect-ratio tiles, hover/`focus-within`), reusing existing Aurora tokens.
- **`theme.json`** — `core/image.lightbox.allowEditing` (exposes the lightbox toggle; lightbox is enabled per-image in the pattern, not globally).
- **`functions.php`** — registers the `kk-aurora-media` pattern category.

## #30 acceptance criteria
- [x] Gallery component created (pattern + CSS)
- [x] Responsive grid layout
- [x] Lazy-load (WordPress injects `loading="lazy"` at render for `core/image`)
- [x] Optional lightbox/modal (native, keyboard-operable; no custom JS)
- [x] Photography positioned as credential (copy + framing)
- [ ] WCAG AA / alt text on all images — lands when real images are inserted (content step)

## Verification status — NOT yet rendered
- ✅ `theme.json` valid JSON; all PHP output escaped (`esc_url`/`esc_attr`/`esc_html` — satisfies the repo's enforced `WordPress.Security.EscapeOutput` rule); image markup matches core's `save` output (no hand-written `loading`/`decoding`, which would trip block validation).
- ⚠️ Could **not** run PHPCS or render locally (no `php`/WP in the build env). **Pending before marking ready:**
  - [ ] CI (`test-pr.yml`) PHPCS green
  - [ ] Block-editor check on Local/staging: insert "Photography Showcase" → no "unexpected content" warning, grid + lightbox render correctly at 360 / 390 / 768 / desktop

## Follow-up (separate, Track A)
This is an inserter-library component — it renders nowhere until inserted. **Applying** it to the live `/photography/` page (swap inline images for the pattern, add real photos + alt text) is an approval-gated Pagely content edit; back up the page first (#75 caution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
