### PR TITLE
content: draft Vancouver AI community page

### DIFF
--- a/content/drafts/2026-06-11-vancouver-ai-community-page/internal-links.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/internal-links.md
@@ -1,0 +1,26 @@
+# Internal Link Plan - Vancouver AI Community
+
+Do not edit existing live pages in the issue #18 worker lane. Add these only after KK approves the draft page as a destination.
+
+## Recommended Inbound Links
+
+- `/about/`: link the BC+AI or Vancouver AI role reference to `/community/vancouver-ai/`.
+- `/recent-projects-include/`: add the page as a supporting proof link near the BC+AI work section.
+- `/speaking/`: link any Vancouver AI appearance or Both Hands Full proof section to the page.
+- `/generative-ai-services/`: link community and ecosystem-building language to this page if the services page keeps that offer.
+- Relevant Vancouver AI blog posts: add the page as a local hub once the public page exists.
+
+## Outbound Links In Draft
+
+- `https://luma.com/vancouver-ai`
+- `https://bc-ai.ca/`
+- `https://bc-ai.ca/membership/`
+- `https://www.bothhandsfull.com/`
+- `/speaking/`
+- `/recent-projects-include/`
+
+## Link Gates
+
+- Confirm `/community/` parent page behavior before using the intended URL. Public read-only checks currently show `/community/` and `/community/vancouver-ai/` redirecting to older posts.
+- Recheck external links immediately before WordPress draft creation.
+- If the final URL changes, update every planned inbound link before publish.

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/post.html
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/post.html
@@ -1,0 +1,185 @@
+<!-- wp:heading {"level":1} -->
+<h1 class="wp-block-heading">Vancouver AI Community</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Vancouver AI is a public room for people who want to understand AI without pretending it is simple.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Artists, founders, educators, researchers, students, policy people, technologists, organizers, and the AI-curious all need somewhere to compare notes. Not a sales funnel. Not a doom circle. A real room where people can ask better questions together.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Kris helps convene that room through BC+AI, public talks, practical learning sessions, member pathways, and a steady commitment to keeping AI conversations grounded in people, place, and community.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://luma.com/vancouver-ai">See upcoming Vancouver AI events</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://bc-ai.ca/membership/">Join BC+AI</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/speaking/">Book Kris for a talk</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Why This Page Exists</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>AI is changing work, art, education, media, government, climate decisions, and community life faster than most institutions can explain it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Vancouver needs public learning spaces where people can stay curious without being naive, stay critical without becoming frozen, and build enough shared language to make better decisions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The best Vancouver AI rooms are mixed on purpose. Builders sit beside skeptics. Artists sit beside engineers. Policy meets practice. Beginners are allowed to ask the obvious question. People deep in the stack are asked to explain why the work matters.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What Happens In The Community</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Public Meetups</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Vancouver AI gatherings give people a place to see demos, hear field reports, ask direct questions, and meet others working through the same messy transition.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Use the public event calendar for the current schedule and next gathering.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Talks And Recordings</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Kris's Vancouver AI talks tend to hold both hands full: the tools are compromised and powerful, extractive and useful, exhausting and creatively explosive.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The March 2026 Vancouver AI talk is a useful public proof point for that tone. It addresses stolen work, creative agency, environmental cost, bias, labor pressure, and why community matters when the technology gets loud.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:embed {"url":"https://www.youtube.com/watch?v=T5ANAthZewE","type":"video","providerNameSlug":"youtube","responsive":true} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=T5ANAthZewE
+</div></figure>
+<!-- /wp:embed -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Member Pathways</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>BC+AI membership is the clearest next step for people who want ongoing community, ecosystem signal, member pathways, and a stronger local network.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Membership details, benefits, and pricing should come from the current BC+AI membership page, not from this local draft.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Partner Pathways</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Useful partners bring space, resources, platforms, expertise, and care for the public-interest side of AI adoption.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The best fit is aligned action, not generic brand placement.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">How To Plug In</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Attend</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Start with the public Vancouver AI event calendar. Bring the real question you are trying to answer, even if it is still half-formed.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://luma.com/vancouver-ai">View Vancouver AI events</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Join</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Join BC+AI if you want a more durable connection to the ecosystem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://bc-ai.ca/membership/">Explore BC+AI membership</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Partner</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Start with BC+AI if your organization wants to support a more public, local, and community-accountable AI ecosystem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://bc-ai.ca/">Visit BC+AI</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Bring Kris Into Your Room</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>If your team, conference, school, board, or community needs a high-signal AI talk, workshop, host, or moderator, start with Kris's speaking page.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="/speaking/">Explore AI keynote speaking</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Resources And Recordings</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li><a href="https://luma.com/vancouver-ai">Vancouver AI events on Luma</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://bc-ai.ca/">BC+AI</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://bc-ai.ca/membership/">BC+AI membership</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://www.bothhandsfull.com/">Both Hands Full</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="/speaking/">Kris's AI keynote speaking</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="/recent-projects-include/">Kris's work</a></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/post.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/post.md
@@ -1,0 +1,102 @@
+---
+title: Vancouver AI Community
+slug: vancouver-ai
+intended_url: /community/vancouver-ai/
+parent_slug: community
+post_date: '2026-06-11'
+status: draft
+post_type: page
+author_wp_id: 1
+excerpt: Vancouver AI is a public room for people in Vancouver who want to learn, question, build, and stay human while AI changes the ground under everyone.
+seo:
+  meta_title: Vancouver AI Community | Kris Krug
+  meta_description: A local Vancouver AI community page for public learning, events, recordings, participation pathways, and human-gated partnership details.
+source_context:
+- content/source-packs/keynotes-2026/wp-payloads/vancouver-ai-community.html
+- content/source-packs/keynotes-2026/verification/ISSUE-18-VANCOUVER-AI-COMMUNITY-VERIFICATION-2026-05-21.md
+- content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/post.md
+images: []
+---
+
+# Vancouver AI Community
+
+Vancouver AI is a public room for people who want to understand AI without pretending it is simple.
+
+Artists, founders, educators, researchers, students, policy people, technologists, organizers, and the AI-curious all need somewhere to compare notes. Not a sales funnel. Not a doom circle. A real room where people can ask better questions together.
+
+Kris helps convene that room through BC+AI, public talks, practical learning sessions, member pathways, and a steady commitment to keeping AI conversations grounded in people, place, and community.
+
+[See upcoming Vancouver AI events](https://luma.com/vancouver-ai)
+[Join BC+AI](https://bc-ai.ca/membership/)
+[Book Kris for a talk](/speaking/)
+
+## Why This Page Exists
+
+AI is changing work, art, education, media, government, climate decisions, and community life faster than most institutions can explain it.
+
+Vancouver needs public learning spaces where people can stay curious without being naive, stay critical without becoming frozen, and build enough shared language to make better decisions.
+
+The best Vancouver AI rooms are mixed on purpose. Builders sit beside skeptics. Artists sit beside engineers. Policy meets practice. Beginners are allowed to ask the obvious question. People deep in the stack are asked to explain why the work matters.
+
+## What Happens In The Community
+
+### Public Meetups
+
+Vancouver AI gatherings give people a place to see demos, hear field reports, ask direct questions, and meet others working through the same messy transition.
+
+Use the public event calendar for the current schedule and next gathering.
+
+### Talks And Recordings
+
+Kris's Vancouver AI talks tend to hold both hands full: the tools are compromised and powerful, extractive and useful, exhausting and creatively explosive.
+
+The March 2026 Vancouver AI talk is a useful public proof point for that tone. It addresses stolen work, creative agency, environmental cost, bias, labor pressure, and why community matters when the technology gets loud.
+
+https://www.youtube.com/watch?v=T5ANAthZewE
+
+### Member Pathways
+
+BC+AI membership is the clearest next step for people who want ongoing community, ecosystem signal, member pathways, and a stronger local network.
+
+Membership details, benefits, and pricing should come from the current BC+AI membership page, not from this local draft.
+
+### Partner Pathways
+
+Useful partners bring space, resources, platforms, expertise, and care for the public-interest side of AI adoption.
+
+The best fit is aligned action, not generic brand placement.
+
+## How To Plug In
+
+### Attend
+
+Start with the public Vancouver AI event calendar. Bring the real question you are trying to answer, even if it is still half-formed.
+
+[View Vancouver AI events](https://luma.com/vancouver-ai)
+
+### Join
+
+Join BC+AI if you want a more durable connection to the ecosystem.
+
+[Explore BC+AI membership](https://bc-ai.ca/membership/)
+
+### Partner
+
+Start with BC+AI if your organization wants to support a more public, local, and community-accountable AI ecosystem.
+
+[Visit BC+AI](https://bc-ai.ca/)
+
+### Bring Kris Into Your Room
+
+If your team, conference, school, board, or community needs a high-signal AI talk, workshop, host, or moderator, start with Kris's speaking page.
+
+[Explore AI keynote speaking](/speaking/)
+
+## Resources And Recordings
+
+- [Vancouver AI events on Luma](https://luma.com/vancouver-ai)
+- [BC+AI](https://bc-ai.ca/)
+- [BC+AI membership](https://bc-ai.ca/membership/)
+- [Both Hands Full](https://www.bothhandsfull.com/)
+- [Kris's AI keynote speaking](/speaking/)
+- [Kris's work](/recent-projects-include/)

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/publish-gate.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/publish-gate.md
@@ -1,0 +1,40 @@
+# Publish Gate - Vancouver AI Community
+
+Status: local draft package only. No WordPress draft was created. No live site write was performed.
+
+## Scope
+
+- Track A content package for issue #18.
+- Intended public path: `/community/vancouver-ai/`.
+- Local canonical body: `post.html`.
+- Local source body and metadata: `post.md`.
+
+## Human Gates
+
+- Confirm whether the WordPress parent page `/community/` exists. Public read-only checks currently show `/community/` redirecting to `https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/`.
+- Confirm whether the child page slug should be `vancouver-ai` or whether a different IA decision supersedes this path.
+- Resolve the current `/community/vancouver-ai/` redirect to `https://kriskrug.co/2023/10/20/vancouver-ai-community-lunch-meetup-fostering-community-in-vancouvers-budding-ai-landscape/` before creating or publishing a page at the requested path.
+- Verify any attendance, member, growth, or cadence claims before they enter public copy.
+- Approve any member testimonial before adding it.
+- Confirm academic, civic, venue, nonprofit, and sponsor names before adding them.
+- Choose final featured or social image and alt text.
+- Create a WordPress draft only, then run desktop and mobile preview QA before publish.
+
+## Source Notes
+
+- Existing issue #18 source-pack payload used as context: `content/source-packs/keynotes-2026/wp-payloads/vancouver-ai-community.html`.
+- Existing issue #18 verification note used as context: `content/source-packs/keynotes-2026/verification/ISSUE-18-VANCOUVER-AI-COMMUNITY-VERIFICATION-2026-05-21.md`.
+- March 2026 public talk context used from `content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/post.md`.
+
+## Acceptance Coverage
+
+- Dedicated page path: packaged for `/community/vancouver-ai/`, blocked on parent page confirmation.
+- Meetup schedule and frequency: linked to Luma, cadence gated.
+- Attendee numbers and growth: gated pending current verification.
+- How to join or participate: included.
+- Events calendar: linked.
+- Resources and recordings: included with public YouTube talk.
+- Member testimonials: gated pending approved quotes.
+- Academic partnerships: gated pending confirmed public sources or KK approval.
+- Mobile responsive: uses core Gutenberg blocks, preview still required.
+- WCAG 2.1 AA: semantic headings, links, and embed structure staged, preview/accessibility QA still required.

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/seo-meta.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/seo-meta.md
@@ -1,0 +1,20 @@
+# SEO Snapshot - Vancouver AI Community
+
+| Field | Value |
+|---|---|
+| Visible title | Vancouver AI Community |
+| Intended URL | `/community/vancouver-ai/` |
+| WordPress page slug | `vancouver-ai` |
+| Parent page gate | Public `/community/` currently redirects to an older post. Confirm IA and redirect behavior before draft creation. |
+| SEO title | Vancouver AI Community \| Kris Krug |
+| Meta description | A local Vancouver AI community page for public learning, events, recordings, participation pathways, and human-gated partnership details. |
+| Excerpt | Vancouver AI is a public room for people in Vancouver who want to learn, question, build, and stay human while AI changes the ground under everyone. |
+| Social image | Human gate: choose an approved Vancouver AI event image or public video thumbnail with rights and alt text. |
+
+## Claim Gates
+
+- Do not publish member counts, attendance numbers, growth numbers, or event cadence until checked against current public sources or KK approval.
+- Do not add testimonials until the quote, name, title, and permission are explicit.
+- Do not add academic partnership names until the relationship is confirmed by a current public source or KK approval.
+- Keep the page as a WordPress draft until preview, mobile review, accessibility review, and link checks pass.
+- The requested `/community/vancouver-ai/` path currently redirects to an older Vancouver AI post, so the final route needs a human-approved redirect or parent-page decision.


### PR DESCRIPTION
## Summary
- add a local Track A page draft package for `/community/vancouver-ai/`
- include source metadata, SEO notes, internal-link notes, and publish gates
- keep attendance/member/growth claims gated instead of inventing numbers

Refs #18

## Tests
- `python3` HTML parser check on `post.html`
- local package quality check with the repo venv
- `rg -n "TODO|TBD|FIXME" content/drafts/2026-06-11-vancouver-ai-community-page` returned no matches
- `rg -n "—|–|/Users/|localhost|127\.0\.0\.1|notion\.so|file://|wp-admin" content/drafts/2026-06-11-vancouver-ai-community-page` returned no matches
- public link checks returned 200 for Luma, BC+AI, BC+AI membership, and YouTube

## Human gates before WP draft creation
- decide whether `/community/` should be a real parent page, because it currently redirects to older content
- decide whether `/community/vancouver-ai/` should replace or redirect away from the older Vancouver AI post path
- verify current attendance, member, growth, and cadence claims before adding them
- approve testimonials, partnerships, and final featured/social image
