### PR TITLE
Add: Notion publisher update diff gate

### DIFF
--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -64,6 +64,9 @@ python kk_notion_to_wp.py --publish https://www.notion.so/<page-id>
 
 # Live update of an existing slug, guarded by title similarity
 python kk_notion_to_wp.py --update https://www.notion.so/<page-id>
+
+# No-write update review: fetches the existing slug target and prints a diff
+python kk_notion_to_wp.py --diff https://www.notion.so/<page-id>
 ```
 
 ## Local draft package publisher
@@ -114,7 +117,7 @@ Create-only draft runs are allowed when all of these are true:
 6. Media uploads are approved and have alt text, or the draft is image-free.
 7. The resulting WP post ID, edit URL, and run notes are recorded in `publish.log`.
 
-Public publish or `--update` runs require explicit KK sign-off, a fresh dry-run/review, authenticated slug/ID/status verification, and a rollback note. Bulk edits, destructive cleanup, plugin/theme/schema/robots changes, and media-heavy imports need a narrower deploy plan before they run.
+Public publish or `--update` runs require explicit KK sign-off, a fresh dry-run/review, authenticated slug/ID/status verification, and a rollback note. For updates, run `--diff` first and review the emitted diff before any `--update` command. `--diff` fetches the existing post by slug, applies the same title-similarity guard as `--update`, and exits before WordPress create/update/media/taxonomy write requests. Bulk edits, destructive cleanup, plugin/theme/schema/robots changes, and media-heavy imports need a narrower deploy plan before they run.
 
 Without WordPress credentials the command is always effectively dry-run only.
 
@@ -142,6 +145,7 @@ Default behavior is CREATE-only:
 - If no post with the slug exists, the connector creates a new WP post.
 - If a post with the slug already exists, the connector aborts instead of silently updating.
 - To update an existing post, pass `--update`. The update path also checks that the existing title is similar to the new title before it sends a REST update. The current threshold lives in `TITLE_SIMILARITY_UPDATE_THRESHOLD` and is covered by tests.
+- Before using `--update`, run `--diff` to print a no-write comparison between the existing WP slug target and the proposed Notion payload. Treat the diff as evidence for human review, not approval to update.
 
 This makes reruns safe by default. If you need a new version rather than an update, pass `--slug` with a new slug.
 

--- a/scripts/notion-to-wp/kk_notion_to_wp.py
+++ b/scripts/notion-to-wp/kk_notion_to_wp.py
@@ -26,6 +26,11 @@ Usage:
         Will refuse to update if the existing post's title is wildly different
         from the new title (likely wrong-post collision).
 
+    python kk_notion_to_wp.py --diff <notion-url>
+        Fetch the existing post matched by slug, enforce the same title guard,
+        print a unified diff of selected WP fields vs. the proposed payload,
+        and exit before any WordPress write request.
+
     Override flags (any combination):
         --title "Custom Title"        Override the title derived from Notion
         --slug custom-slug            Override the slug derived from the title
@@ -53,6 +58,7 @@ from __future__ import annotations
 import argparse
 import base64
 import dataclasses
+import difflib
 import json
 import os
 import re
@@ -343,7 +349,6 @@ def title_similarity(a: str, b: str) -> float:
     the 'wrong post' check — we only need to detect WILDLY different titles
     (the 2026-05-15 incident had "Web Summit Vancouver 2026" overwritten by
     "Calling Us All In" — similarity ≈ 0.16, well below the 0.5 threshold)."""
-    import difflib
     a = (a or "").strip().lower()
     b = (b or "").strip().lower()
     if not a or not b:
@@ -354,6 +359,74 @@ def title_similarity(a: str, b: str) -> float:
 def update_title_guard(new_title: str, existing_title: str) -> tuple[bool, float]:
     sim = title_similarity(new_title, existing_title)
     return sim >= TITLE_SIMILARITY_UPDATE_THRESHOLD, sim
+
+
+def _wp_text_field(value) -> str:
+    if isinstance(value, dict):
+        raw = value.get("raw")
+        if raw:
+            return raw
+        rendered = value.get("rendered") or ""
+        return re.sub(r"<[^>]+>", "", rendered).strip()
+    return value or ""
+
+
+def update_diff(existing_post: dict, proposed_payload: dict) -> str:
+    existing = {
+        "title": _wp_text_field(existing_post.get("title")),
+        "slug": existing_post.get("slug") or "",
+        "status": existing_post.get("status") or "",
+        "date": existing_post.get("date") or "",
+        "excerpt": _wp_text_field(existing_post.get("excerpt")),
+        "content": _wp_text_field(existing_post.get("content")),
+        "meta": existing_post.get("meta") or {},
+    }
+    proposed = {
+        "title": proposed_payload.get("title") or "",
+        "slug": proposed_payload.get("slug") or "",
+        "status": proposed_payload.get("status") or "",
+        "date": proposed_payload.get("date") or "",
+        "excerpt": proposed_payload.get("excerpt") or "",
+        "content": proposed_payload.get("content") or "",
+        "meta": proposed_payload.get("meta") or {},
+    }
+    before = json.dumps(existing, indent=2, ensure_ascii=False, sort_keys=True).splitlines(keepends=True)
+    after = json.dumps(proposed, indent=2, ensure_ascii=False, sort_keys=True).splitlines(keepends=True)
+    return "".join(difflib.unified_diff(
+        before,
+        after,
+        fromfile="existing-wp-post",
+        tofile="proposed-notion-payload",
+    ))
+
+
+def emit_update_diff_review(wp: "WordPress", slug: str, title: str, payload: dict, log, emit=print) -> int:
+    existing_id = wp.find_post_by_slug(slug)
+    log(f"existing post with slug {slug!r}? {existing_id}")
+    if existing_id is None:
+        log("ABORTING: --diff needs an existing post with this slug; no WP write was attempted.")
+        return 6
+
+    existing = wp.get_post(existing_id)
+    existing_title = (existing.get("title") or {}).get("raw", "")
+    title_match, sim = update_title_guard(title, existing_title)
+    log(f"  existing post title: {existing_title!r}")
+    log(f"  new post title:      {title!r}")
+    log(f"  title similarity:    {sim:.2f}")
+    if not title_match:
+        log(f"ABORTING: existing title is too different from new title "
+            f"(similarity {sim:.2f} < {TITLE_SIMILARITY_UPDATE_THRESHOLD}).")
+        log("No diff was emitted and no WP write was attempted.")
+        return 3
+
+    diff_text = update_diff(existing, payload)
+    if diff_text:
+        emit(diff_text)
+    else:
+        emit("No update diff: selected existing WP fields match the proposed payload.")
+    log("Diff-only run complete; no WP create, update, taxonomy, or media write request was sent.")
+    log("Review the diff, then re-run with --update only after explicit operator approval.")
+    return 0
 
 
 def derive_social_message(excerpt: str, max_chars: int = 280) -> str:
@@ -605,7 +678,8 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
         title_override: str | None = None,
         slug_override: str | None = None,
         date_override: str | None = None,
-        category_override: str | None = None) -> int:
+        category_override: str | None = None,
+        diff_update: bool = False) -> int:
     cfg = load_config()
     nclient = Notion(cfg.notion_token)
     page_id = parse_page_id(notion_url)
@@ -761,7 +835,11 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
         },
     }
 
-    if dry_run or not cfg.has_wp_credentials:
+    if (dry_run and not diff_update) or not cfg.has_wp_credentials:
+        if diff_update and not cfg.has_wp_credentials:
+            log("ABORTING: --diff requires WP credentials to fetch the existing post by slug.")
+            log("No WP write was attempted.")
+            return 5
         if not cfg.has_wp_credentials:
             log("WP credentials not present — dry-run output only.")
         log("Dry-run payload (truncated):")
@@ -779,6 +857,9 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
 
     # 6. Live mode — upload images, then create/update post
     wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
+
+    if diff_update:
+        return emit_update_diff_review(wp, slug, title, payload, log)
 
     for nurl, meta in list(image_map.items()):
         if nurl != meta.get("_notion_url"):  # skip alias entries
@@ -952,6 +1033,9 @@ def main():
     p.add_argument("--update", action="store_true",
                    help="Allow updating an existing post (matched by slug). Default is CREATE-only. "
                         "Required since the 2026-05-15 incident.")
+    p.add_argument("--diff", action="store_true",
+                   help="Print a no-write diff against the existing slug target and exit. "
+                        "Requires WP credentials but never creates, updates, uploads media, or creates terms.")
     p.add_argument("--title", default=None,
                    help="Override the post title (otherwise derived from Notion title property).")
     p.add_argument("--slug", default=None,
@@ -973,6 +1057,7 @@ def main():
         slug_override=args.slug,
         date_override=args.date,
         category_override=args.category,
+        diff_update=args.diff,
     ))
 
 

--- a/scripts/notion-to-wp/tests/test_update_guard.py
+++ b/scripts/notion-to-wp/tests/test_update_guard.py
@@ -9,6 +9,60 @@ sys.path.insert(0, str(SCRIPT_DIR))
 import kk_notion_to_wp  # noqa: E402
 
 
+class FakeWordPress:
+    def __init__(self, existing_post=None, existing_id=123):
+        self.existing_post = existing_post
+        self.existing_id = existing_id
+        self.write_calls = []
+
+    def find_post_by_slug(self, slug):
+        return self.existing_id
+
+    def get_post(self, post_id):
+        return self.existing_post
+
+    def upload_media(self, *args, **kwargs):
+        self.write_calls.append("upload_media")
+        raise AssertionError("diff review must not upload media")
+
+    def ensure_term(self, *args, **kwargs):
+        self.write_calls.append("ensure_term")
+        raise AssertionError("diff review must not create or resolve terms")
+
+    def create_post(self, *args, **kwargs):
+        self.write_calls.append("create_post")
+        raise AssertionError("diff review must not create posts")
+
+    def update_post(self, *args, **kwargs):
+        self.write_calls.append("update_post")
+        raise AssertionError("diff review must not update posts")
+
+
+def existing_post(title="Web Summit Vancouver 2026", content="<p>Old body</p>"):
+    return {
+        "id": 123,
+        "title": {"raw": title},
+        "slug": "web-summit-vancouver-2026",
+        "status": "draft",
+        "date": "2026-05-07T12:00:00",
+        "excerpt": {"raw": "Old excerpt"},
+        "content": {"raw": content},
+        "meta": {"advanced_seo_description": "Old excerpt"},
+    }
+
+
+def proposed_payload(title="Web Summit Vancouver 2026", content="<p>New body</p>"):
+    return {
+        "title": title,
+        "slug": "web-summit-vancouver-2026",
+        "status": "draft",
+        "date": "2026-05-07T12:00:00",
+        "excerpt": "New excerpt",
+        "content": content,
+        "meta": {"advanced_seo_description": "New excerpt"},
+    }
+
+
 class UpdateTitleGuardTests(unittest.TestCase):
     def test_guard_allows_matching_title_case_insensitive(self):
         allowed, similarity = kk_notion_to_wp.update_title_guard(
@@ -42,6 +96,74 @@ class UpdateTitleGuardTests(unittest.TestCase):
             similarity,
             kk_notion_to_wp.TITLE_SIMILARITY_UPDATE_THRESHOLD,
         )
+
+    def test_update_diff_is_deterministic(self):
+        diff = kk_notion_to_wp.update_diff(existing_post(), proposed_payload())
+
+        self.assertIn("--- existing-wp-post", diff)
+        self.assertIn("+++ proposed-notion-payload", diff)
+        self.assertIn('-  "excerpt": "Old excerpt"', diff)
+        self.assertIn('+  "excerpt": "New excerpt"', diff)
+        self.assertIn('-  "content": "<p>Old body</p>"', diff)
+        self.assertIn('+  "content": "<p>New body</p>"', diff)
+
+    def test_diff_review_emits_diff_without_wp_write_calls(self):
+        wp = FakeWordPress(existing_post=existing_post())
+        logs = []
+        emitted = []
+
+        code = kk_notion_to_wp.emit_update_diff_review(
+            wp,
+            "web-summit-vancouver-2026",
+            "Web Summit Vancouver 2026",
+            proposed_payload(),
+            logs.append,
+            emitted.append,
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(wp.write_calls, [])
+        self.assertEqual(len(emitted), 1)
+        self.assertIn("proposed-notion-payload", emitted[0])
+        self.assertTrue(any("no WP create, update, taxonomy, or media write" in msg for msg in logs))
+
+    def test_diff_review_blocks_incident_style_wrong_post_collision(self):
+        wp = FakeWordPress(existing_post=existing_post(title="Web Summit Vancouver 2026"))
+        logs = []
+        emitted = []
+
+        code = kk_notion_to_wp.emit_update_diff_review(
+            wp,
+            "web-summit-vancouver-2026",
+            "Calling Us All In",
+            proposed_payload(title="Calling Us All In"),
+            logs.append,
+            emitted.append,
+        )
+
+        self.assertEqual(code, 3)
+        self.assertEqual(wp.write_calls, [])
+        self.assertEqual(emitted, [])
+        self.assertTrue(any("too different" in msg for msg in logs))
+
+    def test_diff_review_requires_existing_slug_target(self):
+        wp = FakeWordPress(existing_post=None, existing_id=None)
+        logs = []
+        emitted = []
+
+        code = kk_notion_to_wp.emit_update_diff_review(
+            wp,
+            "missing-slug",
+            "Missing Slug",
+            proposed_payload(title="Missing Slug"),
+            logs.append,
+            emitted.append,
+        )
+
+        self.assertEqual(code, 6)
+        self.assertEqual(wp.write_calls, [])
+        self.assertEqual(emitted, [])
+        self.assertTrue(any("needs an existing post" in msg for msg in logs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
Adds a no-write `--diff` review gate to the Notion-to-WordPress publisher update path.

### Why
Issue #169 asks for visible diff evidence before any `--update` run, following the overwrite incident tracked in #75.

### Changes
- Adds `--diff` to `kk_notion_to_wp.py`.
- Fetches the existing WP post by slug and applies the existing title-similarity guard.
- Emits a unified diff of selected existing WP fields versus the proposed Notion payload.
- Exits before WP create/update/media/taxonomy write calls.
- Extends the update-guard tests with fake WordPress no-write coverage.
- Documents the operator flow in the Notion publisher README.

### Tests
- `scripts/notion-to-wp/.venv/bin/python -m unittest scripts/notion-to-wp/tests/test_update_guard.py`
- `scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests`
- `scripts/notion-to-wp/.venv/bin/python -m py_compile scripts/notion-to-wp/kk_notion_to_wp.py`
- `make test`
- `make docs-truth-check`
- `scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/kk_notion_to_wp.py --help | rg -n -- "--diff|--update|--dry-run"`
- `git diff --check`

### Evals
Safety eval covered by `test_diff_review_blocks_incident_style_wrong_post_collision`: the “Calling Us All In” vs “Web Summit Vancouver 2026” collision returns the existing guard failure path, emits no diff, and records no fake WP write calls.

### Risks
- The diff compares selected fields and can still be noisy for HTML content.
- `--diff` requires WP credentials because it must read the existing slug target.
- Diff output may contain unpublished/protected draft content, so operators should treat it as review evidence, not public-safe material.

### Follow-up
- Keep credential rotation and broader publishing policy work tracked separately in #75.
- Consider adding a small live dry-run checklist once a safe known draft target is selected.

Closes #169
Refs #75
