### PR TITLE
fix: make proximity publish script path relative

### DIFF
--- a/scripts/notion-to-wp/publish_proximity_game.py
+++ b/scripts/notion-to-wp/publish_proximity_game.py
@@ -22,10 +22,10 @@ import html
 from dotenv import dotenv_values
 from kk_notion_to_wp import WordPress, slugify, WP_BASE_URL_DEFAULT, WP_DEFAULT_AUTHOR_ID
 
-STAGE = pathlib.Path(
-    "/Users/kk/Code/kriskrug-wp/content/drafts/2026-06-04-the-great-canadian-proximity-game"
-)
-ENV = pathlib.Path(__file__).resolve().parent / ".env"
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-06-04-the-great-canadian-proximity-game"
+ENV = SCRIPT_DIR / ".env"
 EXECUTE = "--execute" in sys.argv
 UPDATE = "--update" in sys.argv
 WRITE = EXECUTE or UPDATE


### PR DESCRIPTION
## Summary
- Make `publish_proximity_game.py` path resolution environment-agnostic by deriving repo paths from script location.

## Changes
- In `scripts/notion-to-wp/publish_proximity_game.py`:
  - replace hardcoded absolute `STAGE` path with repo-relative path computation (`SCRIPT_DIR`, `REPO_ROOT`).
  - keep `.env` resolution aligned to script directory (`SCRIPT_DIR / ".env").

## Validation
- Not run (small path-logic refactor only).

### Portability note
This follow-up keeps the script runnable across environments and clones by avoiding hardcoded absolute paths.
It now derives both the draft directory and `.env` location from script-relative paths (`SCRIPT_DIR`/repo root).
