### PR TITLE
content: stage proximity game draft and publish helper

### DIFF
--- a/content/drafts/2026-06-04-the-great-canadian-proximity-game/post.html
+++ b/content/drafts/2026-06-04-the-great-canadian-proximity-game/post.html
@@ -1,0 +1,87 @@
+<!-- wp:paragraph -->
+<p>I've <a href="https://kriskrug.co/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/">been around this long enough</a> to know the choreography. A big federal strategy drops. The money is real, the ambition is real, and on the merits <a href="https://www.pm.gc.ca/en/news/news-releases/2026/06/04/prime-minister-carney-launches-ai-all-canadas-new-national-artificial" target="_blank" rel="noopener noreferrer">Carney and Solomon</a> took a real run at a genuinely hard problem. Bold beats timid. Good.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And then, within the hour, the second thing starts. The thing that has nothing to do with the strategy and everything to do with who gets to stand next to it. The proximity game.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>I'm not guessing at the rules. Somebody drew them up for me this week, panel by panel.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>A man in a flag pin in front of Parliament. "Let's collaborate. Strategically." A table of beaming directors. "Your impact is transformational." "Your stakeholder alignment is visionary." The Federal Funding Machine roaring to life and spraying cash over a forest of reaching hands. "Amazing work. Here's twenty-five million for ecosystem coordination." The trophy reads Alignment Champion. And the caption at the bottom that tells the truth nobody says out loud. In Canada, the grant is temporary, but proximity is forever.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>I laughed. Then I stopped laughing, because I had just watched a live performance of it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The move</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here is the signature move of the genre. You quote the Minister's own slogan back to the Minister, in a post that tags the Minister. Pom poms, not pitchforks. And the room nods like wisdom just happened.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That is not commentary. That is a courtier nodding at the king and hoping he is seen doing it. The whole performance is a loyalty oath dressed up as analysis. Strip out the access flex and the slogan-quoting and there is nothing underneath. Somebody mistook standing near the ministers for having something to say.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And it is a con even on its own terms. The pom-poms binary gives you two doors. Cheer, or be the mob. There is no third one, and that is the function, not an accident. It lets you wave off every real objection, the missing delivery mechanism, the <a href="https://bc-ai.ca/news/sovereign-ai-for-whom/" target="_blank" rel="noopener noreferrer">data-centre "benefits" nobody can measure</a>, the <a href="https://www.theglobeandmail.com/business/article-ottawas-ai-strategy-includes-more-than-23-billion-for-training/" target="_blank" rel="noopener noreferrer">worker-retraining asks the strategy quietly dropped</a>, as "negativity," without engaging one of them. Reframing real critique as emotional skepticism is how you dodge answering it. And <a href="https://www.theglobeandmail.com/business/commentary/article-ottawa-wants-ai-for-all-but-do-all-canadians-want-ai-in-their-lives/" target="_blank" rel="noopener noreferrer">plenty of Canadians have real questions</a>, not pitchforks.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>My favourite tell is the throat-clearing. "Not in a naive way," they write, and then read you the brochure. "This strategy stakes a real claim." Summarizing the thing is not having a view of the thing. And then the sign-off, "let's get to work," at the bottom of a post that is one hundred percent pom poms and zero percent work. Cheering from the luxury box and calling it labour. Even <a href="https://www.theglobeandmail.com/business/article-google-ottawa-artificial-intelligence-strategy-evan-solomon-tech/" target="_blank" rel="noopener noreferrer">Google's chief economist showed up to clap</a>. Applause was never going to be in short supply.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What got deleted</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here is how I know the game is real and not just a cartoon.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>I left a comment this week. It named actual work and asked an actual question. Who benefits, who governs, <a href="https://bc-ai.ca/news/the-ai-values-gap/" target="_blank" rel="noopener noreferrer">who gets access</a>. It was gone inside the hour.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That deletion told me more than the post ever could. A guy whose whole pitch is "hold it to account and let's get to work" deleted the one comment that did both, because naming real work made the applause look as thin as it was. That is the thesis collapsing in real time.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>You can delete a comment off your page. You cannot delete the work off mine.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Both hands full</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>For the record, I am not anti-applause. I am genuinely glad this strategy exists. I just refuse the binary it is being sold under.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>It was never pom poms or pitchforks for me. It is <a href="https://kriskrug.co/2026/01/24/both-hands-full/">both hands full</a>. You can be thrilled about AI for All and still hold the questions that decide whether it works. That is not skepticism. That is the job. I have been <a href="https://kriskrug.co/2025/03/09/transcending-techs-darker-impulses/">making this case in public for years</a>, long before there was federal money on the table to applaud.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And here is the part the proximity game cannot see. The government's <a href="https://ised-isde.canada.ca/site/ised/en/artificial-intelligence-ecosystem/overview-canadas-national-artificial-intelligence-strategy" target="_blank" rel="noopener noreferrer">own overview</a> promises free AI training for everyone in Canada and faster adoption among small businesses, and then names not one organization to actually deliver any of it. A strategy can fund compute and set targets all day. None of it teaches a twelve-person shop which workflow is safe to hand to a machine. That happens in a room down the street, with people you trust. Not in a PDF from Ottawa.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That layer mostly does not exist yet. <a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">We have spent years building it anyway</a>. Real upskilling for creative pros, comms teams, sales teams, SMEs and nonprofits. <a href="https://bc-ai.ca/certification/responsible-ai-professional/" target="_blank" rel="noopener noreferrer">Responsible AI certification</a>, sold out and growing. Thirty months of <a href="https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/">community meetups</a>, every month, never skipped. A 300-strong professional network. And this October, the <a href="https://bc-ai.ca/events/2026-10-29-futureproof-festival-by-bc-ai/" target="_blank" rel="noopener noreferrer">Futureproof Festival</a> takes over Vancouver for a week. Nobody sprayed cash on us to start. We built it because it needed building.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proximity gets you invited. Delivery gets it done. One is temporary. The other is the only thing that makes AI for All mean all of us.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So pick your game. You can chase the room, or you can <a href="https://bc-ai.ca/news/aligning-bc-ai-canada-ai-strategy-trusted-local-adoption/" target="_blank" rel="noopener noreferrer">build the thing the strategy forgot to</a>. I know which one I am doing.</p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-06-04-the-great-canadian-proximity-game/post.md
+++ b/content/drafts/2026-06-04-the-great-canadian-proximity-game/post.md
@@ -1,0 +1,63 @@
+---
+title: The Great Canadian Proximity Game
+slug: the-great-canadian-proximity-game
+excerpt: Canada launched its AI for All strategy this week, and the applause economy switched on within the hour. Here is the difference between cheering for a strategy and actually delivering one.
+categories:
+  - AI Ethics & Philosophy
+tags:
+  - ai-for-all
+  - canada-ai-strategy
+  - both-hands-full
+  - ai-policy
+  - bc-ai
+  - ai-delivery-layer
+seo:
+  meta_title: The Great Canadian Proximity Game | Kris Krüg
+  meta_description: Canada launched its AI for All strategy this week, and the applause economy switched on within the hour. Proximity gets you invited. Delivery gets it done.
+---
+
+# The Great Canadian Proximity Game
+
+I've [been around this long enough](https://kriskrug.co/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/) to know the choreography. A big federal strategy drops. The money is real, the ambition is real, and on the merits [Carney and Solomon](https://www.pm.gc.ca/en/news/news-releases/2026/06/04/prime-minister-carney-launches-ai-all-canadas-new-national-artificial) took a real run at a genuinely hard problem. Bold beats timid. Good.
+
+And then, within the hour, the second thing starts. The thing that has nothing to do with the strategy and everything to do with who gets to stand next to it. The proximity game.
+
+I'm not guessing at the rules. Somebody drew them up for me this week, panel by panel.
+
+A man in a flag pin in front of Parliament. "Let's collaborate. Strategically." A table of beaming directors. "Your impact is transformational." "Your stakeholder alignment is visionary." The Federal Funding Machine roaring to life and spraying cash over a forest of reaching hands. "Amazing work. Here's twenty-five million for ecosystem coordination." The trophy reads Alignment Champion. And the caption at the bottom that tells the truth nobody says out loud. In Canada, the grant is temporary, but proximity is forever.
+
+I laughed. Then I stopped laughing, because I had just watched a live performance of it.
+
+## The move
+
+Here is the signature move of the genre. You quote the Minister's own slogan back to the Minister, in a post that tags the Minister. Pom poms, not pitchforks. And the room nods like wisdom just happened.
+
+That is not commentary. That is a courtier nodding at the king and hoping he is seen doing it. The whole performance is a loyalty oath dressed up as analysis. Strip out the access flex and the slogan-quoting and there is nothing underneath. Somebody mistook standing near the ministers for having something to say.
+
+And it is a con even on its own terms. The pom-poms binary gives you two doors. Cheer, or be the mob. There is no third one, and that is the function, not an accident. It lets you wave off every real objection, the missing delivery mechanism, the [data-centre "benefits" nobody can measure](https://bc-ai.ca/news/sovereign-ai-for-whom/), the [worker-retraining asks the strategy quietly dropped](https://www.theglobeandmail.com/business/article-ottawas-ai-strategy-includes-more-than-23-billion-for-training/), as "negativity," without engaging one of them. Reframing real critique as emotional skepticism is how you dodge answering it. And [plenty of Canadians have real questions](https://www.theglobeandmail.com/business/commentary/article-ottawa-wants-ai-for-all-but-do-all-canadians-want-ai-in-their-lives/), not pitchforks.
+
+My favourite tell is the throat-clearing. "Not in a naive way," they write, and then read you the brochure. "This strategy stakes a real claim." Summarizing the thing is not having a view of the thing. And then the sign-off, "let's get to work," at the bottom of a post that is one hundred percent pom poms and zero percent work. Cheering from the luxury box and calling it labour. Even [Google's chief economist showed up to clap](https://www.theglobeandmail.com/business/article-google-ottawa-artificial-intelligence-strategy-evan-solomon-tech/). Applause was never going to be in short supply.
+
+## What got deleted
+
+Here is how I know the game is real and not just a cartoon.
+
+I left a comment this week. It named actual work and asked an actual question. Who benefits, who governs, [who gets access](https://bc-ai.ca/news/the-ai-values-gap/). It was gone inside the hour.
+
+That deletion told me more than the post ever could. A guy whose whole pitch is "hold it to account and let's get to work" deleted the one comment that did both, because naming real work made the applause look as thin as it was. That is the thesis collapsing in real time.
+
+You can delete a comment off your page. You cannot delete the work off mine.
+
+## Both hands full
+
+For the record, I am not anti-applause. I am genuinely glad this strategy exists. I just refuse the binary it is being sold under.
+
+It was never pom poms or pitchforks for me. It is [both hands full](https://kriskrug.co/2026/01/24/both-hands-full/). You can be thrilled about AI for All and still hold the questions that decide whether it works. That is not skepticism. That is the job. I have been [making this case in public for years](https://kriskrug.co/2025/03/09/transcending-techs-darker-impulses/), long before there was federal money on the table to applaud.
+
+And here is the part the proximity game cannot see. The government's [own overview](https://ised-isde.canada.ca/site/ised/en/artificial-intelligence-ecosystem/overview-canadas-national-artificial-intelligence-strategy) promises free AI training for everyone in Canada and faster adoption among small businesses, and then names not one organization to actually deliver any of it. A strategy can fund compute and set targets all day. None of it teaches a twelve-person shop which workflow is safe to hand to a machine. That happens in a room down the street, with people you trust. Not in a PDF from Ottawa.
+
+That layer mostly does not exist yet. [We have spent years building it anyway](https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/). Real upskilling for creative pros, comms teams, sales teams, SMEs and nonprofits. [Responsible AI certification](https://bc-ai.ca/certification/responsible-ai-professional/), sold out and growing. Thirty months of [community meetups](https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/), every month, never skipped. A 300-strong professional network. And this October, the [Futureproof Festival](https://bc-ai.ca/events/2026-10-29-futureproof-festival-by-bc-ai/) takes over Vancouver for a week. Nobody sprayed cash on us to start. We built it because it needed building.
+
+Proximity gets you invited. Delivery gets it done. One is temporary. The other is the only thing that makes AI for All mean all of us.
+
+So pick your game. You can chase the room, or you can [build the thing the strategy forgot to](https://bc-ai.ca/news/aligning-bc-ai-canada-ai-strategy-trusted-local-adoption/). I know which one I am doing.

--- a/scripts/notion-to-wp/publish_proximity_game.py
+++ b/scripts/notion-to-wp/publish_proximity_game.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Stage "The Great Canadian Proximity Game" as a DRAFT on kriskrug.co.
+
+Text post with hand-placed links (the auto-linker is NOT run here). Models the
+create-draft pattern of publish_you_cant_drink_data.py without the photo/gallery
+machinery. WP-only: reads creds straight from .env, so no NOTION_TOKEN required.
+
+Markers in post.md:
+  # X    -> post title (first one is skipped; comes from frontmatter)
+  ## X   -> wp:heading (h2)
+  ### X  -> wp:heading (h3)
+  ---    -> wp:separator
+  else   -> wp:paragraph
+
+Dry-run by default. --execute creates the draft (status=draft, NEVER publishes,
+aborts if the slug already exists). --update refreshes the body of the existing
+draft found by slug.
+"""
+import re, sys, json, pathlib
+import yaml
+import html
+from dotenv import dotenv_values
+from kk_notion_to_wp import WordPress, slugify, WP_BASE_URL_DEFAULT, WP_DEFAULT_AUTHOR_ID
+
+STAGE = pathlib.Path(
+    "/Users/kk/Code/kriskrug-wp/content/drafts/2026-06-04-the-great-canadian-proximity-game"
+)
+ENV = pathlib.Path(__file__).resolve().parent / ".env"
+EXECUTE = "--execute" in sys.argv
+UPDATE = "--update" in sys.argv
+WRITE = EXECUTE or UPDATE
+
+
+def inline(s: str) -> str:
+    def link(m):
+        text, url = m.group(1), m.group(2)
+        extra = "" if url.startswith(("https://kriskrug.co", "/")) \
+            else ' target="_blank" rel="noopener noreferrer"'
+        return f'<a href="{url}"{extra}>{text}</a>'
+    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link, s)
+    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
+    return s
+
+
+def term_id(wp, taxonomy: str, name: str) -> int:
+    """Resolve a category/tag to an ID, creating it only if truly absent.
+
+    Robust to two things kk_notion_to_wp.ensure_term trips on: WP returns names
+    HTML-encoded (``AI Ethics &amp; Philosophy``), and re-creating an existing
+    term 400s with ``term_exists`` (the existing id is in the error payload)."""
+    slug = slugify(name)
+    r = wp.s.get(f"{wp.base}/wp-json/wp/v2/{taxonomy}",
+                 params={"search": name, "per_page": 100}, timeout=30)
+    r.raise_for_status()
+    for t in r.json():
+        if html.unescape(t.get("name", "")).lower() == name.lower() or t.get("slug", "") == slug:
+            return t["id"]
+    r2 = wp.s.post(f"{wp.base}/wp-json/wp/v2/{taxonomy}",
+                   json={"name": name, "slug": slug}, timeout=30)
+    if r2.status_code == 400:
+        data = (r2.json() or {}).get("data") or {}
+        if data.get("term_id"):
+            return int(data["term_id"])
+    r2.raise_for_status()
+    return r2.json()["id"]
+
+
+def render(body: str) -> str:
+    out = []
+    seen_title = False
+    for b in [x.strip() for x in re.split(r"\n\s*\n", body) if x.strip()]:
+        if b.startswith("# ") and not seen_title:
+            seen_title = True
+            continue
+        if b == "---":
+            out.append('<!-- wp:separator -->\n'
+                       '<hr class="wp-block-separator has-alpha-channel-opacity"/>\n'
+                       '<!-- /wp:separator -->')
+        elif b.startswith("## "):
+            out.append(f'<!-- wp:heading -->\n'
+                       f'<h2 class="wp-block-heading">{inline(b[3:].strip())}</h2>\n'
+                       f'<!-- /wp:heading -->')
+        elif b.startswith("### "):
+            out.append(f'<!-- wp:heading {{"level":3}} -->\n'
+                       f'<h3 class="wp-block-heading">{inline(b[4:].strip())}</h3>\n'
+                       f'<!-- /wp:heading -->')
+        else:
+            para = "<br>".join(inline(line.strip()) for line in b.split("\n"))
+            out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
+    return "\n\n".join(out)
+
+
+# ---- load draft ----
+raw = (STAGE / "post.md").read_text()
+fmatch = re.match(r"\A---\n(.*?)\n---\n?(.*)\Z", raw, flags=re.S)
+fm = yaml.safe_load(fmatch.group(1))
+body = fmatch.group(2).strip()
+assert "—" not in body, "em-dash leaked into post.md body"
+
+content = render(body)
+(STAGE / "post.html").write_text(content)
+assert "—" not in content, "em-dash leaked into content"
+n_links = content.count("<a href=")
+n_blocks = content.count("<!-- wp:")
+print(f"[blocks] {n_blocks} blocks | {n_links} links | post.html staged ({len(content)} bytes)")
+
+if not WRITE:
+    print("\nDRY-RUN complete. --execute creates the draft; --update updates the existing one.")
+    sys.exit(0)
+
+# ---- WP client (WP-only creds; no NOTION_TOKEN needed) ----
+env = dotenv_values(ENV)
+user = env.get("WP_USER")
+pw = (env.get("WP_APP_PASSWORD") or "").replace(" ", "")
+author_id = int(env.get("WP_DEFAULT_AUTHOR_ID", WP_DEFAULT_AUTHOR_ID))
+if not (user and pw):
+    sys.exit(f"[ABORT] WP_USER / WP_APP_PASSWORD missing from {ENV}")
+wp = WordPress(WP_BASE_URL_DEFAULT, user, pw)
+
+TITLE = fm["title"]
+SLUG = fm["slug"]
+EXCERPT = fm.get("excerpt", "")
+CATEGORIES = fm.get("categories", []) or []
+TAGS = fm.get("tags", []) or []
+SEO = fm.get("seo", {}) or {}
+
+existing = wp.find_post_by_slug(SLUG)
+
+if UPDATE:
+    if not existing:
+        sys.exit(f"[ABORT] --update but no post with slug {SLUG}. Run --execute first.")
+    post = wp.update_post(existing, {"content": content})
+    pid = existing
+    print(f"[post] UPDATED draft id={pid} status={post['status']}")
+else:
+    if existing:
+        sys.exit(f"[ABORT] a post with slug {SLUG} already exists (id={existing}). Use --update.")
+    cat_ids = [term_id(wp, "categories", c) for c in CATEGORIES]
+    tag_ids = [term_id(wp, "tags", t) for t in TAGS]
+    payload = {
+        "title": TITLE, "slug": SLUG, "status": "draft",
+        "author": author_id, "content": content, "excerpt": EXCERPT,
+        "categories": cat_ids, "tags": tag_ids,
+        "meta": {
+            "jetpack_seo_html_title": SEO.get("meta_title", ""),
+            "advanced_seo_description": SEO.get("meta_description", ""),
+        },
+    }
+    post = wp.create_post(payload)
+    pid = post["id"]
+    print(f"[post] CREATED draft id={pid} status={post['status']}")
+
+# ---- verify (must remain a draft) ----
+v = wp.get_post(pid)
+vc = v["content"]["raw"]
+checks = {
+    "is_draft_not_publish": v["status"] == "draft",
+    "title_ok": v["title"]["raw"] == TITLE,
+    "links_present": vc.count("<a href=") >= 12,
+    "kriskrug_link": "kriskrug.co/2026/01/24/both-hands-full" in vc,
+    "bcai_link": "bc-ai.ca/news/aligning-bc-ai" in vc,
+    "gov_links": "pm.gc.ca" in vc and "ised-isde.canada.ca" in vc,
+    "external_newtab": 'rel="noopener noreferrer"' in vc,
+    "no_em_dash": "—" not in vc,
+}
+preview = f"{wp.base}/?p={pid}&preview=true"
+edit = f"{wp.base}/wp-admin/post.php?post={pid}&action=edit"
+(STAGE / "publish.log").write_text(
+    f"{'updated' if UPDATE else 'created'} draft id={pid} status={post['status']}\n"
+    f"preview={preview}\nedit={edit}\n\nVERIFY:\n" + json.dumps(checks, indent=2)
+)
+print("\n=== VERIFY ===")
+for k, val in checks.items():
+    print(f"  {'OK ' if val else 'FAIL'} {k}")
+print(f"\nPREVIEW: {preview}\nEDIT:    {edit}\nDONE — left as DRAFT.")


### PR DESCRIPTION
## Summary
- Add draft assets for "The Great Canadian Proximity Game".
- Add script to stage the draft as a WordPress draft (`scripts/notion-to-wp/publish_proximity_game.py`).

## Changes
- New file: `content/drafts/2026-06-04-the-great-canadian-proximity-game/post.md`
- New file: `content/drafts/2026-06-04-the-great-canadian-proximity-game/post.html`
- New file: `scripts/notion-to-wp/publish_proximity_game.py`

## Validation
- Not run (content/script additions only).
