### PR TITLE
Update: prepare AI crawler robots policy

### DIFF
--- a/fixes/robots-txt-ai-policy.php
+++ b/fixes/robots-txt-ai-policy.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Issue #171: Full robots.txt policy for kriskrug.co via WordPress filter.
+ *
+ * Stance: AI/search discovery and citation — all known AI crawlers are allowed
+ * to index public content, with the standard admin/search disallows applied.
+ *
+ * This snippet supersedes fixes/issue-37-robots-add-sitemaps.php. It handles
+ * everything in one filter: sitemap additions, User-agent: * search disallows,
+ * and the named AI-crawler group. Do not run both snippets at once.
+ *
+ * IMPORTANT — this only works if robots.txt is VIRTUAL (served by WordPress).
+ * If a physical /robots.txt exists at the Pagely document root, that file wins
+ * and this filter never runs. To check:
+ *     curl https://kriskrug.co/robots.txt
+ * If the physical file is present, edit it directly instead (see fixes/robots.txt).
+ *
+ * Deploy:   paste into the Code Snippets plugin (run everywhere) OR drop in
+ *           wp-content/mu-plugins/kk-robots-ai-policy.php.
+ * Verify:   curl https://kriskrug.co/robots.txt | grep -i "ClaudeBot\|image-sitemap"
+ * Rollback: deactivate the snippet / delete the mu-plugin file. No data changes.
+ * Updated:  2026-06-08 — see WalksWithASwagger/kriskrug-wp fixes/robots.txt for
+ *           the canonical artifact and crawler list.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'robots_txt', 'kk_robots_ai_policy', 20, 2 );
+
+/**
+ * Apply full robots.txt policy: sitemaps + User-agent: * additions + AI-crawler group.
+ *
+ * Additive and idempotent: lines already present in the output are skipped.
+ *
+ * @param string $output The robots.txt content built so far.
+ * @param bool   $public Whether the site is set to be indexed (Settings > Reading).
+ * @return string
+ */
+function kk_robots_ai_policy( $output, $public ) {
+	if ( ! $public ) {
+		return $output;
+	}
+
+	$additions = array();
+
+	// ── Sitemaps ────────────────────────────────────────────────────────────
+	// Core/Jetpack already emit sitemap.xml and news-sitemap.xml; we add the
+	// image and video sitemaps that crawlers would otherwise miss.
+	$sitemaps = array(
+		home_url( '/image-sitemap-index-1.xml' ),
+		home_url( '/video-sitemap-1.xml' ),
+	);
+	foreach ( $sitemaps as $url ) {
+		$line = 'Sitemap: ' . esc_url_raw( $url );
+		if ( false === strpos( $output, $url ) ) {
+			$additions[] = $line;
+		}
+	}
+
+	// ── User-agent: * search disallows ──────────────────────────────────────
+	// WordPress core emits "Disallow: /wp-admin/" already; add the missing
+	// search/query-string rules.
+	$wildcard_disallows = array(
+		'Disallow: /?s=',
+		'Disallow: /search/',
+	);
+	foreach ( $wildcard_disallows as $rule ) {
+		if ( false === strpos( $output, $rule ) ) {
+			$additions[] = $rule;
+		}
+	}
+
+	// ── Named AI-crawler group ───────────────────────────────────────────────
+	// Explicit group so these crawlers see clear per-agent rules even if they
+	// do not inherit from User-agent: *. Stance: allow all public content.
+	$ai_group_marker = 'User-agent: OAI-SearchBot';
+	if ( false === strpos( $output, $ai_group_marker ) ) {
+		$ai_crawlers = array(
+			'OAI-SearchBot',
+			'GPTBot',
+			'ChatGPT-User',
+			'ClaudeBot',
+			'Claude-User',
+			'Claude-SearchBot',
+			'PerplexityBot',
+			'Perplexity-User',
+			'Google-Extended',
+			'Applebot-Extended',
+			'CCBot',
+			'Amazonbot',
+			'cohere-ai',
+			'Bytespider',
+		);
+
+		$additions[] = '';
+		$additions[] = '# AI/search crawlers are intentionally allowed for public content.';
+		foreach ( $ai_crawlers as $bot ) {
+			$additions[] = 'User-agent: ' . $bot;
+		}
+		$additions[] = 'Disallow: /wp-admin/';
+		$additions[] = 'Allow: /wp-admin/admin-ajax.php';
+		$additions[] = 'Disallow: /?s=';
+		$additions[] = 'Disallow: /search/';
+		$additions[] = 'Allow: /';
+	}
+
+	if ( empty( $additions ) ) {
+		return $output;
+	}
+
+	return rtrim( $output ) . "\n" . implode( "\n", $additions ) . "\n";
+}

--- a/fixes/robots-txt-update.txt
+++ b/fixes/robots-txt-update.txt
@@ -1,175 +1,143 @@
-## robots.txt — recommended update for kriskrug.co
+# robots.txt deployment guide for kriskrug.co
 
-# Deploy: replace current /robots.txt with the contents of section A or section B below.
-# Pagely: file lives at server document root, OR can be filtered via WP's `robots_txt` filter
-#         if you'd rather keep it in code (a mu-plugin example is at the bottom of this file).
-#
-# Current content is shown for reference; both new options REPLACE it entirely.
-#
-# ======================================================================
-# CURRENT (as of 2026-05-14)
-# ======================================================================
-# Sitemap: https://kriskrug.co/sitemap.xml
-# Sitemap: https://kriskrug.co/news-sitemap.xml
-# User-agent: *
-# Disallow: /wp-admin/
-# Allow: /wp-admin/admin-ajax.php
-#
-# Problems:
-# - No image sitemap listed
-# - No explicit stance on AI crawlers (everything defaults to allowed)
-# - No llms.txt reference
+Status: ready for approved deploy
+Decision recorded: 2026-06-07
+Chosen stance: AI/search discovery and citation
+Deployable artifact: `fixes/robots.txt`
 
-# ======================================================================
-# OPTION A — "BE CITED" stance (RECOMMENDED for KK)
-# Allows every legitimate AI crawler so KK gets cited in ChatGPT, Claude,
-# Perplexity, Gemini AI Overviews, Bing Copilot, etc.
-# ======================================================================
+## Decision
 
-# Sitemaps
+KK chose the "AI/search" path on 2026-06-07: let reputable AI/search crawlers reach public content so kriskrug.co can be cited, retrieved, and represented in AI-assisted search surfaces.
+
+This is the right move for the current site because the roadmap is optimizing for discoverability, public proof, photography/speaking authority, and AI-era search presence. It does not attempt a "no training" stance. That tradeoff should be revisited if the priority shifts from public reach to content-control or licensing.
+
+## Current live output
+
+Captured on 2026-06-07 from `curl -fsSL https://kriskrug.co/robots.txt`:
+
+```txt
 Sitemap: https://kriskrug.co/sitemap.xml
 Sitemap: https://kriskrug.co/news-sitemap.xml
-Sitemap: https://kriskrug.co/image-sitemap-index-1.xml
-Sitemap: https://kriskrug.co/video-sitemap-1.xml
-
-# Optional: point AI crawlers to the curated index
-# llms.txt is not in the formal robots.txt spec, but a comment is fine
-# llms.txt: https://kriskrug.co/llms.txt
-
-# Default rules for all crawlers
 User-agent: *
 Disallow: /wp-admin/
 Allow: /wp-admin/admin-ajax.php
-Disallow: /?s=
-Disallow: /search/
+```
 
-# AI / LLM crawlers — explicitly allowed (this is the same as default but makes it intentional)
-User-agent: GPTBot
-Allow: /
+Live sitemap checks on 2026-06-07:
 
-User-agent: ChatGPT-User
-Allow: /
+```txt
+https://kriskrug.co/sitemap.xml                200 text/xml; charset=UTF-8
+https://kriskrug.co/news-sitemap.xml           200 text/xml; charset=UTF-8
+https://kriskrug.co/image-sitemap-index-1.xml  200 text/xml; charset=UTF-8
+https://kriskrug.co/video-sitemap-1.xml        200 text/xml; charset=UTF-8
+https://kriskrug.co/llms.txt                   404 text/html; charset=UTF-8
+```
 
-User-agent: OAI-SearchBot
-Allow: /
+The `llms.txt` URL is included in the prepared robots file as a comment only. It is not a robots directive, and it can land before or after the `llms.txt` deploy path is approved.
 
-User-agent: ClaudeBot
-Allow: /
+## What changes
 
-User-agent: anthropic-ai
-Allow: /
+`fixes/robots.txt` keeps the existing public crawl posture and adds:
 
-User-agent: Claude-Web
-Allow: /
+- image/video sitemap references
+- explicit AI/search crawler allow posture
+- search-result URL disallows for noisy internal search pages
+- a comment pointing readers toward the curated `llms.txt` URL
 
-User-agent: PerplexityBot
-Allow: /
+The AI/search crawler block repeats the `/wp-admin/`, `admin-ajax.php`, and search disallow rules. This avoids depending on crawlers inheriting the generic `User-agent: *` group when a more specific user-agent group exists.
 
-User-agent: Perplexity-User
-Allow: /
+## Deploy options
 
-User-agent: Google-Extended
-Allow: /
+Option 1: physical root file
 
-User-agent: Applebot-Extended
-Allow: /
+1. Confirm whether Pagely has a physical root file:
 
-User-agent: CCBot
-Allow: /
+   ```bash
+   ls -la /path/to/site/root/robots.txt
+   ```
 
-User-agent: Amazonbot
-Allow: /
+2. If present, replace that file with the exact contents of `fixes/robots.txt`.
+3. Keep a timestamped copy of the previous file for rollback.
 
-User-agent: cohere-ai
-Allow: /
+Option 2: WordPress virtual robots filter
 
-User-agent: Bytespider
-Allow: /
+If no physical root file exists, WordPress may be serving virtual robots output. Add the selected content through a narrow mu-plugin or snippet using the `robots_txt` filter:
 
-# ======================================================================
-# OPTION B — "NO TRAINING, YES RETRIEVAL" stance
-# Allows user-initiated retrieval bots (ChatGPT-User, Perplexity-User,
-# ClaudeBot when answering live queries) but blocks training crawlers
-# (Google-Extended, anthropic-ai when used for training, CCBot).
-#
-# Use this if KK wants to be quotable in live AI answers but does NOT
-# want his work scooped into foundation-model training datasets.
-# Caveat: the distinction between training and retrieval is fuzzy for
-# several of these bots — this is a directional stance, not airtight.
-# ======================================================================
+```php
+add_filter('robots_txt', function ($output, $public) {
+    if (!$public) {
+        return $output;
+    }
 
-# Sitemap: https://kriskrug.co/sitemap.xml
-# Sitemap: https://kriskrug.co/news-sitemap.xml
-# Sitemap: https://kriskrug.co/image-sitemap-index-1.xml
-# Sitemap: https://kriskrug.co/video-sitemap-1.xml
-#
-# User-agent: *
-# Disallow: /wp-admin/
-# Allow: /wp-admin/admin-ajax.php
-#
-# # Retrieval / user-initiated: ALLOWED
-# User-agent: ChatGPT-User
-# Allow: /
-#
-# User-agent: OAI-SearchBot
-# Allow: /
-#
-# User-agent: Perplexity-User
-# Allow: /
-#
-# User-agent: PerplexityBot
-# Allow: /
-#
-# User-agent: ClaudeBot
-# Allow: /
-#
-# # Training-purpose crawlers: DISALLOWED
-# User-agent: GPTBot
-# Disallow: /
-#
-# User-agent: Google-Extended
-# Disallow: /
-#
-# User-agent: Applebot-Extended
-# Disallow: /
-#
-# User-agent: anthropic-ai
-# Disallow: /
-#
-# User-agent: Claude-Web
-# Disallow: /
-#
-# User-agent: CCBot
-# Disallow: /
-#
-# User-agent: Amazonbot
-# Disallow: /
-#
-# User-agent: cohere-ai
-# Disallow: /
-#
-# User-agent: Bytespider
-# Disallow: /
+    return <<<'TXT'
+[paste the contents of fixes/robots.txt here]
+TXT;
+}, 10, 2);
+```
 
-# ======================================================================
-# DEPLOYMENT NOTES
-# ======================================================================
-#
-# 1. If a physical /robots.txt file exists at server root, it wins over
-#    WordPress's virtual robots.txt. Check on Pagely via SSH:
-#      ls -la /path/to/site/root/robots.txt
-#    If present, edit it directly. If absent, WP serves a virtual one.
-#
-# 2. To replace the virtual robots.txt without writing a file, drop a
-#    mu-plugin with this filter:
-#
-#    add_filter('robots_txt', function ($output, $public) {
-#        if (!$public) return $output;   // respects WP's "discourage search" toggle
-#        return <<<TXT
-#    [paste your chosen Option A or B content here, without the leading #]
-#    TXT;
-#    }, 10, 2);
-#
-# 3. Validate after deploy:
-#      curl https://kriskrug.co/robots.txt
-#    Use Google Search Console's robots.txt tester to confirm syntax.
+Use the physical root file if Pagely already serves one. Avoid deploying both paths at once unless the precedence has been verified.
+
+## Rollback
+
+Physical file rollback:
+
+1. Restore the timestamped previous root `robots.txt`.
+2. Run `curl -fsSL https://kriskrug.co/robots.txt`.
+3. Confirm the live output matches the previous captured file.
+
+WordPress filter rollback:
+
+1. Disable or remove the mu-plugin/snippet.
+2. Clear any relevant site cache.
+3. Run `curl -fsSL https://kriskrug.co/robots.txt`.
+4. Confirm WordPress has returned to the prior virtual output.
+
+Known prior output to restore if needed:
+
+```txt
+Sitemap: https://kriskrug.co/sitemap.xml
+Sitemap: https://kriskrug.co/news-sitemap.xml
+User-agent: *
+Disallow: /wp-admin/
+Allow: /wp-admin/admin-ajax.php
+```
+
+## Validation
+
+Before deploy:
+
+```bash
+curl -fsSL https://kriskrug.co/robots.txt
+curl -I https://kriskrug.co/sitemap.xml
+curl -I https://kriskrug.co/news-sitemap.xml
+curl -I https://kriskrug.co/image-sitemap-index-1.xml
+curl -I https://kriskrug.co/video-sitemap-1.xml
+```
+
+After approved deploy:
+
+```bash
+curl -fsSL https://kriskrug.co/robots.txt | diff -u fixes/robots.txt -
+curl -fsSL https://kriskrug.co/robots.txt
+```
+
+Then validate syntax in Google Search Console's robots.txt tester.
+
+## Sources used for crawler names
+
+- Existing repo draft: `fixes/robots-txt-update.txt`
+- OpenAI crawler docs (`https://developers.openai.com/api/docs/bots`): OAI-SearchBot, GPTBot, ChatGPT-User
+- Anthropic crawler docs (`https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler`): ClaudeBot, Claude-User, Claude-SearchBot
+- Perplexity help center (`https://www.perplexity.ai/help-center/en/articles/10354969-how-does-perplexity-follow-robots-txt`): PerplexityBot
+- Google Search crawler docs (`https://developers.google.com/crawling/docs/crawlers-fetchers/google-common-crawlers`): Google-Extended
+- Apple Support (`https://support.apple.com/en-us/119829`): Applebot-Extended
+- Common Crawl (`https://commoncrawl.org/ccbot`): CCBot
+
+`Amazonbot`, `cohere-ai`, `Bytespider`, and `Perplexity-User` are retained from the existing repo draft. Re-check this crawler list during future SEO maintenance; crawler names and product semantics drift.
+
+## Not included
+
+- No live deploy is performed by this repo change.
+- No legal conclusion is made about training rights.
+- No network-level bot enforcement is added.
+- No `llms.txt` file is deployed by this change.

--- a/fixes/robots.txt
+++ b/fixes/robots.txt
@@ -1,0 +1,41 @@
+# robots.txt for kriskrug.co
+# Stance: AI/search discovery and citation.
+# Source: WalksWithASwagger/kriskrug-wp fixes/robots.txt
+# Last reviewed: 2026-06-07
+
+Sitemap: https://kriskrug.co/sitemap.xml
+Sitemap: https://kriskrug.co/news-sitemap.xml
+Sitemap: https://kriskrug.co/image-sitemap-index-1.xml
+Sitemap: https://kriskrug.co/video-sitemap-1.xml
+
+# Curated LLM index. This is a comment, not a robots.txt directive.
+# llms.txt: https://kriskrug.co/llms.txt
+
+User-agent: *
+Disallow: /wp-admin/
+Allow: /wp-admin/admin-ajax.php
+Disallow: /?s=
+Disallow: /search/
+
+# AI/search crawlers are intentionally allowed for public content.
+# Keep the baseline admin/search disallows in this group because specific
+# user-agent groups may not inherit the rules from User-agent: *.
+User-agent: OAI-SearchBot
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: ClaudeBot
+User-agent: Claude-User
+User-agent: Claude-SearchBot
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Google-Extended
+User-agent: Applebot-Extended
+User-agent: CCBot
+User-agent: Amazonbot
+User-agent: cohere-ai
+User-agent: Bytespider
+Disallow: /wp-admin/
+Allow: /wp-admin/admin-ajax.php
+Disallow: /?s=
+Disallow: /search/
+Allow: /


### PR DESCRIPTION
### Summary
Prepares an explicit AI/search robots.txt policy for kriskrug.co.

### Why
Issue #171 needed a product decision before changing crawler behavior. KK chose the AI/search discovery path on 2026-06-07, so this PR turns the old option list into a deploy-ready artifact plus deployment notes.

### Changes
- Adds `fixes/robots.txt` as the deployable root-file artifact.
- Rewrites `fixes/robots-txt-update.txt` as the decision, deploy, rollback, and validation guide.
- Preserves the existing sitemap/wp-admin rules and adds image/video sitemap references.
- Repeats admin/search disallows inside the AI crawler group so specific bot groups do not accidentally bypass the baseline rules.
- Records crawler-name sources and notes that non-official retained names should be rechecked during future SEO maintenance.

### Tests
- `python3` robots artifact assertion script
- `curl -fsSL https://kriskrug.co/robots.txt`
- `curl` status checks for sitemap/news/image/video sitemap URLs and `/llms.txt`
- `make docs-truth-check`
- `make test`
- `git diff --check`

### Evals
Not applicable; this does not affect AI/agent behavior.

### Risks
- Public crawler policy is a product choice; this PR prepares the approved AI/search stance but does not live-deploy it.
- Crawler user-agent names and semantics drift, so the guide explicitly records sources and maintenance notes.
- Pagely root-file vs WordPress virtual robots precedence must be checked before live deploy.

### Follow-up
- After approval, deploy either the physical root file or the WordPress `robots_txt` filter path, then validate with curl and Google Search Console.
- Coordinate with the separate `llms.txt` artifact PR so `/llms.txt` eventually returns 200.

Closes #171