### PR TITLE
Add: category coverage audit and Luma events spike

### DIFF
--- a/docs/current-state/LUMA-UPCOMING-EVENTS-SPIKE-2026-06-11.md
+++ b/docs/current-state/LUMA-UPCOMING-EVENTS-SPIKE-2026-06-11.md
@@ -1,0 +1,74 @@
+# Luma Upcoming Events MVP Spike
+
+Date: 2026-06-11
+Issue: #177
+Related: #62, #196
+Scope: documentation-only feasibility spike. No event MVP implementation, deploy, GitHub write, or production change.
+
+## Question
+
+Can the existing `plugins/kk-sidebar-promos` Luma iCal sync support a one-feed upcoming-events MVP before building the broader #62 multi-calendar portal?
+
+## Short Answer
+
+Yes, but as reuse-with-extension, not as a zero-code reuse.
+
+The plugin already has the useful foundation for a one-feed MVP: one configurable Luma iCal URL, WordPress HTTP fetch, a lightweight iCal parser, daily WP-Cron, manual sync from admin, a private promo CPT, and local smoke coverage. That is enough to avoid starting from scratch.
+
+The current sync deliberately imports only the next upcoming event and turns it into one Featured sidebar promo. It does not persist a list of upcoming events, expose event-specific fields beyond summary/date/link, or render an event-list page/block. A real "upcoming events" MVP should extend the existing parser/sync path into a small one-feed event list, rather than treating the sidebar promo renderer as the product surface.
+
+## What Exists
+
+- `includes/luma-sync.php` fetches the configured iCal URL, parses VEVENT records, picks the earliest event whose `start_ts` is in the future, and upserts one published Featured promo keyed by `source=luma` and `source_id=<uid>`.
+- `kk_sp_parse_ical()` can parse multiple VEVENT records from one feed, but the sync only uses the single next event.
+- The parsed event shape is currently `uid`, `start_ts`, `summary`, `summary_short`, and `url`.
+- `includes/cron.php` schedules daily `kk_sp_luma_sync` and daily Featured promo expiry.
+- `includes/render.php` provides the existing block/widget/shortcode surface for sidebar promos. It is optimized for one Featured card plus rotating Pillars, not an event list.
+- `DEPLOYMENT.md` documents manual admin upload, Luma iCal configuration, manual sync, daily cron, rollback, and pre-deploy smoke checks.
+- `.github/workflows/test-pr.yml` runs the plugin smoke test when `plugins/kk-sidebar-promos/` changes.
+
+## MVP Feasibility
+
+Feasible MVP:
+
+- One configured Luma iCal feed only.
+- Upcoming events only.
+- Render a simple page/block/shortcode listing the next N events from that feed.
+- Each item can safely start with title/summary, start date/time, and event URL.
+- No RSVP integration beyond linking to Luma.
+- No multi-calendar merge, search, filters, subscribe output, or cross-project taxonomy.
+
+Recommended implementation path for a follow-up issue:
+
+1. Extract a small reusable function from the existing Luma path that returns normalized upcoming events from one iCal body/feed.
+2. Add fixture-based tests for multiple VEVENTs, timezone dates, all-day dates, missing UID fallback, escaped text, old events being excluded, and ordering by start time.
+3. Add either a shortcode/block for `[kk_upcoming_events]` or a narrow dynamic block that renders the next N normalized events.
+4. Decide whether the MVP reads the feed live with transient caching or stores normalized events in a separate CPT/meta shape. Do not overload `kk_promo` unless the product stays "one featured promo."
+5. Gate any production usage behind #196 if the work depends on deploying `kk-sidebar-promos`.
+
+## Risks And Limits
+
+- Product scope risk: #62 asks for a unified multi-source calendar with filters, subscriptions, and RSVP integration. The one-feed MVP should be positioned as a validation step, not a partial delivery of #62.
+- Data model risk: `kk_promo` stores promo metadata, not event metadata. It stores the event date as a Featured promo end date and has no first-class start/end/location/status fields.
+- Parser drift risk: Luma iCal output may change. Current parser covers a useful subset but does not currently persist description, location, organizer, status, recurrence, or event end time.
+- Ordering risk: the promo renderer chooses the newest non-expired Featured promo by post date, not by event start time. That is fine for sidebar promos and wrong for an event list.
+- Cron risk: WP-Cron depends on site traffic and plugin activation. A page/block MVP should have a visible stale/fallback state if the feed fetch fails.
+- Deployment risk: the plugin is built and tested but still parked for production; #196 owns the deploy/park/archive decision.
+
+## Follow-Up Issues
+
+- Keep #62 parked as the broad unified calendar portal until the one-feed MVP proves useful.
+- Resolve #196 before any production plugin deploy or production dependency on `kk-sidebar-promos`.
+- New implementation issue: "Add one-feed Luma upcoming-events renderer" with scope limited to one feed, upcoming events only, no RSVP integration, no multi-calendar filtering.
+- New test issue if split out: "Expand Luma iCal fixtures for upcoming-events MVP" covering multi-event parsing, timezone/all-day handling, ordering, stale feed behavior, and field escaping.
+- New product decision issue if needed: "Choose upcoming-events surface" to decide between a page shortcode, dynamic block, or Aurora template placement.
+
+## Verification Performed
+
+- Read issue #177, #62, and #196 from GitHub without writes.
+- Inspected `plugins/kk-sidebar-promos/includes/luma-sync.php`, `render.php`, `cron.php`, `settings.php`, `cpt.php`, `DEPLOYMENT.md`, `readme.txt`, and `tests/smoke.php`.
+- Confirmed the existing local smoke test includes Luma iCal parser coverage and that CI runs it for sidebar promo plugin changes.
+
+## Decision
+
+Reuse the existing Luma sync foundation for a one-feed MVP, but implement the MVP in a separate follow-up code issue. Do not deploy the plugin or broaden #177 into event-product implementation.

--- a/scripts/category_coverage_audit.py
+++ b/scripts/category_coverage_audit.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Read-only category coverage audit for recent WordPress posts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from dataclasses import asdict, dataclass
+from html import unescape
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+DEFAULT_BASE_URL = "https://kriskrug.co"
+DEFAULT_POST_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class Category:
+    wp_id: int
+    name: str
+    slug: str
+    live_count: int | None
+
+
+@dataclass(frozen=True)
+class PostRecord:
+    wp_id: int
+    slug: str
+    title: str
+    link: str
+    date: str
+    category_ids: tuple[int, ...]
+
+
+def strip_html(value: str | None) -> str:
+    if not value:
+        return ""
+    text = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", unescape(text)).strip()
+
+
+def category_from_item(item: dict[str, Any]) -> Category:
+    return Category(
+        wp_id=int(item.get("id") or 0),
+        name=strip_html(str(item.get("name") or "")),
+        slug=str(item.get("slug") or ""),
+        live_count=int(item["count"]) if item.get("count") is not None else None,
+    )
+
+
+def post_from_item(item: dict[str, Any]) -> PostRecord:
+    title = item.get("title") or {}
+    rendered_title = title.get("rendered") if isinstance(title, dict) else title
+    return PostRecord(
+        wp_id=int(item.get("id") or 0),
+        slug=str(item.get("slug") or ""),
+        title=strip_html(str(rendered_title or "")),
+        link=str(item.get("link") or ""),
+        date=str(item.get("date") or ""),
+        category_ids=tuple(int(value) for value in item.get("categories") or []),
+    )
+
+
+def is_misc_category(category: Category) -> bool:
+    return category.slug.casefold() == "misc" or category.name.casefold() == "misc"
+
+
+def build_audit(posts: list[PostRecord], categories: dict[int, Category]) -> dict[str, Any]:
+    category_counts = Counter(category_id for post in posts for category_id in post.category_ids)
+    category_size_counts = Counter(len(post.category_ids) for post in posts)
+    misc_ids = {category_id for category_id, category in categories.items() if is_misc_category(category)}
+    misc_posts = [post for post in posts if misc_ids.intersection(post.category_ids)]
+    unknown_ids = sorted(category_id for category_id in category_counts if category_id not in categories)
+
+    category_rows = []
+    for category_id in sorted(set(category_counts) | set(categories)):
+        category = categories.get(category_id)
+        category_rows.append(
+            {
+                "id": category_id,
+                "name": category.name if category else f"Unknown category {category_id}",
+                "slug": category.slug if category else "",
+                "recent_post_count": category_counts.get(category_id, 0),
+                "live_count": category.live_count if category else None,
+                "is_misc": bool(category and is_misc_category(category)),
+            }
+        )
+    category_rows.sort(key=lambda row: (-row["recent_post_count"], row["name"].casefold(), row["id"]))
+
+    return {
+        "posts_scanned": len(posts),
+        "category_counts": category_rows,
+        "misc": {
+            "category_ids": sorted(misc_ids),
+            "recent_post_count": len(misc_posts),
+            "live_count": sum((categories[category_id].live_count or 0) for category_id in misc_ids),
+            "recent_posts": [post_summary(post) for post in misc_posts],
+            "status": "found" if misc_ids else "not_found",
+        },
+        "multi_category_distribution": [
+            {"categories_per_post": size, "posts": count} for size, count in sorted(category_size_counts.items())
+        ],
+        "multi_category_posts": [
+            post_summary(post) | {"category_ids": list(post.category_ids)}
+            for post in posts
+            if len(post.category_ids) > 1
+        ],
+        "empty_categories": [
+            asdict(category)
+            for category in sorted(categories.values(), key=lambda item: (item.name.casefold(), item.wp_id))
+            if category.live_count == 0
+        ],
+        "unknown_category_ids": unknown_ids,
+    }
+
+
+def post_summary(post: PostRecord) -> dict[str, Any]:
+    return {
+        "id": post.wp_id,
+        "slug": post.slug,
+        "title": post.title,
+        "link": post.link,
+        "date": post.date,
+    }
+
+
+def render_human(report: dict[str, Any]) -> str:
+    audit = report["audit"]
+    lines = [
+        f"Category coverage audit: {report['base_url']}",
+        "Read-only: public WordPress REST GET requests only; no create/update/delete calls.",
+        "",
+        f"Recent posts requested: {report['post_limit']}",
+        f"Recent posts scanned: {audit['posts_scanned']}",
+        "",
+        "Misc usage:",
+        misc_line(audit["misc"]),
+        "",
+        "Multi-category distribution:",
+    ]
+    for row in audit["multi_category_distribution"]:
+        label = "category" if row["categories_per_post"] == 1 else "categories"
+        lines.append(f"- {row['categories_per_post']} {label}: {row['posts']} posts")
+    if not audit["multi_category_distribution"]:
+        lines.append("- No posts scanned.")
+
+    lines.extend(
+        [
+            "",
+            "Category counts for recent posts:",
+            "",
+            "| Category | Slug | Recent posts | Live count | Flags |",
+            "|---|---|---:|---:|---|",
+        ]
+    )
+    for row in audit["category_counts"]:
+        flags = []
+        if row["is_misc"]:
+            flags.append("Misc")
+        if row["live_count"] == 0:
+            flags.append("empty")
+        if row["id"] in audit["unknown_category_ids"]:
+            flags.append("unknown")
+        live_count = "" if row["live_count"] is None else str(row["live_count"])
+        lines.append(
+            f"| {row['name']} | `{row['slug'] or '-'}` | {row['recent_post_count']} | "
+            f"{live_count} | {', '.join(flags) or '-'} |"
+        )
+
+    lines.extend(["", "Empty categories:"])
+    if audit["empty_categories"]:
+        for category in audit["empty_categories"]:
+            lines.append(f"- {category['name']} (`{category['slug']}`)")
+    else:
+        lines.append("- None found in category REST response.")
+
+    lines.extend(["", "Recent Misc posts:"])
+    if audit["misc"]["recent_posts"]:
+        for post in audit["misc"]["recent_posts"]:
+            label = post["slug"] or post["title"] or f"post-{post['id']}"
+            lines.append(f"- {post['date']} `{label}` ({post['link']})")
+    else:
+        lines.append("- None in the scanned recent posts.")
+
+    return "\n".join(lines) + "\n"
+
+
+def misc_line(misc: dict[str, Any]) -> str:
+    if misc["status"] == "not_found":
+        return "- Misc category was not present in the category REST response."
+    return (
+        f"- {misc['recent_post_count']} scanned posts use Misc "
+        f"(category IDs: {', '.join(str(value) for value in misc['category_ids'])}; "
+        f"live count: {misc['live_count']})."
+    )
+
+
+def fetch_json_page(base_url: str, path: str, params: dict[str, Any], timeout: int) -> tuple[list[dict[str, Any]], int]:
+    url = base_url.rstrip("/") + path + "?" + urlencode(params)
+    request = Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "kriskrug-category-coverage-audit/1.0"},
+    )
+    with urlopen(request, timeout=timeout) as response:
+        charset = response.headers.get_content_charset() or "utf-8"
+        payload = json.loads(response.read().decode(charset, "replace"))
+        if not isinstance(payload, list):
+            raise RuntimeError(f"Expected list payload from {path}")
+        total_pages = int(response.headers.get("X-WP-TotalPages") or "1")
+        return payload, total_pages
+
+
+def fetch_paginated(
+    base_url: str,
+    path: str,
+    params: dict[str, Any],
+    timeout: int,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        remaining = None if limit is None else limit - len(items)
+        if remaining is not None and remaining <= 0:
+            break
+        page_params = dict(params)
+        page_params["page"] = page
+        page_params["per_page"] = min(100, remaining) if remaining is not None else 100
+        batch, total_pages = fetch_json_page(base_url, path, page_params, timeout)
+        if not batch:
+            break
+        items.extend(batch)
+        if page >= total_pages:
+            break
+        page += 1
+    return items[:limit] if limit is not None else items
+
+
+def collect_report(base_url: str, post_limit: int, timeout: int) -> dict[str, Any]:
+    post_items = fetch_paginated(
+        base_url,
+        "/wp-json/wp/v2/posts",
+        {
+            "status": "publish",
+            "orderby": "date",
+            "order": "desc",
+            "_fields": "id,slug,title,link,date,categories",
+        },
+        timeout,
+        limit=post_limit,
+    )
+    category_items = fetch_paginated(
+        base_url,
+        "/wp-json/wp/v2/categories",
+        {
+            "hide_empty": "false",
+            "orderby": "name",
+            "order": "asc",
+            "_fields": "id,name,slug,count",
+        },
+        timeout,
+    )
+    posts = [post_from_item(item) for item in post_items]
+    categories = {
+        category.wp_id: category
+        for category in (category_from_item(item) for item in category_items)
+    }
+    return {
+        "base_url": base_url.rstrip("/"),
+        "post_limit": post_limit,
+        "read_only": True,
+        "rest_requests": [
+            "GET /wp-json/wp/v2/posts",
+            "GET /wp-json/wp/v2/categories",
+        ],
+        "audit": build_audit(posts, categories),
+    }
+
+
+def minimum_post_limit(value: str) -> int:
+    parsed = int(value)
+    if parsed < DEFAULT_POST_LIMIT:
+        raise argparse.ArgumentTypeError(f"must be at least {DEFAULT_POST_LIMIT}")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument(
+        "--limit",
+        type=minimum_post_limit,
+        default=DEFAULT_POST_LIMIT,
+        help="Recent posts to scan; minimum 100.",
+    )
+    parser.add_argument("--timeout", type=int, default=30)
+    parser.add_argument("--format", choices=("human", "json"), default="human")
+    args = parser.parse_args()
+
+    report = collect_report(args.base_url, args.limit, args.timeout)
+    if args.format == "json":
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_human(report), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_category_coverage_audit.py
+++ b/scripts/tests/test_category_coverage_audit.py
@@ -1,0 +1,110 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from category_coverage_audit import (  # noqa: E402
+    build_audit,
+    category_from_item,
+    post_from_item,
+    render_human,
+)
+
+
+class CategoryCoverageAuditTests(unittest.TestCase):
+    def test_fixture_posts_produce_category_counts_and_misc_callout(self):
+        categories = {
+            category.wp_id: category
+            for category in [
+                category_from_item({"id": 1, "name": "Misc", "slug": "misc", "count": 769}),
+                category_from_item({"id": 7, "name": "AI Creatives", "slug": "ai-creatives", "count": 12}),
+                category_from_item({"id": 8, "name": "Field Notes", "slug": "field-notes", "count": 3}),
+            ]
+        }
+        posts = [
+            post_from_item(
+                {
+                    "id": 101,
+                    "slug": "one",
+                    "title": {"rendered": "One"},
+                    "link": "https://kriskrug.co/one/",
+                    "date": "2026-06-01T00:00:00",
+                    "categories": [1],
+                }
+            ),
+            post_from_item(
+                {
+                    "id": 102,
+                    "slug": "two",
+                    "title": {"rendered": "Two"},
+                    "link": "https://kriskrug.co/two/",
+                    "date": "2026-06-02T00:00:00",
+                    "categories": [7, 8],
+                }
+            ),
+            post_from_item(
+                {
+                    "id": 103,
+                    "slug": "three",
+                    "title": {"rendered": "Three"},
+                    "link": "https://kriskrug.co/three/",
+                    "date": "2026-06-03T00:00:00",
+                    "categories": [7],
+                }
+            ),
+        ]
+
+        audit = build_audit(posts, categories)
+
+        counts = {row["slug"]: row["recent_post_count"] for row in audit["category_counts"]}
+        self.assertEqual(counts["misc"], 1)
+        self.assertEqual(counts["ai-creatives"], 2)
+        self.assertEqual(counts["field-notes"], 1)
+        self.assertEqual(audit["misc"]["recent_post_count"], 1)
+        self.assertEqual(audit["misc"]["live_count"], 769)
+        self.assertEqual(
+            audit["multi_category_distribution"],
+            [{"categories_per_post": 1, "posts": 2}, {"categories_per_post": 2, "posts": 1}],
+        )
+        self.assertEqual([post["slug"] for post in audit["multi_category_posts"]], ["two"])
+
+    def test_empty_categories_are_reported_without_posts(self):
+        categories = {
+            12: category_from_item({"id": 12, "name": "Empty Topic", "slug": "empty-topic", "count": 0})
+        }
+
+        audit = build_audit([], categories)
+        report = {
+            "base_url": "https://kriskrug.co",
+            "post_limit": 100,
+            "audit": audit,
+        }
+        human = render_human(report)
+        payload = json.dumps(audit)
+
+        self.assertIn("Empty Topic", human)
+        self.assertIn("No posts scanned", human)
+        self.assertIn("empty-topic", payload)
+
+    def test_post_parser_handles_missing_or_empty_categories(self):
+        post = post_from_item(
+            {
+                "id": 104,
+                "slug": "bare",
+                "title": {"rendered": "Bare &amp; Clean"},
+                "link": "https://kriskrug.co/bare/",
+                "date": "2026-06-04T00:00:00",
+                "categories": [],
+            }
+        )
+
+        self.assertEqual(post.title, "Bare & Clean")
+        self.assertEqual(post.category_ids, ())
+        audit = build_audit([post], {})
+        self.assertEqual(audit["multi_category_distribution"], [{"categories_per_post": 0, "posts": 1}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only category coverage audit for recent WordPress posts
- add tests for category parsing, Misc reporting, empty categories, and multi-category distribution
- add a docs-only spike for reusing the kk-sidebar-promos Luma sync as a one-feed upcoming-events MVP

## Verification
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -v`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile scripts/category_coverage_audit.py scripts/tests/test_category_coverage_audit.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/category_coverage_audit.py --format json --timeout 30`
- `make plugin-smoke`
- `make docs-truth-check`

Closes #175
Closes #177
Refs #62
Refs #196