### PR TITLE
docs: refresh entry-doc pointers to June 2026 truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,18 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 
 ## Read this in order (top of repo, top of context)
 
-1. [`docs/current-state/README.md`](docs/current-state/README.md) — index of the May-2026 baseline snapshot
-2. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
-3. [`docs/current-state/REPO_STATE.md`](docs/current-state/REPO_STATE.md) — what's actually built vs. just documented
-4. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
-5. [`docs/current-state/HANDOFF-2026-05-24.md`](docs/current-state/HANDOFF-2026-05-24.md) — 2026-05-24 Aurora/theme/content handoff
-6. [`docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) — reconciled Aurora v1.3.0 QA + rollout status
-7. [`docs/current-state/SESSION-HANDOFF-2026-05-24.md`](docs/current-state/SESSION-HANDOFF-2026-05-24.md) — Track A/Track B ownership and latest lane handoff
-8. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — latest normalized startup truth memo; verify against the newest committed `docs/current-state/reports/morning-truth-*.md`
-9. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
+1. [`docs/current-state/README.md`](docs/current-state/README.md) — index; start with the newest `reports/morning-truth-*.md`
+2. [`docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md`](docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) — June 2026 execution queue (verify closed steps against GitHub)
+3. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
+4. [`docs/current-state/REPO_STATE.md`](docs/current-state/REPO_STATE.md) — what's actually built vs. just documented
+5. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
+6. [`docs/current-state/HANDOFF-2026-05-24.md`](docs/current-state/HANDOFF-2026-05-24.md) — 2026-05-24 Aurora/theme/content handoff
+7. [`docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](docs/current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) — reconciled Aurora v1.3.0 QA + rollout status
+8. [`docs/current-state/SESSION-HANDOFF-2026-05-24.md`](docs/current-state/SESSION-HANDOFF-2026-05-24.md) — Track A/Track B ownership and latest lane handoff
+9. [`docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md`](docs/current-state/TRACK-A-MORNING-TRUTH-2026-05-24.md) — normalized startup truth memo (historical); prefer newest `reports/morning-truth-*.md`
+10. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
+
+Roadmap-derived execution issues filed 2026-06-09: **#186–#197** (CI, prod drift, tracker hygiene).
 
 For the detailed diagnostic behind that plan, read [`docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`](docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md).
 
@@ -79,4 +82,4 @@ If the task explicitly forbids file changes, run `make status-readonly` instead.
 
 ---
 
-**Last verified:** 2026-05-25 02:19 UTC via `make morning-truth`. If you're reading this much later than that and the rest of the repo has drifted, treat `docs/current-state/` plus the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth and flag the drift for a fresh audit.
+**Last verified:** 2026-06-09 via `docs/current-state/reports/morning-truth-20260609-043246Z.md`. If you're reading this much later and the repo has drifted, run `make morning-truth` (or `make status-readonly`) and treat the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth.

--- a/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
+++ b/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
@@ -1,5 +1,7 @@
 # Post-Ship Audit + Workplan - 2026-06-04
 
+**STATUS (2026-06-09):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. Open follow-ups are tracked in roadmap issues **#186–#197** and open GitHub issues **#125**, **#127**, **#187**, **#188**, **#189**. Reconcile counts against the newest `reports/morning-truth-*.md` before executing.
+
 ## Shipped Today
 
 - PR #148 merged: `content: polish Work page proof metadata`.

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -5,11 +5,11 @@
 
 This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated handoff/truth docs plus the newest committed `reports/morning-truth-*.md` artifact as the current front door.
 
-## Current Front Door (verified 2026-06-04 06:29 UTC)
+## Current Front Door (verified 2026-06-09)
 
 Read these first for current execution context:
 
-1. [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) plus `reports/morning-truth-20260604-062927Z.md`
+1. [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) plus `reports/morning-truth-20260609-043246Z.md`
 2. [LOCAL-WP-QA-2026-06-04.md](LOCAL-WP-QA-2026-06-04.md)
 3. [AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md](AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md)
 4. [WORK-PAGE-METADATA-68-2026-06-04.md](WORK-PAGE-METADATA-68-2026-06-04.md)


### PR DESCRIPTION
## Summary
Refresh AGENTS.md and current-state README to June 2026 execution truth.

## Why
Closes #192 — entry docs cited closed issues and stale morning-truth pointers.

## Changes
- AGENTS.md, docs/current-state/README.md, POST-SHIP-AUDIT banner

## Tests
docs-truth-check (manual run on branch)

## Follow-up
Re-run after #190 tracker hygiene

Made with [Cursor](https://cursor.com)