### PR TITLE
docs: normalize post-closeout issue count

### DIFF
--- a/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
+++ b/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
@@ -1,6 +1,6 @@
 # Post-Ship Audit + Workplan - 2026-06-04
 
-**STATUS (2026-06-11):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. PR #205 is merged; open PRs are `0`; open issues are `70`, including the June 11 follow-ups #206-#209. GSAP/CDN production drift remains tracked by #189/#204, and Rafiki/content queue closeout is tracked by #206-#208. Reconcile counts with `make status-readonly` before executing.
+**STATUS (2026-06-11):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. PRs #205 and #210 are merged; open PRs are `0`; open issues are `69`, including the gated June 11 follow-ups #206-#208. GSAP/CDN production drift remains tracked by #189/#204, and Rafiki/content queue closeout is tracked by #206-#208. Reconcile counts with `make status-readonly` before executing.
 
 ## Shipped Today
 
@@ -25,7 +25,7 @@ Current state:
 - WordPress smoke: `6.9.4`, `0` failures, `0` warnings.
 - WordPress draft counts from 2026-06-11 `make status-readonly`: `0` future posts, `74` draft posts, `5` draft pages.
 - Local draft package audit: `51` local packages, `6` zero-word or missing-slug packages, `1` package with TODOs (`sovereign-ai-for-whom`).
-- Issue queue from 2026-06-11 `make status-readonly`: `70` open issues, `30` priority-high, `6` Track B, `7` Aurora v2, `16` swarm-ready, `15` swarm-parked, `16` needs-human-review.
+- Issue queue from 2026-06-11 `make status-readonly`: `69` open issues, `30` priority-high, `6` Track B, `7` Aurora v2, `16` swarm-ready, `15` swarm-parked, `16` needs-human-review.
 - Work page OG image is now nonblank in public HTML for `/recent-projects-include/` and `/work/`, but issue #126 still asks for social-share debugger validation.
 
 ## Ready For KK

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -133,11 +133,11 @@ Then use historical plans for context:
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
 - **Current addendum:** start with the post-ship audit/workplan and newest morning-truth report, then use the Local WP QA note, Aurora 1.3.10 workplan, Work metadata closeout, Aurora logo closeout, and the 2026-05-24 handoff set ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
-- **June 11 addendum:** PR #205 is merged, open PRs are `0`, open issues are `70` including #206-#209, production still reports WordPress `6.9.4`, and the draft queue is `0` future posts, `74` draft posts, and `5` draft pages via `make status-readonly`.
-- **Follow-up addendum:** GSAP/CDN production drift remains tracked by #189/#204; Rafiki/content queue closeout is split across #206, #207, and #208; this docs refresh is #209.
+- **June 11 addendum:** PRs #205 and #210 are merged, open PRs are `0`, open issues are `69` including #206-#208, production still reports WordPress `6.9.4`, and the draft queue is `0` future posts, `74` draft posts, and `5` draft pages via `make status-readonly`.
+- **Follow-up addendum:** GSAP/CDN production drift remains tracked by #189/#204; Rafiki/content queue closeout is split across #206, #207, and #208; docs drift refresh #209 is closed.
 - **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-06-11 20:09 UTC (`make status-readonly` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
 - **Draft queue addendum:** `make status-readonly` reported `0` future posts, `74` draft posts, and `5` draft pages on 2026-06-11 20:09 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
-- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #205 merged, and `gh issue list --state open --limit 200` returned `70` open issues on 2026-06-11 20:09 UTC.
+- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #210 merged, and `gh issue list --state open --limit 200` returned `69` open issues on 2026-06-11 20:16 UTC.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** the strict backup/restore proof gate was retired on 2026-05-22. Use dry-runs, exact slug/ID/status checks, page/post snapshots or reversible diffs, and explicit rollback notes. Keep improving backup coverage as resilience, not as a blanket blocker.
 
@@ -149,7 +149,7 @@ Then use historical plans for context:
 | `/projects/` route health (`#3`) | `curl -sI https://kriskrug.co/projects/` | Status line now returns `301` redirecting to the Work surface (`/recent-projects-include/`). |
 | Work OG image (`#68`, `#126`) | `curl -sL "https://kriskrug.co/recent-projects-include/?cachebust=<ts>" \| rg -n "og:image"` | Cache-busted readback shows a non-blank OG image (latest truth pass resolved to the BC+AI ecosystem image). |
 | Homepage reveal resilience (`#116` follow-through) | `curl -sL https://kriskrug.co/ \| rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"` | Safety-net marker is absent; GSAP/ScrollTrigger scripts are still CDN-loaded. |
-| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `70` open issues including #206-#209. |
+| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `69` open issues including #206-#208. |
 | Draft queue truth | `make status-readonly` or `make draft-queue-audit` | Snapshot values: `0` future posts, `74` draft posts, `5` draft pages. |
 | WP version gate | `make wp7-smoke EXPECT_VERSION=6.9.4` | Public version check + key endpoint smoke pass. |
 | Declared-vs-live drift | `make current-state-drift-check` | Flags mismatches between `WORK-PLAN-2026-05-23.md` declarations and live counts/version. |

--- a/docs/current-state/WORK-PLAN-2026-05-23.md
+++ b/docs/current-state/WORK-PLAN-2026-05-23.md
@@ -8,7 +8,7 @@
 
 **Purpose:** historical roadmap snapshot after the Sovereign AI draft pipeline closeout.
 **Snapshot time:** 2026-05-22 19:43 PDT / 2026-05-23 02:43 UTC.
-**Queue normalization:** 2026-06-11 20:09 UTC via `make status-readonly`; PR #205 is merged, #206-#208 track Rafiki/content follow-ups, and #209 tracks this docs drift refresh.
+**Queue normalization:** 2026-06-11 20:16 UTC via `make status-readonly`; PRs #205 and #210 are merged, #206-#208 track Rafiki/content follow-ups, and #209 is closed.
 **Branch:** `main`
 **Mode:** Track A first. Keep Aurora on Track B.
 
@@ -16,7 +16,7 @@
 
 - `origin/main` is at `314a9f4 Merge PR #205: content: repair draft queue for Rafiki image review`.
 - Open PRs: `0`.
-- Open issues: `70`, including #206, #207, #208, and #209.
+- Open issues: `69`, including the gated content follow-ups #206, #207, and #208.
 - Open `auto-implement` issues: `0`. This label is not an automation trigger.
 - Open `priority:high` issues: `30`.
 - Open `track-b` issues: `6`.
@@ -102,7 +102,7 @@ Done when:
 
 ### Lane 3 - Issue Hygiene And Tracker Trust
 
-Goal: reduce the 70 open issues into useful work lanes.
+Goal: reduce the 69 open issues into useful work lanes.
 
 First packet:
 


### PR DESCRIPTION
## Summary
- Normalize current-state docs after #209 closed through PR #210.
- Update open issue count from 70 to 69 and mark #209 closed.
- Keep #206-#208 as the remaining gated content follow-ups.

## Verification
- git diff --check
- make current-state-drift-check
- make docs-truth-check