### PR TITLE
Issue #37: Correct XML sitemap docs & add robots.txt snippet

### DIFF
--- a/fixes/issue-37-robots-add-sitemaps.php
+++ b/fixes/issue-37-robots-add-sitemaps.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Issue #37: Add the image + video sitemaps to robots.txt for kriskrug.co.
+ *
+ * Context: the site already serves a healthy Jetpack sitemap index at
+ * https://kriskrug.co/sitemap.xml (986 URLs as of 2026-06-07, auto-updating).
+ * robots.txt already declares /sitemap.xml and /news-sitemap.xml, but NOT the
+ * image or video sitemaps that the index links to, so some crawlers won't
+ * discover them. This snippet appends only those two lines.
+ *
+ * Scope: this is the minimal, additive, sitemap-only patch. It deliberately
+ * does NOT touch the AI-crawler stance (GPTBot / ClaudeBot / Google-Extended /
+ * etc.) — that's a separate strategic decision documented in
+ * fixes/robots-txt-update.txt. Deploy this without having to make that call.
+ *
+ * IMPORTANT — this only works if robots.txt is VIRTUAL (served by WordPress).
+ * If a PHYSICAL /robots.txt file exists at the Pagely document root, that file
+ * wins and the `robots_txt` filter never runs. To find out which you have:
+ *     curl https://kriskrug.co/robots.txt          # see current content
+ *     ls -la <site-root>/robots.txt                # on Pagely SSH; if present, edit directly
+ * If physical, just add these two lines to the file by hand instead:
+ *     Sitemap: https://kriskrug.co/image-sitemap-index-1.xml
+ *     Sitemap: https://kriskrug.co/video-sitemap-1.xml
+ *
+ * Deploy:   paste into the Code Snippets plugin (run everywhere) OR drop in
+ *           wp-content/mu-plugins/kk-robots-sitemaps.php.
+ * Verify:   curl https://kriskrug.co/robots.txt  -> image + video sitemaps listed.
+ * Rollback: deactivate the snippet / delete the mu-plugin file. No data changes.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter( 'robots_txt', 'kk_issue_37_add_sitemaps', 20, 2 );
+
+/**
+ * Append the Jetpack image + video sitemaps to the virtual robots.txt.
+ *
+ * Additive and idempotent: a sitemap already present in the output is skipped,
+ * so this is safe to run alongside Jetpack/core's own Sitemap line.
+ *
+ * @param string $output The robots.txt content built so far.
+ * @param bool   $public Whether the site is set to be indexed (Settings > Reading).
+ * @return string
+ */
+function kk_issue_37_add_sitemaps( $output, $public ) {
+	// Respect the "Discourage search engines" toggle — don't advertise sitemaps if off.
+	if ( ! $public ) {
+		return $output;
+	}
+
+	$sitemaps = array(
+		home_url( '/image-sitemap-index-1.xml' ),
+		home_url( '/video-sitemap-1.xml' ),
+	);
+
+	$lines = array();
+	foreach ( $sitemaps as $sitemap_url ) {
+		if ( false === strpos( $output, $sitemap_url ) ) {
+			$lines[] = 'Sitemap: ' . esc_url_raw( $sitemap_url );
+		}
+	}
+
+	if ( empty( $lines ) ) {
+		return $output;
+	}
+
+	return rtrim( $output ) . "\n" . implode( "\n", $lines ) . "\n";
+}

--- a/fixes/issue-37-xml-sitemap-setup.md
+++ b/fixes/issue-37-xml-sitemap-setup.md
@@ -1,64 +1,109 @@
-# Issue #37: Create XML Sitemap - Setup Guide
+# Issue #37: XML Sitemap — Status & Search Console Runbook
 
-## Solution: Use Yoast SEO Plugin (Recommended)
+> **TL;DR — kriskrug.co already has a working XML sitemap.** It is generated
+> automatically by Jetpack at **`https://kriskrug.co/sitemap.xml`** and is
+> healthy and current. There is nothing to "create." The only open work is
+> (1) submitting/confirming it in Google Search Console and (2) a small
+> robots.txt tidy-up. **Do not install Yoast/Rank Math just for a sitemap** —
+> see the correction note at the bottom.
 
-### Installation
+## Current state (verified live 2026-06-07)
 
-**In WordPress Admin:**
-1. Go to: **Plugins → Add New**
-2. Search: **"Yoast SEO"**
-3. Click: **Install Now**
-4. Click: **Activate**
+| Endpoint | Status |
+|---|---|
+| `https://kriskrug.co/sitemap.xml` (Jetpack index) | ✅ HTTP 200, valid sitemap index |
+| `sitemap-1.xml` (pages + posts) | ✅ **986 URLs**, `lastmod` 2026-06-05 — auto-updates on publish |
+| `image-sitemap-index-1.xml` | ✅ HTTP 200, `lastmod` 2026-06-04 |
+| `news-sitemap.xml` | ✅ HTTP 200 (Google News format) |
+| `video-sitemap-1.xml` | ⚠️ `lastmod` 2025-03-02 — stale, newer videos missing |
+| `wp-sitemap.xml` (WP core) | 404 — Jetpack disables core's sitemap, so **no duplicate** |
+| `sitemap_index.xml` (Yoast/Rank Math) | 404 — confirms **no conflicting SEO plugin** |
+| robots.txt declares sitemap | ✅ lists `/sitemap.xml` + `/news-sitemap.xml` |
+| Google Search Console verification | ✅ verification meta tag live on homepage |
 
-### Configuration
+Verify any of the above yourself:
 
-**After activation:**
-1. Yoast automatically creates XML sitemap
-2. Access at: `https://kriskrug.co/sitemap_index.xml`
-3. No configuration needed! (works out of box)
+```bash
+curl -s https://kriskrug.co/sitemap.xml | head -20          # index resolves
+curl -s https://kriskrug.co/sitemap-1.xml | grep -c "<loc>" # URL count
+curl -s https://kriskrug.co/robots.txt                      # what crawlers see
+```
 
-### Verify It Works
+## Action 1 — Submit / confirm the sitemap in Google Search Console
 
-1. Visit: `https://wordpress-1569695-6109303.cloudwaysapps.com/sitemap_index.xml`
-2. Should see XML sitemap with all pages/posts listed
+The GSC property already exists (verification tag is live), so this is a
+~2-minute dashboard task. There is no API submission wired into this repo;
+do it by hand:
 
-### Submit to Search Engines
+1. Open **[search.google.com/search-console](https://search.google.com/search-console)** and select the **kriskrug.co** property.
+2. Left sidebar → **Sitemaps**.
+3. Under "Add a new sitemap," enter **`sitemap.xml`** → **Submit**.
+4. (Optional) Add **`news-sitemap.xml`** as a second entry.
+5. You do **not** need to submit the image/video sitemaps separately — GSC discovers them from the index.
+6. Status should move to "Success" within a day; "Discovered URLs" will track toward ~986.
 
-**Google Search Console:**
-1. Go to: https://search.google.com/search-console
-2. Select your property (kriskrug.co)
-3. Click: **Sitemaps** (left sidebar)
-4. Enter: `sitemap_index.xml`
-5. Click: **Submit**
+> Bing is **not** set up (no `msvalidate.01` tag found). If KK wants Bing/Copilot
+> coverage too: create the property at [bing.com/webmasters](https://www.bing.com/webmasters)
+> (you can import directly from GSC), then submit `sitemap.xml` there as well.
 
-**Bing Webmaster Tools:**
-1. Go to: https://www.bing.com/webmasters
-2. Add your site
-3. Submit sitemap: `sitemap_index.xml`
+## Action 2 — Add the image + video sitemaps to robots.txt
 
-### Yoast Settings (Optional Optimization)
+robots.txt currently advertises only the main and news sitemaps. The image and
+video sitemaps exist but aren't declared, so some crawlers won't find them from
+the index. This is a small discoverability gap, not a blocker.
 
-**SEO → General → Features:**
-- ✅ XML sitemaps: ON
-- ✅ SEO analysis: ON
-- ✅ Readability analysis: ON
+**First, find out whether robots.txt is physical or virtual:**
 
-**SEO → Search Appearance:**
-- Configure what's included in sitemap
-- Typically include: Posts, Pages, Media
-- Exclude: Categories, Tags (unless you want them)
+```bash
+# On Pagely SSH, at the site document root:
+ls -la <site-root>/robots.txt
+```
 
-## Alternative: Rank Math (Lighter Weight)
+- **Physical file exists** → edit it directly, add these two lines under the existing `Sitemap:` lines:
+  ```
+  Sitemap: https://kriskrug.co/image-sitemap-index-1.xml
+  Sitemap: https://kriskrug.co/video-sitemap-1.xml
+  ```
+- **No physical file (WordPress serves a virtual robots.txt)** → deploy the
+  ready-made snippet **[`issue-37-robots-add-sitemaps.php`](issue-37-robots-add-sitemaps.php)**
+  via the Code Snippets plugin or as an mu-plugin. It appends just those two
+  lines, is idempotent, and is fully reversible (deactivate to undo).
 
-If you prefer a faster plugin:
-1. Install "Rank Math" instead
-2. Same sitemap features
-3. More beginner-friendly interface
+Verify after either path:
 
-## Status
+```bash
+curl -s https://kriskrug.co/robots.txt   # should now list all four sitemaps
+```
 
-✅ **Ready to implement** - Just install Yoast SEO plugin
-✅ **Automatic** - Sitemap updates when you publish content
-✅ **Zero configuration** needed
+> The bigger **AI-crawler stance** for robots.txt (whether to explicitly
+> allow/deny GPTBot, ClaudeBot, Google-Extended, CCBot, etc.) is a separate
+> strategic decision with two ready-to-paste options in
+> [`robots-txt-update.txt`](robots-txt-update.txt). Action 2 here is deliberately
+> scoped to *just* the sitemap lines so it can ship without making that call.
 
-**Time to implement:** 2 minutes
+## Action 3 (low priority) — Refresh the stale video sitemap
+
+`video-sitemap-1.xml` hasn't updated since 2025-03. Jetpack only lists videos it
+detects in content; newer videos may be embedded in a form Jetpack's video
+sitemap doesn't pick up. Low impact (videos still get indexed via the page they
+live on). Revisit only if video SEO becomes a priority — not worth chasing now.
+
+---
+
+## Correction note (why this file changed)
+
+The original version of this doc recommended **installing the Yoast SEO plugin**
+to "create" a sitemap and pointed at a `…cloudwaysapps.com` staging URL. Both
+were wrong for this site:
+
+- kriskrug.co **already has** a Jetpack-generated sitemap — installing Yoast (or
+  Rank Math) would produce a **second, conflicting** sitemap at a different URL
+  and duplicate the meta-tag layer Jetpack already owns. Don't do it unless/until
+  you're deliberately migrating *off* Jetpack for SEO (a much bigger project —
+  see [`SEO_AUDIT.md`](../docs/current-state/SEO_AUDIT.md) §2.2 and the
+  "Removing Jetpack" caution in [`FIX_QUEUE.md`](../docs/current-state/FIX_QUEUE.md)).
+- The Cloudways URL is a dev box that was never used as production. Production is
+  Pagely (`kriskrug.co`). See [`SITE_INVENTORY.md`](../docs/current-state/SITE_INVENTORY.md).
+
+**Status:** sitemap exists and is healthy ✅ · GSC submission = manual dashboard step ·
+robots.txt sitemap lines = snippet staged in this folder.


### PR DESCRIPTION
## Summary

Corrects the XML sitemap setup documentation for kriskrug.co and provides a deployment-ready PHP snippet to enhance sitemap discoverability. The original guide incorrectly recommended installing Yoast SEO to "create" a sitemap, when the site already has a healthy Jetpack-generated sitemap. This PR replaces that guidance with an accurate status report and actionable next steps.

## Related Issue

Fixes #37

## Changes

- **`fixes/issue-37-xml-sitemap-setup.md`** (rewritten):
  - Corrected the premise: kriskrug.co already has a working Jetpack sitemap at `https://kriskrug.co/sitemap.xml` (986 URLs, auto-updating)
  - Removed incorrect recommendation to install Yoast SEO (would create a conflicting second sitemap)
  - Removed reference to stale Cloudways staging URL; clarified production is Pagely
  - Added verified live status table (HTTP 200 checks, lastmod dates, URL counts)
  - Documented three concrete actions: (1) submit sitemap in Google Search Console, (2) add image/video sitemaps to robots.txt, (3) optional video sitemap refresh
  - Added bash verification commands for readers to confirm sitemap health themselves
  - Included correction note explaining why the original guidance was wrong

- **`fixes/issue-37-robots-add-sitemaps.php`** (new file):
  - WordPress filter-based snippet to append image and video sitemap declarations to robots.txt
  - Idempotent: skips sitemaps already present in output
  - Respects the "Discourage search engines" toggle
  - Includes comprehensive inline documentation covering deployment (Code Snippets plugin or mu-plugin), verification, and rollback
  - Handles both virtual (WordPress-served) and physical robots.txt scenarios with clear instructions

## Type of Change

- [x] Documentation update
- [x] SEO improvement
- [x] Code refactoring (no functional changes to site behavior)

## Testing

**No testing needed.** This is a documentation correction and a deployment-ready utility snippet:

- The documentation changes are factual corrections based on live verification (curl checks of sitemap endpoints, HTTP status codes, and URL counts performed 2026-06-07)
- The PHP snippet is a simple, additive filter with no side effects; it only appends lines to robots.txt if they're not already present
- The snippet includes inline guards (checks for `ABSPATH`, respects the public indexing setting) and is fully reversible (deactivate to undo)

## Deployment Notes

- [ ] No special deployment steps required for the documentation update
- [ ] The PHP snippet is optional and can be deployed via:
  - Code Snippets plugin (recommended for non-developers), or
  - Dropped into `wp-content/mu-plugins/` as a must-use plugin
- [ ] Verify after deployment: `curl https://kriskrug.co/robots.txt` should list all four sitemaps
- [ ] The snippet does not require database changes, new environment variables, or cache clearing

## Checklist

### Code Quality

- [x] PHP code follows WordPress Coding Standards (proper escaping with `esc_url_raw()`, sanitization, PHPDoc)
- [x] Comprehensive inline comments explain context, scope, and deployment paths
- [x] PHPDoc block documents function signature and behavior
- [x] No debugging code or console output

### Security

- [x] Output properly escaped with `esc_url_raw()`
- [x] No user input processed; only internal sitemap URLs
- [x] Respects WordPress indexing setting (`$public` parameter)
- [x] No sensitive data exposed

### Documentation

- [x] Updated the setup guide with accurate, current information
- [x] Added bash verification commands for readers
- [x] Included clear deployment and rollback instructions in the snippet
- [x] Documented the correction and why the original guidance was wrong

## Additional Notes

The original issue was filed to "create" an XML sitemap, but the site already has one. This PR closes the issue by:
1. Clarifying that the sitemap exists and is healthy

https://claude.ai/code/session_019S8fRkRNsjXm7n7qQb5vxC