### PR TITLE
ci: run notion-to-wp unit tests and plugin smoke in PR validation

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,6 +20,8 @@ jobs:
       has_php: ${{ steps.changed-files.outputs.has_php }}
       has_js: ${{ steps.changed-files.outputs.has_js }}
       has_docs: ${{ steps.changed-files.outputs.has_docs }}
+      has_notion: ${{ steps.changed-files.outputs.has_notion }}
+      has_sidebar_promos: ${{ steps.changed-files.outputs.has_sidebar_promos }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,12 +44,16 @@ jobs:
               name.startsWith('docs/') ||
               ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'Makefile', 'scripts/docs_truth_check.py'].includes(name)
             );
+            const hasNotion = names.some((name) => name.startsWith('scripts/notion-to-wp/'));
+            const hasSidebarPromos = names.some((name) => name.startsWith('plugins/kk-sidebar-promos/'));
 
             core.info(`Changed files: ${names.length}`);
-            core.info(`has_php=${hasPhp} has_js=${hasJs} has_docs=${hasDocs}`);
+            core.info(`has_php=${hasPhp} has_js=${hasJs} has_docs=${hasDocs} has_notion=${hasNotion} has_sidebar_promos=${hasSidebarPromos}`);
             core.setOutput('has_php', hasPhp ? 'true' : 'false');
             core.setOutput('has_js', hasJs ? 'true' : 'false');
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
+            core.setOutput('has_notion', hasNotion ? 'true' : 'false');
+            core.setOutput('has_sidebar_promos', hasSidebarPromos ? 'true' : 'false');
 
       - name: Check PR title format
         uses: actions/github-script@v7
@@ -102,6 +108,29 @@ jobs:
 
       - name: WordPress PHP validation
         run: make validate
+
+      - name: KK Sidebar Promos smoke test
+        if: needs.validate.outputs.has_sidebar_promos == 'true'
+        run: php plugins/kk-sidebar-promos/tests/smoke.php
+
+  # Notion publisher unit tests
+  notion-tests:
+    needs: validate
+    runs-on: ubuntu-latest
+    if: needs.validate.outputs.has_notion == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Notion publisher test dependencies
+        run: pip install -r scripts/notion-to-wp/requirements.txt
+
+      - name: Run Notion publisher unit tests
+        run: python -m unittest discover -s scripts/notion-to-wp/tests -v
 
   # JavaScript/Node validation
   javascript-validation:
@@ -176,7 +205,7 @@ jobs:
 
   # Summarize all checks
   summary:
-    needs: [validate, php-validation, javascript-validation, docs-truth-check, security-scan]
+    needs: [validate, php-validation, notion-tests, javascript-validation, docs-truth-check, security-scan]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add path-filtered `notion-tests` job (Python 3.12 + `requirements.txt` + unittest discover)
- Run `kk-sidebar-promos` smoke test when `plugins/kk-sidebar-promos/**` changes
- Include `notion-tests` in PR summary gate

## Why
Closes #186 — the 25 incident-response connector tests and plugin smoke only ran locally via `make test`, not in CI.

## Changes
- `.github/workflows/test-pr.yml` only

## Tests
- [x] Local: `pip install -r scripts/notion-to-wp/requirements.txt && python -m unittest discover -s scripts/notion-to-wp/tests` → 25 passed
- [x] Local: `php plugins/kk-sidebar-promos/tests/smoke.php` → passed
- [ ] CI on this PR (workflow change should trigger jobs when notion path touched — this PR touches workflow only; notion job skips; validate + security-scan run)

## Evals
N/A

## Risks
Low — additive jobs, skipped when paths unchanged

## Follow-up
#197 connector refactor should merge after this lands

Made with [Cursor](https://cursor.com)