### PR TITLE
Docs: normalize issue count after swarm closeout

### DIFF
--- a/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
+++ b/docs/current-state/POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md
@@ -1,6 +1,6 @@
 # Post-Ship Audit + Workplan - 2026-06-04
 
-**STATUS (2026-06-11):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. PRs #205 and #210 are merged; open PRs are `0`; open issues are `69`, including the gated June 11 follow-ups #206-#208. GSAP/CDN production drift remains tracked by #189/#204, and Rafiki/content queue closeout is tracked by #206-#208. Reconcile counts with `make status-readonly` before executing.
+**STATUS (2026-06-11):** Partially superseded. Steps referencing **#149** (Local WP QA), **#150** (article module tuning), and **#126** (Work OG) are **closed** with evidence. PRs #205, #210, and #212 are merged; open PRs are `0`; open issues are `63`, including the gated June 11 follow-ups #206-#208. GSAP/CDN production drift remains tracked by #189/#204, Rafiki/content queue closeout is tracked by #206-#208, and #62 is parked with the Luma spike result from #177/#212. Reconcile counts with `make status-readonly` before executing.
 
 ## Shipped Today
 
@@ -25,7 +25,7 @@ Current state:
 - WordPress smoke: `6.9.4`, `0` failures, `0` warnings.
 - WordPress draft counts from 2026-06-11 `make status-readonly`: `0` future posts, `74` draft posts, `5` draft pages.
 - Local draft package audit: `51` local packages, `6` zero-word or missing-slug packages, `1` package with TODOs (`sovereign-ai-for-whom`).
-- Issue queue from 2026-06-11 `make status-readonly`: `69` open issues, `30` priority-high, `6` Track B, `7` Aurora v2, `16` swarm-ready, `15` swarm-parked, `16` needs-human-review.
+- Issue queue from 2026-06-11 20:40 UTC live GitHub readback: `63` open issues, `29` priority-high, `6` Track B, `7` Aurora v2, `6` swarm-ready, `15` swarm-parked, `21` needs-human-review.
 - Work page OG image is now nonblank in public HTML for `/recent-projects-include/` and `/work/`, but issue #126 still asks for social-share debugger validation.
 
 ## Ready For KK

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -133,11 +133,11 @@ Then use historical plans for context:
 - **Jetpack is on the Free plan**, which is why WordPress.com MCP write access is currently blocked.
 - **Baseline note:** the May 14 snapshot started before later page-level snapshots, source packs, and Aurora theme work were added. Read the dated addenda above for current operating state.
 - **Current addendum:** start with the post-ship audit/workplan and newest morning-truth report, then use the Local WP QA note, Aurora 1.3.10 workplan, Work metadata closeout, Aurora logo closeout, and the 2026-05-24 handoff set ([`HANDOFF-2026-05-24.md`](HANDOFF-2026-05-24.md), [`AURORA-V3-QA-ROADMAP-2026-05-24.md`](AURORA-V3-QA-ROADMAP-2026-05-24.md), [`SESSION-HANDOFF-2026-05-24.md`](SESSION-HANDOFF-2026-05-24.md), [`TRACK-A-MORNING-TRUTH-2026-05-24.md`](TRACK-A-MORNING-TRUTH-2026-05-24.md)).
-- **June 11 addendum:** PRs #205 and #210 are merged, open PRs are `0`, open issues are `69` including #206-#208, production still reports WordPress `6.9.4`, and the draft queue is `0` future posts, `74` draft posts, and `5` draft pages via `make status-readonly`.
+- **June 11 addendum:** PRs #205, #210, and #212 are merged, open PRs are `0`, open issues are `63` including #206-#208, production still reports WordPress `6.9.4`, and the draft queue is `0` future posts, `74` draft posts, and `5` draft pages via `make status-readonly`.
 - **Follow-up addendum:** GSAP/CDN production drift remains tracked by #189/#204; Rafiki/content queue closeout is split across #206, #207, and #208; docs drift refresh #209 is closed.
 - **WordPress 7.0 addendum:** production still publicly reports WordPress 6.9.4 as of 2026-06-11 20:09 UTC (`make status-readonly` / `make wp7-smoke EXPECT_VERSION=6.9.4`). Use [`WP-7-UPGRADE-2026-05-22.md`](WP-7-UPGRADE-2026-05-22.md), `make wp7-smoke`, and `make wp7-admin-readiness` before any staging or production upgrade.
 - **Draft queue addendum:** `make status-readonly` reported `0` future posts, `74` draft posts, and `5` draft pages on 2026-06-11 20:09 UTC; `sovereign-ai-for-whom` is already WP draft `11905`.
-- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #210 merged, and `gh issue list --state open --limit 200` returned `69` open issues on 2026-06-11 20:16 UTC.
+- **Issue queue addendum:** `gh pr list --state open --limit 200` returned `0` open PRs after PR #212 merged, and `gh issue list --state open --limit 200` returned `63` open issues on 2026-06-11 20:40 UTC.
 - **Read-only fingerprinting works** through the public WP REST API; that's how this snapshot was built.
 - **Path to "safe to modify":** the strict backup/restore proof gate was retired on 2026-05-22. Use dry-runs, exact slug/ID/status checks, page/post snapshots or reversible diffs, and explicit rollback notes. Keep improving backup coverage as resilience, not as a blanket blocker.
 
@@ -149,7 +149,7 @@ Then use historical plans for context:
 | `/projects/` route health (`#3`) | `curl -sI https://kriskrug.co/projects/` | Status line now returns `301` redirecting to the Work surface (`/recent-projects-include/`). |
 | Work OG image (`#68`, `#126`) | `curl -sL "https://kriskrug.co/recent-projects-include/?cachebust=<ts>" \| rg -n "og:image"` | Cache-busted readback shows a non-blank OG image (latest truth pass resolved to the BC+AI ecosystem image). |
 | Homepage reveal resilience (`#116` follow-through) | `curl -sL https://kriskrug.co/ \| rg -n "Aurora reveal safety net|gsap.min.js|ScrollTrigger.min.js"` | Safety-net marker is absent; GSAP/ScrollTrigger scripts are still CDN-loaded. |
-| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `69` open issues including #206-#208. |
+| Queue truth | `gh pr list --state open --limit 100` and `gh issue list --state open --limit 200` | Snapshot values: `0` open PRs, `63` open issues including #206-#208. |
 | Draft queue truth | `make status-readonly` or `make draft-queue-audit` | Snapshot values: `0` future posts, `74` draft posts, `5` draft pages. |
 | WP version gate | `make wp7-smoke EXPECT_VERSION=6.9.4` | Public version check + key endpoint smoke pass. |
 | Declared-vs-live drift | `make current-state-drift-check` | Flags mismatches between `WORK-PLAN-2026-05-23.md` declarations and live counts/version. |

--- a/docs/current-state/WORK-PLAN-2026-05-23.md
+++ b/docs/current-state/WORK-PLAN-2026-05-23.md
@@ -2,28 +2,28 @@
 
 > **Status:** historical baseline after PR #129 (2026-05-24).
 > Use `README.md`, `POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md`, and the
-> 2026-06-11 20:09 UTC `make status-readonly` pass for current execution truth.
-> Live-count declarations below were refreshed from the 2026-06-11 20:09 UTC
-> status-readonly pass after PR #205 merged; branch assumptions remain historical.
+> 2026-06-11 20:40 UTC swarm closeout for current execution truth.
+> Live-count declarations below were refreshed after PR #212 merged; branch
+> assumptions remain historical.
 
 **Purpose:** historical roadmap snapshot after the Sovereign AI draft pipeline closeout.
 **Snapshot time:** 2026-05-22 19:43 PDT / 2026-05-23 02:43 UTC.
-**Queue normalization:** 2026-06-11 20:16 UTC via `make status-readonly`; PRs #205 and #210 are merged, #206-#208 track Rafiki/content follow-ups, and #209 is closed.
+**Queue normalization:** 2026-06-11 20:40 UTC via live GitHub readback after PR #212 merged; #206-#208 track Rafiki/content follow-ups, #209/#175/#177/#190/#160/#8/#10 are closed, and #62 remains parked with the Luma spike result attached.
 **Branch:** `main`
 **Mode:** Track A first. Keep Aurora on Track B.
 
 ## Verified State
 
-- `origin/main` is at `314a9f4 Merge PR #205: content: repair draft queue for Rafiki image review`.
+- `origin/main` is at `5143a1f Merge PR #212: Add category coverage audit and Luma events spike`.
 - Open PRs: `0`.
-- Open issues: `69`, including the gated content follow-ups #206, #207, and #208.
+- Open issues: `63`, including the gated content follow-ups #206, #207, and #208.
 - Open `auto-implement` issues: `0`. This label is not an automation trigger.
-- Open `priority:high` issues: `30`.
+- Open `priority:high` issues: `29`.
 - Open `track-b` issues: `6`.
 - Open `aurora-v2` issues: `7`.
-- Open `swarm-ready` issues: `16`.
+- Open `swarm-ready` issues: `6`.
 - Open `swarm-parked` issues: `15`.
-- Open `needs-human-review` issues: `16`.
+- Open `needs-human-review` issues: `21`.
 - `origin/aurora/v2` is `18` ahead and `88` behind `origin/main`.
 - Worktrees visible today:
   - primary checkout on `codex/docs-reliability-normalization`,
@@ -102,7 +102,7 @@ Done when:
 
 ### Lane 3 - Issue Hygiene And Tracker Trust
 
-Goal: reduce the 69 open issues into useful work lanes.
+Goal: reduce the 63 open issues into useful work lanes.
 
 First packet:
 

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -73,12 +73,12 @@ KNOWN_STALE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "Draft queue count is stale; current normalized count is 71 draft posts.",
     ),
     (
-        re.compile(r"Open issues:\s*`?(?:61|63)`?", re.I),
-        "Open issue count is stale; current normalized count is 66 open issues.",
+        re.compile(r"Open issues:\s*`?(?:61|69)`?", re.I),
+        "Open issue count is stale; current normalized count is 63 open issues.",
     ),
     (
-        re.compile(r"Open issues\s*\|\s*(?:61|63|64)\s*\|", re.I),
-        "Open issue table count is stale; current normalized count is 66 open issues.",
+        re.compile(r"Open issues\s*\|\s*(?:61|64|69)\s*\|", re.I),
+        "Open issue table count is stale; current normalized count is 63 open issues.",
     ),
     (
         re.compile(r"Open PRs\s*\|\s*2\s*\|", re.I),
@@ -90,7 +90,7 @@ KNOWN_STALE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
     (
         re.compile(r"GitHub shows 64 open issues", re.I),
-        "Open issue count is stale; current normalized count is 66 open issues.",
+        "Open issue count is stale; current normalized count is 63 open issues.",
     ),
     (
         re.compile(r"Draft posts\s*\|\s*32\s*\|", re.I),


### PR DESCRIPTION
## Summary
- refresh current-state docs after the issue swarm and PR #212 merge
- update live issue-count labels from 69 to 63
- teach docs-truth-check that the current normalized issue count is 63

## Verification
- `git diff --check`
- `make docs-truth-check`
- `make current-state-drift-check`

Refs #175
Refs #177
Refs #190
Refs #206
Refs #207
Refs #208