### PR TITLE
docs: record auto-implement label cleanup

### DIFF
--- a/docs/current-state/ISSUE-LABEL-CLEANUP-2026-06-09.md
+++ b/docs/current-state/ISSUE-LABEL-CLEANUP-2026-06-09.md
@@ -1,0 +1,17 @@
+# Issue Label Cleanup — 2026-06-09
+
+## auto-implement label removal (#191)
+
+The `auto-implement` label previously implied the parked `agent-pr-generator.yml` workflow would run. That automation is a manual diagnostic stub only.
+
+| Metric | Value |
+|---|---:|
+| Open issues before | 42 |
+| Open issues after | 0 |
+| Label description | Historical — agent-pr-generator parked; no automation triggers |
+
+### Issues edited (42)
+
+#4, #5, #7, #8, #9, #10, #11, #13, #14, #15, #18, #19, #20, #21, #22, #36, #38, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64
+
+Routing labels `swarm-ready` and `swarm-parked` were not changed.


### PR DESCRIPTION
## Summary
Documents removal of misleading `auto-implement` labels from 42 open issues.

## Why
Closes #191 — agent-pr-generator is parked; the label implied automation that does not exist.

## Changes
- `docs/current-state/ISSUE-LABEL-CLEANUP-2026-06-09.md`

## Tests
Tracker-only; label removal already executed on GitHub (42→0).

## Follow-up
None

Made with [Cursor](https://cursor.com)