### PR TITLE
Chore: remove dead mobile-menu JS + add #127 mobile QA plan (Refs #127)

### DIFF
--- a/docs/current-state/AURORA-MOBILE-QA-127.md
+++ b/docs/current-state/AURORA-MOBILE-QA-127.md
@@ -1,0 +1,47 @@
+# Aurora Mobile / Responsive QA — Issue #127
+
+**Status:** Code audit complete; manual device QA pending. **Scope:** verification of the *current* horizontal-scroll nav contract (not a hamburger — see #28). This doc is the test plan + the code-level findings; the visual checks must be run on a real device or Chrome DevTools **device mode** (a plain browser window resize does not reflow to the mobile breakpoints).
+
+## 1. Code-level audit (what's already implemented)
+
+| Area | Finding | Evidence |
+|---|---|---|
+| Keyboard nav | Roving focus implemented: ArrowLeft/Right wrap, Home/End jump, `scrollIntoView` keeps the focused pill visible | `assets/js/theme.js` `initPrimaryNavKeyboard()` |
+| Focus indicators | `:focus-visible` outlines on nav links, utility link, CTA, cards | `style.css:692`, plus per-component `:focus-visible` rules |
+| Skip link | Present and styled (`.skip-link` → `#aurora-main`) | `parts/header.html`, `style.css:419` |
+| Mobile nav layout | ≤700px: `.aurora-primary-nav` becomes a full-width horizontal `overflow-x:auto` row of pill links (scrollbar hidden); actions stay top-right | `style.css:2605–2662` |
+| Reduced motion | Covered in CSS (`@media (prefers-reduced-motion: reduce)` at `style.css:78, 3791`) and JS (smooth-scroll + reading-progress in `theme.js`, all of `aurora-animations.js`) | grep-confirmed |
+| Dead code | Removed orphan `initMobileMenu()` (targeted `.aurora-menu-toggle`/`.aurora-mobile-menu`, which exist in no template/part) in this branch | this PR |
+
+**Breakpoints in play:** 360, 700, 781/782, 980, 1180px (+ `min-width:900`).
+
+### Likely findings to confirm on device
+1. **Touch-target sizing (probable fail).** Mobile nav pills are `padding:0.46rem 0.58rem` + `font-size:0.76rem; line-height:1` → computed height ≈ **27px**; `.aurora-utility-link` is `min-height:36px`; `.aurora-header-cta` is `min-height:40px`. All are **below the 44–48px** touch-target guideline. (Relevant to #33/#28 criteria; recommend bumping nav-pill vertical padding and raising utility/CTA min-heights to ≥44px.)
+2. **768px is a transitional band.** The ≤700px mobile-nav rules do **not** apply at 768px, so the nav renders in a tablet/desktop-ish state there. Verify it neither wraps awkwardly nor overflows at exactly 768.
+
+## 2. Manual QA checklist — run at 360 / 390 / 768 (desktop as control)
+
+Use Chrome DevTools device mode (or a real phone). For each width:
+
+### Navigation & keyboard
+- [ ] Primary nav is reachable and all links are operable.
+- [ ] `Tab` reaches the first nav link; `ArrowRight`/`ArrowLeft` move focus and wrap; `Home`/`End` jump to first/last.
+- [ ] The focused pill scrolls into view (no focus lost off-screen).
+- [ ] Focus indicators are clearly visible on nav links, Dispatch link, and the CTA.
+- [ ] Skip link appears on first `Tab` and jumps to main content.
+- [ ] Touch targets ≥ 44px (see finding #1 — expected to fail until padding bumped).
+
+### Layout & overflow
+- [ ] No horizontal page overflow on **home, work, speaking, contact** (`document.documentElement.scrollWidth === clientWidth`).
+- [ ] Hero image crop/scale is acceptable; headline not clipped.
+- [ ] Work "Public artifacts" cards stack to one column; no image/text overlap (cross-check #120, verified clean on live).
+- [ ] No element bleeds past the viewport edge (tables, code blocks, embeds, wide images).
+
+### Motion & a11y
+- [ ] With OS "Reduce Motion" on, GSAP/scroll animations are disabled and no content depends on them.
+- [ ] Color contrast holds on header, nav pills, CTA, and card text (spot-check with DevTools).
+
+## 3. Process
+- File **one bug issue per failure**, labeled `aurora-v2`, `mobile`, `track-b`, referencing #127 — do **not** fix inside #127.
+- When all boxes pass (or failures are filed), record the results back in this doc and close #127.
+- Remember: the live site reflects the *deployed* theme, which may lag `main` — confirm the build under test matches before filing theme bugs (see the repo↔live drift note).

--- a/theme/kk-aurora/assets/js/theme.js
+++ b/theme/kk-aurora/assets/js/theme.js
@@ -8,36 +8,8 @@
   'use strict';
 
   // ============================================
-  // MOBILE MENU
+  // PRIMARY NAV KEYBOARD
   // ============================================
-
-  function initMobileMenu() {
-    const toggle = document.querySelector('.aurora-menu-toggle');
-    const menu = document.querySelector('.aurora-mobile-menu');
-    
-    if (!toggle || !menu) return;
-    
-    toggle.addEventListener('click', () => {
-      const isOpen = toggle.getAttribute('aria-expanded') === 'true';
-      
-      toggle.setAttribute('aria-expanded', !isOpen);
-      menu.classList.toggle('is-open');
-      document.body.classList.toggle('menu-open');
-      
-      // Trap focus within menu when open
-      if (!isOpen) {
-        menu.querySelector('a, button')?.focus();
-      }
-    });
-    
-    // Close on escape
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && menu.classList.contains('is-open')) {
-        toggle.click();
-        toggle.focus();
-      }
-    });
-  }
 
   function initPrimaryNavKeyboard() {
     const nav = document.querySelector('.aurora-primary-nav');
@@ -478,7 +450,6 @@
   // ============================================
 
   function init() {
-    initMobileMenu();
     initPrimaryNavKeyboard();
     initSmoothScroll();
     initExternalLinks();


### PR DESCRIPTION
## What

Two parts of the #127 mobile/responsive QA pass that are doable without a real device:

1. **Dead-code cleanup** — removes the orphan `initMobileMenu()` from `theme.js`. It targeted `.aurora-menu-toggle` / `.aurora-mobile-menu`, which exist in **no** template or part (the shipped header uses the horizontal scroll nav by design — see #28). Verified with `node --check`.
2. **QA plan** — `docs/current-state/AURORA-MOBILE-QA-127.md`: a code-level a11y/responsive audit plus a manual device-QA checklist (360 / 390 / 768).

## Why a plan instead of a finished QA

The visual QA at mobile widths can't be run from this environment — a browser-window resize does not reflow the live page to its mobile breakpoints (it renders/captures at ~1440px). The checklist is written for Chrome DevTools **device mode** or a real phone.

## Code-level findings (details in the doc)
- ✅ Keyboard nav (Arrow/Home/End roving focus), `:focus-visible`, skip link, reduced-motion are all implemented.
- ⚠️ **Touch targets look undersized:** mobile nav pills compute to ~27px tall; utility link 36px; CTA 40px — all below the 44–48px guideline. Flagged for the device pass.
- ⚠️ **768px is a transitional breakpoint band** (the ≤700px mobile-nav rules don't apply there) — needs an explicit look.

## Scope
This PR delivers the cleanup + the test plan. Executing the visual checklist and filing per-failure bugs remains open under #127 (needs device tooling). `Refs #127` (not `Fixes`) — criteria aren't all verified yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
