### PR TITLE
Add read-only startup status target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ Read [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODE
 
 Run `make morning-truth` at session start (or before execution) to emit a timestamped read-only report under `docs/current-state/reports/` with git/issue/worktree state, WP smoke, draft queue counts, and current-state drift flags.
 
+If the task explicitly forbids file changes, run `make status-readonly` instead. It prints the same startup truth shape to stdout and does not write a report file.
+
 ---
 
 **Last verified:** 2026-05-25 02:19 UTC via `make morning-truth`. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` plus the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth and flag the drift for a fresh audit.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth docs-truth-check clean
+.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -157,6 +157,9 @@ current-state-drift-check: ## Compare declared current-state snapshot values vs 
 
 morning-truth: ## Run startup truth checks and write a timestamped markdown report
 	@python3 scripts/morning_truth_report.py --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
+
+status-readonly: ## Print startup truth checks without writing a report
+	@python3 scripts/morning_truth_report.py --stdout --skip-fetch --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
 
 docs-truth-check: ## Scan non-evidence docs for known stale current-state claims
 	@python3 scripts/docs_truth_check.py --exclude docs/current-state/reports --exclude docs/current-state/raw

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ skills/                          # Claude Code skills used in this repo
 - **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
 - **Reviewing staged drafts:** `content/drafts/README.md`
+- **Read-only startup status:** `make status-readonly` prints current repo/site signals without writing a report
 - **Filing an issue:** `issues-to-create/` for drafts; existing ones at [WalksWithASwagger/kriskrug-wp/issues](https://github.com/WalksWithASwagger/kriskrug-wp/issues)
 
 ## How work happens here

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a timestamped Track-A morning truth report."""
+"""Generate a Track-A morning truth report."""
 
 from __future__ import annotations
 
@@ -178,18 +178,28 @@ def main() -> int:
     parser.add_argument("--command-timeout", type=int, default=120, help="Timeout for shell subcommands in seconds.")
     parser.add_argument("--request-timeout", type=int, default=20, help="Timeout for each public smoke HTTP request.")
     parser.add_argument("--out", help="Write report to this path.")
+    parser.add_argument("--stdout", action="store_true", help="Print the report instead of writing a file.")
+    parser.add_argument("--skip-fetch", action="store_true", help="Skip git fetch for strictly non-mutating runs.")
     args = parser.parse_args()
+    if args.stdout and args.out:
+        parser.error("--stdout cannot be combined with --out")
 
     repo_root = Path(__file__).resolve().parents[1]
     now = datetime.now(UTC)
     stamp = now.strftime("%Y%m%d-%H%M%SZ")
-    out_path = Path(args.out) if args.out else repo_root / "docs/current-state/reports" / f"morning-truth-{stamp}.md"
-    if not out_path.is_absolute():
-        out_path = (repo_root / out_path).resolve()
-    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path = None
+    if not args.stdout:
+        out_path = Path(args.out) if args.out else repo_root / "docs/current-state/reports" / f"morning-truth-{stamp}.md"
+        if not out_path.is_absolute():
+            out_path = (repo_root / out_path).resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    startup_results = [
-        run_command("Git Fetch", ["git", "fetch", "--prune"], repo_root, timeout=args.command_timeout),
+    startup_results = []
+    if not args.skip_fetch:
+        startup_results.append(
+            run_command("Git Fetch", ["git", "fetch", "--prune"], repo_root, timeout=args.command_timeout)
+        )
+    startup_results.extend([
         run_command("Git Status", ["git", "status", "--short", "--branch"], repo_root, timeout=args.command_timeout),
         run_command("Recent Log", ["git", "log", "--oneline", "-n", "20"], repo_root, timeout=args.command_timeout),
         run_command("Open PRs", ["gh", "pr", "list", "--state", "open", "--limit", "50"], repo_root, timeout=args.command_timeout),
@@ -202,7 +212,7 @@ def main() -> int:
             repo_root,
             timeout=args.command_timeout,
         ),
-    ]
+    ])
 
     issues_json_result, issues_json = run_json_command(
         "Issue JSON",
@@ -417,8 +427,12 @@ def main() -> int:
         lines.append(render_command_block(aurora_local_status))
         lines.append("")
 
-    out_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
-    print(out_path)
+    report = "\n".join(lines).rstrip() + "\n"
+    if args.stdout:
+        print(report, end="")
+    else:
+        out_path.write_text(report, encoding="utf-8")
+        print(out_path)
     return 0
 
 


### PR DESCRIPTION
### Summary
Adds `make status-readonly`, a print-only startup truth command for sessions where file changes are forbidden.

### Why
`make morning-truth` intentionally writes a timestamped report under `docs/current-state/reports/`. Issue #172 asks for the same startup truth shape without report churn.

### Changes
- Adds `--stdout` to `scripts/morning_truth_report.py` so the report can be printed instead of written.
- Adds `--skip-fetch` so the read-only target avoids `git fetch --prune` metadata changes.
- Adds `make status-readonly` wired to `--stdout --skip-fetch`.
- Documents the command in `AGENTS.md` and `README.md`.
- Leaves `make morning-truth` unchanged.

### Tests
- `make status-readonly > /tmp/kriskrug-status-readonly.out`
- Verified `docs/current-state/reports` file count and latest report path were unchanged before/after the command.
- Verified output includes `Morning Truth Report`, `Snapshot Summary`, `Git Status`, and `WP7 Public Smoke` sections.
- Verified output does not include a `Git Fetch` section.
- `python3 -m py_compile scripts/morning_truth_report.py`
- `make docs-truth-check`
- `make help | rg -n "status-readonly|morning-truth"`
- `git diff --check`
- `make test`

### Evals
Not applicable; this does not affect AI/agent behavior.

### Risks
- The print-only command still performs live read-only checks, so it can take about as long as morning truth.
- Agents may still choose `make morning-truth`; docs now point them to `make status-readonly` when file writes are forbidden.

### Follow-up
None required for this slice.

Closes #172
