### PR TITLE
content: draft AI glossary page

### DIFF
--- a/content/drafts/ai-glossary-2026-05/post.md
+++ b/content/drafts/ai-glossary-2026-05/post.md
@@ -1,0 +1,217 @@
+---
+title: "AI Glossary"
+slug: "glossary"
+status: draft
+type: page
+target_url: "/glossary/"
+excerpt: "Plain-language definitions for the AI, local technology, data governance, Indigenous governance, and creative AI terms that show up across KrisKrug.co."
+seo:
+  meta_title: "AI Glossary | Kris Krug"
+  meta_description: "Plain-language definitions for AI, local technology, data governance, Indigenous governance, and creative AI terms used on KrisKrug.co."
+  focus_keyphrase: "AI glossary"
+  secondary_keyphrases:
+    - "AI terminology"
+    - "generative AI glossary"
+    - "local AI"
+    - "data governance"
+    - "Indigenous data sovereignty"
+review_gates:
+  - "KK editorial review"
+  - "SME/source review for Indigenous governance, rights, legal, protocol, and cultural terms"
+  - "Accessible in-page search/filter build or explicit waiver"
+  - "Mobile and accessibility QA before publication"
+---
+
+# AI Glossary
+
+AI conversations get hard to enter when every sentence assumes you already know the vocabulary. This glossary is a plain-language bridge for readers of KrisKrug.co, especially people arriving through posts about creative AI, local AI, data centres, Indigenous governance, public-interest technology, and community accountability.
+
+The goal is not to flatten complex ideas. The goal is to give newcomers enough context to keep reading, ask better questions, and notice when a term is being used too loosely.
+
+## Related Reading
+
+- [AI Services, Training & Strategy](/generative-ai-services/)
+- [About Kris Krug](/about/)
+- [Web Summit Vancouver 2026](/2026/05/07/web-summit-vancouver-2026/)
+- [Calling Us All In](/2026/05/14/calling-us-all-in/)
+- [Reconciliation & Indigenous Land Acknowledgement](/reconciliation-indigenous-land-acknowledgement/) - include only after the sensitive-term review is complete.
+
+## Browse by Letter
+
+[A](#a) | [B](#b) | [C](#c) | [D](#d) | [E](#e) | [F](#f) | [G](#g) | [H](#h) | [I](#i) | [L](#l) | [M](#m) | [O](#o) | [P](#p) | [R](#r) | [S](#s) | [T](#t) | [U](#u) | [V](#v) | [W](#w)
+
+## A
+
+**Agent:** An AI system that can take multiple steps toward a goal, often using tools, files, web search, or other software along the way.
+
+**AI alignment:** The work of making AI systems behave in ways that match human goals, safety needs, and social values. Alignment is not only a technical problem; it also depends on whose goals and values are being centered.
+
+**AI ethics:** The practice of asking whether AI systems are fair, accountable, understandable, safe, consent-based, and worth building in the first place.
+
+**Algorithm:** A set of instructions for solving a problem or making a decision. In AI, algorithms help systems find patterns, rank options, generate content, or make predictions.
+
+**Artificial intelligence (AI):** Software that performs tasks people often associate with intelligence, such as recognizing patterns, generating language or images, planning, translating, summarizing, or making recommendations.
+
+**Automation:** Using software or machines to do work that people otherwise do manually. Automation can save time, but it can also hide decisions, remove context, or shift power away from workers and communities.
+
+## B
+
+**Benchmark:** A test used to compare AI systems. Benchmarks can be useful, but they rarely capture the full social, cultural, or local impact of a tool.
+
+**Bias:** A pattern that causes a system to treat people, groups, languages, places, or ideas unevenly. Bias can come from training data, design choices, deployment context, or the assumptions of the people building the system.
+
+## C
+
+**Chatbot:** A conversational interface for software. Modern chatbots often use large language models to answer questions, draft text, summarize files, or help with tasks.
+
+**ChatGPT:** OpenAI's conversational AI product. It is a product built around AI models, not the same thing as the underlying model itself.
+
+**Claude:** Anthropic's conversational AI product. Like ChatGPT, it is a product experience wrapped around underlying models and safety systems.
+
+**Community benefits agreement:** A negotiated agreement that spells out how a project will benefit local communities, often including jobs, infrastructure, training, environmental safeguards, or accountability measures.
+
+**Compute:** The processing power needed to train or run AI systems. Compute often depends on specialized chips, energy, cooling, networking, and data centre infrastructure.
+
+**Consent:** Clear permission from people or communities before their data, stories, likeness, cultural knowledge, or creative work is used. Consent should be informed, specific, and revocable where possible.
+
+**Consultation:** A process for asking affected people or communities for input. Consultation is not the same as consent, shared governance, or decision-making power.
+
+**Corpus:** A collection of text, images, audio, video, code, or other material used for search, research, analysis, or AI training.
+
+## D
+
+**Data centre:** A building or campus that houses servers, networking, storage, cooling, and power systems. AI data centres can have major effects on electricity demand, water use, land, labour, and local infrastructure.
+
+**Data governance:** The rules, responsibilities, and decision-making processes for collecting, storing, using, sharing, and deleting data.
+
+**Data sovereignty:** The idea that data should be governed by the laws, rights, values, and decision-making authority of the people, communities, or nations it comes from.
+
+**Digital colonialism:** A pattern where technology systems extract data, labour, knowledge, attention, or value from communities without meaningful consent, benefit, or governance power.
+
+## E
+
+**Embedding:** A mathematical representation of text, images, audio, or other data that helps AI systems compare meaning and similarity.
+
+**Explainability:** The ability to understand why an AI system produced a result or recommendation. Some AI systems are hard to explain, which can make accountability harder.
+
+**Extractive technology:** Technology that takes more value from people, communities, workers, creators, or environments than it returns.
+
+## F
+
+**Fine-tuning:** Additional training that adapts a model for a specific style, task, domain, or dataset.
+
+**Foundation model:** A large model trained on broad data that can be adapted to many tasks, such as writing, coding, image generation, search, or analysis.
+
+**Free, prior and informed consent (FPIC):** A standard in Indigenous rights that means consent should be given freely, before a project proceeds, and with enough information for communities to make a real decision.
+
+**Frontier model:** A model at or near the leading edge of AI capability. The term is often used for powerful systems from major AI labs.
+
+## G
+
+**Generative AI:** AI that creates new text, images, audio, video, code, or other outputs from prompts, examples, or source material.
+
+**GPU:** A graphics processing unit. GPUs are chips that are especially useful for the parallel calculations behind modern AI.
+
+**Guardrails:** Rules, filters, prompts, policies, or product design choices meant to reduce harmful outputs or unsafe behaviour.
+
+## H
+
+**Hallucination:** A confident AI output that is false, unsupported, or invented. Hallucinations are one reason important AI outputs need review.
+
+**Host Nation:** An Indigenous Nation on whose territory an event, project, facility, or decision is taking place. Confirm wording and protocol with the Nation and local context.
+
+**Human-in-the-loop:** A workflow where a person reviews, approves, edits, or can override AI output before it affects people or systems.
+
+## I
+
+**Indigenomics:** An Indigenous economic lens and movement associated with building Indigenous economic power, governance, and participation at scale. Confirm final wording with current Indigenomics.ai language before publication.
+
+**Indigenous AI:** AI work shaped by Indigenous rights, governance, knowledge systems, community priorities, and self-determination rather than imposed from outside.
+
+**Indigenous data sovereignty:** The right of Indigenous Peoples and Nations to govern data about their peoples, lands, resources, knowledge, and communities.
+
+**Indigenous governance:** Decision-making authority grounded in Indigenous laws, institutions, rights, protocols, and relationships. Do not reduce this to stakeholder feedback.
+
+**Indigenous rights holder:** An Indigenous Nation or people with rights that must be respected. A rights holder is not the same as a stakeholder.
+
+**Inference:** Running a trained model to produce an output, such as an answer, image, classification, or recommendation.
+
+## L
+
+**Large language model (LLM):** An AI model trained to work with language. LLMs can draft, summarize, translate, classify, reason over text, and power chatbot products.
+
+**Local AI:** AI that runs on a user's own device, server, or private infrastructure instead of relying entirely on a cloud service.
+
+## M
+
+**Machine learning:** A branch of AI where systems learn patterns from data instead of being programmed with every rule by hand.
+
+**Model:** The trained system that turns inputs into outputs. In AI writing tools, the model is the engine, while the app is the product wrapped around it.
+
+**Model weights:** The learned parameters inside a model. Weights are part of what allow a trained model to produce useful outputs.
+
+**Multimodal AI:** AI that can work across more than one kind of input or output, such as text, images, audio, video, and code.
+
+## O
+
+**OCAP:** A First Nations data governance framework standing for ownership, control, access, and possession. Confirm final wording and attribution before publication.
+
+**Open model:** A model released with enough access for others to inspect, use, adapt, or run it, depending on the license and release terms.
+
+**Open weights:** Model weights that are available for others to download or run. Open weights do not automatically mean open data, open training methods, or unrestricted rights.
+
+## P
+
+**Prompt:** The instruction, question, context, file, or example given to an AI system.
+
+**Prompt engineering:** The practice of designing prompts and workflows so AI systems produce more useful, reliable, or constrained outputs.
+
+**Public-interest compute:** Compute capacity reserved or governed for civic, academic, public, Indigenous, nonprofit, or community benefit rather than only private profit.
+
+## R
+
+**Reconciliation:** The ongoing work of repairing relationships and systems shaped by colonialism. In technology work, this should include material commitments, governance, accountability, and respect for Indigenous rights.
+
+**Red teaming:** Testing a system by trying to make it fail, break rules, expose vulnerabilities, or produce harmful outputs.
+
+**Retrieval-augmented generation (RAG):** A method where an AI system retrieves relevant documents or data before generating an answer, making it easier to cite sources and use current context.
+
+**Rights holder:** A person, people, or Nation with legal, inherent, or recognized rights affected by a decision. Rights holders require a different level of respect and authority than general stakeholders.
+
+## S
+
+**Self-determination:** The right of a people or community to make decisions about its own future, governance, resources, culture, and development.
+
+**Sovereign AI:** AI infrastructure, capability, or governance controlled by a country, Nation, region, or community. The term should always raise the question: sovereign for whom?
+
+**Stakeholder:** A person or group with an interest in a decision. Stakeholders matter, but the term should not be used to flatten rights holders, host Nations, workers, creators, or affected communities into one generic category.
+
+**Synthetic media:** Images, audio, video, or text created or heavily modified by AI.
+
+## T
+
+**Token:** A chunk of text that an AI model processes. Tokens can be words, parts of words, punctuation, or other units.
+
+**Traditional knowledge:** Knowledge held by Indigenous Peoples and communities through lived practice, relationship, stewardship, language, and culture. It should not be treated as free training data.
+
+**Training data:** The material used to teach an AI model patterns. Training data can include text, images, audio, video, code, or structured records.
+
+**Transformer:** A model architecture that helped make modern language models possible by allowing systems to track relationships across large amounts of text.
+
+**Two-Eyed Seeing:** A concept associated with Mi'kmaw Elder Albert Marshall about learning to see from both Indigenous and Western knowledge systems. Confirm wording and attribution before publication.
+
+## U
+
+**Unceded territory:** Land that was not surrendered through treaty. Use local wording carefully and confirm with the relevant Nation or trusted local sources.
+
+## V
+
+**Vector database:** A database designed to store and search embeddings, often used for semantic search and RAG systems.
+
+**Vision model:** An AI model that can interpret images or video.
+
+## W
+
+**Water and energy footprint:** The water, electricity, cooling, land, and infrastructure demands created by technology systems, including AI data centres.
+
+**Workflow automation:** Software that connects steps in a process so repeated work can happen with less manual effort. Good automation should still keep accountability clear.

--- a/content/drafts/ai-glossary-2026-05/seo-meta.md
+++ b/content/drafts/ai-glossary-2026-05/seo-meta.md
@@ -1,0 +1,39 @@
+# SEO - AI Glossary
+
+**SEO title:** AI Glossary | Kris Krug
+
+**Slug:** glossary
+
+**Target URL:** /glossary/
+
+**Status:** Local draft package only. Do not publish without KK and sensitive-term review.
+
+**Meta description:** Plain-language definitions for AI, local technology, data governance, Indigenous governance, and creative AI terms used on KrisKrug.co.
+
+**Suggested excerpt:** Plain-language definitions for the AI, local technology, data governance, Indigenous governance, and creative AI terms that show up across KrisKrug.co.
+
+**Focus keyword:** AI glossary
+
+**Secondary keywords:** AI terminology, generative AI glossary, local AI, data governance, Indigenous data sovereignty
+
+**Open Graph**
+- og:title - AI Glossary | Kris Krug
+- og:description - A plain-language field guide to AI terms, community technology language, and governance concepts used across KrisKrug.co.
+- og:image - Hold until KK chooses whether the page needs a visual treatment. This can publish image-free.
+
+**Suggested schema:** WebPage plus BreadcrumbList. Hold DefinedTermSet schema until sensitive terms and source attribution are settled.
+
+**Recommended page type:** WordPress page
+
+**Recommended parent:** none
+
+**Publication caution:** The draft includes terms touching Indigenous governance, rights, protocol, data governance, and legal concepts. Publish only after KK review and source or SME review for the sensitive-term queue in `README.md`.
+
+**Search gate:** Issue #44 should not close until in-page search/filter is built or explicitly waived. Minimum behavior: visible label, keyboard usable input, term and definition filtering, no-JS fallback with all terms visible, clear no-results state, and result count announced with `aria-live="polite"`.
+
+**Internal links after publication**
+- Link from posts and pages that use dense AI terminology.
+- Link from AI infrastructure and data centre posts where terms such as `sovereign AI`, `public-interest compute`, and `data centre` appear.
+- Link from local AI and creative workflow posts where terms such as `RAG`, `vector database`, `open weights`, and `model` appear.
+- Link from `/generative-ai-services/`, `/about/`, `/blog/`, and future AI education pages if KK wants this to become a permanent reader aid.
+- Link from reconciliation or Indigenous governance pages only after sensitive-term review.


### PR DESCRIPTION
## Summary
- add a local page draft for `/glossary/` with 69 plain-language AI and governance terms
- add SEO/social metadata and publication cautions
- preserve gates for KK editorial review, sensitive-term review, and accessible search/filter behavior

Refs #44

## Tests
- `rg -n "TODO|TBD|FIXME" content/drafts/ai-glossary-2026-05/post.md content/drafts/ai-glossary-2026-05/seo-meta.md` returned no matches
- `rg -n "—|–|/Users/|localhost|127\.0\.0\.1|notion\.so|file://" content/drafts/ai-glossary-2026-05/post.md content/drafts/ai-glossary-2026-05/seo-meta.md` returned no matches
- `scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests`

## Human gates before publish
- KK editorial review
- SME/source review for Indigenous governance, rights, legal, protocol, and cultural terms
- accessible in-page search/filter build or explicit waiver
- mobile/accessibility QA on the actual WordPress page
