### PR TITLE
Add: deployable llms.txt artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ scripts/notion-to-wp/            # Notion → kriskrug.co publisher
 fixes/                           # Production-ready code snippets / migrations
   ├── schema-snippets.php        # JSON-LD (Person + WebSite + Article + Breadcrumb + Service)
   ├── schema-snippets-deployed.php  # The version actually running on prod
-  ├── llms-txt-template.md       # Curated llms.txt for AI search
+  ├── llms.txt                   # Deployment-ready curated llms.txt for AI search
+  ├── llms-txt-template.md       # Deployment and rollback guide for llms.txt
   ├── robots-txt-update.txt      # Two AI-crawler stance options
   └── issue-*.{css,php,md}       # Older queued fixes from earlier batches
 

--- a/docs/current-state/FIX_QUEUE.md
+++ b/docs/current-state/FIX_QUEUE.md
@@ -32,8 +32,8 @@ Ranked by **impact × effort**. P0 = highest impact / lowest friction. Do these 
 
 ### P0.2 — Add `llms.txt` at site root
 - **Why:** Zero-cost AI-discoverability win. Curated map for ChatGPT, Claude, Perplexity browsing.
-- **Path:** Take template from `fixes/llms-txt-template.md`, fill in verified URLs (BC + AI association URL, Indigenomics.ai, social handles), drop at server root via SSH/SFTP, OR use the mu-plugin rewrite approach from the template.
-- **Effort:** 30 min (template is ready).
+- **Path:** Deploy `fixes/llms.txt` to the server root via SSH/SFTP, OR use the mu-plugin rewrite approach from `fixes/llms-txt-template.md`.
+- **Effort:** 30 min (artifact is ready).
 - **Dependencies:** target path and rollback note.
 - **Verify:** `curl -i https://kriskrug.co/llms.txt` returns 200 + `Content-Type: text/plain`.
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -121,7 +121,8 @@ Then use historical plans for context:
 
 | File | Fix item |
 |---|---|
-| `fixes/llms-txt-template.md` | Curated `llms.txt` content for site root (P0.2). |
+| `fixes/llms.txt` | Deployment-ready curated `llms.txt` content for site root (P0.2). |
+| `fixes/llms-txt-template.md` | Deployment and rollback guide for `llms.txt` (P0.2). |
 | `fixes/robots-txt-update.txt` | Two robots.txt options with explicit AI-crawler stances (P0.4). |
 | `fixes/schema-snippets.php` | Mu-plugin: `Person`, `WebSite`, `Article`, `BreadcrumbList`, `Service` JSON-LD (P0.3). Supersedes the older `issue-39-schema-markup.php`. |
 | `fixes/schema-snippets-deployed.php` | Production Code Snippets version. Public HTML appears to include this schema path as of 2026-05-20; verify in wp-admin before editing. |

--- a/docs/current-state/ROADMAP.md
+++ b/docs/current-state/ROADMAP.md
@@ -29,7 +29,7 @@ Low-effort high-impact items that mostly close out FIX_QUEUE P0.
 
 | Item | Effort | Source | Notes |
 |---|---|---|---|
-| Deploy `/llms.txt` | S | FIX_QUEUE P0.2 | Template in `fixes/llms-txt-template.md`. Verify URLs (BC + AI, Indigenomics, social handles) before publishing |
+| Deploy `/llms.txt` | S | FIX_QUEUE P0.2 | Artifact in `fixes/llms.txt`; deployment/rollback notes in `fixes/llms-txt-template.md`. Live deploy still needs approval |
 | Update `robots.txt` with explicit AI-crawler stance | S | FIX_QUEUE P0.4 | Two options in `fixes/robots-txt-update.txt`. "Be cited" is the recommended stance |
 | Fix homepage H1 (currently empty + "Why Choose Me?" duplicate) | M | FIX_QUEUE P0.5 | Theme template fix in a Catch Responsive child theme |
 | Add LinkedIn URL + headshot to Person schema | S | INCIDENT follow-up | KK confirms his actual LinkedIn URL; upload a real headshot to media library; edit the Code Snippets snippet |

--- a/fixes/llms-txt-template.md
+++ b/fixes/llms-txt-template.md
@@ -1,88 +1,45 @@
-# llms.txt — Template for kriskrug.co
+# llms.txt deployment guide for kriskrug.co
 
-**Deploy location:** `https://kriskrug.co/llms.txt` (site root, served as `text/plain` or `text/markdown`).
+`fixes/llms.txt` is the deployment-ready source for the site-root file at:
 
-**How to deploy on Pagely:**
-- **Option A (recommended):** Drop the file at the document root via SFTP / SSH. Pagely will serve it directly without WP routing it through PHP.
-- **Option B:** Use a plugin like *File Manager* in wp-admin to drop the file at root.
-- **Option C:** Add a tiny mu-plugin that registers `/llms.txt` as a rewrite rule and outputs this content. Easier to update later; slower than a static file.
+```text
+https://kriskrug.co/llms.txt
+```
 
-**Verify it works:**
+As of 2026-06-07, the live URL returns `404 text/html`, so the expected first deploy changes that response to `200` with plain-text or Markdown content.
+
+## Deploy
+
+Recommended path: upload `fixes/llms.txt` to the Pagely document root as `llms.txt` through SSH or SFTP. A static root file is preferred because it avoids WordPress routing and plugin dependencies.
+
+Alternative path: if a static root file is not available, deploy a tiny mu-plugin or Code Snippets entry that registers `/llms.txt` and returns the exact contents of `fixes/llms.txt` as `text/plain; charset=utf-8`.
+
+Do not deploy this file without KK approval and a current rollback path.
+
+## Rollback
+
+If the site previously returned 404, remove the deployed `llms.txt` file or disable the snippet/rewrite that serves it.
+
+If an older live `llms.txt` exists by the time this deploy runs, copy it to a timestamped backup before replacing it, then restore that backup to roll back.
+
+## Verify
+
+Before deploy:
+
 ```bash
 curl -i https://kriskrug.co/llms.txt
-# expect HTTP/2 200 and Content-Type: text/plain (or text/markdown)
+# expected before first deploy: HTTP 404 text/html
 ```
 
----
+After deploy:
 
-## File contents
-
-```markdown
-# Kris Krüg
-
-> Generative AI strategist, photographer, and community builder based in Vancouver, BC.
-> I work with creative professionals, media organizations, and Indigenous communities
-> on responsible adoption of AI. Founder of the BC + AI Ecosystem Industry Association.
-
-## About
-
-- [About Kris Krüg](https://kriskrug.co/about/): Personal background, philosophy, and current focus
-- [The KK Worldview](https://kriskrug.co/the-kk-worldview/): My beliefs about AI, creativity, and the human role
-- [Reconciliation & Indigenous Land Acknowledgement](https://kriskrug.co/reconciliation-indigenous-land-acknowledgement/): Commitments and context
-- [Contact](https://kriskrug.co/contact/): How to reach me
-
-## Services & offers
-
-- [AI Upgrade for Modern Media Leaders](https://kriskrug.co/ai-upgrade-for-modern-media-leaders/): Training and strategy for newsrooms, PR teams, and editorial leaders
-- [AI Upgrade for Creative Professionals](https://kriskrug.co/ai-upgrade-for-creative-professionals/): For photographers, designers, artists, and filmmakers
-- [AI Upgrade Community Coaching](https://kriskrug.co/ai-upgrade-community-coaching-w-kris-krug-peter-bittner/): Cohort-based coaching with Peter Bittner
-- [Generative AI Creative Services](https://kriskrug.co/generative-ai-services/): Custom creative-services engagements
-- [Generative AI Workshops](https://kriskrug.co/generative-ai-workshop-for-artists-creatives/): For artists and creative communities
-- [Cinematic Podcasts](https://kriskrug.co/cinematic-podcasts-hollywood-grade-storytelling-meets-generative-ai/): Hollywood-grade storytelling for branded podcasts
-
-## Podcast & speaking
-
-- [MØTLEYKRÜG Podcast](https://kriskrug.co/motleykrug-podcast/): Conversations with builders, artists, and Indigenous technologists
-- [Speaking](https://kriskrug.co/speaking/): Topics, talks, and booking info
-- [Podcast Guesting / EPK](https://kriskrug.co/podcast-guesting-page-epk/): For podcast hosts looking to book Kris
-
-## Notable writing (selected, evergreen)
-
-- [BC + AI Is Live](https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/): Founding statement for the BC + AI Ecosystem Industry Association
-- [BC's AI Ecosystem: A Mycelial Network of Creation](https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/): How a regional AI scene actually works
-- [A Creative Technologist's AI Age Manifesto](https://kriskrug.co/2025/03/30/a-creative-technologists-ai-age-manifesto/): Working principles
-- [How to Build an AI Second Brain That Actually Works for You](https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/): Practical personal-knowledge workflow
-- [How Indigenomics.ai is Flipping the Script on Economic Power in Canada](https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/): Indigenous-led AI economics
-- [What Journalists Need to Know About AI Right Now](https://kriskrug.co/2025/06/24/what-journalists-need-to-know-about-ai-right-now/): Newsroom-focused primer
-- [Punk Rock AI](https://kriskrug.co/2026/05/04/punk-rock-ai/): A counter-corporate stance on AI culture
-- [Web Summit Vancouver 2026](https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/): Independent coverage
-
-## Projects & communities
-
-- [BC + AI Ecosystem Industry Association](https://bcaiecosystem.org/) — Kris is founding Executive Director (verify URL — placeholder)
-- [Indigenomics.ai](https://indigenomics.ai/) — Kris serves as CTO
-- [Vancouver AI Meetup](https://kriskrug.co/?s=vancouver+ai+meetup) — Monthly community gathering Kris helps host
-
-## Blog archive
-
-- [Blog index](https://kriskrug.co/blog/): All posts, most recent first
-
-## Optional
-
-- [Testimonials](https://kriskrug.co/testimonials/)
-- [Publications](https://kriskrug.co/publications/)
-- [Events](https://kriskrug.co/events/)
-- [Sponsor the Cyberpunk Chronicles newsletter](https://kriskrug.co/sponsor-cyberpunk-chronicles-newsletter/)
-- [Privacy Policy](https://kriskrug.co/privacy-policy/)
-- [Product Review Policy](https://kriskrug.co/product-review-policy-instructions/)
+```bash
+curl -fsSL https://kriskrug.co/llms.txt -o /tmp/kriskrug-llms-live.txt
+diff -u fixes/llms.txt /tmp/kriskrug-llms-live.txt
+curl -i https://kriskrug.co/llms.txt | sed -n '1,12p'
+# expected: HTTP 200 and Content-Type text/plain, text/markdown, or compatible text content
 ```
 
----
+## Maintenance
 
-## Notes for KK before publishing
-
-1. **Verify URLs** — I wrote `bcaiecosystem.org` and `indigenomics.ai` as placeholders. Confirm the actual canonical URLs and adjust before deploying.
-2. **The format** follows the `llms.txt` spec by Jeremy Howard et al. The first heading is the site title; the blockquote is the short description LLMs use; H2 sections group related links; each link is a Markdown bullet with `[title](url): one-line summary`.
-3. **Why this list and not the full site:** `llms.txt` is *curated*. The point is to send LLMs to the high-signal, you-stand-behind-this content — not to crawl all 941 posts. The blog index covers the rest.
-4. **The "Notable writing" section is the one to update most often.** Refresh it every 3-6 months as new evergreen pieces land.
-5. **Consider a companion `llms-full.txt`** that includes the full Markdown text of the top 10 pages, so LLMs can read your canonical content without parsing HTML. Higher effort; do after `llms.txt` proves valuable.
+Refresh `fixes/llms.txt` every 3-6 months or after major page/archive changes. Keep it curated; `llms-full.txt` remains a separate future artifact and should not be bundled with this first deploy.

--- a/fixes/llms.txt
+++ b/fixes/llms.txt
@@ -1,0 +1,52 @@
+# Kris Krüg
+
+> Vancouver-based generative AI strategist, photographer, and community builder. Founder + Executive Director of BC + AI Ecosystem, with past CTO work at Indigenomics.ai.
+
+## Core pages
+
+- [About Kris Krüg](https://kriskrug.co/about/): Personal background, current rooms, and proof of work
+- [The KK Worldview](https://kriskrug.co/the-kk-worldview/): Beliefs about AI, creativity, and the human role
+- [Reconciliation & Indigenous Land Acknowledgement](https://kriskrug.co/reconciliation-indigenous-land-acknowledgement/): Commitments and context for place-based technology work
+- [Contact](https://kriskrug.co/contact/): How to reach Kris
+
+## Services and offers
+
+- [AI Upgrade for Modern Media Leaders](https://kriskrug.co/ai-upgrade-for-modern-media-leaders/): Training and strategy for newsrooms, PR teams, and editorial leaders
+- [AI Upgrade for Creative Professionals](https://kriskrug.co/ai-upgrade-for-creative-professionals/): AI workflows for photographers, designers, artists, and filmmakers
+- [AI Upgrade Community Coaching](https://kriskrug.co/ai-upgrade-community-coaching-w-kris-krug-peter-bittner/): Cohort-based coaching with Peter Bittner
+- [Generative AI Creative Services](https://kriskrug.co/generative-ai-services/): Custom creative-services engagements
+- [Generative AI Workshops](https://kriskrug.co/generative-ai-workshop-for-artists-creatives/): Workshops for artists and creative communities
+- [Cinematic Podcasts](https://kriskrug.co/cinematic-podcasts-hollywood-grade-storytelling-meets-generative-ai/): Hollywood-grade storytelling for branded podcasts
+
+## Podcast and speaking
+
+- [MØTLEYKRÜG Podcast](https://kriskrug.co/motleykrug-podcast/): Conversations with builders, artists, and Indigenous technologists
+- [Speaking](https://kriskrug.co/speaking/): Topics, talks, and booking information
+- [Podcast Guesting / EPK](https://kriskrug.co/podcast-guesting-page-epk/): Booking context for podcast hosts
+
+## Notable writing
+
+- [BC + AI Is Live](https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/): Founding statement for the BC + AI Ecosystem Industry Association
+- [BC's AI Ecosystem: A Mycelial Network of Creation](https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/): How a regional AI scene actually works
+- [A Creative Technologist's AI Age Manifesto](https://kriskrug.co/2025/03/30/a-creative-technologists-ai-age-manifesto/): Working principles for creative technology
+- [How to Build an AI Second Brain That Actually Works for You](https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/): Practical personal-knowledge workflow
+- [How Indigenomics.ai is Flipping the Script on Economic Power in Canada](https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/): Indigenous-led AI economics
+- [What Journalists Need to Know About AI Right Now](https://kriskrug.co/2025/06/24/what-journalists-need-to-know-about-ai-right-now/): Newsroom-focused primer
+- [Punk Rock AI](https://kriskrug.co/2026/05/04/punk-rock-ai/): A counter-corporate stance on AI culture
+- [Web Summit Vancouver 2026](https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/): Independent coverage and field notes
+
+## Projects and communities
+
+- [BC + AI Ecosystem](https://bc-ai.ca/): Community infrastructure for responsible, inclusive, place-rooted AI in British Columbia
+- [Indigenomics.ai](https://indigenomics.ai/): Indigenous economic sovereignty and evidence-systems work Kris has supported through prior CTO work
+- [Vancouver AI Meetup](https://kriskrug.co/?s=vancouver+ai+meetup): Monthly community gathering archive and related posts
+
+## Archives and policies
+
+- [Blog index](https://kriskrug.co/blog/): All posts, most recent first
+- [Testimonials](https://kriskrug.co/testimonials/): Client and collaborator proof
+- [Publications](https://kriskrug.co/publications/): Published work and media references
+- [Events](https://kriskrug.co/events/): Events and appearances
+- [Sponsor the Cyberpunk Chronicles newsletter](https://kriskrug.co/sponsor-cyberpunk-chronicles-newsletter/): Newsletter sponsorship information
+- [Privacy Policy](https://kriskrug.co/privacy-policy/): Site privacy policy
+- [Product Review Policy](https://kriskrug.co/product-review-policy-instructions/): Product review policy and instructions


### PR DESCRIPTION
### Summary
Adds a deployment-ready `llms.txt` artifact for kriskrug.co and updates the old template into a deployment/rollback guide.

### Why
Issue #170 tracks the missing site-root `llms.txt`. Live `https://kriskrug.co/llms.txt` still returns `404 text/html`, while the repo only had a template with an unresolved BC+AI placeholder URL.

### Changes
- Adds `fixes/llms.txt` as the curated deployable source file.
- Updates `fixes/llms-txt-template.md` into a concise deployment, rollback, and verification guide.
- Replaces the unresolved `bcaiecosystem.org` placeholder with the verified canonical `https://bc-ai.ca/` URL.
- Updates README/current-state/FIX_QUEUE/ROADMAP references so future agents use the artifact directly.
- Does not deploy anything live.

### Tests
- `curl -sS -o /tmp/kriskrug-llms-live-check.txt -w '%{http_code} %{content_type} %{url_effective}\n' https://kriskrug.co/llms.txt` returned `404 text/html; charset=UTF-8 https://kriskrug.co/llms.txt`.
- Local output-format check: `fixes/llms.txt` has a top-level title, summary blockquote, 6 H2 sections, and 31 Markdown link bullets with summaries.
- Link sweep: all 31 URLs in `fixes/llms.txt` returned HTTP 200 after redirects.
- Placeholder sweep found no `placeholder`, `verify URL`, `bcaiecosystem.org`, or `social handles` markers in the artifact/docs touched here.
- `make docs-truth-check`
- `make test`
- `git diff --check`

### Evals
Output-format eval passed: title, summary, curated sections, and link-summary bullets are present. No AI/agent behavior changes.

### Risks
- Live serving path is still unverified until a human-approved Pagely/root-file deploy happens.
- Content can become stale as offerings and evergreen posts change; the guide calls for a 3-6 month refresh cadence.
- Reviewers may confuse this repo artifact with a live deploy; this PR is artifact/docs only.

### Follow-up
- Deploy `fixes/llms.txt` to the site root only after approval and rollback confirmation.
- After deployment, run the curl/diff validation in `fixes/llms-txt-template.md`.
- Keep `llms-full.txt` separate and later.

Closes #170
