### PR TITLE
docs: refresh current-state drift after queue closeout

### DIFF
--- a/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
+++ b/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
@@ -1,6 +1,6 @@
 # Post-Ship Audit + Workplan - 2026-06-04
 
-**STATUS (2026-06-09):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. Open follow-ups are tracked in roadmap issues **#186–#197** and open GitHub issues **#125**, **#127**, **#187**, **#188**, **#189**. Reconcile counts against the newest `reports/morning-truth-*.md` before executing.
+**STATUS (2026-06-11):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. PR #205 is merged; open PRs are `0`; open issues are `70`, including the June 11 follow-ups #206-#209. GSAP/CDN production drift remains tracked by #189/#204, and Rafiki/content queue closeout is tracked by #206-#208. Reconcile counts with `make status-readonly` before executing.
 
 ## Shipped Today
 
@@ -23,9 +23,9 @@ Sources:
 Current state:
 
 - WordPress smoke: `6.9.4`, `0` failures, `0` warnings.
-- WordPress draft counts from morning-truth: `0` future posts, `71` draft posts, `5` draft pages.
+- WordPress draft counts from 2026-06-11 `make status-readonly`: `0` future posts, `74` draft posts, `5` draft pages.
 - Local draft package audit: `51` local packages, `6` zero-word or missing-slug packages, `1` package with TODOs (`sovereign-ai-for-whom`).
-- Issue queue: `66` open issues, `24` priority-high, `17` Track B, `20` Aurora v2, `16` swarm-ready, `13` swarm-parked, `4` needs-human-review.
+- Issue queue from 2026-06-11 `make status-readonly`: `70` open issues, `30` priority-high, `6` Track B, `7` Aurora v2, `16` swarm-ready, `15` swarm-parked, `16` needs-human-review.
 - Work page OG image is now nonblank in public HTML for `/recent-projects-include/` and `/work/`, but issue #126 still asks for social-share debugger validation.
 
 ## Ready For KK

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -5,11 +5,11 @@
 
 This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated handoff/truth docs plus the newest committed `reports/morning-truth-*.md` artifact as the current front door.
 
-## Current Front Door (verified 2026-06-09)
+## Current Front Door (verified 2026-06-11 via `make status-readonly`)
 
 Read these first for current execution context:
 
-1. [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md) plus `reports/morning-truth-20260609-043246Z.md`
+1. [POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md](POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md), `reports/morning-truth-20260609-043246Z.md`, and the latest read-only startup truth from `make status-readonly`
 2. [LOCAL-WP-QA-2026-06-04.md](LOCAL-WP-QA-2026-06-04.md)
 3. [AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md](AURORA-ARTICLE-LUX-COMPOSITION-1.3.10-WORKPLAN-2026-06-03.md)
 4. [WORK-PAGE-METADATA-68-2026-06-04.md](WORK-PAGE-METADATA-68-2026-06-04.md)
@@ -70,8 +70,8 @@ Then use historical plans for context:
 | [SESSION-HANDOFF-2026-05-24.md](SESSION-HANDOFF-2026-05-24.md) | Track A/Track B lane handoff with ownership boundaries and public-surface updates. |
 | [AURORA-V3-QA-ROADMAP-2026-05-24.md](AURORA-V3-QA-ROADMAP-2026-05-24.md) | Reconciled Aurora v1.3.0 line, local QA evidence, and post-merge rollout priorities. |
 | [TRACK-A-MORNING-TRUTH-2026-05-24.md](TRACK-A-MORNING-TRUTH-2026-05-24.md) | Read-only truth memo with live evidence, drift flags, and verification matrix for safe next-session startup. |
-| `reports/` | Timestamped outputs from `make morning-truth` (read-only startup truth reports). Newest committed artifact as of 2026-06-04: `morning-truth-20260604-062927Z.md`. |
-| [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) | Historical Track A baseline after the Sovereign AI draft pipeline closeout. Queue counts are normalized to the 2026-05-25 truth pass; verify live before acting. |
+| `reports/` | Timestamped outputs from `make morning-truth` (read-only startup truth reports). Newest committed artifact as of 2026-06-09: `morning-truth-20260609-043246Z.md`; refresh live counts with `make status-readonly` before acting. |
+| [WORK-PLAN-2026-05-23.md](WORK-PLAN-2026-05-23.md) | Historical Track A baseline after the Sovereign AI draft pipeline closeout. Live-count declarations were refreshed from the 2026-06-11 `make status-readonly` truth pass; branch assumptions remain historical. |
 | [WORK-PLAN-2026-05-21.md](WORK-PLAN-2026-05-21.md) | Historical next-session front door after the diagnostic/polish branch, docs tidy pass, and sidebar promo hardening. Superseded by `WORK-PLAN-2026-05-23.md`. |
 | [DRAFT-QUALITY-RESET-2026-05-22.md](DRAFT-QUALITY-RESET-2026-05-22.md) | Active Track A publishing correction: live draft counts, why the May 21-22 drafts are not schedule-ready, and the required editorial/link/image/block QA gate. |
 | [DRAFT-QUEUE-AUDIT-2026-05-22.md](DRAFT-QUEUE-AUDIT-2026-05-22.md) | Historical draft queue routing snapshot plus the Sovereign AI addendum (`11905`); re-run `make draft-queue-audit` for live counts. |
@@ -133,13 +133,15 @@ Then use historical plans for context:
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
 - **Current addendum:** start with the post-ship audit/workplan and newest morning-truth report, then use the Local WP QA note, Aurora 1.3.10 workplan, Work metadata closeout, Aurora logo closeout, and the 2026-05-24 handoff set ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
-- **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-06-04 06:29 UTC (`make morning-truth` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
-- **Draft queue addendum:** `make morning-truth` reported `0` future posts, `71` draft posts, and `5` draft pages on 2026-06-04 06:29 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
-- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #147 merged, and `gh issue list --state open --limit 200` returned `66` open issues on 2026-06-04 06:31 UTC.
+- **June 11 addendum:** PR #205 is merged, open PRs are `0`, open issues are `70` including #206-#209, production still reports WordPress `6.9.4`, and the draft queue is `0` future posts, `74` draft posts, and `5` draft pages via `make status-readonly`.
+- **Follow-up addendum:** GSAP/CDN production drift remains tracked by #189/#204; Rafiki/content queue closeout is split across #206, #207, and #208; this docs refresh is #209.
+- **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-06-11 20:09 UTC (`make status-readonly` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
+- **Draft queue addendum:** `make status-readonly` reported `0` future posts, `74` draft posts, and `5` draft pages on 2026-06-11 20:09 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
+- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #205 merged, and `gh issue list --state open --limit 200` returned `70` open issues on 2026-06-11 20:09 UTC.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** the strict backup/restore proof gate was retired on 2026-05-22. Use dry-runs, exact slug/ID/status checks, page/post snapshots or reversible diffs, and explicit rollback notes. Keep improving backup coverage as resilience, not as a blanket blocker.
 
-## Verification Matrix (2026-06-04 06:29 UTC)
+## Verification Matrix (2026-06-11 20:09 UTC)
 
 | Surface | Proof command / URL | Expected truth signal |
 |---|---|---|
@@ -147,8 +149,8 @@ Then use historical plans for context:
 | `/projects/` route health (`#3`) | `curl -sI https://kriskrug.co/projects/` | Status line now returns `301` redirecting to the Work surface (`/recent-projects-include/`). |
 | Work OG image (`#68`, `#126`) | `curl -sL "https://kriskrug.co/recent-projects-include/?cachebust=<ts>" \| rg -n "og:image"` | Cache-busted readback shows a non-blank OG image (latest truth pass resolved to the BC+AI ecosystem image). |
 | Homepage reveal resilience (`#116` follow-through) | `curl -sL https://kriskrug.co/ \| rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"` | Safety-net marker is absent; GSAP/ScrollTrigger scripts are still CDN-loaded. |
-| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `66` open issues. |
-| Draft queue truth | `make draft-queue-audit` | Snapshot values: `0` future posts, `71` draft posts, `5` draft pages. |
+| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `70` open issues including #206-#209. |
+| Draft queue truth | `make status-readonly` or `make draft-queue-audit` | Snapshot values: `0` future posts, `74` draft posts, `5` draft pages. |
 | WP version gate | `make wp7-smoke EXPECT_VERSION=6.9.4` | Public version check + key endpoint smoke pass. |
 | Declared-vs-live drift | `make current-state-drift-check` | Flags mismatches between `WORK-PLAN-2026-05-23.md` declarations and live counts/version. |
 | Aurora branch-model risk (read-only) | `git branch -r \| rg 'aurora/v[23]'` plus `git rev-list --left-right --count origin/main...origin/aurora/v3-reconcile` when a specific salvage is proposed | Confirms that `main` is the canonical Track B base and that `aurora/v2` / `aurora/v3-reconcile` are evidence branches, not wholesale merge targets. |

--- a/docs/current-state/WORK-PLAN-2026-05-23.md
+++ b/docs/current-state/WORK-PLAN-2026-05-23.md
@@ -1,28 +1,29 @@
 # Work Plan - 2026-05-23
 
 > **Status:** historical baseline after PR #129 (2026-05-24).
-> Use `HANDOFF-2026-05-24.md`, `AURORA-V3-QA-ROADMAP-2026-05-24.md`, and
-> `TRACK-A-MORNING-TRUTH-2026-05-24.md` for current execution truth.
-> Queue counts below were normalized to the 2026-05-25 02:19 UTC truth snapshot
-> (`reports/morning-truth-20260525-021945Z.md`); branch assumptions remain historical.
+> Use `README.md`, `POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md`, and the
+> 2026-06-11 20:09 UTC `make status-readonly` pass for current execution truth.
+> Live-count declarations below were refreshed from the 2026-06-11 20:09 UTC
+> status-readonly pass after PR #205 merged; branch assumptions remain historical.
 
 **Purpose:** historical roadmap snapshot after the Sovereign AI draft pipeline closeout.
 **Snapshot time:** 2026-05-22 19:43 PDT / 2026-05-23 02:43 UTC.
-**Queue normalization:** 2026-05-25 02:19 UTC via `gh pr list`, `gh issue list`, `make draft-queue-audit`, and `make wp7-smoke EXPECT_VERSION=6.9.4`.
+**Queue normalization:** 2026-06-11 20:09 UTC via `make status-readonly`; PR #205 is merged, #206-#208 track Rafiki/content follow-ups, and #209 tracks this docs drift refresh.
 **Branch:** `main`
 **Mode:** Track A first. Keep Aurora on Track B.
 
 ## Verified State
 
-- `origin/main` is at `59c1d4c content: add Notion draft backlog packages`.
+- `origin/main` is at `314a9f4 Merge PR #205: content: repair draft queue for Rafiki image review`.
 - Open PRs: `0`.
-- Open issues: `66`.
-- Historical `auto-implement` issues: `44`. This label is not an automation trigger.
-- Open `priority:high` issues: `25`.
-- Open `track-b` + `aurora-v2` issues: `13`.
-- Open `swarm-ready` issues: `13`.
-- Open `swarm-parked` issues: `11`.
-- Open `needs-human-review` issues: `3`.
+- Open issues: `70`, including #206, #207, #208, and #209.
+- Open `auto-implement` issues: `0`. This label is not an automation trigger.
+- Open `priority:high` issues: `30`.
+- Open `track-b` issues: `6`.
+- Open `aurora-v2` issues: `7`.
+- Open `swarm-ready` issues: `16`.
+- Open `swarm-parked` issues: `15`.
+- Open `needs-human-review` issues: `16`.
 - `origin/aurora/v2` is `18` ahead and `88` behind `origin/main`.
 - Worktrees visible today:
   - primary checkout on `codex/docs-reliability-normalization`,
@@ -31,7 +32,8 @@
   - `/Users/kk/Code/kriskrug-wp-main-canonical-20260524` detached at PR #130 state,
   - locked Claude agent worktree on `aurora/v2`.
 - Production still publicly reports WordPress `6.9.4`.
-- WordPress draft queue: `0` scheduled posts, `71` draft posts, `5` draft pages.
+- WordPress draft queue: `0` scheduled posts, `74` draft posts, `5` draft pages.
+- GSAP/CDN production drift remains tracked by #189/#204.
 - `Sovereign AI for Whom?` exists as WP draft `11905` with featured media `11899`; do not create another draft.
 - Reviewable draft posts: `11905`, `11876`, `11877`, `11878`.
 - Thin draft posts needing rebuild/media/block cleanup before scheduling: `11879`-`11885`.
@@ -100,7 +102,7 @@ Done when:
 
 ### Lane 3 - Issue Hygiene And Tracker Trust
 
-Goal: reduce the 66 open issues into useful work lanes.
+Goal: reduce the 70 open issues into useful work lanes.
 
 First packet:
 


### PR DESCRIPTION
## Summary
- Refresh current-state docs to the June 11 post-closeout truth after PR #205 merged.
- Normalize open PR/issue and draft queue counts to the latest read-only status.
- Link remaining intentional drift to #189/#204 and #206-#208.

## Verification
- git diff --check
- make current-state-drift-check
- make docs-truth-check

Closes #209