### PR TITLE
content: complete six-field Rafiki image briefs for 7 blocked drafts (Refs #206)

### DIFF
--- a/content/drafts/2026-05-19-ai-media-appearances-podcast-guesting/image-brief.md
+++ b/content/drafts/2026-05-19-ai-media-appearances-podcast-guesting/image-brief.md
@@ -19,3 +19,15 @@ Approved real media still, press image, CBC/audio artifact, headshot, or a simpl
 ## Refusal lines
 
 No stock podcast studio. No fake microphones. No fake interview screens. No fake broadcasters. No generic waveform wallpaper. No unreadable generated text.
+
+## Aspect ratio
+
+16:9 landscape (WP featured-image standard for this theme). A horizontal proof-stack collage fits this shape; arrange the real stills/marks inside a centered 1200×630 (1.91:1) safe zone so nothing important is lost to the featured/OG card crop.
+
+## Finishing notes
+
+- **Real sources only.** Build from approved media stills, press images, CBC/audio artifacts, or an existing headshot — never a fabricated studio or broadcaster. The whole point is verifiable credibility.
+- Confirm each source in the collage is cleared for use (rights/permission) before assembly.
+- Do **not** reuse rejected media `12270`. Review the assembled candidate in the Rafiki viewer before WP upload.
+- If outlet logos/marks are included, keep them crisp and correctly rendered or drop them — no smeared or misspelled marks.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/2026-05-24-ai-wont-fix-your-broken-permit-process/image-brief.md
+++ b/content/drafts/2026-05-24-ai-wont-fix-your-broken-permit-process/image-brief.md
@@ -19,3 +19,14 @@ Rafiki-generated process diagram or approved real civic/workshop artifact if one
 ## Refusal lines
 
 No robots. No fake UI. No dashboard. No generic civic table scene. No glowing brains. No magic-wand automation metaphor. No unreadable generated text.
+
+## Aspect ratio
+
+16:9 landscape master (WP featured-image standard for this theme). A horizontal process/audit flow fits this shape natively; keep the key nodes and any hand-noted labels inside a centered 1200×630 (1.91:1) safe zone so the featured/OG card crop stays legible.
+
+## Finishing notes
+
+- Review every candidate in the Rafiki viewer before any WP upload. Do **not** reuse rejected media `12265`.
+- `aefl` lane: civic field notes, accountability, calm rigor, visible human judgment. Muted documentary palette — no vendor-demo gloss, no glow.
+- Prefer minimal or no baked-in text. If a few step labels are essential, keep them short and verify they render legibly and spelled correctly; otherwise let the diagram read as craft and carry wording in the post body.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/2026-05-24-canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/image-brief.md
+++ b/content/drafts/2026-05-24-canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/image-brief.md
@@ -19,3 +19,15 @@ Rafiki-generated diagram, text-led poster, or approved documentary photo/artifac
 ## Refusal lines
 
 No giant glowing AI machine. No greenwashed server farm. No generic Canadian infrastructure scene. No fake Indigenous motifs. No robots. No fake UI. No unreadable generated text.
+
+## Aspect ratio
+
+16:9 landscape master (WP featured-image standard for this theme). If a text-led poster variant is generated, compose the type inside a centered 1200×630 (1.91:1) safe zone so the featured/OG card crop stays legible. An approved documentary photo, if one exists, should be cropped to the same 16:9 / 1.91:1 card framing.
+
+## Finishing notes
+
+- Review every candidate in the Rafiki viewer before any WP upload. Do **not** reuse rejected media `12266`.
+- `aefl` lane held to sparse tension: muted, documentary, public-interest rigor. No infrastructure hype, no glow, no greenwash.
+- Hold the refusal lines hard here — no fake Indigenous motifs, no shiny/inevitable data-centre imagery. When in doubt, prefer restraint or a real documentary source over a generated scene.
+- Keep baked-in text minimal and verified-legible; let the post body carry the argument.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/2026-05-24-what-would-chat-do-and-why-thats-the-wrong-question/image-brief.md
+++ b/content/drafts/2026-05-24-what-would-chat-do-and-why-thats-the-wrong-question/image-brief.md
@@ -19,3 +19,15 @@ Rafiki-generated diagram or text-first visual. A text-only hero remains acceptab
 ## Refusal lines
 
 No luminous mirror person. No fake community faces. No robot. No glowing brain. No spiritual-tech portal. No fake UI. No unreadable generated text.
+
+## Aspect ratio
+
+16:9 landscape master (WP featured-image standard for this theme) **if an image is used**; compose any type or diagram inside a centered 1200×630 (1.91:1) safe zone. A text-only hero is an accepted fallback — if KK chooses it, no featured image is generated and this aspect note does not apply.
+
+## Finishing notes
+
+- **Text-only hero is acceptable** per the source brief; if the sentence is stronger than any image, ship it with no featured image rather than force a weak one.
+- If an image is used: review in the Rafiki viewer before WP upload and do **not** reuse rejected media `12269`.
+- `hopecode` lane: field notes, root lines, evidence scraps, marginalia — human judgment over model authority. Keep baked-in text minimal and verified-legible.
+- Hold the refusal lines: no mirror person, no portal, no glowing brain.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/2026-05-24-zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/image-brief.md
+++ b/content/drafts/2026-05-24-zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/image-brief.md
@@ -19,3 +19,15 @@ Approved real meetup photo, event photo, or existing BC + AI artifact. Rafiki ge
 ## Refusal lines
 
 No fake people. No fake ceremony. No invented crowd. No planetarium-style abstraction. No generic community illustration. No fake readable text. No stock networking scene.
+
+## Aspect ratio
+
+16:9 landscape (WP featured-image standard for this theme). A real landscape meetup/event photo is the target; crop to the 16:9 / 1200×630 (1.91:1) card framing. If Rafiki backup is unavoidable, generate 16:9 with the same safe-zone discipline.
+
+## Finishing notes
+
+- **Real photo first.** This is the one brief where generation is explicitly backup-only — prefer an approved BC + AI meetup/event photo or existing artifact over anything generated.
+- Confirm usage rights and that identifiable people are cleared/comfortable being shown before selecting a real photo. No unconsented faces.
+- Do **not** reuse rejected media `12267`. Review any candidate in the Rafiki viewer before WP upload.
+- `bcai` lane: documented, relational, lived — not imagined. No invented crowds or ceremony.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/2026-06-04-the-great-canadian-proximity-game/image-brief.md
+++ b/content/drafts/2026-06-04-the-great-canadian-proximity-game/image-brief.md
@@ -19,3 +19,14 @@ Rafiki-generated editorial diagram or type-led poster, reviewed in the Rafiki vi
 ## Refusal lines
 
 No robots. No fake ministers. No generic boardroom. No civic spotlight scene. No glowing network map. No fake readable text. No stock-style public-sector illustration.
+
+## Aspect ratio
+
+16:9 landscape master (WP featured-image standard for this theme). The visual job leans toward a type-led editorial poster, so compose the central mark and any large type inside a centered 1200×630 (1.91:1) safe zone so the featured/OG card crop stays legible. If a 4:5 portrait poster variant is generated for in-body use, keep a separate 16:9 crop for the featured slot.
+
+## Finishing notes
+
+- Review every candidate in the Rafiki viewer before any WP upload. Do **not** reuse rejected media `12264`.
+- Let the post title carry the words — do not ask the model to render a headline or labels inside the image (rendered copy misspells; see the SFU SIAT candidate failure). Keep "type-led" to a few clean, legible marks at most, or go text-free.
+- `hopecode` lane: analog texture, field-note evidence, marginalia, root lines, a little bite. Muted/analog palette, no SaaS gloss, no glow.
+- Export at least 1200px on the long edge. Keep WP status `draft`; no schedule until KK approves the exact preview.

--- a/content/drafts/PUBLISH-QUEUE-2026-06-11.md
+++ b/content/drafts/PUBLISH-QUEUE-2026-06-11.md
@@ -56,6 +56,12 @@ The original five-item plan cannot safely become a five-draft WordPress queue as
 
 WordPress REST readback is clean for the ready drafts. On 2026-06-11, KK explicitly approved scheduling one ready post for today and one for two days from now, so `11876` and `11878` moved to `future`. Seven generated-image drafts are still image-blocked with featured media cleared and rejected media `12264`-`12270` preserved only as audit references. Browser preview QA remains a KK/login gate for unscheduled drafts and image-blocked drafts: Chrome reached the WordPress login screen for `wp-admin/post.php?post=11876&action=edit`, and direct `?p=11876&preview=true` returned the public 404 while logged out.
 
+## Image-brief status (#206)
+
+2026-06-15: All seven image-blocked drafts now carry a full six-field Rafiki brief (`image-brief.md`): visual job, style lane, preferred source type, refusal lines, **aspect ratio**, and **finishing notes**. The aspect-ratio and finishing-notes fields were added per post (not boilerplate) — generation aspect tuned to each visual job with a 1200×630 / 1.91:1 featured-card safe zone, plus a per-post handoff checklist (Rafiki-viewer review, do-not-reuse the rejected media ID, keep WP `draft`, named style lane).
+
+This completes #206 acceptance bullet 1 (briefs). It does **not** close #206: bullet 2 (replacement *source approved* before the WP media lane) stays gated on KK plus actual Rafiki generation/selection, which is not done here. `how-we-did-it` (SFU SIAT, WP `12038`) is **WITHDRAWN — CONFIDENTIAL (KK 2026-06-14)** and needs no image work; its brief is retained only as a record.
+
 ## Rejected generated media
 
 Do not reuse these media IDs without explicit KK approval:


### PR DESCRIPTION
## What

Completes the Rafiki image briefs for all seven image-blocked KrisKrug.co drafts so each meets the full six-field spec #206 requires.

The briefs already existed (created 2026-06-12) with **visual job / style lane / preferred source type / refusal lines**, but were missing the last two AC fields. This PR adds them, tailored per post:

- **Aspect ratio** — 16:9 master with a 1200×630 / 1.91:1 featured-card safe zone, nudged to each visual job (type-led poster, process diagram, proof-stack collage, real event photo).
- **Finishing notes** — per-post handoff checklist: Rafiki-viewer review, do-not-reuse the rejected `1226x` media ID, hold the refusal lines, keep WP `draft`, match the named lane.

`how-we-did-it` (SFU SIAT) was left untouched — it's **withdrawn/confidential (KK 2026-06-14)** and was already six-field.

Findings recorded back into `content/drafts/PUBLISH-QUEUE-2026-06-11.md`.

## Scope honesty

This completes #206 **AC bullet 1 (briefs)**. It does **not** close #206 — AC bullet 2 (replacement *source approved* into the WP media lane) stays gated on KK + actual Rafiki generation/selection, which is out of scope here.

## Verification

- All 7 `image-brief.md` files confirmed to contain all six `##` sections.
- Docs/content only; no PHP, no live WordPress writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)