### PR TITLE
docs: backfill aurora changelog and release checklist

### DIFF
--- a/docs/current-state/AURORA-RELEASE-CHECKLIST.md
+++ b/docs/current-state/AURORA-RELEASE-CHECKLIST.md
@@ -1,0 +1,41 @@
+# Aurora Theme Release Checklist
+
+Use this checklist for every manual `kk-aurora` production deploy on Pagely (wp-admin zip upload — no SFTP/SSH).
+
+## Pre-release (repo)
+
+- [ ] Bump `Version:` in `theme/kk-aurora/style.css`
+- [ ] Bump `KK_AURORA_VERSION` in `theme/kk-aurora/functions.php` to match
+- [ ] Add changelog entry in `theme/kk-aurora/readme.txt` with PR/commit references
+- [ ] Run `make verify` (or at minimum `make test` + `make validate`)
+- [ ] Visual spot-check on Local WP (`http://localhost:10003`) if available
+
+## Package
+
+- [ ] Zip `theme/kk-aurora/` (exclude `.DS_Store`, editor cruft)
+- [ ] Record zip checksum: `shasum -a 256 kk-aurora.zip`
+- [ ] Retain previous zip as rollback artifact (name with version)
+
+## Deploy (wp-admin)
+
+- [ ] Upload zip via Appearance → Themes → Add New → Upload
+- [ ] Confirm active theme version in wp-admin matches expected
+- [ ] Remove Customizer "Additional CSS" safety-net if present (masks reveal bugs)
+
+## Post-deploy verification
+
+- [ ] Purge Pagely cache
+- [ ] Logged-out spot-check: homepage, `/blog/`, one real post
+- [ ] `make status-readonly` — confirm GSAP CDN check if version includes GSAP removal
+- [ ] Cross-post evidence to open issues (#125, #127, #189 as applicable)
+
+## Rollback
+
+- [ ] Re-upload previous version zip from retained artifact
+- [ ] Purge Pagely cache again
+- [ ] Re-verify logged-out render
+
+## Notes
+
+- Versions **1.3.16–1.3.18** are on branch `aurora/synthetic-feel-refactor` (PR #185) pending merge to `main`.
+- Production was at **1.3.12** as of 2026-06-09 morning-truth; repo `main` is **1.3.15**.

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -17,7 +17,7 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 * Full Site Editing (FSE) block theme
 * Dark mode by default
 * Animated gradient accents
-* GSAP/ScrollTrigger animations
+* CSS/JS scroll reveals (no GSAP dependency on main; GSAP removed in 1.3.15)
 * High contrast accessibility
 * Mobile-first responsive design
 * Custom block patterns
@@ -38,6 +38,19 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 * Pink: #EC4899 (highlights)
 
 == Changelog ==
+
+= 1.3.15 =
+* GSAP CDN removed; one-accent signal/wildcard color scheme refactor (PR #184).
+* Self-hosted Clash Display; micro-interactions use native IntersectionObserver reveals.
+
+= 1.3.14 =
+* Global footer social links (PR #164).
+* Aurora prose rhythm on generic pages (PR #166).
+
+= 1.3.13 =
+* Photography showcase gallery pattern (PR #162).
+* Mobile QA pass and dead mobile-menu JS removal (PR #163).
+* Shopify Buy Button pattern for Shop page (PR #159).
 
 = 1.3.12 =
 * Stabilized Article Map active-section tracking during mobile and scripted scroll.


### PR DESCRIPTION
## Summary
Backfill readme.txt through 1.3.15 on main and add deploy checklist.

## Why
Closes #193 — six versions undocumented; deploys not auditable.

## Changes
- theme/kk-aurora/readme.txt
- docs/current-state/AURORA-RELEASE-CHECKLIST.md

## Tests
Manual git cross-check

## Follow-up
Add 1.3.16–1.3.18 entries when PR #185 merges

Made with [Cursor](https://cursor.com)