### PR TITLE
Update: apply aurora-prose rhythm to generic pages (Refs #122)

### DIFF
--- a/theme/kk-aurora/templates/page.html
+++ b/theme/kk-aurora/templates/page.html
@@ -8,7 +8,7 @@
   </div>
   <!-- /wp:group -->
 
-  <!-- wp:post-content {"className":"aurora-page-content","layout":{"type":"constrained","contentSize":"860px"}} /-->
+  <!-- wp:post-content {"className":"aurora-page-content aurora-prose","layout":{"type":"constrained","contentSize":"860px"}} /-->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
## What
One-line template change: adds `aurora-prose` to the post-content block in `templates/page.html`.

## Why
Root cause of #122 ("~25 generic pages are undesigned: bare title + legacy content"): pages render their body with `.aurora-page-content`, which shares only base rules (color, heading color, image radius) with posts and **misses the rich `.aurora-prose` rhythm** (vertical spacing, heading scale, list/quote/figure styling) that `single.html` applies to posts. Adding the class lifts every generic page to post-quality typography at once.

## Scope
- This is the **"lift the floor"** step — it improves the whole long tail (Publications, Testimonials, Events, Worldview, Reconciliation, Projects, Podcast/EPK, policy pages) in one change.
- **Bespoke** templates/heroes for high-commercial-value pages (Services hub, AI Upgrade offers, Speaking) remain separate follow-ups, per the #122 scope.
- Verified safe: `.aurora-prose` rules are pure typography with no paragraph max-width that would conflict with the 860px page container; `.aurora-page-content` base rules are retained (both classes applied).

## Verify
- CI: PHPCS skips (no PHP), `validate` runs.
- Visual (post-deploy / editor): open any generic page (e.g. `/publications/`, `/testimonials/`) and confirm improved paragraph spacing, heading scale, and list/quote styling matching posts.

`Refs #122` — resolves the consistent-spacing AC; the prioritized bespoke list stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
