### PR TITLE
feat: add read-only Jetpack SEO metadata inventory script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
+.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit seo-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -137,6 +137,15 @@ draft-queue-audit: ## Run read-only draft queue audit (LOCAL_ONLY=1 FORMAT=json)
 		python3 scripts/notion-to-wp/draft_queue_audit.py --local-only --format "$${FORMAT:-markdown}"; \
 	else \
 		scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --format "$${FORMAT:-markdown}"; \
+	fi
+
+seo-audit: ## Run read-only Jetpack SEO metadata inventory (FORMAT=markdown|json|csv)
+	@if [ "$${FORMAT:-markdown}" = "csv" ]; then \
+		scripts/notion-to-wp/.venv/bin/python scripts/seo-audit/inventory.py --format csv --output "$${OUTPUT:-content/seo-audit-inventory.csv}"; \
+	elif [ "$${FORMAT:-markdown}" = "json" ]; then \
+		scripts/notion-to-wp/.venv/bin/python scripts/seo-audit/inventory.py --format json; \
+	else \
+		scripts/notion-to-wp/.venv/bin/python scripts/seo-audit/inventory.py --format markdown; \
 	fi
 
 jetpack-feedback-audit: ## Run PII-safe read-only Jetpack Forms feedback counts/routing audit (FORMAT=json)

--- a/scripts/seo-audit/README.md
+++ b/scripts/seo-audit/README.md
@@ -1,0 +1,32 @@
+# SEO audit scripts
+
+Read-only tooling for Jetpack SEO metadata coverage.
+
+## inventory.py
+
+Pulls published posts and pages via the WordPress REST API (`context=edit`) and reports whether Jetpack SEO fields are set:
+
+- `jetpack_seo_html_title`
+- `advanced_seo_description`
+- `jetpack_publicize_message` (posts only)
+
+### Usage
+
+```bash
+make seo-audit
+# or
+scripts/notion-to-wp/.venv/bin/python scripts/seo-audit/inventory.py --format csv --output content/seo-audit-$(date +%Y%m%d).csv
+```
+
+Requires `WP_USER` and `WP_APP_PASSWORD` in `scripts/notion-to-wp/.env` (same as the Notion connector).
+
+### Scope
+
+- **In:** published `post` and `page` types
+- **Out:** `transcript` CPT (not deployed), write operations
+
+### Tests
+
+```bash
+python3 -m unittest discover -s scripts/seo-audit/tests -v
+```

--- a/scripts/seo-audit/inventory.py
+++ b/scripts/seo-audit/inventory.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Read-only Jetpack SEO metadata inventory for posts and pages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from inventory_lib import SEORecord, record_from_item, render_markdown, summarize, write_csv
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+NOTION_DIR = SCRIPT_DIR.parent / "notion-to-wp"
+sys.path.insert(0, str(NOTION_DIR))
+
+from kk_notion_to_wp import WordPress, load_config  # noqa: E402
+
+
+def fetch_published(wp: WordPress, kind: str) -> list[dict[str, Any]]:
+    endpoint = "posts" if kind == "post" else "pages"
+    page = 1
+    items: list[dict[str, Any]] = []
+    while True:
+        response = wp.s.get(
+            f"{wp.base}/wp-json/wp/v2/{endpoint}",
+            params={
+                "status": "publish",
+                "per_page": 100,
+                "page": page,
+                "context": "edit",
+                "_fields": "id,slug,title,link,meta",
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+        batch = response.json()
+        if not batch:
+            break
+        items.extend(batch)
+        total_pages = int(response.headers.get("X-WP-TotalPages", "1"))
+        if page >= total_pages:
+            break
+        page += 1
+    return items
+
+
+def collect_inventory(wp: WordPress) -> list[SEORecord]:
+    records: list[SEORecord] = []
+    for kind in ("post", "page"):
+        for item in fetch_published(wp, kind):
+            records.append(record_from_item(kind, item))
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only Jetpack SEO metadata inventory")
+    parser.add_argument("--format", choices=("markdown", "json", "csv"), default="markdown")
+    parser.add_argument("--output", type=Path, help="Write CSV/JSON to this path")
+    args = parser.parse_args()
+
+    cfg = load_config()
+    if not cfg.has_wp_credentials:
+        print("WP_USER and WP_APP_PASSWORD required in scripts/notion-to-wp/.env", file=sys.stderr)
+        return 1
+
+    wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
+    records = collect_inventory(wp)
+
+    if args.format == "json":
+        payload = {"summary": summarize(records), "records": [asdict(r) for r in records]}
+        text = json.dumps(payload, indent=2)
+        if args.output:
+            args.output.write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+    elif args.format == "csv":
+        out = args.output or Path("content/seo-audit-inventory.csv")
+        write_csv(out, records)
+        print(f"Wrote {len(records)} rows to {out}")
+    else:
+        print(render_markdown(records))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seo-audit/inventory_lib.py
+++ b/scripts/seo-audit/inventory_lib.py
@@ -1,0 +1,96 @@
+"""Pure helpers for SEO inventory (no WordPress imports)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+SEO_TITLE_KEYS = ("jetpack_seo_html_title",)
+META_DESC_KEYS = ("advanced_seo_description",)
+SOCIAL_KEYS = ("jetpack_publicize_message",)
+
+
+@dataclass
+class SEORecord:
+    kind: str
+    wp_id: int
+    slug: str
+    title: str
+    link: str
+    has_seo_title: bool
+    seo_title_length: int
+    has_meta_description: bool
+    meta_description_length: int
+    has_social_message: bool
+    social_message_length: int
+
+
+def meta_value(meta: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = meta.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def record_from_item(kind: str, item: dict[str, Any]) -> SEORecord:
+    meta = item.get("meta") or {}
+    seo_title = meta_value(meta, SEO_TITLE_KEYS)
+    meta_desc = meta_value(meta, META_DESC_KEYS)
+    social = meta_value(meta, SOCIAL_KEYS)
+    return SEORecord(
+        kind=kind,
+        wp_id=int(item["id"]),
+        slug=str(item.get("slug") or ""),
+        title=str(item.get("title", {}).get("rendered") or item.get("title") or ""),
+        link=str(item.get("link") or ""),
+        has_seo_title=bool(seo_title),
+        seo_title_length=len(seo_title),
+        has_meta_description=bool(meta_desc),
+        meta_description_length=len(meta_desc),
+        has_social_message=bool(social),
+        social_message_length=len(social),
+    )
+
+
+def summarize(records: list[SEORecord]) -> dict[str, Any]:
+    return {
+        "total": len(records),
+        "posts": sum(1 for r in records if r.kind == "post"),
+        "pages": sum(1 for r in records if r.kind == "page"),
+        "missing_seo_title": sum(1 for r in records if not r.has_seo_title),
+        "missing_meta_description": sum(1 for r in records if not r.has_meta_description),
+        "missing_social_message": sum(1 for r in records if r.kind == "post" and not r.has_social_message),
+    }
+
+
+def render_markdown(records: list[SEORecord]) -> str:
+    stats = summarize(records)
+    lines = [
+        "# Jetpack SEO Metadata Inventory",
+        "",
+        "Read-only snapshot. `transcript` CPT excluded (not deployed).",
+        "",
+        "## Summary",
+        "",
+        f"- Total: {stats['total']} ({stats['posts']} posts, {stats['pages']} pages)",
+        f"- Missing SEO title: {stats['missing_seo_title']}",
+        f"- Missing meta description: {stats['missing_meta_description']}",
+        f"- Posts missing social message: {stats['missing_social_message']}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_csv(path, records: list[SEORecord]) -> None:  # noqa: ANN001
+    import csv
+    from pathlib import Path
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(asdict(records[0]).keys()) if records else [])
+        if records:
+            writer.writeheader()
+            for record in records:
+                writer.writerow(asdict(record))

--- a/scripts/seo-audit/tests/test_inventory.py
+++ b/scripts/seo-audit/tests/test_inventory.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from inventory_lib import SEORecord, record_from_item, summarize  # noqa: E402
+
+
+class InventoryTests(unittest.TestCase):
+    def test_record_from_item_detects_populated_meta(self):
+        item = {
+            "id": 42,
+            "slug": "sample-post",
+            "title": {"rendered": "Sample Post"},
+            "link": "https://kriskrug.co/sample-post/",
+            "meta": {
+                "jetpack_seo_html_title": "Custom SEO Title",
+                "advanced_seo_description": "Custom meta description.",
+                "jetpack_publicize_message": "Share hook",
+            },
+        }
+        record = record_from_item("post", item)
+        self.assertTrue(record.has_seo_title)
+        self.assertTrue(record.has_meta_description)
+        self.assertTrue(record.has_social_message)
+
+    def test_record_from_item_handles_missing_meta(self):
+        item = {
+            "id": 7,
+            "slug": "bare-page",
+            "title": {"rendered": "Bare Page"},
+            "link": "https://kriskrug.co/bare-page/",
+            "meta": {},
+        }
+        record = record_from_item("page", item)
+        self.assertFalse(record.has_seo_title)
+        self.assertFalse(record.has_meta_description)
+
+    def test_summarize_counts_gaps(self):
+        records = [
+            SEORecord("post", 1, "a", "A", "https://x/a", True, 5, False, 0, False, 0),
+            SEORecord("page", 2, "b", "B", "https://x/b", False, 0, True, 10, False, 0),
+        ]
+        stats = summarize(records)
+        self.assertEqual(stats["missing_seo_title"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Read-only SEO inventory script + fixture tests + make seo-audit target.

## Why
Closes #194 — ground truth for #36 and #161.

## Changes
- scripts/seo-audit/*
- Makefile seo-audit target

## Tests
- 3 unit tests pass (inventory_lib fixtures)
- Live run requires WP credentials (manual)

## Follow-up
Wire seo-audit tests into CI when #198 merges

Made with [Cursor](https://cursor.com)