### PR TITLE
Add: social links to the global footer (Refs #29)

### DIFF
--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -44,6 +44,13 @@
         <a href="/privacy-policy/">Privacy</a>
         <a href="/contact/">Contact</a>
       </div>
+      <div>
+        <h3>Elsewhere</h3>
+        <a href="https://www.instagram.com/kriskrug">Instagram</a>
+        <a href="https://twitter.com/feelmoreplants">Twitter / X</a>
+        <a href="https://www.youtube.com/kriskrug">YouTube</a>
+        <a href="https://www.linkedin.com/in/kriskrug/">LinkedIn</a>
+      </div>
     </nav>
   </div>
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -2356,7 +2356,7 @@ a {
 .aurora-footer-nav {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
 }
 
 .aurora-footer-nav h3 {


### PR DESCRIPTION
## What
Adds an **"Elsewhere"** column to the global footer (`parts/footer.html`) with Instagram, Twitter/X, YouTube, and LinkedIn, and switches `.aurora-footer-nav` to an `auto-fit` grid so the four columns flow responsively (mobile still collapses to one column via the existing ≤700px rule).

## Why
This is the one genuinely-unmet acceptance criterion from #29 ("social links visible"). Verified on 2026-06-06: the global theme footer (`aurora-footer-2026`) had **no** social links — they only appeared as contact-page body content. The footer's other #29 criteria (dark bg, sections, newsletter, privacy/legal) were already delivered.

## URLs
Match the live contact page (maintainer-confirmed set). Twitter uses **@feelmoreplants**; note this differs from the `@kriskrug` handle in the deployed Person schema (`fixes/schema-snippets-deployed.php`) — worth reconciling the schema separately if @feelmoreplants is canonical.

## Notes
- External links rely on the theme's `initExternalLinks()` (theme.js) to add `target`/`rel`/SR text, matching the existing Projects-column convention.
- `Refs #29` (not `Fixes`) — resolves the last open AC at the source level; verify on the live footer after deploy before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
