### PR TITLE
SEO closeout: harden metadata backfill and evidence reports

### DIFF
--- a/content/drafts/seo-crafted-approved-2026-06-17-pages.json
+++ b/content/drafts/seo-crafted-approved-2026-06-17-pages.json
@@ -1,0 +1,11 @@
+{
+  "items": [
+    {
+      "id": 2315,
+      "slug": "home",
+      "meta": {
+        "advanced_seo_description": "Read Kris Krug's latest posts and field notes on responsible AI, creative technology, community building, media, photography, and digital culture."
+      }
+    }
+  ]
+}

--- a/docs/current-state/reports/morning-truth-20260617-155059Z.md
+++ b/docs/current-state/reports/morning-truth-20260617-155059Z.md
@@ -1,0 +1,472 @@
+# Morning Truth Report - 2026-06-17 15:50:59 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `0`
+- Open issues: `55`
+- WordPress version (smoke): `6.9.4`
+- Draft queue: future posts `8`, draft posts `64`, draft pages `5`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `24`
+- `aurora-v2`: `6`
+- `track-b`: `5`
+- `swarm-ready`: `6`
+- `swarm-parked`: `14`
+- `needs-human-review`: `14`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 0 | no |
+| Open Issues | 63 | 55 | YES |
+| WordPress Version | 6.9.4 | 6.9.4 | no |
+| Scheduled Posts | 2 | 8 | YES |
+| Draft Posts | 72 | 64 | YES |
+| Draft Pages | 5 | 5 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` vs `origin/aurora/v2`: `50	38`
+- Local `aurora/v2` status: `## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip`
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## main...origin/main
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+01fc9aa docs: session closeout 2026-06-17 + storyhive draft consolidation
+1fa1999 content: surface Storyhive Victoria video and close transcript loop
+a027969 Merge pull request #227 from WalksWithASwagger/codex/favicon-161
+9b5395e Merge pull request #226 from WalksWithASwagger/codex/image-briefs-206
+6e66805 seo: add deploy-ready favicon/app-icon packet + gap inventory (Refs #161)
+8d6438f content: complete six-field Rafiki image briefs for 7 blocked drafts (Refs #206)
+5823fca Merge pull request #225: Internal linking #38 — pillar hubs + spoke-injection engine
+c4d5750 content(#38): Wave B legacy rollout complete — site-wide under-linked 86% -> 2%
+4abeba8 fix(#38): internal-link counter excludes media/system URLs (false cap-met bug)
+65bb5c7 feat(#38): Wave A live + fold 4 categories into nearest pillar
+0fb0429 content(#38): inject-links pilot — 3 Vancouver AI posts, 0 failed, footers verified live
+4842ad1 feat(#38): Phase 3 spoke-injection engine — footer-guaranteed + contextual, minimal-diff safe
+1a1c98b docs(#38): internal-linking progress — 8 v2 pillars live, em dashes purged, Phase 3 next
+530c108 fix(seo): purge em dashes from all SEO meta site-wide (KK's hard rule)
+345ba6e design(#38): redo all 7 remaining pillars in v2 — image card grids, KK voice, no em dashes
+7bdc1b9 design(#38): art-direct Vancouver AI pillar v2 — image card grid, tight type, no em dashes
+8da7d43 docs(#38): record 8 published pillar pages (hub URLs + IDs)
+238cfac content(#38): draft 8 topic-cluster pillar pages for review
+30b3102 Merge pull request #224: SEO overhaul + category taxonomy + publisher safety (parallel lanes 2026-06-14)
+b6c3861 feat(#223): add --legacy era-bucket mode to reassign_categories
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+222	OPEN	[EPIC] Harden platform trust, forms, and publisher operations	priority:high, platform, needs-human-review, roadmap, tech-debt	2026-06-13T02:01:11Z
+219	OPEN	[EPIC] Restore KrisKrug.co content cadence safely	priority:high, content, needs-human-review, roadmap	2026-06-16T17:15:37Z
+197	OPEN	Split kk_notion_to_wp.py into focused connector modules	priority:low, needs-human-review, tech-debt, refactor	2026-06-09T22:58:45Z
+196	OPEN	Decide go/no-go on kk-sidebar-promos production deploy	priority:medium, platform, roadmap, needs-decision, blocked	2026-06-09T22:58:43Z
+174	OPEN	Verify monitored contact-form notification routing	documentation, priority:high, marketing, platform, needs-human-review, swarm-parked	2026-06-13T02:41:46Z
+173	OPEN	Run PII-safe Jetpack Forms inventory	priority:high, platform, needs-human-review, swarm-parked	2026-06-07T17:06:06Z
+128	OPEN	Triage Jetpack contact-form submissions + fix notification routing	priority:high, marketing, platform, needs-human-review, swarm-parked	2026-05-29T19:01:33Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, swarm-ready, swarm-wave-2	2026-06-04T22:39:55Z
+125	OPEN	[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration	enhancement, priority:medium, performance, track-b, aurora-v2, swarm-ready, swarm-wave-2	2026-06-04T22:39:56Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+95	OPEN	[CONTENT P0] Review media appearances draft before publish/backlinks	enhancement, priority:high, content, needs-human-review, swarm-parked	2026-05-29T19:01:33Z
+86	OPEN	[AURORA P2] Run performance and accessibility QA on real staging	bug, enhancement, priority:high, mobile, accessibility, performance, track-b, aurora-v2, swarm-ready, swarm-wave-3	2026-06-04T15:36:06Z
+64	OPEN	[PORTAL] Unified Search Across All 6 Projects	enhancement, priority:high, platform, swarm-parked	2026-06-09T23:05:12Z
+63	OPEN	[PORTAL] Beautiful Constellation Navigation Design	enhancement, priority:medium, mobile, content, accessibility, ux, swarm-parked	2026-06-09T23:05:13Z
+62	OPEN	[PORTAL] Unified Event Calendar - Luma API Integration	enhancement, priority:high, platform, mobile, seo, swarm-parked	2026-06-11T20:39:40Z
+61	OPEN	[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words	enhancement, priority:high, content, swarm-parked	2026-06-09T23:05:16Z
+60	OPEN	[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts	enhancement, priority:medium, content	2026-06-09T23:05:17Z
+59	OPEN	[ARCHIVE] Create Photography Archive - Decades of Work	enhancement, priority:high, mobile, content	2026-06-09T23:05:19Z
+58	OPEN	[MARKETING] User-Generated Content Collection System	enhancement, priority:low, marketing, community, content	2026-06-09T23:05:21Z
+57	OPEN	[MARKETING] Cross-Promotion Framework with BC+AI	enhancement, priority:medium, marketing	2026-06-09T23:05:22Z
+56	OPEN	[MARKETING] Social Media Amplification System	enhancement, priority:medium, marketing, swarm-parked	2026-06-09T23:05:23Z
+55	OPEN	[MARKETING] Formalize Speaking Circuit Strategy	enhancement, priority:high, marketing, content	2026-06-09T23:05:25Z
+54	OPEN	[MARKETING] Create Community Advocate Program	enhancement, priority:medium, marketing, community, swarm-parked	2026-06-09T23:05:26Z
+53	OPEN	[MARKETING] Build Community Referral Program	enhancement, priority:medium, marketing, community, content, swarm-parked	2026-06-09T23:05:28Z
+52	OPEN	[MARKETING] Create Content Syndication Strategy	enhancement, priority:medium, marketing, content, swarm-parked	2026-06-09T23:05:29Z
+51	OPEN	[MARKETING] Implement Email Onboarding Sequences	enhancement, priority:high, marketing, swarm-parked	2026-06-09T23:05:31Z
+50	OPEN	[MARKETING] Launch Podcast Guesting Tour Strategy	enhancement, priority:high, marketing	2026-06-09T23:05:32Z
+49	OPEN	[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides	enhancement, priority:high, marketing, content, swarm-parked	2026-06-09T23:05:33Z
+48	OPEN	[A11Y] Create Accessibility Statement	enhancement, priority:high, accessibility, needs-human-review, swarm-wave-1	2026-06-11T20:35:40Z
+47	OPEN	[A11Y] Keyboard Navigation Improvements	enhancement, priority:high, content, accessibility	2026-06-09T23:05:36Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-06-09T23:05:38Z
+45	OPEN	[SEO] Add RSS Feeds for Blog Categories	enhancement, priority:low, seo	2026-06-09T23:05:39Z
+44	OPEN	[CONTENT] Create Glossary Page for AI Terminology	enhancement, priority:low, mobile, content, accessibility, swarm-ready, swarm-wave-3	2026-06-09T23:05:41Z
+43	OPEN	[SEO] Add Twitter Card Tags	enhancement, priority:medium, seo, needs-human-review, swarm-wave-1	2026-06-11T20:35:36Z
+42	OPEN	[PERFORMANCE] Implement Lazy Loading for Images	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:43Z
+41	OPEN	[PERFORMANCE] Reduce Plugin Bloat	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:45Z
+40	OPEN	[SEO] Optimize Images for Performance and SEO	enhancement, priority:medium, mobile, seo, performance	2026-06-09T23:05:46Z
+38	OPEN	[SEO] Implement Internal Linking Strategy	enhancement, priority:medium, seo	2026-06-15T06:33:05Z
+36	OPEN	[SEO] Add Unique Meta Descriptions	enhancement, priority:high, priority:medium, seo, needs-human-review, swarm-wave-1	2026-06-14T20:25:57Z
+30	OPEN	[DESIGN] Photography Showcase Component	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:52Z
+29	OPEN	[DESIGN] Footer Redesign	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:51Z
+23	OPEN	[CONTENT] Reorganize Blog Categories	enhancement, priority:medium, mobile, content, needs-human-review	2026-05-18T17:09:21Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+21	OPEN	[CONTENT] Create Photography Portfolio as Credential Section	enhancement, priority:medium, mobile, content	2026-06-09T23:05:56Z
+20	OPEN	[CONTENT] Update Voice/Tone to Professional but Warm	enhancement, priority:medium, content	2026-06-09T23:05:58Z
+19	OPEN	[CONTENT] Add Community Impact Metrics Throughout Site	enhancement, priority:medium, mobile, content, accessibility, performance	2026-06-09T23:06:38Z
+18	OPEN	[CONTENT] Create Vancouver AI Community Page	enhancement, priority:medium, mobile, content, swarm-ready, swarm-wave-2	2026-06-09T23:06:36Z
+15	OPEN	[CONTENT] Create The Upgrade AI Co-Founder Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:48Z
+14	OPEN	[CONTENT] Create Indigenomics.ai CTO Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:45Z
+13	OPEN	[CONTENT] Create BC+AI Leadership Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:43Z
+11	OPEN	[UX] Create Membership Benefits Comparison Matrix	enhancement, priority:medium, mobile, content, ux	2026-06-09T23:06:30Z
+9	OPEN	[A11Y] Fix Search Field Accessibility	bug, priority:medium, accessibility, swarm-ready, swarm-wave-1	2026-06-09T23:06:28Z
+7	OPEN	[CONTENT] Add Pricing Information to Services	enhancement, priority:medium, mobile, content	2026-06-09T23:06:25Z
+5	OPEN	[BUG] Fix Color Contrast for WCAG Compliance	bug, priority:high, accessibility	2026-06-09T23:06:23Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-06-09T23:06:22Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD 01fc9aaa6c613cbe8848618ab7d753782504019c
+branch refs/heads/main
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-keynote
+HEAD 5a6f50364dbd76797e702d6f0326b76b66f2d885
+branch refs/heads/codex/aurora-keynote-redesign
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-reconcile
+HEAD f3c4edc04c360ee9adfc2bb6ac42ed10452b7268
+branch refs/heads/aurora/v3-reconcile
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80
+HEAD 81a62abfa2693ae41220cc5acfa21d4161100347
+branch refs/heads/aurora/v2
+locked claude agent agent-aec50fddbd7207f80 (pid 73140)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `0`
+
+```text
+18	289
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":222,"title":"[EPIC] Harden platform trust, forms, and publisher operations","updatedAt":"2026-06-13T02:01:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":219,"title":"[EPIC] Restore KrisKrug.co content cadence safely","updatedAt":"2026-06-16T17:15:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":197,"title":"Split kk_notion_to_wp.py into focused connector modules","updatedAt":"2026-06-09T22:58:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":196,"title":"Decide go/no-go on kk-sidebar-promos production deploy","updatedAt":"2026-06-09T22:58:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":174,"title":"Verify monitored contact-form notification routing","updatedAt":"2026-06-13T02:41:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":173,"title":"Run PII-safe Jetpack Forms inventory","updatedAt":"2026-06-07T17:06:06Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":128,"title":"Triage Jetpack contact-form submissions + fix notification routing","updatedAt":"2026-05-29T19:01:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-06-04T22:39:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":125,"title":"[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration","updatedAt":"2026-06-04T22:39:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":95,"title":"[CONTENT P0] Review media appearances draft before publish/backlinks","updatedAt":"2026-05-29T19:01:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":86,"title":"[AURORA P2] Run performance and accessibility QA on real staging","updatedAt":"2026-06-04T15:36:06Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":64,"title":"[PORTAL] Unified Search Across All 6 Projects","updatedAt":"2026-06-09T23:05:12Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":63,"title":"[PORTAL] Beautiful Constellation Navigation Design","updatedAt":"2026-06-09T23:05:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":62,"title":"[PORTAL] Unified Event Calendar - Luma API Integration","updatedAt":"2026-06-11T20:39:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":61,"title":"[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words","updatedAt":"2026-06-09T23:05:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":60,"title":"[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts","updatedAt":"2026-06-09T23:05:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":59,"title":"[ARCHIVE] Create Photography Archive - Decades of Work","updatedAt":"2026-06-09T23:05:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":58,"title":"[MARKETING] User-Generated Content Collection System","updatedAt":"2026-06-09T23:05:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":57,"title":"[MARKETING] Cross-Promotion Framework with BC+AI","updatedAt":"2026-06-09T23:05:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":56,"title":"[MARKETING] Social Media Amplification System","updatedAt":"2026-06-09T23:05:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":55,"title":"[MARKETING] Formalize Speaking Circuit Strategy","updatedAt":"2026-06-09T23:05:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":54,"title":"[MARKETING] Create Community Advocate Program","updatedAt":"2026-06-09T23:05:26Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":53,"title":"[MARKETING] Build Community Referral Program","updatedAt":"2026-06-09T23:05:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":52,"title":"[MARKETING] Create Content Syndication Strategy","updatedAt":"2026-06-09T23:05:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":51,"title":"[MARKETING] Implement Email Onboarding Sequences","updatedAt":"2026-06-09T23:05:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":50,"title":"[MARKETING] Launch Podcast Guesting Tour Strategy","updatedAt":"2026-06-09T23:05:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":49,"title":"[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides","updatedAt":"2026-06-09T23:05:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":48,"title":"[A11Y] Create Accessibility Statement","updatedAt":"2026-06-11T20:35:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":47,"title":"[A11Y] Keyboard Navigation Improvements","updatedAt":"2026-06-09T23:05:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-06-09T23:05:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":45,"title":"[SEO] Add RSS Feeds for Blog Categories","updatedAt":"2026-06-09T23:05:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":44,"title":"[CONTENT] Create Glossary Page for AI Terminology","updatedAt":"2026-06-09T23:05:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":43,"title":"[SEO] Add Twitter Card Tags","updatedAt":"2026-06-11T20:35:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":42,"title":"[PERFORMANCE] Implement Lazy Loading for Images","updatedAt":"2026-06-09T23:05:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":41,"title":"[PERFORMANCE] Reduce Plugin Bloat","updatedAt":"2026-06-09T23:05:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":40,"title":"[SEO] Optimize Images for Performance and SEO","updatedAt":"2026-06-09T23:05:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":38,"title":"[SEO] Implement Internal Linking Strategy","updatedAt":"2026-06-15T06:33:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":36,"title":"[SEO] Add Unique Meta Descriptions","updatedAt":"2026-06-14T20:25:57Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":30,"title":"[DESIGN] Photography Showcase Component","updatedAt":"2026-05-24T21:12:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":29,"title":"[DESIGN] Footer Redesign","updatedAt":"2026-05-24T21:12:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":23,"title":"[CONTENT] Reorganize Blog Categories","updatedAt":"2026-05-18T17:09:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":21,"title":"[CONTENT] Create Photography Portfolio as Credential Section","updatedAt":"2026-06-09T23:05:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":20,"title":"[CONTENT] Update Voice/Tone to Professional but Warm","updatedAt":"2026-06-09T23:05:58Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":19,"title":"[CONTENT] Add Community Impact Metrics Throughout Site","updatedAt":"2026-06-09T23:06:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":18,"title":"[CONTENT] Create Vancouver AI Community Page","updatedAt":"2026-06-09T23:06:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":15,"title":"[CONTENT] Create The Upgrade AI Co-Founder Section","updatedAt":"2026-06-11T20:32:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":14,"title":"[CONTENT] Create Indigenomics.ai CTO Section","updatedAt":"2026-06-11T20:32:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":13,"title":"[CONTENT] Create BC+AI Leadership Section","updatedAt":"2026-06-11T20:32:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"}],"number":11,"title":"[UX] Create Membership Benefits Comparison Matrix","updatedAt":"2026-06-09T23:06:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":9,"title":"[A11Y] Fix Search Field Accessibility","updatedAt":"2026-06-09T23:06:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":7,"title":"[CONTENT] Add Pricing Information to Services","updatedAt":"2026-06-09T23:06:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":5,"title":"[BUG] Fix Color Contrast for WCAG Compliance","updatedAt":"2026-06-09T23:06:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-06-09T23:06:22Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=8, draft_posts=64, draft_pages=5
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 6.9.4 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.180.0",
+          "jetpack": "346d8384549cea9b9909",
+          "popup-maker": "1.22.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "6.9.4"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/recent-projects-include/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/blaze",
+          "jetpack/v4/blaze-app",
+          "jetpack/v4/explat",
+          "jetpack/v4/import",
+          "jetpack/v4/stats-app",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "wpcom/v2",
+          "wpcom/v3",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "6.9.4",
+  "started_at": "2026-06-17T15:51:11Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/WORK-PLAN-2026-05-23.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 0
+    },
+    {
+      "declared": 63,
+      "drift": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 55
+    },
+    {
+      "declared": "6.9.4",
+      "drift": false,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "6.9.4"
+    },
+    {
+      "declared": 2,
+      "drift": true,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 8
+    },
+    {
+      "declared": 72,
+      "drift": true,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 64
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 5
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/WORK-PLAN-2026-05-23.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301
+date: Wed, 17 Jun 2026 15:51:36 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+location: https://kriskrug.co/recent-projects-include/
+server: Pagely-ARES/1.22.2
+x-gateway-request-id: 83c62bd5656ab99c1a6e0a7d791aa1da
+x-jetpack-boost-cache: miss
+vary: accept,content-type
+expires: Wed, 17 Jun 2026 16:25:53 GMT
+cache-control: max-age=3600
+x-redirect-by: KK Hotfix
+x-gateway-cache-key: 1781646646.349|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: HIT
+x-gateway-skip-cache: 0
+```
+
+### Aurora Local vs Origin Divergence
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2`
+- Exit code: `0`
+
+```text
+50	38
+```
+
+### Aurora Local Status
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 status --short --branch`
+- Exit code: `0`
+
+```text
+## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip
+```

--- a/docs/current-state/reports/morning-truth-20260617-162551Z.md
+++ b/docs/current-state/reports/morning-truth-20260617-162551Z.md
@@ -1,0 +1,483 @@
+# Morning Truth Report - 2026-06-17 16:25:51 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `0`
+- Open issues: `53`
+- WordPress version (smoke): `6.9.4`
+- Draft queue: future posts `8`, draft posts `64`, draft pages `5`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `23`
+- `aurora-v2`: `6`
+- `track-b`: `5`
+- `swarm-ready`: `6`
+- `swarm-parked`: `13`
+- `needs-human-review`: `13`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 0 | no |
+| Open Issues | 63 | 53 | YES |
+| WordPress Version | 6.9.4 | 6.9.4 | no |
+| Scheduled Posts | 2 | 8 | YES |
+| Draft Posts | 72 | 64 | YES |
+| Draft Pages | 5 | 5 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` vs `origin/aurora/v2`: `50	38`
+- Local `aurora/v2` status: `## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip`
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## main...origin/main
+ M scripts/seo-backfill/backfill_lib.py
+ M scripts/seo-backfill/backfill_meta.py
+ M scripts/seo-backfill/tests/test_backfill_lib.py
+?? content/drafts/seo-crafted-approved-2026-06-17-pages.json
+?? docs/current-state/reports/morning-truth-20260617-155059Z.md
+?? docs/current-state/reports/seo-audit-20260617-leftover-lanes.csv
+?? docs/current-state/reports/seo-backfill-20260617-160047Z.md
+?? docs/current-state/reports/seo-backfill-20260617-160053Z.md
+?? docs/current-state/reports/seo-backfill-20260617-160130Z.md
+?? docs/current-state/reports/seo-backfill-20260617-160229Z.md
+?? docs/current-state/reports/seo-overwrite-20260617-160047Z.md
+?? docs/current-state/reports/seo-overwrite-20260617-160739Z.md
+?? docs/current-state/reports/wp-post-ia-media-rollout-20260617-dry-run.md
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+01fc9aa docs: session closeout 2026-06-17 + storyhive draft consolidation
+1fa1999 content: surface Storyhive Victoria video and close transcript loop
+a027969 Merge pull request #227 from WalksWithASwagger/codex/favicon-161
+9b5395e Merge pull request #226 from WalksWithASwagger/codex/image-briefs-206
+6e66805 seo: add deploy-ready favicon/app-icon packet + gap inventory (Refs #161)
+8d6438f content: complete six-field Rafiki image briefs for 7 blocked drafts (Refs #206)
+5823fca Merge pull request #225: Internal linking #38 — pillar hubs + spoke-injection engine
+c4d5750 content(#38): Wave B legacy rollout complete — site-wide under-linked 86% -> 2%
+4abeba8 fix(#38): internal-link counter excludes media/system URLs (false cap-met bug)
+65bb5c7 feat(#38): Wave A live + fold 4 categories into nearest pillar
+0fb0429 content(#38): inject-links pilot — 3 Vancouver AI posts, 0 failed, footers verified live
+4842ad1 feat(#38): Phase 3 spoke-injection engine — footer-guaranteed + contextual, minimal-diff safe
+1a1c98b docs(#38): internal-linking progress — 8 v2 pillars live, em dashes purged, Phase 3 next
+530c108 fix(seo): purge em dashes from all SEO meta site-wide (KK's hard rule)
+345ba6e design(#38): redo all 7 remaining pillars in v2 — image card grids, KK voice, no em dashes
+7bdc1b9 design(#38): art-direct Vancouver AI pillar v2 — image card grid, tight type, no em dashes
+8da7d43 docs(#38): record 8 published pillar pages (hub URLs + IDs)
+238cfac content(#38): draft 8 topic-cluster pillar pages for review
+30b3102 Merge pull request #224: SEO overhaul + category taxonomy + publisher safety (parallel lanes 2026-06-14)
+b6c3861 feat(#223): add --legacy era-bucket mode to reassign_categories
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+222	OPEN	[EPIC] Harden platform trust, forms, and publisher operations	priority:high, platform, needs-human-review, roadmap, tech-debt	2026-06-17T16:22:33Z
+219	OPEN	[EPIC] Restore KrisKrug.co content cadence safely	priority:high, content, needs-human-review, roadmap	2026-06-17T16:22:03Z
+197	OPEN	Split kk_notion_to_wp.py into focused connector modules	priority:low, needs-human-review, tech-debt, refactor	2026-06-17T16:22:17Z
+174	OPEN	Verify monitored contact-form notification routing	documentation, priority:high, marketing, platform, needs-human-review, swarm-parked	2026-06-17T16:20:11Z
+128	OPEN	Triage Jetpack contact-form submissions + fix notification routing	priority:high, marketing, platform, needs-human-review, swarm-parked	2026-06-17T16:20:21Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, swarm-ready, swarm-wave-2	2026-06-04T22:39:55Z
+125	OPEN	[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration	enhancement, priority:medium, performance, track-b, aurora-v2, swarm-ready, swarm-wave-2	2026-06-04T22:39:56Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+95	OPEN	[CONTENT P0] Review media appearances draft before publish/backlinks	enhancement, priority:high, content, needs-human-review, swarm-parked	2026-05-29T19:01:33Z
+86	OPEN	[AURORA P2] Run performance and accessibility QA on real staging	bug, enhancement, priority:high, mobile, accessibility, performance, track-b, aurora-v2, swarm-ready, swarm-wave-3	2026-06-04T15:36:06Z
+64	OPEN	[PORTAL] Unified Search Across All 6 Projects	enhancement, priority:high, platform, swarm-parked	2026-06-09T23:05:12Z
+63	OPEN	[PORTAL] Beautiful Constellation Navigation Design	enhancement, priority:medium, mobile, content, accessibility, ux, swarm-parked	2026-06-09T23:05:13Z
+62	OPEN	[PORTAL] Unified Event Calendar - Luma API Integration	enhancement, priority:high, platform, mobile, seo, swarm-parked	2026-06-11T20:39:40Z
+61	OPEN	[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words	enhancement, priority:high, content, swarm-parked	2026-06-09T23:05:16Z
+60	OPEN	[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts	enhancement, priority:medium, content	2026-06-09T23:05:17Z
+59	OPEN	[ARCHIVE] Create Photography Archive - Decades of Work	enhancement, priority:high, mobile, content	2026-06-09T23:05:19Z
+58	OPEN	[MARKETING] User-Generated Content Collection System	enhancement, priority:low, marketing, community, content	2026-06-09T23:05:21Z
+57	OPEN	[MARKETING] Cross-Promotion Framework with BC+AI	enhancement, priority:medium, marketing	2026-06-09T23:05:22Z
+56	OPEN	[MARKETING] Social Media Amplification System	enhancement, priority:medium, marketing, swarm-parked	2026-06-09T23:05:23Z
+55	OPEN	[MARKETING] Formalize Speaking Circuit Strategy	enhancement, priority:high, marketing, content	2026-06-09T23:05:25Z
+54	OPEN	[MARKETING] Create Community Advocate Program	enhancement, priority:medium, marketing, community, swarm-parked	2026-06-09T23:05:26Z
+53	OPEN	[MARKETING] Build Community Referral Program	enhancement, priority:medium, marketing, community, content, swarm-parked	2026-06-09T23:05:28Z
+52	OPEN	[MARKETING] Create Content Syndication Strategy	enhancement, priority:medium, marketing, content, swarm-parked	2026-06-09T23:05:29Z
+51	OPEN	[MARKETING] Implement Email Onboarding Sequences	enhancement, priority:high, marketing, swarm-parked	2026-06-09T23:05:31Z
+50	OPEN	[MARKETING] Launch Podcast Guesting Tour Strategy	enhancement, priority:high, marketing	2026-06-09T23:05:32Z
+49	OPEN	[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides	enhancement, priority:high, marketing, content, swarm-parked	2026-06-09T23:05:33Z
+48	OPEN	[A11Y] Create Accessibility Statement	enhancement, priority:high, accessibility, needs-human-review, swarm-wave-1	2026-06-11T20:35:40Z
+47	OPEN	[A11Y] Keyboard Navigation Improvements	enhancement, priority:high, content, accessibility	2026-06-09T23:05:36Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-06-09T23:05:38Z
+45	OPEN	[SEO] Add RSS Feeds for Blog Categories	enhancement, priority:low, seo	2026-06-09T23:05:39Z
+44	OPEN	[CONTENT] Create Glossary Page for AI Terminology	enhancement, priority:low, mobile, content, accessibility, swarm-ready, swarm-wave-3	2026-06-09T23:05:41Z
+43	OPEN	[SEO] Add Twitter Card Tags	enhancement, priority:medium, seo, needs-human-review, swarm-wave-1	2026-06-11T20:35:36Z
+42	OPEN	[PERFORMANCE] Implement Lazy Loading for Images	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:43Z
+41	OPEN	[PERFORMANCE] Reduce Plugin Bloat	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:45Z
+40	OPEN	[SEO] Optimize Images for Performance and SEO	enhancement, priority:medium, mobile, seo, performance	2026-06-17T16:21:48Z
+38	OPEN	[SEO] Implement Internal Linking Strategy	enhancement, priority:medium, seo	2026-06-15T06:33:05Z
+36	OPEN	[SEO] Add Unique Meta Descriptions	enhancement, priority:high, priority:medium, seo, needs-human-review, swarm-wave-1	2026-06-17T16:21:20Z
+30	OPEN	[DESIGN] Photography Showcase Component	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:52Z
+29	OPEN	[DESIGN] Footer Redesign	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:51Z
+23	OPEN	[CONTENT] Reorganize Blog Categories	enhancement, priority:medium, mobile, content, needs-human-review	2026-05-18T17:09:21Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+21	OPEN	[CONTENT] Create Photography Portfolio as Credential Section	enhancement, priority:medium, mobile, content	2026-06-09T23:05:56Z
+20	OPEN	[CONTENT] Update Voice/Tone to Professional but Warm	enhancement, priority:medium, content	2026-06-09T23:05:58Z
+19	OPEN	[CONTENT] Add Community Impact Metrics Throughout Site	enhancement, priority:medium, mobile, content, accessibility, performance	2026-06-09T23:06:38Z
+18	OPEN	[CONTENT] Create Vancouver AI Community Page	enhancement, priority:medium, mobile, content, swarm-ready, swarm-wave-2	2026-06-09T23:06:36Z
+15	OPEN	[CONTENT] Create The Upgrade AI Co-Founder Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:48Z
+14	OPEN	[CONTENT] Create Indigenomics.ai CTO Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:45Z
+13	OPEN	[CONTENT] Create BC+AI Leadership Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:43Z
+11	OPEN	[UX] Create Membership Benefits Comparison Matrix	enhancement, priority:medium, mobile, content, ux	2026-06-09T23:06:30Z
+9	OPEN	[A11Y] Fix Search Field Accessibility	bug, priority:medium, accessibility, swarm-ready, swarm-wave-1	2026-06-09T23:06:28Z
+7	OPEN	[CONTENT] Add Pricing Information to Services	enhancement, priority:medium, mobile, content	2026-06-09T23:06:25Z
+5	OPEN	[BUG] Fix Color Contrast for WCAG Compliance	bug, priority:high, accessibility	2026-06-09T23:06:23Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-06-17T16:21:35Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD 01fc9aaa6c613cbe8848618ab7d753782504019c
+branch refs/heads/main
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-keynote
+HEAD 5a6f50364dbd76797e702d6f0326b76b66f2d885
+branch refs/heads/codex/aurora-keynote-redesign
+
+worktree /Users/kk/Code/kriskrug-wp-aurora-reconcile
+HEAD f3c4edc04c360ee9adfc2bb6ac42ed10452b7268
+branch refs/heads/aurora/v3-reconcile
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80
+HEAD 81a62abfa2693ae41220cc5acfa21d4161100347
+branch refs/heads/aurora/v2
+locked claude agent agent-aec50fddbd7207f80 (pid 73140)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `0`
+
+```text
+18	289
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":222,"title":"[EPIC] Harden platform trust, forms, and publisher operations","updatedAt":"2026-06-17T16:22:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":219,"title":"[EPIC] Restore KrisKrug.co content cadence safely","updatedAt":"2026-06-17T16:22:03Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":197,"title":"Split kk_notion_to_wp.py into focused connector modules","updatedAt":"2026-06-17T16:22:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":174,"title":"Verify monitored contact-form notification routing","updatedAt":"2026-06-17T16:20:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":128,"title":"Triage Jetpack contact-form submissions + fix notification routing","updatedAt":"2026-06-17T16:20:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-06-04T22:39:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":125,"title":"[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration","updatedAt":"2026-06-04T22:39:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":95,"title":"[CONTENT P0] Review media appearances draft before publish/backlinks","updatedAt":"2026-05-29T19:01:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":86,"title":"[AURORA P2] Run performance and accessibility QA on real staging","updatedAt":"2026-06-04T15:36:06Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":64,"title":"[PORTAL] Unified Search Across All 6 Projects","updatedAt":"2026-06-09T23:05:12Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":63,"title":"[PORTAL] Beautiful Constellation Navigation Design","updatedAt":"2026-06-09T23:05:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":62,"title":"[PORTAL] Unified Event Calendar - Luma API Integration","updatedAt":"2026-06-11T20:39:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":61,"title":"[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words","updatedAt":"2026-06-09T23:05:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":60,"title":"[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts","updatedAt":"2026-06-09T23:05:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":59,"title":"[ARCHIVE] Create Photography Archive - Decades of Work","updatedAt":"2026-06-09T23:05:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":58,"title":"[MARKETING] User-Generated Content Collection System","updatedAt":"2026-06-09T23:05:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":57,"title":"[MARKETING] Cross-Promotion Framework with BC+AI","updatedAt":"2026-06-09T23:05:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":56,"title":"[MARKETING] Social Media Amplification System","updatedAt":"2026-06-09T23:05:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":55,"title":"[MARKETING] Formalize Speaking Circuit Strategy","updatedAt":"2026-06-09T23:05:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":54,"title":"[MARKETING] Create Community Advocate Program","updatedAt":"2026-06-09T23:05:26Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":53,"title":"[MARKETING] Build Community Referral Program","updatedAt":"2026-06-09T23:05:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":52,"title":"[MARKETING] Create Content Syndication Strategy","updatedAt":"2026-06-09T23:05:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":51,"title":"[MARKETING] Implement Email Onboarding Sequences","updatedAt":"2026-06-09T23:05:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":50,"title":"[MARKETING] Launch Podcast Guesting Tour Strategy","updatedAt":"2026-06-09T23:05:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":49,"title":"[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides","updatedAt":"2026-06-09T23:05:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":48,"title":"[A11Y] Create Accessibility Statement","updatedAt":"2026-06-11T20:35:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":47,"title":"[A11Y] Keyboard Navigation Improvements","updatedAt":"2026-06-09T23:05:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-06-09T23:05:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":45,"title":"[SEO] Add RSS Feeds for Blog Categories","updatedAt":"2026-06-09T23:05:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":44,"title":"[CONTENT] Create Glossary Page for AI Terminology","updatedAt":"2026-06-09T23:05:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":43,"title":"[SEO] Add Twitter Card Tags","updatedAt":"2026-06-11T20:35:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":42,"title":"[PERFORMANCE] Implement Lazy Loading for Images","updatedAt":"2026-06-09T23:05:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":41,"title":"[PERFORMANCE] Reduce Plugin Bloat","updatedAt":"2026-06-09T23:05:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":40,"title":"[SEO] Optimize Images for Performance and SEO","updatedAt":"2026-06-17T16:21:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":38,"title":"[SEO] Implement Internal Linking Strategy","updatedAt":"2026-06-15T06:33:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":36,"title":"[SEO] Add Unique Meta Descriptions","updatedAt":"2026-06-17T16:21:20Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":30,"title":"[DESIGN] Photography Showcase Component","updatedAt":"2026-05-24T21:12:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":29,"title":"[DESIGN] Footer Redesign","updatedAt":"2026-05-24T21:12:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":23,"title":"[CONTENT] Reorganize Blog Categories","updatedAt":"2026-05-18T17:09:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":21,"title":"[CONTENT] Create Photography Portfolio as Credential Section","updatedAt":"2026-06-09T23:05:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":20,"title":"[CONTENT] Update Voice/Tone to Professional but Warm","updatedAt":"2026-06-09T23:05:58Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":19,"title":"[CONTENT] Add Community Impact Metrics Throughout Site","updatedAt":"2026-06-09T23:06:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":18,"title":"[CONTENT] Create Vancouver AI Community Page","updatedAt":"2026-06-09T23:06:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":15,"title":"[CONTENT] Create The Upgrade AI Co-Founder Section","updatedAt":"2026-06-11T20:32:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":14,"title":"[CONTENT] Create Indigenomics.ai CTO Section","updatedAt":"2026-06-11T20:32:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":13,"title":"[CONTENT] Create BC+AI Leadership Section","updatedAt":"2026-06-11T20:32:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"}],"number":11,"title":"[UX] Create Membership Benefits Comparison Matrix","updatedAt":"2026-06-09T23:06:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":9,"title":"[A11Y] Fix Search Field Accessibility","updatedAt":"2026-06-09T23:06:28Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":7,"title":"[CONTENT] Add Pricing Information to Services","updatedAt":"2026-06-09T23:06:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":5,"title":"[BUG] Fix Color Contrast for WCAG Compliance","updatedAt":"2026-06-09T23:06:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-06-17T16:21:35Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=8, draft_posts=64, draft_pages=5
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 6.9.4 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.181.0",
+          "jetpack": "346d8384549cea9b9909",
+          "popup-maker": "1.22.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "6.9.4"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/recent-projects-include/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/blaze",
+          "jetpack/v4/blaze-app",
+          "jetpack/v4/explat",
+          "jetpack/v4/import",
+          "jetpack/v4/stats-app",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "wpcom/v2",
+          "wpcom/v3",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "6.9.4",
+  "started_at": "2026-06-17T16:26:01Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/WORK-PLAN-2026-05-23.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 0
+    },
+    {
+      "declared": 63,
+      "drift": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 53
+    },
+    {
+      "declared": "6.9.4",
+      "drift": false,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "6.9.4"
+    },
+    {
+      "declared": 2,
+      "drift": true,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 8
+    },
+    {
+      "declared": 72,
+      "drift": true,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 64
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 5
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/WORK-PLAN-2026-05-23.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301
+date: Wed, 17 Jun 2026 16:26:25 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+location: https://kriskrug.co/recent-projects-include/
+server: Pagely-ARES/1.22.2
+x-gateway-request-id: 2e3bf704fe41b9e93003d226fd930f73
+x-jetpack-boost-cache: miss
+vary: accept,content-type
+expires: Wed, 17 Jun 2026 17:26:25 GMT
+cache-control: max-age=3600
+x-redirect-by: KK Hotfix
+x-gateway-cache-key: 1781646646.349|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: EXPIRED
+x-gateway-skip-cache: 0
+```
+
+### Aurora Local vs Origin Divergence
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2`
+- Exit code: `0`
+
+```text
+50	38
+```
+
+### Aurora Local Status
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 status --short --branch`
+- Exit code: `0`
+
+```text
+## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip
+```

--- a/docs/current-state/reports/seo-audit-20260617-leftover-lanes.csv
+++ b/docs/current-state/reports/seo-audit-20260617-leftover-lanes.csv
@@ -1,0 +1,998 @@
+kind,wp_id,slug,title,link,has_seo_title,seo_title_length,has_meta_description,meta_description_length,has_social_message,social_message_length
+post,11905,sovereign-ai-for-whom,Sovereign AI for Whom?,https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/,True,34,True,163,False,0
+post,11878,speak-it-into-existence-ai-voice-first-workflows,Speak It Into Existence: Voice-First AI Workflows,https://kriskrug.co/2026/06/13/speak-it-into-existence-ai-voice-first-workflows/,True,50,True,141,True,181
+post,11877,i-wont-fake-the-people-who-showed-up,I Won&#8217;t Fake the People Who Showed Up,https://kriskrug.co/2026/06/13/i-wont-fake-the-people-who-showed-up/,True,60,True,150,True,211
+post,12184,canada-ai-for-all-strategy-skeptical-guide,"Canada’s AI for All Strategy: A Skeptical Guide to the Hype, the Money, and the Missing Guardrails",https://kriskrug.co/2026/06/04/canada-ai-for-all-strategy-skeptical-guide/,True,57,True,150,True,188
+post,12183,ai-keynote-slides-visual-workflow,AI Keynote Slides Need Taste Before Prompts,https://kriskrug.co/2026/06/04/ai-keynote-slides-visual-workflow/,True,43,True,160,True,187
+post,12033,agent-orchestrators-creative-insurgents-the-new-stack,"Agent Orchestrators, Creative Insurgents &#038; The New Stack",https://kriskrug.co/2026/06/03/agent-orchestrators-creative-insurgents-the-new-stack/,True,56,True,143,True,143
+post,12149,long-road-to-futureproof,The Long Road to Futureproof,https://kriskrug.co/2026/06/01/long-road-to-futureproof/,True,40,True,145,True,152
+post,6348,ai-mindset-creative-paradigm,The AI Mindset: Adapting to the New Creative Paradigm,https://kriskrug.co/2026/05/24/ai-mindset-creative-paradigm/,True,53,True,146,True,146
+post,11936,you-cant-drink-data,You Can&#8217;t Drink Data,https://kriskrug.co/2026/05/23/you-cant-drink-data/,True,53,True,151,True,209
+post,10594,make-culture-not-content,"Make Culture, Not Content",https://kriskrug.co/2026/05/16/make-culture-not-content/,True,54,True,157,True,149
+post,11178,your-taste-is-your-moat,Why Judgment Beats &#8220;Creativity&#8221; in the AI Era,https://kriskrug.co/2026/05/15/your-taste-is-your-moat/,True,58,True,108,True,106
+post,11765,calling-us-all-in,Calling Us All In,https://kriskrug.co/2026/05/14/calling-us-all-in/,True,57,True,149,True,239
+post,11826,web-summit-vancouver-2026,Web Summit Vancouver 2026,https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/,True,54,True,144,True,79
+post,11700,punk-rock-ai,Punk Rock AI,https://kriskrug.co/2026/05/04/punk-rock-ai/,True,56,True,153,True,222
+post,11620,applied-ethical-ai-responsible-ai-professional-certification-rap,Applied Ethical AI: Responsible AI Professional Certification (RAP),https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/,True,53,True,157,True,195
+post,11358,spa-at-the-end-of-time,Spa at the End of Time,https://kriskrug.co/2026/02/20/spa-at-the-end-of-time/,True,44,True,158,True,96
+post,11252,name-the-bias,Name the Bias,https://kriskrug.co/2026/02/03/name-the-bias/,True,45,True,149,True,280
+post,11171,both-hands-full,Both Hands Full,https://kriskrug.co/2026/01/24/both-hands-full/,True,53,True,154,True,176
+post,11014,vancouver-tech-journal-isnt-journalism,Vancouver Tech Journal Isn&#8217;t Journalism,https://kriskrug.co/2025/12/11/vancouver-tech-journal-isnt-journalism/,True,51,True,145,True,52
+post,9937,ai-training-for-media-pr-and-creative-professionals,"AI Training for Media, PR, and Creative Professionals",https://kriskrug.co/2025/07/08/ai-training-for-media-pr-and-creative-professionals/,True,53,True,149,True,112
+post,9774,what-journalists-need-to-know-about-ai-right-now,What Journalists Need to Know About AI—Right Now,https://kriskrug.co/2025/06/24/what-journalists-need-to-know-about-ai-right-now/,True,61,True,129,True,129
+post,9549,ai-ate-the-future,AI Ate the Future,https://kriskrug.co/2025/06/09/ai-ate-the-future/,True,54,True,156,True,191
+post,9374,bc-ai-is-live-and-were-building-the-future-we-actually-want,BC + AI Ecosystem Industry Association Is Live,https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/,True,58,True,152,True,297
+post,9197,vancouver-ai-meetup-16-where-tech-creativity-and-community-collide,"Vancouver AI Meetup #16: Where Tech, Creativity, and Community Collide",https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/,True,53,True,147,True,147
+post,9044,vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future,DIY AI in Vancouver: Building a Grassroots BC AI Industry Association,https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/,True,51,True,156,True,207
+post,8947,web-summit-vancouver-2025-survival-guide,Web Summit Vancouver 2025 Survival Guide,https://kriskrug.co/2025/04/13/web-summit-vancouver-2025-survival-guide/,True,52,True,139,True,139
+post,8856,how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada,How Indigenomics AI is Flipping The Script On Economic Power in Canada,https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/,True,50,True,171,True,171
+post,8859,we-dont-do-panels-we-do-portals,We Don’t Do Panels. We Do Portals.,https://kriskrug.co/2025/04/07/we-dont-do-panels-we-do-portals/,True,46,True,147,True,147
+post,8802,how-to-build-an-ai-second-brain-that-actually-works-for-you,How to Build an AI Second Brain That Actually Works for You,https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/,True,44,True,146,True,212
+post,8786,a-creative-technologists-ai-age-manifesto,A Creative Technologists AI Age Manifesto,https://kriskrug.co/2025/03/30/a-creative-technologists-ai-age-manifesto/,True,53,True,133,True,133
+post,8663,is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid,&#8220;Is A Hotdog A Sandwich?&#8221;: Vancouver AI Data Storytelling Hackathon w/ Andrew Reid,https://kriskrug.co/2025/03/20/is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid/,True,55,True,134,True,266
+post,8544,transcending-techs-darker-impulses,Transcending Tech&#8217;s Darker Impulses,https://kriskrug.co/2025/03/09/transcending-techs-darker-impulses/,True,47,True,149,True,290
+post,8508,data-storytelling-hackathon-where-ai-meets-art-and-data-sings-its-truth,"Data Storytelling Hackathon: Where AI Meets Art, And Data Sings Its Truth",https://kriskrug.co/2025/03/06/data-storytelling-hackathon-where-ai-meets-art-and-data-sings-its-truth/,True,41,True,149,True,188
+post,8418,vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap,Vancouver AI: The Community Building BC&#8217;s AI Future &#8211; February Meetup Recap,https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/,True,49,True,159,True,159
+post,8407,shane-gibsons-ai-sales-dojo,Shane Gibson&#8217;s AI Sales Dojo,https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/,True,28,True,154,True,298
+post,8314,bcs-ai-ecosystem-a-mycelial-network-of-creation,BC&#8217;s AI Ecosystem: A Mycelial Network of Creation,https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/,True,37,True,146,True,300
+post,8182,vancouver-ai-january-2025-recap-one-year-of-creative-rebellion-open-source-disruption,Vancouver AI January 2025 Recap: One Year of Creative Rebellion &amp; Open-Source Disruption,https://kriskrug.co/2025/02/02/vancouver-ai-january-2025-recap-one-year-of-creative-rebellion-open-source-disruption/,True,44,True,154,True,209
+post,7500,human-biography-podcast-w-sharad-khare,Human Biography Podcast w/ Sharad Kharé,https://kriskrug.co/2025/01/25/human-biography-podcast-w-sharad-khare/,True,51,True,151,True,121
+post,7927,ais-next-chapter-notes-from-bcs-ai-ecosystem,AI&#8217;s Next Chapter: Notes from BC&#8217;s AI Ecosystem,https://kriskrug.co/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/,True,59,True,152,True,252
+post,7781,system-check-vancouver-ai-community-meetups-december,Vancouver’s AI Meetups: Where Code Meets Culture,https://kriskrug.co/2024/12/28/system-check-vancouver-ai-community-meetups-december/,True,60,True,156,True,200
+post,7810,fears-hopes-and-dreams-for-our-relationship-with-ai,"Fears, Hopes, and Dreams for Our Relationship with AI",https://kriskrug.co/2024/12/20/fears-hopes-and-dreams-for-our-relationship-with-ai/,True,39,True,157,True,221
+post,7751,generative-ai-cinematic-podcasts-how-kevin-friel-is-hacking-the-future-of-media,Generative AI Cinematic Podcasts &amp; How Kevin Friel is Hacking the Future of Media,https://kriskrug.co/2024/12/17/generative-ai-cinematic-podcasts-how-kevin-friel-is-hacking-the-future-of-media/,True,46,True,155,True,255
+post,7696,neurips-vanouver-best-ai-papers-of-2024,NeuRIPS Vancouver: Best AI &amp; ML Papers of 2024,https://kriskrug.co/2024/12/11/neurips-vanouver-best-ai-papers-of-2024/,True,41,True,152,True,212
+post,7692,field-notes-from-neurips-latent-lounge,Field Notes from NeurIPS&#8217; Latent Lounge,https://kriskrug.co/2024/12/11/field-notes-from-neurips-latent-lounge/,True,51,True,154,True,243
+post,7631,autolume-post-photographic-cybernetic-portraiture,AlphaPrism: Post-Photographic Cybernetic Portraiture,https://kriskrug.co/2024/12/02/autolume-post-photographic-cybernetic-portraiture/,True,50,True,146,True,167
+post,6322,great-creative-reckoning-a-techartists-manifesto-on-generative-artificial-intelligence,Great Creative Reckoning: A Techartist&#8217;s Manifesto on Generative Artificial Intelligence.,https://kriskrug.co/2024/11/22/great-creative-reckoning-a-techartists-manifesto-on-generative-artificial-intelligence/,True,45,True,159,True,104
+post,7411,paddling-together-a-future-built-on-connection-creativity-and-community,"Paddling Together: A Future Built on Connection, Creativity, and Community",https://kriskrug.co/2024/11/19/paddling-together-a-future-built-on-connection-creativity-and-community/,True,38,True,155,True,233
+post,7450,indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai,Redefining the Future of Indigenous Economic Sovereignty through AI,https://kriskrug.co/2024/11/14/indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai/,True,42,True,153,True,233
+post,7322,kicking-ass-in-2025-a-techartists-guide-to-creative-survival,Kicking Ass in 2025: A Techartist&#8217;s Guide to Creative Survival,https://kriskrug.co/2024/10/28/kicking-ass-in-2025-a-techartists-guide-to-creative-survival/,True,50,True,155,True,92
+post,7250,indigenous-innovation-in-technology-and-the-future-of-indigenous-economies,Indigenous Innovation in Technology and the Future of Indigenous Economies,https://kriskrug.co/2024/10/15/indigenous-innovation-in-technology-and-the-future-of-indigenous-economies/,True,58,True,171,True,177
+post,7177,future-proof-inside-vancouvers-thriving-ai-ecosystem,Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem,https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/,True,45,True,156,True,156
+post,7143,healing-through-creativity-my-journey-with-deepwell-dtx-dave-zaboski,Healing Through Creativity: My Journey with DeepWell DTX &amp; Dave Zaboski,https://kriskrug.co/2024/10/07/healing-through-creativity-my-journey-with-deepwell-dtx-dave-zaboski/,True,44,True,152,True,81
+post,6988,ai-for-the-people-why-open-source-is-the-future-of-tech-sovereignty,AI for the People: Why Open-Source is the Future of Tech Sovereignty,https://kriskrug.co/2024/09/12/ai-for-the-people-why-open-source-is-the-future-of-tech-sovereignty/,True,49,True,156,True,227
+post,6937,the-human-algorithm-enya-learning-keynote,The Human Algorithm: Enya Learning Keynote,https://kriskrug.co/2024/09/11/the-human-algorithm-enya-learning-keynote/,True,54,True,159,True,255
+post,6901,the-outsiders-insider-guide-to-web-summit-vancouver,The Outsider&#8217;s Insider Guide to Web Summit Vancouver,https://kriskrug.co/2024/09/05/the-outsiders-insider-guide-to-web-summit-vancouver/,True,52,True,156,True,223
+post,6896,ai-upgrade-for-creatives-professor-peter-and-the-the-pirate-king,AI Upgrade for Creatives &#8211; Professor Peter and KK the Pirate King,https://kriskrug.co/2024/09/05/ai-upgrade-for-creatives-professor-peter-and-the-the-pirate-king/,True,44,True,159,True,231
+post,6815,august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics,"August Vancouver AI Community Meetup Recap &#8211; Hackers, Hustlers &amp; Heretics",https://kriskrug.co/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics/,True,55,True,156,True,145
+post,6727,web-summit-vancouver-2025-and-how-you-can-shape-it,Web Summit Vancouver 2025 And How You Can Shape It,https://kriskrug.co/2024/08/22/web-summit-vancouver-2025-and-how-you-can-shape-it/,True,47,True,157,True,139
+post,6670,llms-and-beyond-reframing-the-future-of-artificial-intelligence,LLMs and Beyond: Reframing the Future of Artificial Intelligence,https://kriskrug.co/2024/08/12/llms-and-beyond-reframing-the-future-of-artificial-intelligence/,True,43,True,149,True,225
+post,6552,ai-and-music-the-digital-renaissance-you-didnt-see-coming,AI and Music: The Digital Renaissance You Didn&#8217;t See Coming,https://kriskrug.co/2024/08/09/ai-and-music-the-digital-renaissance-you-didnt-see-coming/,True,35,True,151,True,176
+post,6554,ai-meetup-mayhem-stickers-startups-and-squamish-songs,"AI Meetup Mayhem: Stickers, Startups, and Squamish Songs!",https://kriskrug.co/2024/08/04/ai-meetup-mayhem-stickers-startups-and-squamish-songs/,True,53,True,150,True,211
+post,6517,hacker-artists-revolutionizing-music-dance-w-ai-punk-quentin-nolot,Hacker Artists Revolutionizing Music &amp; Dance w/ AI Punk Quentin Nolot,https://kriskrug.co/2024/08/02/hacker-artists-revolutionizing-music-dance-w-ai-punk-quentin-nolot/,True,37,True,155,True,146
+post,6453,small-file-rebellion-hacking-the-digital-carbon-footprint-at-our-networks-2024,Small File Rebellion: Hacking the Digital Carbon Footprint at Our Networks 2024,https://kriskrug.co/2024/07/28/small-file-rebellion-hacking-the-digital-carbon-footprint-at-our-networks-2024/,True,44,True,148,True,196
+post,6470,the-raw-truth-about-building-communities-that-actually-give-a-shit,The Raw Truth About Building Communities That Actually Give a Shit,https://kriskrug.co/2024/07/28/the-raw-truth-about-building-communities-that-actually-give-a-shit/,True,46,True,152,True,229
+post,6435,digital-rebellion-w-lori-emersons-at-our-networks-2024,Digital Rebellion w/ Lori Emerson&#8217;s  at Our Networks 2024,https://kriskrug.co/2024/07/27/digital-rebellion-w-lori-emersons-at-our-networks-2024/,True,51,True,151,True,248
+post,6344,fuck-the-status-quo-ais-messy-love-child-with-creativity,Fuck the Status Quo: AI&#8217;s Messy Love Child with Creativity,https://kriskrug.co/2024/07/19/fuck-the-status-quo-ais-messy-love-child-with-creativity/,True,51,True,156,True,168
+post,6251,creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights,Creativity in the Age of AI: Vancouver AI Community Meetup &#8211; June 2024 Highlights,https://kriskrug.co/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/,True,45,True,155,True,212
+post,6221,new-segment-on-cbc-radio-early-edition-ai-sandbox-with-kris-krug,New Segment on CBC Radio Early Edition: AI Sandbox with Kris Krüg,https://kriskrug.co/2024/07/03/new-segment-on-cbc-radio-early-edition-ai-sandbox-with-kris-krug/,True,50,True,153,True,145
+post,6169,a-love-letter-to-vancouver-minimal-viable-demos,A Love Letter to Vancouver: Minimal Viable Demos,https://kriskrug.co/2024/07/01/a-love-letter-to-vancouver-minimal-viable-demos/,True,60,True,158,True,83
+post,6144,ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence,AI is Not Your Friend: Why We Need to Rethink Our Relationship with Artificial Intelligence,https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/,True,47,True,156,True,255
+post,6108,blog-ai-the-revolution-of-governance-and-cybersecurity-a-night-with-anthony-green,: The Revolution of Governance and Cybersecurity &#8211; A Night with Anthony Green,https://kriskrug.co/2024/06/26/blog-ai-the-revolution-of-governance-and-cybersecurity-a-night-with-anthony-green/,True,49,True,155,True,148
+post,6038,blog-rise-of-the-vancouver-technopunks-hosting-the-web-summit-on-our-terms,Rise of the Vancouver Technopunks: Hosting the Web Summit on Our Terms,https://kriskrug.co/2024/06/19/blog-rise-of-the-vancouver-technopunks-hosting-the-web-summit-on-our-terms/,True,53,True,155,True,255
+post,6019,augie-studio-review-ai-driven-video-production-analysis,Augie Studio Review: AI-Driven Video Production Analysis,https://kriskrug.co/2024/06/18/augie-studio-review-ai-driven-video-production-analysis/,True,47,True,160,True,204
+post,5833,the-cyborg-art-of-autolume-when-ai-meets-the-human-lens,The Cyborg Art of Autolume: When AI Meets the Human Lens,https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/,True,51,True,147,True,255
+post,5975,building-community-elevating-the-ecosystem-panel-at-vancouver-startup-week,Building Community: Elevating the Ecosystem Panel at Vancouver Startup Week,https://kriskrug.co/2024/06/16/building-community-elevating-the-ecosystem-panel-at-vancouver-startup-week/,True,44,True,159,True,244
+post,5915,hacking-ai-for-the-peoples-revolution,Hacking AI for the People&#8217;s (r)evolution,https://kriskrug.co/2024/06/15/hacking-ai-for-the-peoples-revolution/,True,52,True,156,True,210
+post,5823,the-emergence-of-fabric-augmenting-human-potential-through-open-source-ai,You&#8217;re Doing it Wrong! How you *should* be using AIs,https://kriskrug.co/2024/06/06/the-emergence-of-fabric-augmenting-human-potential-through-open-source-ai/,True,43,True,151,True,142
+post,5847,future-hackers-vancouvers-startup-ecosystem,Future Hackers: Vancouver&#8217;s Startup Ecosystem,https://kriskrug.co/2024/06/04/future-hackers-vancouvers-startup-ecosystem/,True,57,True,156,True,212
+post,5768,june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines,Vancouver AI Community Meetup Recap: June 2024 at Future Proof Creatives Studio,https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/,True,36,True,151,True,182
+post,5723,unpacking-ai-ethics-at-american-marketing-associationvisionconf2024,Unpacking AI Ethics at American Marketing Association#VisionConf2024,https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/,True,45,True,159,True,170
+post,5698,jennifer-podemski-storytelling-masterclass-yorkton-film-festival,Jennifer Podemski Storytelling Masterclass &#8211; Yorkton Film Festival,https://kriskrug.co/2024/05/26/jennifer-podemski-storytelling-masterclass-yorkton-film-festival/,True,52,True,147,True,187
+post,5680,ai-in-filmmaking-at-the-yorkton-film-festival,AI in Filmmaking at the Yorkton Film Festival,https://kriskrug.co/2024/05/25/ai-in-filmmaking-at-the-yorkton-film-festival/,True,57,True,156,True,200
+post,5661,lisa-jacksons-wilfred-buck-documentary-premier-at-the-yorkton-film-festival,Lisa Jackson&#8217;s &#8220;Wilfred Buck&#8221; documentary premier at the Yorkton Film Festival,https://kriskrug.co/2024/05/25/lisa-jacksons-wilfred-buck-documentary-premier-at-the-yorkton-film-festival/,True,54,True,153,True,200
+post,5626,love-in-the-time-of-ai-my-affair-with-sexy-companion-chatbots,Love in the Time of AI: My Affair with Sexy Companion Chatbots,https://kriskrug.co/2024/05/19/love-in-the-time-of-ai-my-affair-with-sexy-companion-chatbots/,True,42,True,147,True,255
+post,5590,exploring-the-power-of-custom-gpts-my-ai-creations,Exploring the Power of Custom GPTs: My AI Creations,https://kriskrug.co/2024/05/15/exploring-the-power-of-custom-gpts-my-ai-creations/,True,38,True,151,True,249
+post,5505,the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts,The Metacreative Code: Philippe Pasquier&#8217;s Remix of AI and Creative Arts,https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/,True,51,True,154,True,201
+post,5489,cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola,"Cognitive AI, Creativity, and Ethics w/ Professor Steve DiPaola",https://kriskrug.co/2024/05/04/cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola/,True,52,True,155,True,162
+post,5357,ai-mindset-keynote-at-innovate-west-2024-in-vancouver,AI Mindset Keynote at Innovate West 2024 in Vancouver,https://kriskrug.co/2024/04/20/ai-mindset-keynote-at-innovate-west-2024-in-vancouver/,True,40,True,152,True,192
+post,5385,the-creative-disruption-ai-crashes-the-art-party,The Creative Disruption: AI Crashes the Art Party,https://kriskrug.co/2024/04/20/the-creative-disruption-ai-crashes-the-art-party/,True,49,True,158,True,179
+post,5371,not-all-white-guys-unpacking-the-wealth-tax-debate-in-canada,Not All White Guys: Unpacking the Wealth Tax Debate in Canada,https://kriskrug.co/2024/04/19/not-all-white-guys-unpacking-the-wealth-tax-debate-in-canada/,True,46,True,152,True,181
+post,5344,from-timbits-to-tech-titans-guy-kawasakis-blueprint-for-innovation,From Timbits to Tech Titans: Guy Kawasaki&#8217;s Blueprint for Innovation,https://kriskrug.co/2024/04/16/from-timbits-to-tech-titans-guy-kawasakis-blueprint-for-innovation/,True,53,True,158,True,217
+post,5285,the-cyborg-future-when-sci-fi-gets-real-and-complicated,The Cyborg Future: When Sci-Fi Gets Real (And Complicated),https://kriskrug.co/2024/04/08/the-cyborg-future-when-sci-fi-gets-real-and-complicated/,True,40,True,148,True,162
+post,5236,ai-skills-for-tommorows-storytellers-with-openai-creative-director-souki-mansoor,AI Skills for Tomorrow&#8217;s Storytellers with OpenAI Creator Community Specialist Souki Mansoor,https://kriskrug.co/2024/04/05/ai-skills-for-tommorows-storytellers-with-openai-creative-director-souki-mansoor/,True,50,True,152,True,217
+post,5217,spaceport-vancouver-ai-community-meetup,Spaceport Vancouver: AI Community Meetup,https://kriskrug.co/2024/04/04/spaceport-vancouver-ai-community-meetup/,True,52,True,155,True,255
+post,5160,the-creative-quest-ai-art-and-the-adaptability-paradox,The Adaptability Paradox,https://kriskrug.co/2024/03/30/the-creative-quest-ai-art-and-the-adaptability-paradox/,True,36,True,154,True,255
+post,5078,the-future-is-verified-insights-and-critical-reflections-from-interacs-vip-talk-at-sxsw,The Future is Verified: Insights and Critical Reflections from Interac&#8217;s VIP Talk at SXSW,https://kriskrug.co/2024/03/30/the-future-is-verified-insights-and-critical-reflections-from-interacs-vip-talk-at-sxsw/,True,47,True,150,True,238
+post,5020,death-of-the-follower-the-future-of-creativity-on-the-web,Death of the Follower &amp; the Future of Creativity on the Web,https://kriskrug.co/2024/03/18/death-of-the-follower-the-future-of-creativity-on-the-web/,True,46,True,153,True,243
+post,4997,exploring-the-intersection-of-gaming-and-mental-health,Exploring the Intersection of Gaming and Mental Health,https://kriskrug.co/2024/03/15/exploring-the-intersection-of-gaming-and-mental-health/,True,47,True,159,True,256
+post,4980,the-poet-of-code-unmasking-ais-coded-gaze-at-sxsw,The Poet of Code: Unmasking AI&#8217;s Coded Gaze at SXSW,https://kriskrug.co/2024/03/15/the-poet-of-code-unmasking-ais-coded-gaze-at-sxsw/,True,40,True,148,True,255
+post,4960,broetry-content-farms-tldr-is-the-internet-ok,"Broetry, Content Farms, TL;DR—Is the Internet OK?",https://kriskrug.co/2024/03/14/broetry-content-farms-tldr-is-the-internet-ok/,True,50,True,156,True,218
+post,4948,the-avant-garde-future-of-art-creativity,The Inside-Out Evolution,https://kriskrug.co/2024/03/14/the-avant-garde-future-of-art-creativity/,True,36,True,156,True,254
+post,4892,global-indigenous-technology-house,Global Indigenous Technology House,https://kriskrug.co/2024/03/11/global-indigenous-technology-house/,True,46,True,156,True,156
+post,4877,navigating-names-and-narratives-my-reflections-on-frontier,Navigating Names and Narratives: My Reflections on &#8220;Frontier&#8221;,https://kriskrug.co/2024/03/08/navigating-names-and-narratives-my-reflections-on-frontier/,True,46,True,154,True,216
+post,4851,the-art-of-ai-storytelling,The Art of AI Storytelling,https://kriskrug.co/2024/03/05/the-art-of-ai-storytelling/,True,38,True,144,True,178
+post,4826,join-the-future-proof-creatives-community,Future Proof Creatives Community &#038; Event Series,https://kriskrug.co/2024/03/05/join-the-future-proof-creatives-community/,True,59,True,149,True,210
+post,4803,building-healthy-digital-communities-in-the-ai-era,Building AI Communities,https://kriskrug.co/2024/03/04/building-healthy-digital-communities-in-the-ai-era/,True,35,True,155,True,172
+post,4773,creative-toolbox,Creative Toolbox: Best of the Best AI Tools,https://kriskrug.co/2024/03/01/creative-toolbox/,True,55,True,146,True,255
+post,4763,my-take-on-navigating-the-ai-revolution,Adding Heart to AI&#8217;s Brains,https://kriskrug.co/2024/03/01/my-take-on-navigating-the-ai-revolution/,True,39,True,150,True,255
+post,4706,vancouver-community-connections-at-the-intersection-of-creativity-and-ai,Vancouver Community &#038; Connections at the Intersection of Creativity and AI,https://kriskrug.co/2024/02/24/vancouver-community-connections-at-the-intersection-of-creativity-and-ai/,True,43,True,154,True,154
+post,4635,bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai,Bridging Innovation and Ethics: Future Proof Creatives and the Path Forward in AI,https://kriskrug.co/2024/02/13/bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai/,True,36,True,157,True,191
+post,4539,exploring-the-intersection-of-photography-and-generative-ai,Exploring the Intersection of Photography and Generative AI,https://kriskrug.co/2024/01/31/exploring-the-intersection-of-photography-and-generative-ai/,True,51,True,157,True,255
+post,4495,inside-the-innaugural-vancouver-ai-community-meetup,Inside the Innaugural Vancouver AI Community Meetup,https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/,True,50,True,148,True,177
+post,4174,2024-the-year-of-ai-revolution-a-rebels-guide-to-predicting-the-future,2024: The Year of AI Revolution &#8211; A Rebel&#8217;s Guide to the Future,https://kriskrug.co/2024/01/19/2024-the-year-of-ai-revolution-a-rebels-guide-to-predicting-the-future/,True,42,True,157,True,202
+post,4372,building-ai-companions-w-john-anthony-hartman-of-ihaverobots,Building AI Companions w/ John Anthony Hartman of IHAVEROBOTS,https://kriskrug.co/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/,True,46,True,152,True,126
+post,4359,generative-ai-future-proof-creatives-online-training-workshops-2024,Generative AI &#8211; Future Proof Creatives Online Training Workshops 2024,https://kriskrug.co/2023/12/28/generative-ai-future-proof-creatives-online-training-workshops-2024/,True,52,True,155,True,255
+post,4348,2024-vancouver-ai-community-meetups,Vancouver AI Community Meetups &amp; BC + AI Ecosystem,https://kriskrug.co/2023/12/27/2024-vancouver-ai-community-meetups/,True,44,True,152,True,132
+post,4216,art-island-hornbys-exploration-of-why-the-fuck-we-make-art-anyway,"Art Island: Hornby&#8217;s Exploration of &#8216;Why the Fuck We Make Art, Anyway.&#8221;",https://kriskrug.co/2023/12/07/art-island-hornbys-exploration-of-why-the-fuck-we-make-art-anyway/,True,44,True,147,True,168
+post,4146,empowering-community-in-the-ai-era-fostering-authentic-connections-and-creative-collaboration,Growing a Grassroots AI Community,https://kriskrug.co/2023/11/20/empowering-community-in-the-ai-era-fostering-authentic-connections-and-creative-collaboration/,True,45,True,148,True,177
+post,3277,reinventing-for-the-ai-age-with-youtube-veteran-chris-pirillo,Reinventing for the AI Age with YouTube Veteran Chris Pirillo,https://kriskrug.co/2023/11/18/reinventing-for-the-ai-age-with-youtube-veteran-chris-pirillo/,True,45,True,152,True,255
+post,4011,artist-profile-brandt-designs-envisioning-the-future-of-pool-tables-as-art-installations,Artist Profile: Brandt Designs Envisioning the Future of Pool Tables as Art Installations,https://kriskrug.co/2023/11/13/artist-profile-brandt-designs-envisioning-the-future-of-pool-tables-as-art-installations/,True,48,True,140,True,140
+post,4002,20-ways-to-resist-ais-mind-enslavement,20 Ways to Resist AI&#8217;s Mind Enslavement,https://kriskrug.co/2023/11/05/20-ways-to-resist-ais-mind-enslavement/,True,51,True,155,True,201
+post,3814,the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things,Most Benevolent Outcomes Prayer for AI &#038; All Living Things,https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/,False,0,True,201,True,242
+post,3908,web3-will-fail-if-it-doesnt-put-people-before-profits-and-technology,"The Web3 Manifesto: Challenging Tech Titans with Trust, Ownership, Privacy and Inclusion",https://kriskrug.co/2023/11/01/web3-will-fail-if-it-doesnt-put-people-before-profits-and-technology/,False,0,True,200,True,200
+post,3832,future-in-review-2023-photographing-the-festival-of-futurism,Future in Review 2023:  Photographing the Festival of Futurism,https://kriskrug.co/2023/11/01/future-in-review-2023-photographing-the-festival-of-futurism/,False,0,True,201,True,201
+post,3853,deconstruct-your-business-model-on-a-lean-canvas-google-news-initiative-launch-lab-week-two-report,Deconstruct Your Business Model on a Lean Canvas: Google News Initiative Launch Lab Week Two Report,https://kriskrug.co/2023/10/31/deconstruct-your-business-model-on-a-lean-canvas-google-news-initiative-launch-lab-week-two-report/,False,0,True,201,True,201
+post,3820,rethinking-ownership-and-copyright-in-the-age-of-generative-ai,Rethinking Ownership and Copyright in the Age of Generative AI,https://kriskrug.co/2023/10/30/rethinking-ownership-and-copyright-in-the-age-of-generative-ai/,False,0,True,162,True,255
+post,3611,revealing-the-future-of-education-an-unconventional-creative-exchange,Revealing the Future of Education: An Unconventional Creative Exchange,https://kriskrug.co/2023/10/29/revealing-the-future-of-education-an-unconventional-creative-exchange/,False,0,True,166,True,123
+post,3273,marilyn-wilson-interview-q-a,"Marilyn Wilson Interview &#8211; Finding Inspiration at the Intersection of Nature, Fiction and Online Communities",https://kriskrug.co/2023/10/27/marilyn-wilson-interview-q-a/,False,0,True,192,True,193
+post,3773,mapping-the-blueprint-the-genesis-of-a-media-venture-google-news-initiative-pre-launch-lab,Mapping the Blueprint: The Genesis of a Media Venture &#8211; Google News Initiative Pre-Launch Lab,https://kriskrug.co/2023/10/26/mapping-the-blueprint-the-genesis-of-a-media-venture-google-news-initiative-pre-launch-lab/,False,0,True,201,True,255
+post,3764,embarking-on-a-digital-news-voyage-week-1-recap-of-the-google-news-initiative-pre-launch-lab,Google News Initiative Pre-Launch Lab: Building AI,https://kriskrug.co/2023/10/26/embarking-on-a-digital-news-voyage-week-1-recap-of-the-google-news-initiative-pre-launch-lab/,False,0,True,197,True,197
+post,3736,embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab,Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab,https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/,False,0,True,183,True,255
+post,3708,hacking-the-digital-ecosystem-expert-insights-from-jordan-behan,Hacking the Digital Ecosystem: Expert Insights from Jordan Behan,https://kriskrug.co/2023/10/23/hacking-the-digital-ecosystem-expert-insights-from-jordan-behan/,False,0,True,142,True,215
+post,2805,ais-true-threats-corporate-control-centralization-of-power-and-cultural-adaptation,AI&#8217;s True Threats,https://kriskrug.co/2023/10/22/ais-true-threats-corporate-control-centralization-of-power-and-cultural-adaptation/,True,29,True,145,True,145
+post,3627,breaking-the-language-barrier-my-deepfake-experiment-shocks-and-sparks-debate,Breaking the Language Barrier: My Deepfake Experiment Shocks and Sparks Debate,https://kriskrug.co/2023/10/21/breaking-the-language-barrier-my-deepfake-experiment-shocks-and-sparks-debate/,True,35,True,369,True,253
+post,3677,ai-art-changes-in-animation-special-effects-film-games-the-creative-industries,"AI &#038; Art: Changes in Animation, Special Effects, Film, Games &#038; the Creative Industries",https://kriskrug.co/2023/10/21/ai-art-changes-in-animation-special-effects-film-games-the-creative-industries/,True,86,True,126,True,126
+post,3640,vancouver-ai-community-lunch-meetup-fostering-community-in-vancouvers-budding-ai-landscape,Vancouver AI Community Lunch Meetup: Fostering Community in Vancouver&#8217;s Budding AI Landscape,https://kriskrug.co/2023/10/20/vancouver-ai-community-lunch-meetup-fostering-community-in-vancouvers-budding-ai-landscape/,False,0,True,201,True,255
+post,3631,shaping-the-creative-continuum-my-take-on-the-vanas-ai-panel,Shaping the Creative Continuum &#8211; My Take on the VANAS AI Panel,https://kriskrug.co/2023/10/19/shaping-the-creative-continuum-my-take-on-the-vanas-ai-panel/,False,0,True,201,True,235
+post,3480,elevate-your-event-with-kris-krugs-comprehensive-media-making-services,"Photography, Videos &#038; Social Media Making for Events, Retreats, Workshops &#038; Conferences",https://kriskrug.co/2023/10/19/elevate-your-event-with-kris-krugs-comprehensive-media-making-services/,False,0,True,156,True,156
+post,3567,community-art-project-development-process-guide,Community Art Project Development Process Guide,https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/,True,59,True,187,True,187
+post,3539,the-art-of-augmented-creativity-balancing-ai-community-and-self,"The Art of Augmented Creativity: Balancing AI, Community, and Self",https://kriskrug.co/2023/10/13/the-art-of-augmented-creativity-balancing-ai-community-and-self/,False,0,True,175,True,255
+post,3275,how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape,"How AI tools like Midjourney, DALL·E &amp; ChatGPT are reshaping the creative landscape",https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/,False,0,True,201,True,214
+post,3429,the-future-of-immersive-storytelling-perspectives-from-the-frontier-summit,The Future of Immersive Storytelling: Perspectives from The Frontier Summit,https://kriskrug.co/2023/10/05/the-future-of-immersive-storytelling-perspectives-from-the-frontier-summit/,False,0,True,135,True,135
+post,3425,teasing-the-launch-vancouver-ai-community-meetup,Teasing the Launch: Vancouver AI Community Meetup,https://kriskrug.co/2023/10/05/teasing-the-launch-vancouver-ai-community-meetup/,False,0,True,147,True,229
+post,3407,balancing-artificial-intelligences-existential-dilemmas-and-societal-enhancements-reflections-on-the-frontier-summit-ai-panel,Balancing Artificial Intelligence&#8217;s Existential Dilemmas and Societal Enhancements: Reflections on the Frontier Summit AI Panel,https://kriskrug.co/2023/10/04/balancing-artificial-intelligences-existential-dilemmas-and-societal-enhancements-reflections-on-the-frontier-summit-ai-panel/,False,0,True,201,True,201
+post,3391,organic-intelligence-rika-nakagawa-on-rethinking-sustainability-innovation-and-ai,"Organic Intelligence: Rika Nakagawa on Rethinking Sustainability, Innovation and AI",https://kriskrug.co/2023/10/04/organic-intelligence-rika-nakagawa-on-rethinking-sustainability-innovation-and-ai/,False,0,True,151,True,151
+post,3330,the-future-called-i-answered,The Future Called: I Answered,https://kriskrug.co/2023/09/29/the-future-called-i-answered/,True,41,True,181,True,181
+post,3219,curiosity-above-all-hanging-out-at-the-intersection-of-art-and-technology,Curiosity Above All: Hanging Out At the Intersection of Art and Technology,https://kriskrug.co/2023/09/29/curiosity-above-all-hanging-out-at-the-intersection-of-art-and-technology/,False,0,True,201,True,223
+post,3279,the-ai-mindset-kris-krug-kevin-kelley-discuss-ais-creative-power,The AI Mindset: Kris Krug &amp; Kevin Kelley Discuss AI&#8217;s Creative Power,https://kriskrug.co/2023/09/25/the-ai-mindset-kris-krug-kevin-kelley-discuss-ais-creative-power/,False,0,True,170,True,112
+post,3271,a-practical-guide-to-capturing-creative-ideas-with-chatgpt-mobile-during-travel-now-with,A Practical Guide to Capturing Creative Ideas with ChatGPT Mobile During Travel &#8211; Now with,https://kriskrug.co/2023/09/25/a-practical-guide-to-capturing-creative-ideas-with-chatgpt-mobile-during-travel-now-with/,False,0,True,164,True,164
+post,3243,the-magic-of-asa-mathat-portraiture-and-photography-at-dent-the-future,The Magic of Asa Mathat: Portraiture and Photography at Dent the Future,https://kriskrug.co/2023/09/23/the-magic-of-asa-mathat-portraiture-and-photography-at-dent-the-future/,False,0,True,198,True,198
+post,3181,master-prompts-developing-an-ai-mindset-chatgpt-workshop-recap-dent2023,Master Prompts &#038; Developing an AI Mindset  &#8211; ChatGPT Workshop Recap #DENT2023,https://kriskrug.co/2023/09/22/master-prompts-developing-an-ai-mindset-chatgpt-workshop-recap-dent2023/,False,0,True,166,True,255
+post,3183,coffee-community-and-sobriety-matt-mckennas-decade-at-dent,"Coffee, Community, and Sobriety: Matt McKenna&#8217;s Decade at DENT",https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/,False,0,True,162,True,162
+post,3153,building-an-nlp-powered-ai-transit-assistant-at-hackct-for-national-day-of-civic-hacking,Building an NLP-Powered AI Transit Assistant at HackCT for National Day of Civic Hacking,https://kriskrug.co/2023/09/18/building-an-nlp-powered-ai-transit-assistant-at-hackct-for-national-day-of-civic-hacking/,False,0,True,201,True,201
+post,3151,newsletter-002-rebirth-and-revolution,Newsletter 002: Rebirth and Revolution,https://kriskrug.co/2023/09/18/newsletter-002-rebirth-and-revolution/,True,50,True,201,True,230
+post,3147,hackct-an-exploration-into-open-source-solutions-for-rural-mobility,HackCT: An Exploration into Open-Source Solutions for Rural Mobility,https://kriskrug.co/2023/09/16/hackct-an-exploration-into-open-source-solutions-for-rural-mobility/,False,0,True,193,True,191
+post,3114,the-promise-and-peril-of-ai-my-key-takeaways-from-the-impact-relations-institute-panel,The Promise and Peril of AI: My Key Takeaways from the Impact Relations Institute Panel,https://kriskrug.co/2023/09/09/the-promise-and-peril-of-ai-my-key-takeaways-from-the-impact-relations-institute-panel/,False,0,True,200,True,209
+post,3082,exploring-the-world-of-ai-image-generation-with-artist-frank-yu,Exploring the World of AI Image Generation with Artist Frank Yu,https://kriskrug.co/2023/09/06/exploring-the-world-of-ai-image-generation-with-artist-frank-yu/,False,0,True,148,True,255
+post,3084,trends-in-impact-communications-corporate-esg-with-dr-lisa-costa-robert-scales-and-melissa-orozco,"Trends in Impact Communications &#038; Corporate ESG with Dr. Lisa Costa, Robert Scales and Melissa Orozco",https://kriskrug.co/2023/09/05/trends-in-impact-communications-corporate-esg-with-dr-lisa-costa-robert-scales-and-melissa-orozco/,False,0,True,201,True,213
+post,2965,ai-as-your-creative-co-pilot-a-down-to-earth-guide-for-the-architecture-engineering-construction-industries,"AI as Your Creative Co-pilot: A Down-to-Earth Guide for the Architecture, Engineering &#038; Construction Industries",https://kriskrug.co/2023/09/05/ai-as-your-creative-co-pilot-a-down-to-earth-guide-for-the-architecture-engineering-construction-industries/,False,0,True,153,True,255
+post,2950,community-weaving-how-digital-interactions-shape-our-physical-world,Community Weaving: How Digital Interactions Shape Our Physical World,https://kriskrug.co/2023/09/01/community-weaving-how-digital-interactions-shape-our-physical-world/,False,0,True,201,True,255
+post,2922,hackct-a-mission-to-revolutionize-rural-mobility-in-connecticuts-quiet-corner,HackCT: A Mission to Revolutionize Rural Mobility in Connecticut&#8217;s &#8220;Quiet Corner&#8221;,https://kriskrug.co/2023/08/31/hackct-a-mission-to-revolutionize-rural-mobility-in-connecticuts-quiet-corner/,False,0,True,201,True,201
+post,2930,the-artist-profile-of-charlie-blackcat-smith-the-johnny-appleseed-of-burning-man,The Artist Profile of Charlie Blackcat Smith: The Johnny Appleseed of Burning Man,https://kriskrug.co/2023/08/30/the-artist-profile-of-charlie-blackcat-smith-the-johnny-appleseed-of-burning-man/,False,0,True,202,True,256
+post,2879,burning-man-art-projects-uncle-charlies-red-hot-cock-tyson-ayers-shrine-of-sympathetic-resonance,Burning Man Art Projects &#8211; Uncle Charlie&#8217;s Red Hot Cock &amp; Tyson Ayer&#8217;s Shrine of Sympathetic Resonance,https://kriskrug.co/2023/08/25/burning-man-art-projects-uncle-charlies-red-hot-cock-tyson-ayers-shrine-of-sympathetic-resonance/,False,0,True,138,True,138
+post,2857,through-my-lens-new-projects-and-updates-from-kris-krug,Through My Lens: New Projects and Updates from Kris Krug,https://kriskrug.co/2023/08/22/through-my-lens-new-projects-and-updates-from-kris-krug/,False,0,True,134,True,134
+post,2833,dent-the-future-an-insiders-experiences-at-the-dent-conference,DENT the Future: An Insider&#8217;s Experiences at the Dent Conference,https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/,True,15,True,202,True,202
+post,2819,exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out,Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out,https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/,True,83,True,266,True,261
+post,2795,community-shout-outs-people-projects-to-check-out,Community Shout-Outs: People &#038; Projects Worth Checking Out,https://kriskrug.co/2023/08/08/community-shout-outs-people-projects-to-check-out/,False,0,True,136,True,255
+post,2788,digital-self-the-era-of-ai-avatars-chatbots-audio-cloning,"Digital Self &#038; the Era of AI: Avatars, ChatBots, &#038; Audio Cloning",https://kriskrug.co/2023/08/01/digital-self-the-era-of-ai-avatars-chatbots-audio-cloning/,False,0,True,124,True,255
+post,2781,audio-deep-fakes-ai-chatbots-and-new-web-development-tools,"Audio Deep Fakes, AI ChatBots and New Web Development Tools",https://kriskrug.co/2023/07/30/audio-deep-fakes-ai-chatbots-and-new-web-development-tools/,False,0,True,134,True,244
+post,2767,go-fish-a-psychedelic-dive-into-the-salish-sea-pacific-herring-spawn,&#8216;GO FISH&#8217;: A Psychedelic Dive into the Salish Sea Pacific Herring Spawn,https://kriskrug.co/2023/07/29/go-fish-a-psychedelic-dive-into-the-salish-sea-pacific-herring-spawn/,False,0,True,201,True,202
+post,2750,future-in-review-conference-and-fire-podcast-an-insiders-view,Future in Review Conference and FIRE Podcast: An Insider&#8217;s View,https://kriskrug.co/2023/07/28/future-in-review-conference-and-fire-podcast-an-insiders-view/,False,0,True,201,True,251
+post,2712,updating-my-digital-footprint-a-journey-of-exploration-and-growth,Updating My Digital Footprint: A Journey of Exploration and Growth,https://kriskrug.co/2023/07/23/updating-my-digital-footprint-a-journey-of-exploration-and-growth/,False,0,True,201,True,201
+post,2665,embracing-the-future-my-journey-with-generative-ai-and-building-a-learning-community-on-discord,Embracing the Future: My Journey with Generative AI and Building a Learning Community on Discord,https://kriskrug.co/2023/07/09/embracing-the-future-my-journey-with-generative-ai-and-building-a-learning-community-on-discord/,False,0,True,181,True,181
+post,2661,headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona,"Headed to Burning Man, Shambhala or Coachella? Ignite Your Festival Persona",https://kriskrug.co/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/,False,0,True,157,True,157
+post,2656,ai-as-a-creative-partner-upcoming-keynote-at-canadian-society-for-marketing-professional-services-csmps-annual-general-meeting,Upcoming Keynote: AI as a Creative Partner,https://kriskrug.co/2023/06/07/ai-as-a-creative-partner-upcoming-keynote-at-canadian-society-for-marketing-professional-services-csmps-annual-general-meeting/,True,54,True,201,True,255
+post,2650,the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld,The Cyber Love Garden: A Crossroads of Art and AI at Otherworld,https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/,False,0,True,137,True,137
+post,2640,crafting-the-future-of-ai-one-digital-reflection-at-a-time,"My Deep Dive into the World of Generative AI with OpenAI, ChatGPT &#038; Midjourney",https://kriskrug.co/2023/05/28/crafting-the-future-of-ai-one-digital-reflection-at-a-time/,False,0,True,201,True,201
+post,2643,dive-into-ruganzu-brunos-ecoart-residency-in-kampala-uganda,"Dive into Ruganzu Bruno&#8217;s EcoArt Residency in Kampala, Uganda!",https://kriskrug.co/2021/05/28/dive-into-ruganzu-brunos-ecoart-residency-in-kampala-uganda/,False,0,True,187,True,187
+post,2644,cultivating-connections-the-inspiring-story-of-galiano-island-community-schools-garden-greenhouse-project,Cultivating Connections: The Inspiring Story of Galiano Island Community School&#8217;s Garden &#038; Greenhouse Project,https://kriskrug.co/2020/05/29/cultivating-connections-the-inspiring-story-of-galiano-island-community-schools-garden-greenhouse-project/,False,0,True,153,True,153
+post,2496,feelmore-plants-a-gardening-pop-up-shop-in-vancouvers-west-end,Feelmore Plants &#8211; A Gardening Pop-Up Shop in Vancouver&#8217;s West End,https://kriskrug.co/2019/06/10/feelmore-plants-a-gardening-pop-up-shop-in-vancouvers-west-end/,False,0,True,152,True,152
+post,2461,small-art-printmaking-press-on-whaler-bay-galiano-island,"Small Art Printmaking Press on Whaler Bay, Galiano Island",https://kriskrug.co/2019/04/10/small-art-printmaking-press-on-whaler-bay-galiano-island/,False,0,True,179,True,179
+post,2424,upcoming-galiano-island-events,"Upcoming Galiano Island Events: BioBlitz, Pirate Regatta, Tour des Iles &#038; Instagram Workshop",https://kriskrug.co/2019/04/02/upcoming-galiano-island-events/,False,0,True,201,True,201
+post,2423,dent-2019-photo-recap-gallery,DENT the Future 2019 Photo Recap &#038; Gallery,https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/,True,54,True,201,True,201
+post,2269,knife-collection-inventory,Handmade Knife Collection Inventory,https://kriskrug.co/2019/03/07/knife-collection-inventory/,True,47,True,163,True,163
+post,2287,sharon-anderson-morris,Sharon Anderson Morris &#8211; Empowering independent documentary films &#8211; FiReFilms,https://kriskrug.co/2017/01/20/sharon-anderson-morris/,False,0,True,167,True,167
+post,2255,phillimore-point-galiano-island-summer-2016-bird-inventory,Phillimore Point Galiano Island Summer 2016  Bird Inventory,https://kriskrug.co/2016/08/11/phillimore-point-galiano-island-summer-2016-bird-inventory/,False,0,True,143,True,143
+post,2232,bookworms-wordnerds-unite-on-galiano-island,#BookWorms &#038; #WordNerds Unite on Galiano Island for 2016 Literary Festival,https://kriskrug.co/2016/01/13/bookworms-wordnerds-unite-on-galiano-island/,False,0,True,130,True,130
+post,2227,folsom-california-christmas-bird-inventory,Folsom California Christmas Bird Inventory 2015,https://kriskrug.co/2016/01/03/folsom-california-christmas-bird-inventory/,True,59,True,200,True,200
+post,2213,aerial-photography-combining-my-loves-for-flying-and-making-photos,Aerial Photography: Combining my loves for flying and making photos!,https://kriskrug.co/2015/09/08/aerial-photography-combining-my-loves-for-flying-and-making-photos/,False,0,True,200,True,200
+post,2209,what-is-the-unique-value-that-female-artists-bring-to-electronic-dance-music,What is the unique value that female artists bring to electronic dance music?,https://kriskrug.co/2015/08/14/what-is-the-unique-value-that-female-artists-bring-to-electronic-dance-music/,False,0,True,150,True,150
+post,2179,king-fisher-galiano-island-salmon-classic-fishing-derby,RECAP: 2015 King Fisher Galiano Island Salmon Classic Fishing Derby,https://kriskrug.co/2015/05/05/king-fisher-galiano-island-salmon-classic-fishing-derby/,False,0,True,140,True,140
+post,2175,engineering-serendipity-interview-w-chris-coldewey,Engineering Serendipity interview w/ Chris Coldewey,https://kriskrug.co/2015/04/29/engineering-serendipity-interview-w-chris-coldewey/,False,0,True,201,True,201
+post,2167,galiano-islands-newest-company-king-fisher-apparel,Galiano Island&#8217;s New Outdoor Lifestyle Brand &#8211; King Fisher Apparel,https://kriskrug.co/2015/04/27/galiano-islands-newest-company-king-fisher-apparel/,False,0,True,128,True,128
+post,2160,access-to-media-education-society-digital-storytelling-wokshops-on-galiano-island-penelakut-island,Media Literacy &#038; Digital Storytelling Workshops w/ the Youth of Galiano &#038; Penelakut Islands,https://kriskrug.co/2015/04/20/access-to-media-education-society-digital-storytelling-wokshops-on-galiano-island-penelakut-island/,False,0,True,177,True,177
+post,2007,making-updates,The Cobbler&#8217;s Children Have No Shoes,https://kriskrug.co/2015/04/13/making-updates/,True,48,True,183,True,183
+post,1975,pilot-school-flying-in-the-direction-of-my-dreams,Pilot School &#8211; Flying in the Direction of my Dreams,https://kriskrug.co/2013/09/14/pilot-school-flying-in-the-direction-of-my-dreams/,False,0,True,151,True,151
+post,2001,preparation-under-way-for-south-by-southwest-2014-in-austin-texas,"Preparation Under Way For South By Southwest 2014 in Austin, Texas",https://kriskrug.co/2013/08/22/preparation-under-way-for-south-by-southwest-2014-in-austin-texas/,False,0,True,135,True,135
+post,1974,sunning-surfing-in-baja-california-mexico,Sunning &#038; Surfing in Baja Mexico,https://kriskrug.co/2013/07/26/sunning-surfing-in-baja-california-mexico/,True,44,True,201,True,201
+post,1954,this-is-east-van-community-art-yvr,This Is East Van #Community #Art #YVR,https://kriskrug.co/2012/07/06/this-is-east-van-community-art-yvr/,True,49,True,201,True,201
+post,1934,workin-with-the-united-nations-on-a-digital-crowdsourcing-campaign-to-stop-the-spread-of-hiv,Workin With The United Nations On A Digital Crowdsourcing Campaign to Stop HIV / AIDS,https://kriskrug.co/2011/11/19/workin-with-the-united-nations-on-a-digital-crowdsourcing-campaign-to-stop-the-spread-of-hiv/,False,0,True,201,True,201
+post,1916,a-rolling-stone-gathers-no-moss-africa-south-america-the-pacific-ocean,A rolling stone gathers no moss.,https://kriskrug.co/2011/04/27/a-rolling-stone-gathers-no-moss-africa-south-america-the-pacific-ocean/,True,44,True,169,True,169
+post,1913,cbc-interview-plastic-pollution-the-oceans,CBC Interview: Plastic Pollution &#038; The Oceans,https://kriskrug.co/2011/04/01/cbc-interview-plastic-pollution-the-oceans/,True,57,True,188,True,188
+post,1869,what-we-leave-behind-is-our-digital-footprint,What we leave behind is our digital footprint&#8230;,https://kriskrug.co/2011/02/01/what-we-leave-behind-is-our-digital-footprint/,True,60,True,201,True,201
+post,1857,social-media-documentarian,Social Media Documentarian,https://kriskrug.co/2011/01/17/social-media-documentarian/,True,38,True,147,True,147
+post,1849,south-by-southwest-party-in-vancouver-at-the-waldorf-hotel-january-13th,Vancouver South By Southwest Party at The Waldorf Hotel,https://kriskrug.co/2011/01/04/south-by-southwest-party-in-vancouver-at-the-waldorf-hotel-january-13th/,False,0,True,201,True,201
+post,1841,the-future-of-fashion-photography,The Future of Fashion Photography,https://kriskrug.co/2010/12/27/the-future-of-fashion-photography/,True,45,True,133,True,133
+post,1815,new-emerging-social-networking-tools-bcit-mdia-4250,New &#038; Emerging Social Networking Tools &#8211; BCIT MDIA 2045,https://kriskrug.co/2010/12/02/new-emerging-social-networking-tools-bcit-mdia-4250/,False,0,True,179,True,179
+post,1809,christmas-is-coming-the-geese-are-getting-fat-please-put-a-penny-in-the-old-mans-hat,"Christmas is coming, the geese are getting fat: Please put a penny in the old man&#8217;s hat:",https://kriskrug.co/2010/11/29/christmas-is-coming-the-geese-are-getting-fat-please-put-a-penny-in-the-old-mans-hat/,False,0,True,201,True,201
+post,1802,rip-a-remix-manifesto,RiP! A Remix Manifesto,https://kriskrug.co/2010/11/25/rip-a-remix-manifesto/,True,34,True,188,True,188
+post,1790,the-waldorf-hotel-the-beatty-street-mural,The Waldorf Hotel &#038; The Beatty Street Mural,https://kriskrug.co/2010/11/15/the-waldorf-hotel-the-beatty-street-mural/,True,55,True,177,True,177
+post,1778,photography-ethics-on-vancouvers-downtown-eastside,Photography Ethics on Vancouver&#8217;s Downtown Eastside,https://kriskrug.co/2010/11/10/photography-ethics-on-vancouvers-downtown-eastside/,False,0,True,201,True,201
+post,1756,tweetups-twittersphere-tweeps-twitworking-twestivals-twitter,"Tweetups, Twittersphere, Tweeps, Twitworking, Twestivals &#038; Twitter",https://kriskrug.co/2010/11/03/tweetups-twittersphere-tweeps-twitworking-twestivals-twitter/,False,0,True,193,True,193
+post,1738,new-media-and-web-development-class-001-bcit,New Media and Web Development Class 001 &#8211; BCIT,https://kriskrug.co/2010/10/28/new-media-and-web-development-class-001-bcit/,True,58,True,71,True,71
+post,1729,so-whatcha-been-up-to-summer-photography-update-2010,&#8220;So Whatcha Been Up To?&#8221; &#8211; Summer Photography Update 2010,https://kriskrug.co/2010/08/25/so-whatcha-been-up-to-summer-photography-update-2010/,False,0,True,168,True,168
+post,1713,vancouvers-got-a-posse-at-south-by-soutwest-interactive-2011,&#8216;Vancouver&#8217;s Got A Posse&#8217; at South By Soutwest Interactive 2011,https://kriskrug.co/2010/08/18/vancouvers-got-a-posse-at-south-by-soutwest-interactive-2011/,False,0,True,157,True,157
+post,1710,remixology-thirst-quenching-fresh-media-innovation,ReMixology &#8212; Thirst-Quenching Fresh Media Innovation!,https://kriskrug.co/2010/08/07/remixology-thirst-quenching-fresh-media-innovation/,False,0,True,167,True,167
+post,1689,top-20-vancouver-twitter-peeps-based-on-klout-score,Top 20 Vancouver Twitter Peeps Based on Klout Score,https://kriskrug.co/2010/07/13/top-20-vancouver-twitter-peeps-based-on-klout-score/,False,0,True,175,True,175
+post,1679,ted-x-oil-spill-expedition-headed-to-new-orleans-the-gulf-of-mexico,TED x Oil Spill EXPEDITION: Headed to New Orleans &#038; The Gulf of Mexico,https://kriskrug.co/2010/06/13/ted-x-oil-spill-expedition-headed-to-new-orleans-the-gulf-of-mexico/,False,0,True,194,True,194
+post,1669,what-do-you-do-when-someone-lets-you-evaluate-a-product-wants-you-to-write-about-the-product-sucks-the-person-is-your-friend,"What do you do when someone lets you evaluate a product, &#038; wants you to write about, &#038; the product sucks, &#038; the person is your friend?",https://kriskrug.co/2010/03/18/what-do-you-do-when-someone-lets-you-evaluate-a-product-wants-you-to-write-about-the-product-sucks-the-person-is-your-friend/,False,0,True,170,True,170
+post,1652,deadline-quickly-approaching-have-photographs-included-in-vancouver-2010-winter-olympics,Deadline Quickly Approaching Have Photographs Included in Vancouver 2010 Winter Olympics,https://kriskrug.co/2010/01/25/deadline-quickly-approaching-have-photographs-included-in-vancouver-2010-winter-olympics/,False,0,True,141,True,141
+post,1631,tons-of-rad-music-coming-to-vancouver-as-part-of-the-2010-olympics,Tons Of Rad Music Coming to Vancouver As Part of the 2010 Olympics,https://kriskrug.co/2010/01/20/tons-of-rad-music-coming-to-vancouver-as-part-of-the-2010-olympics/,False,0,True,176,True,176
+post,1606,best-media-art-installations-coming-to-vancouver-2010-code-live-festival,Best Media Art Installations Coming to Vancouver 2010 CODE Live Festival,https://kriskrug.co/2010/01/14/best-media-art-installations-coming-to-vancouver-2010-code-live-festival/,False,0,True,200,True,200
+post,1602,jeremy-crowles-new-show-there-in-spirit-showing-at-w2-perel-gallery-in-dtes,Jeremy Crowle&#8217;s new show &#8216;tHere in Spirit&#8217; showing at W2-Perel Gallery in DTES,https://kriskrug.co/2010/01/09/jeremy-crowles-new-show-there-in-spirit-showing-at-w2-perel-gallery-in-dtes/,False,0,True,153,True,153
+post,1588,doin-it-for-the-love-reflections-on-the-future-at-journalism-that-matters-conference,Doin&#8217; It For The Love &#8211; Reflections On The Future At &#8216;Journalism That Matters&#8217; Conference,https://kriskrug.co/2010/01/08/doin-it-for-the-love-reflections-on-the-future-at-journalism-that-matters-conference/,False,0,True,127,True,127
+post,1582,vancouver-represents-at-un-climate-change-summit-in-copenhagen,Vancouver Represents At UN Climate Change Summit in Copenhagen,https://kriskrug.co/2009/12/18/vancouver-represents-at-un-climate-change-summit-in-copenhagen/,False,0,True,177,True,177
+post,1578,the-yes-men-vs-canada-at-the-united-nations-climate-change-conference-in-copenhagen-denmark,"The Yes Men vs. Canada at The United Nations Climate Change Conference in Copenhagen, Denmark",https://kriskrug.co/2009/12/17/the-yes-men-vs-canada-at-the-united-nations-climate-change-conference-in-copenhagen-denmark/,False,0,True,201,True,201
+post,1558,photo-essay-streets-of-copenhagen-cop15-united-nations-climate-change-summit,PHOTO ESSAY: Streets of Copenhagen &#8211; COP15 United Nations Climate Change Summit,https://kriskrug.co/2009/12/14/photo-essay-streets-of-copenhagen-cop15-united-nations-climate-change-summit/,False,0,True,122,True,122
+post,1547,photo-essay-inside-the-negotiations-cop15,COP15 United Nations Climate Change Summit,https://kriskrug.co/2009/12/14/photo-essay-inside-the-negotiations-cop15/,True,54,True,201,True,201
+post,1537,how-to-take-great-potraits-interview-w-darren-rowse,How To Take Great Portraits Interview w/ Darren Rowse,https://kriskrug.co/2009/10/30/how-to-take-great-potraits-interview-w-darren-rowse/,False,0,True,190,True,190
+post,1528,best-linkedin-recommendation-evah,Best LinkedIn Recommendation Evah!,https://kriskrug.co/2009/10/18/best-linkedin-recommendation-evah/,True,46,True,184,True,184
+post,1509,social-media-tools-strategies-for-event-planning-management,Social Media Tools &#038; Strategies for Event Planners &#038; Organizers,https://kriskrug.co/2009/10/15/social-media-tools-strategies-for-event-planning-management/,False,0,True,159,True,159
+post,1498,whos-gonna-come-geekout-in-hawaii-with-me-oa,Who&#8217;s Gonna Come Geekout in Hawaii With Me?,https://kriskrug.co/2009/10/14/whos-gonna-come-geekout-in-hawaii-with-me-oa/,True,55,True,184,True,184
+post,1487,gnomedex-9-0,"Oh Hai Nerds, Geeks, and Dorks &#8211; Gnomedex 9.0",https://kriskrug.co/2009/08/20/gnomedex-9-0/,True,57,True,200,True,200
+post,1471,field-guide-sxsw-interactive-2009-panel-picker,FIELD GUIDE: SXSW Interactive 2010 Panel Picker,https://kriskrug.co/2009/08/19/field-guide-sxsw-interactive-2009-panel-picker/,True,59,True,170,True,170
+post,1448,ted-comes-to-vancouver-speaker-nominations-for-tedxvan,TED Comes to Vancouver : Speaker Nominations for TEDxVan,https://kriskrug.co/2009/08/18/ted-comes-to-vancouver-speaker-nominations-for-tedxvan/,False,0,True,129,True,129
+post,1432,digital-footprint-from-a-web-of-pages-to-a-web-of-streams,Digital Footprint: From a web of pages to a web of streams,https://kriskrug.co/2009/08/16/digital-footprint-from-a-web-of-pages-to-a-web-of-streams/,False,0,True,201,True,201
+post,1375,returning-to-camden-maine-to-photograph-the-world-changers-of-poptech-2009-america-reimagined,"Returning to Camden, Maine to Photograph the World-Changers of Pop!Tech 2009: America Reimagined",https://kriskrug.co/2009/08/06/returning-to-camden-maine-to-photograph-the-world-changers-of-poptech-2009-america-reimagined/,False,0,True,147,True,147
+post,1401,the-digital-footprint-exploring-electronic-consciousness-online-identity,The Digital Footprint &#8211; Exploring Electronic Consciousness &#038; Online Identity,https://kriskrug.co/2009/08/05/the-digital-footprint-exploring-electronic-consciousness-online-identity/,False,0,True,201,True,201
+post,1379,the-summer-gathering-at-hollyhock-on-cortes-island,The Summer Gathering at Hollyhock on Cortes Island,https://kriskrug.co/2009/08/03/the-summer-gathering-at-hollyhock-on-cortes-island/,False,0,True,200,True,200
+post,1360,from-a-web-of-pages-to-a-web-of-streams-presentation-for-sxsw-2010,&#8216;From a Web of Pages to a Web of Streams&#8217; Presentation for SXSW 2010,https://kriskrug.co/2009/07/14/from-a-web-of-pages-to-a-web-of-streams-presentation-for-sxsw-2010/,False,0,True,127,True,127
+post,1333,intelligent-online-media-monitoring-tools-strategies-panel-for-sxsw-interactive,Intelligent Online Media Monitoring Tools &#038; Strategies Panel for SXSW Interactive,https://kriskrug.co/2009/07/13/intelligent-online-media-monitoring-tools-strategies-panel-for-sxsw-interactive/,False,0,True,201,True,201
+post,1302,china-update-tedxshanghai,Kris Krüg Speaking at TEDx Shanghai &#8211; First Ever TEDx in China,https://kriskrug.co/2009/06/18/china-update-tedxshanghai/,False,0,True,100,True,100
+post,1266,photography-update-sxsw-new-york-fashion-week-renewal-partners-pechu-kucha-the-purple-thistle-collective,"Photography Update &#8211; SXSW, New York Fashion Week, Renewal Partners, Pechu Kucha &#038; the Purple Thistle Collective",https://kriskrug.co/2009/04/29/photography-update-sxsw-new-york-fashion-week-renewal-partners-pechu-kucha-the-purple-thistle-collective/,False,0,True,201,True,201
+post,1252,rad-new-music-services-i-leard-about-today,Rad New Music Services I Learned About Today,https://kriskrug.co/2009/04/27/rad-new-music-services-i-leard-about-today/,True,56,True,151,True,151
+post,1251,photography-recap-2008-was-a-very-good-year,Photography Recap &#8211; 2008 Was A Very Good Year,https://kriskrug.co/2009/01/02/photography-recap-2008-was-a-very-good-year/,True,57,True,200,True,200
+post,1250,china-business-comes-to-sxsw-interactive,China Business comes to SXSW Interactive,https://kriskrug.co/2008/12/30/china-business-comes-to-sxsw-interactive/,True,52,True,137,True,137
+post,1249,anti-israel-protest-us-embassay-in-vancouver,Anti-Israel Protest @ US Embassay in Vancouver,https://kriskrug.co/2008/12/30/anti-israel-protest-us-embassay-in-vancouver/,True,58,True,201,True,201
+post,1248,my-winners-of-the-best-of-604-vancouver-awards,My Winners of the Best of 604 (Vancouver) Awards,https://kriskrug.co/2008/12/10/my-winners-of-the-best-of-604-vancouver-awards/,True,60,True,198,True,198
+post,1247,social-media-training-for-journalists-at-cbc,Social Media Training for Journalists at CBC,https://kriskrug.co/2008/11/18/social-media-training-for-journalists-at-cbc/,True,56,True,201,True,201
+post,1246,internet-visibility-moving-from-a-web-of-pages-to-a-web-of-streams,Internet Visibility &#8211; Moving From a &#8216;Web of Pages&#8217; to a &#8216;Web of Streams&#8217;,https://kriskrug.co/2008/09/29/internet-visibility-moving-from-a-web-of-pages-to-a-web-of-streams/,False,0,True,132,True,132
+post,1245,seven-notes-about-gnomedex,Seven Notes About Gnomedex,https://kriskrug.co/2008/08/26/seven-notes-about-gnomedex/,True,38,True,183,True,183
+post,1244,photography-exhibition-for-charity-at-orb-gallery-in-vancouver,Photography Exhibition for Charity at Orb Gallery in Vancouver,https://kriskrug.co/2008/06/13/photography-exhibition-for-charity-at-orb-gallery-in-vancouver/,False,0,True,201,True,201
+post,1242,kris-krug-artist-statement-crowd-sourcing-stylee,Kris Krug Artist Statement &#8211; Crowd Sourcing StyleÃ©,https://kriskrug.co/2008/05/23/kris-krug-artist-statement-crowd-sourcing-stylee/,False,0,True,192,True,192
+post,1241,checkin-in-from-cbcs-digital-development-labs,Checkin&#8217; In from CBC&#8217;s Digital Development Labs,https://kriskrug.co/2008/04/22/checkin-in-from-cbcs-digital-development-labs/,True,59,True,201,True,201
+post,1240,ion-magazine-new-vancouver-fashion-music-culture-and-art-blog,"ION Magazine &#8211; New Vancouver Fashion, Music, Culture and Art Blog",https://kriskrug.co/2008/03/27/ion-magazine-new-vancouver-fashion-music-culture-and-art-blog/,False,0,True,199,True,199
+post,1239,vancouver-film-school-entertainment-business-managment-graduating-class,Vancouver Film School &#8216;Entertainment Business Managment&#8217; Graduating Class,https://kriskrug.co/2008/02/20/vancouver-film-school-entertainment-business-managment-graduating-class/,False,0,True,169,True,169
+post,1238,2008,2008: To Infinity and Beyond!,https://kriskrug.co/2008/01/02/2008/,True,41,True,142,True,142
+post,1237,audio-tips-on-how-to-take-better-holiday-pictures,AUDIO: Tips on How to Take Better Holiday Pictures,https://kriskrug.co/2007/12/19/audio-tips-on-how-to-take-better-holiday-pictures/,False,0,True,136,True,136
+post,1236,twitter-vs-pownce-which-microblogging-platform-is-right-for-you,Twitter vs Pownce &#8211; Which Microblogging Platform is Right for You?,https://kriskrug.co/2007/10/25/twitter-vs-pownce-which-microblogging-platform-is-right-for-you/,False,0,True,187,True,187
+post,1235,facebook-launches-facebook-applications-f8,Facebook Launches Facebook Applications (F8),https://kriskrug.co/2007/10/25/facebook-launches-facebook-applications-f8/,True,56,True,185,True,185
+post,1234,talking-about-bryght-on-the-lab-with-leo,Talking About Bryght on the Lab with Leo,https://kriskrug.co/2007/10/01/talking-about-bryght-on-the-lab-with-leo/,True,52,True,199,True,199
+post,1233,catching-up-on-blogging-staticphotography,Catching Up On Blogging @ StaticPhotography,https://kriskrug.co/2007/09/24/catching-up-on-blogging-staticphotography/,True,55,True,154,True,154
+post,1232,photowalk-and-photocamp-barcamp-vancouver,PhotoWalk and PhotoCamp @ BarCamp Vancouver,https://kriskrug.co/2007/08/16/photowalk-and-photocamp-barcamp-vancouver/,True,55,True,180,True,180
+post,1230,home-from-gnomedex-70,Home from Gnomedex 7.0,https://kriskrug.co/2007/08/16/home-from-gnomedex-70/,True,34,True,201,True,201
+post,1231,barcamp-vancouver-information-and-details,BarCamp Vancouver Information and Details,https://kriskrug.co/2007/08/14/barcamp-vancouver-information-and-details/,True,53,True,189,True,189
+post,1228,1228,Creative Commons on the Lab with Leo,https://kriskrug.co/2007/08/07/1228/,True,48,True,157,True,157
+post,1229,bryght-world-tour-2007,Bryght World Tour 2007,https://kriskrug.co/2007/08/07/bryght-world-tour-2007/,True,34,True,150,True,150
+post,1227,nextmedia-2007-slideshow,nextMEDIA 2007 Slideshow,https://kriskrug.co/2007/06/13/nextmedia-2007-slideshow/,True,36,True,127,True,127
+post,1226,1226,Wikis in Plain English,https://kriskrug.co/2007/05/30/1226/,True,34,True,104,True,104
+post,1225,which-famous-photographer-are-you,Which Famous Photographer Are you?,https://kriskrug.co/2007/05/22/which-famous-photographer-are-you/,True,46,True,191,True,191
+post,1224,photography-video-from-northern-voice-post-everywhere-on-the-web,Photography Video from Northern Voice Post Everywhere on the Web,https://kriskrug.co/2007/05/14/photography-video-from-northern-voice-post-everywhere-on-the-web/,False,0,True,200,True,200
+post,1223,burnkit-website-reboot,Burnkit Website Reboot,https://kriskrug.co/2007/05/02/burnkit-website-reboot/,True,34,True,143,True,143
+post,1222,to-all-you-wannabe-fashion-photographers,To All You Wannabe Fashion Photographers,https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/,True,52,True,201,True,201
+post,1221,working-with-other-vancouver-fashion-photographers,Working with Other Vancouver Fashion Photographers,https://kriskrug.co/2007/04/11/working-with-other-vancouver-fashion-photographers/,False,0,True,201,True,201
+post,1209,drupal-vs-wordpress-which-is-better-for-blogging,Drupal vs. WordPress: Which is better for blogging?,https://kriskrug.co/2007/04/10/drupal-vs-wordpress-which-is-better-for-blogging/,False,0,True,163,True,163
+post,1220,event-and-music-photography-bloc-party-photos-at-sxsw-2007,Event and Music Photography: Bloc Party Photos at SXSW 2007,https://kriskrug.co/2007/04/10/event-and-music-photography-bloc-party-photos-at-sxsw-2007/,False,0,True,201,True,201
+post,1210,checklist-of-model-photographer-negotiation-items,Checklist of model-photographer negotiation items.,https://kriskrug.co/2007/04/10/checklist-of-model-photographer-negotiation-items/,False,0,True,170,True,170
+post,1219,cold-wet-saturday-fashion-photoshoot-in-vancouver,Cold Wet Saturday Fashion Photoshoot in Vancouver,https://kriskrug.co/2007/04/10/cold-wet-saturday-fashion-photoshoot-in-vancouver/,False,0,True,130,True,130
+post,1211,the-new-york-times-on-corbis-and-the-future-of-the-stock-photography-market,The New York Times on Corbis and the Future of the Stock Photography Market,https://kriskrug.co/2007/04/10/the-new-york-times-on-corbis-and-the-future-of-the-stock-photography-market/,False,0,True,200,True,200
+post,1212,one-city-many-destinations-photo-contest,"One City, Many Destinations Photo Contest",https://kriskrug.co/2007/04/10/one-city-many-destinations-photo-contest/,True,53,True,168,True,168
+post,1213,jpg-magazine-submission-americana-by-kris-krug,JPG Magazine Submission: &#8220;Americana&#8221; by kris krug,https://kriskrug.co/2007/04/09/jpg-magazine-submission-americana-by-kris-krug/,False,0,True,141,True,141
+post,1214,the-travesty-of-canadian-mobile-data-rates,The Travesty of Canadian Mobile Data Rates,https://kriskrug.co/2007/04/09/the-travesty-of-canadian-mobile-data-rates/,True,54,True,123,True,123
+post,1207,headshots-for-local-actor-mark-huculak,Headshots for Local Actor Mark Huculak,https://kriskrug.co/2007/04/04/headshots-for-local-actor-mark-huculak/,True,50,True,196,True,196
+post,1176,kdon-dress-for-sale-at-suicidegirlscom,kdon dress for sale at suicidegirls.com!,https://kriskrug.co/2007/04/04/kdon-dress-for-sale-at-suicidegirlscom/,True,52,True,144,True,144
+post,1177,clothing-not-from-china,Clothing not from China,https://kriskrug.co/2007/04/04/clothing-not-from-china/,True,35,True,179,True,179
+post,1178,learn-better-photography-with-kris-krug-at-northern-voice,Learn better photography with Kris Krug at Northern Voice,https://kriskrug.co/2007/04/04/learn-better-photography-with-kris-krug-at-northern-voice/,False,0,True,177,True,177
+post,1179,kelseyrustin-lake-tahoe,kelsey+rustin | lake tahoe,https://kriskrug.co/2007/04/03/kelseyrustin-lake-tahoe/,True,38,True,155,True,155
+post,1180,understanding-the-communityevangelist-role-and-profiles-of-a-few-of-my-favorite-folks,"Understanding the Community/Evangelist Role, and profiles of a few of my Favorite Folks",https://kriskrug.co/2007/04/03/understanding-the-communityevangelist-role-and-profiles-of-a-few-of-my-favorite-folks/,False,0,True,184,True,184
+post,1181,itunes-and-emi-to-drop-drm,iTunes and EMI to drop DRM,https://kriskrug.co/2007/04/03/itunes-and-emi-to-drop-drm/,True,38,True,164,True,164
+post,1215,the-it-lists-parasuco-it-denim-2,The it Lists &#8211; Parasuco â€œitâ€ Denim,https://kriskrug.co/2007/04/03/the-it-lists-parasuco-it-denim-2/,True,50,True,183,True,183
+post,1182,the-it-lists-parasuco-it-denim,The it Lists &#8211; Parasuco ?it? Denim,https://kriskrug.co/2007/04/03/the-it-lists-parasuco-it-denim/,True,46,True,194,True,194
+post,1183,matthew-good-accused-of-virtual-assault-and-hate-filled-blogging-by-david-gratton,Matthew Good Accused of Virtual Assault And Hate-Filled-Blogging By David Gratton,https://kriskrug.co/2007/03/27/matthew-good-accused-of-virtual-assault-and-hate-filled-blogging-by-david-gratton/,False,0,True,201,True,201
+post,1184,changeeverything-one-change-at-a-time,ChangeEverything One Change at a Time,https://kriskrug.co/2007/03/27/changeeverything-one-change-at-a-time/,True,49,True,138,True,138
+post,1185,social-design-for-the-web-moo-cards-are-the-most,Social Design for the Web: Moo Cards are the Most,https://kriskrug.co/2007/03/27/social-design-for-the-web-moo-cards-are-the-most/,False,0,True,201,True,201
+post,1186,cityphile-izabella-egan,Cityphile Izabella Egan,https://kriskrug.co/2007/03/27/cityphile-izabella-egan/,True,35,True,200,True,200
+post,1187,you-cant-build-community-with-a-carrot,You Can&#8217;t Build Community with a Carrot,https://kriskrug.co/2007/03/27/you-cant-build-community-with-a-carrot/,True,51,True,201,True,201
+post,1188,best-album-of-the-year-neon-bible,Best Album of the Year: Neon Bible,https://kriskrug.co/2007/03/27/best-album-of-the-year-neon-bible/,True,46,True,135,True,135
+post,1190,hot-canadian-bands-cruisin-canadian-stages,Hot Canadian Bands Cruisin&#8217; Canadian Stages,https://kriskrug.co/2007/03/27/hot-canadian-bands-cruisin-canadian-stages/,True,55,True,139,True,139
+post,1189,introducing-flickr-filters,Introducing Flickr Filters,https://kriskrug.co/2007/03/27/introducing-flickr-filters/,True,38,True,151,True,151
+post,1191,guide-to-the-gsoc-web-app-for-student-applicants-google-summer-of-code-announce,Guide to the GSoC Web App for Student Applicants &#8211; Google Summer of Code Announce,https://kriskrug.co/2007/03/23/guide-to-the-gsoc-web-app-for-student-applicants-google-summer-of-code-announce/,False,0,True,126,True,126
+post,1192,six-cool-things-you-can-build-with-openid,Six cool things you can build with OpenID,https://kriskrug.co/2007/03/22/six-cool-things-you-can-build-with-openid/,True,53,True,201,True,201
+post,1216,wikicharts-top-100-2,WikiCharts â€” Top 100,https://kriskrug.co/2007/03/22/wikicharts-top-100-2/,True,34,True,100,True,100
+post,1193,wikicharts-top-100,WikiCharts ? Top 100,https://kriskrug.co/2007/03/22/wikicharts-top-100/,True,32,True,98,True,98
+post,1194,understanding-avatars-in-games-and-social-media,Understanding Avatars in Games and Social Media,https://kriskrug.co/2007/03/22/understanding-avatars-in-games-and-social-media/,True,59,True,166,True,166
+post,1195,congress-for-the-new-urbanism,Congress for the New Urbanism,https://kriskrug.co/2007/03/22/congress-for-the-new-urbanism/,True,41,True,200,True,200
+post,1217,gang-bangs-murder-inc-dg-2,Gang Bangs &#038; Murder Inc. @ D&#038;G?,https://kriskrug.co/2007/03/22/gang-bangs-murder-inc-dg-2/,True,43,True,200,True,200
+post,1196,gang-bangs-murder-inc-dg,Gang Bangs &amp; Murder Inc. @ D&amp;G?,https://kriskrug.co/2007/03/22/gang-bangs-murder-inc-dg/,True,51,True,200,True,200
+post,1197,how-to-support-mobile-content-creation-in-drupal,How to support Mobile Content Creation in Drupal,https://kriskrug.co/2007/03/21/how-to-support-mobile-content-creation-in-drupal/,True,60,True,201,True,201
+post,1198,jpg-magazine-blog-introducing-hotness,JPG Magazine: Blog: Introducing Hotness,https://kriskrug.co/2007/03/21/jpg-magazine-blog-introducing-hotness/,True,51,True,198,True,198
+post,1218,living-vancouver-filmed-at-discollection-today-2,&#8220;living vancouver&#8221; filmed at discollection today,https://kriskrug.co/2007/03/19/living-vancouver-filmed-at-discollection-today-2/,True,60,True,201,True,201
+post,1199,living-vancouver-filmed-at-discollection-today,&quot;living vancouver&quot; filmed at discollection today,https://kriskrug.co/2007/03/19/living-vancouver-filmed-at-discollection-today/,False,0,True,198,True,198
+post,1200,newbies-guide-to-twitter,Newbie&#8217;s guide to Twitter,https://kriskrug.co/2007/03/19/newbies-guide-to-twitter/,True,37,True,148,True,148
+post,1201,bryght-basic-install-profile-details,Bryght &#8216;Basic&#8217; Install Profile Details,https://kriskrug.co/2007/03/19/bryght-basic-install-profile-details/,True,50,True,170,True,170
+post,1202,sxsw-2007-austin-tx,"SXSW 2007 &#8211; Austin, TX",https://kriskrug.co/2007/03/12/sxsw-2007-austin-tx/,True,34,True,85,True,85
+post,1203,belated-but-joyful-northern-voice-podcast-mop-up-ephemeral-feasthouse,"Belated, but Joyful, Northern Voice Podcast Mop-up « Ephemeral Feasthouse",https://kriskrug.co/2007/03/11/belated-but-joyful-northern-voice-podcast-mop-up-ephemeral-feasthouse/,False,0,True,180,True,180
+post,1204,sxsw-the-real-story-behind-snakes-on-a-plane-by-john-wiseman,&quot;SXSW: The Real Story Behind Snakes on a Plane&quot; by John Wiseman,https://kriskrug.co/2007/03/11/sxsw-the-real-story-behind-snakes-on-a-plane-by-john-wiseman/,False,0,True,190,True,190
+post,1205,zufallig-in-austin-texas-am-montag-sxnw,Zufällig in Austin Texas am Montag (SXNW)?,https://kriskrug.co/2007/03/09/zufallig-in-austin-texas-am-montag-sxnw/,True,54,True,129,True,129
+post,1175,austin-invasion-sxsw-is-just-around-the-corner,Austin Invasion: SXSW is Just Around the Corner,https://kriskrug.co/2007/03/06/austin-invasion-sxsw-is-just-around-the-corner/,True,59,True,196,True,196
+post,1206,sxsw-2007-band-list,SXSW 2007 Band List,https://kriskrug.co/2007/03/05/sxsw-2007-band-list/,True,31,True,19,True,19
+post,1174,creativity-and-collaboration-fashion-photoshoot-with-trevor-brady,Creativity and Collaboration: Fashion Photoshoot With Trevor Brady,https://kriskrug.co/2007/02/22/creativity-and-collaboration-fashion-photoshoot-with-trevor-brady/,False,0,True,201,True,201
+post,1154,the-boy-who-cried-wi-fi,The Boy Who Cried Wi-Fi,https://kriskrug.co/2007/02/21/the-boy-who-cried-wi-fi/,True,35,True,185,True,185
+post,1155,karyn-chopik-studio-spring-2007,KARYN CHOPIK Studio &#8211; Spring 2007,https://kriskrug.co/2007/02/21/karyn-chopik-studio-spring-2007/,True,45,True,138,True,138
+post,1156,nowpublic-partners-with-ap,NowPublic partners with AP,https://kriskrug.co/2007/02/21/nowpublic-partners-with-ap/,True,38,True,200,True,200
+post,1157,moosecamp-photocamp,"MooseCamp, PhotoCamp",https://kriskrug.co/2007/02/21/moosecamp-photocamp/,True,32,True,169,True,169
+post,1158,adobe-lightroom-select-photos-by-lens,Adobe Lightroom: Select Photos by Lens,https://kriskrug.co/2007/02/21/adobe-lightroom-select-photos-by-lens/,True,50,True,160,True,160
+post,1159,new-flickr-email-notifications,New Flickr Email Notifications,https://kriskrug.co/2007/02/21/new-flickr-email-notifications/,True,42,True,200,True,200
+post,1160,kris-kim-on-flickr-photo-sharing,Kris &#038; Kim. on Flickr &#8211; Photo Sharing!,https://kriskrug.co/2007/02/21/kris-kim-on-flickr-photo-sharing/,True,50,True,163,True,163
+post,1161,5-black-and-white-photography-tips,5 Black and White Photography Tips,https://kriskrug.co/2007/02/21/5-black-and-white-photography-tips/,True,46,True,201,True,201
+post,1162,northern-voice-wikipedia-the-free-encyclopedia,"Northern Voice &#8211; Wikipedia, the free encyclopedia",https://kriskrug.co/2007/02/20/northern-voice-wikipedia-the-free-encyclopedia/,False,0,True,182,True,182
+post,1163,photocamp-northern-voice-schedule,PhotoCamp @ Northern Voice Schedule,https://kriskrug.co/2007/02/20/photocamp-northern-voice-schedule/,True,47,True,201,True,201
+post,1164,light-blue-line-exploring-the-effects-of-global-warming,Light Blue Line &#8211; exploring the effects of global warming,https://kriskrug.co/2007/02/19/light-blue-line-exploring-the-effects-of-global-warming/,False,0,True,201,True,201
+post,1153,1153,Who&#8217;s Coming to PhotoCamp at Northern Voice?,https://kriskrug.co/2007/02/19/1153/,True,56,True,201,True,201
+post,1165,email-is-the-place-where-information-goes-to-die,Email is the place where information goes to die,https://kriskrug.co/2007/02/16/email-is-the-place-where-information-goes-to-die/,True,60,True,169,True,169
+post,1166,posing-tips-waistlines-thighs-and-bustlines,"Posing Tips &#8211; Waistlines, Thighs and Bustlines",https://kriskrug.co/2007/02/15/posing-tips-waistlines-thighs-and-bustlines/,True,58,True,163,True,163
+post,1167,14-tips-for-great-candlelight-photography,14 Tips for Great Candlelight Photography,https://kriskrug.co/2007/02/15/14-tips-for-great-candlelight-photography/,True,53,True,201,True,201
+post,1168,settings-for-indoor-photography,Settings for Indoor Photography,https://kriskrug.co/2007/02/15/settings-for-indoor-photography/,True,43,True,79,True,79
+post,1169,urban-landscape-photography-tips,Urban Landscape Photography Tips,https://kriskrug.co/2007/02/15/urban-landscape-photography-tips/,True,44,True,155,True,155
+post,1170,assessing-contrast-the-squint-technique,Assessing Contrast &#8211; The Squint Technique,https://kriskrug.co/2007/02/15/assessing-contrast-the-squint-technique/,True,53,True,190,True,190
+post,1171,4-tips-regarding-converging-lines,4 Tips Regarding Converging Lines,https://kriskrug.co/2007/02/15/4-tips-regarding-converging-lines/,True,45,True,198,True,198
+post,1172,how-to-choose-the-right-iso-for-your-digital-photography,How to Choose the Right ISO for your Digital Photography,https://kriskrug.co/2007/02/15/how-to-choose-the-right-iso-for-your-digital-photography/,False,0,True,163,True,163
+post,1173,how-to-pose-hands-in-portraits,How to Pose Hands in Portraits,https://kriskrug.co/2007/02/15/how-to-pose-hands-in-portraits/,True,42,True,112,True,112
+post,1148,photoshoot-with-natalie-pagnucco,Photoshoot With Natalie Pagnucco,https://kriskrug.co/2007/02/13/photoshoot-with-natalie-pagnucco/,True,44,True,181,True,181
+post,1149,bluff-it-as-a-fashion-photographer,Bluff it as a fashion photographer,https://kriskrug.co/2007/02/13/bluff-it-as-a-fashion-photographer/,True,46,True,201,True,201
+post,1150,countdown-to-the-2010-vancouver-olympics,Countdown to the 2010 Vancouver Olympics,https://kriskrug.co/2007/02/12/countdown-to-the-2010-vancouver-olympics/,True,52,True,200,True,200
+post,1151,are-you-bloggable-northern-voice-and-moose-camp-coming-up,Are you Bloggable? Northern Voice and Moose Camp coming up!,https://kriskrug.co/2007/02/12/are-you-bloggable-northern-voice-and-moose-camp-coming-up/,False,0,True,201,True,201
+post,1152,grace-park-photo-used-on-wikipedia,Grace Park Photo Used On Wikipedia,https://kriskrug.co/2007/02/12/grace-park-photo-used-on-wikipedia/,True,46,True,185,True,185
+post,1147,fashion-photoshoot-for-discollection,Fashion Photoshoot for Discollection,https://kriskrug.co/2007/02/06/fashion-photoshoot-for-discollection/,True,48,True,201,True,201
+post,1121,photography-featured-in-beyond-robson,Photography Featured in Beyond Robson,https://kriskrug.co/2007/02/02/photography-featured-in-beyond-robson/,True,49,True,116,True,116
+post,1122,vancouver-olympic-protest-flickr-group,Vancouver Olympic Protest Flickr Group,https://kriskrug.co/2007/02/02/vancouver-olympic-protest-flickr-group/,True,50,True,195,True,195
+post,1123,fotolog-overtaking-flickr,Fotolog overtaking Flickr?,https://kriskrug.co/2007/01/31/fotolog-overtaking-flickr/,True,38,True,173,True,173
+post,1124,minimal-lime-myspace-div-overlay,Minimal Lime MySpace DIV Overlay,https://kriskrug.co/2007/01/30/minimal-lime-myspace-div-overlay/,True,44,True,199,True,199
+post,1125,when-the-postman-looks-twice-or-why-photo-theft-can-be-a-bad-idea-nowadays,when the postman looks twice &#8211; or why photo theft can be a bad idea nowadays,https://kriskrug.co/2007/01/30/when-the-postman-looks-twice-or-why-photo-theft-can-be-a-bad-idea-nowadays/,False,0,True,201,True,201
+post,1126,former-olympian-hops-the-cluetrain-riding-the-rails,"Former Olympian hops the Cluetrain, riding the rails.",https://kriskrug.co/2007/01/26/former-olympian-hops-the-cluetrain-riding-the-rails/,False,0,True,200,True,200
+post,1127,the-canadian-behind-hip-hop-20,The Canadian behind Hip-Hop 2.0,https://kriskrug.co/2007/01/25/the-canadian-behind-hip-hop-20/,True,43,True,201,True,201
+post,1128,rapspacetv-online-hiphop-community,RapSpace.tv Online HipHop Community,https://kriskrug.co/2007/01/25/rapspacetv-online-hiphop-community/,True,47,True,110,True,110
+post,1129,why-do-you-blog,Why Do You Blog?,https://kriskrug.co/2007/01/24/why-do-you-blog/,True,28,True,153,True,153
+post,1130,longboard-hockey-in-vancouer,Longboard Hockey in Vancouer,https://kriskrug.co/2007/01/24/longboard-hockey-in-vancouer/,True,40,True,201,True,201
+post,1131,blogging-for-retailers-white-paper-provides-practical-advice-for-online-merchants,Blogging for Retailers White Paper Provides Practical Advice for Online Merchants,https://kriskrug.co/2007/01/24/blogging-for-retailers-white-paper-provides-practical-advice-for-online-merchants/,False,0,True,201,True,201
+post,1132,hillary-clinton-using-drupal,Hillary Clinton using Drupal,https://kriskrug.co/2007/01/20/hillary-clinton-using-drupal/,True,40,True,193,True,193
+post,1133,basco5-makes-a-northern-voice-mascot,Basco5 Makes a Northern Voice Mascot,https://kriskrug.co/2007/01/19/basco5-makes-a-northern-voice-mascot/,True,48,True,195,True,195
+post,1134,make-money-by-giving-away-your-photos,Make Money By Giving Away Your Photos,https://kriskrug.co/2007/01/18/make-money-by-giving-away-your-photos/,True,49,True,133,True,133
+post,1135,one-click-drupal-5-hosting-preview-release,One-click Drupal 5 Hosting &#8211; Preview Release,https://kriskrug.co/2007/01/16/one-click-drupal-5-hosting-preview-release/,True,56,True,201,True,201
+post,1136,one-year-anniversary-approaching-for-discollection,one year anniversary approaching for discollection,https://kriskrug.co/2007/01/16/one-year-anniversary-approaching-for-discollection/,False,0,True,201,True,201
+post,1137,happy-sixth-birthday-drupal,Happy sixth birthday Drupal,https://kriskrug.co/2007/01/16/happy-sixth-birthday-drupal/,True,39,True,201,True,201
+post,1138,get-a-travel-bursary-for-northern-voice,Get a Travel Bursary for Northern Voice,https://kriskrug.co/2007/01/12/get-a-travel-bursary-for-northern-voice/,True,51,True,201,True,201
+post,1120,krugs-law-of-social-media,Krug&#8217;s Law of Social Media,https://kriskrug.co/2007/01/11/krugs-law-of-social-media/,True,38,True,193,True,193
+post,1139,personal-challenges-on-43things,Personal Challenges on 43Things,https://kriskrug.co/2007/01/09/personal-challenges-on-43things/,True,43,True,187,True,187
+post,1140,change-everything-starts-with-small-steps-close-to-home,Change Everything starts with small steps close to home,https://kriskrug.co/2007/01/09/change-everything-starts-with-small-steps-close-to-home/,False,0,True,201,True,201
+post,1141,trendwatchingcoms-top-5-consumer-trends-for-2007,trendwatching.com&#8217;s TOP 5 CONSUMER TRENDS FOR 2007,https://kriskrug.co/2007/01/09/trendwatchingcoms-top-5-consumer-trends-for-2007/,False,0,True,96,True,96
+post,1142,eric-appels-smartsetr-seriously-rocks,Eric Appel&#8217;s SmartSetr Seriously Rocks,https://kriskrug.co/2007/01/09/eric-appels-smartsetr-seriously-rocks/,True,50,True,201,True,201
+post,1143,googles-identity-infrastructure-is-messed-up-and-no-one-is-talking,Google&#8217;s Identity Infrastructure is Messed Up and No One Is Talking,https://kriskrug.co/2007/01/09/googles-identity-infrastructure-is-messed-up-and-no-one-is-talking/,False,0,True,191,True,191
+post,1144,the-compact-the-antithesis-of-american-consumerism,The Compact &#8211; the Antithesis of American Consumerism,https://kriskrug.co/2007/01/09/the-compact-the-antithesis-of-american-consumerism/,False,0,True,201,True,201
+post,1145,weve-finally-posted-the-northern-voice-2007-schedule-grid,Weâ€™ve (Finally) Posted the Northern Voice 2007 Schedule Grid,https://kriskrug.co/2007/01/08/weve-finally-posted-the-northern-voice-2007-schedule-grid/,False,0,True,201,True,201
+post,1119,photoshoot-tips-for-models,Photoshoot Tips for Models,https://kriskrug.co/2007/01/08/photoshoot-tips-for-models/,True,38,True,198,True,198
+post,1146,linkedin-answers-getting-hot,LinkedIn Answers Getting Hot,https://kriskrug.co/2007/01/08/linkedin-answers-getting-hot/,True,40,True,200,True,200
+post,1118,web-directions-north-sxsw-in-vancouver,Web Directions North  &#8211; SXSW in Vancouver?,https://kriskrug.co/2007/01/03/web-directions-north-sxsw-in-vancouver/,True,54,True,189,True,189
+post,1094,todays-special-photoshoot-with-chantelle-bousquet-and-jessie-harris,Today&#8217;s Special Photoshoot with Chantelle Bousquet and Jessie Harris,https://kriskrug.co/2006/12/28/todays-special-photoshoot-with-chantelle-bousquet-and-jessie-harris/,False,0,True,144,True,144
+post,1093,screamo-photoshoot-with-lenore-owens-and-mitchell-bowman,Screamo Photoshoot with Lenore Owens and Mitchell Bowman,https://kriskrug.co/2006/12/28/screamo-photoshoot-with-lenore-owens-and-mitchell-bowman/,False,0,True,145,True,145
+post,1095,streisand-effect-the-increase-in-popularity-of-an-item-due-to-interest-driven-by-the-publicized-outrage-over-its-existence,Streisand effect  &#8211; The increase in popularity of an item due to interest driven by the publicized outrage over its existence.,https://kriskrug.co/2006/12/28/streisand-effect-the-increase-in-popularity-of-an-item-due-to-interest-driven-by-the-publicized-outrage-over-its-existence/,False,0,True,125,True,125
+post,1096,thomas-hawks-digital-connection-photowalking-with-flickrs-heather-champ,Thomas Hawk&#8217;s Digital Connection: Photowalking with Flickr&#8217;s Heather Champ,https://kriskrug.co/2006/12/22/thomas-hawks-digital-connection-photowalking-with-flickrs-heather-champ/,False,0,True,171,True,171
+post,1097,anyone-up-for-a-dslr-summit-in-san-francisco,Anyone Up for a DSLR Summit in San Francisco?,https://kriskrug.co/2006/12/22/anyone-up-for-a-dslr-summit-in-san-francisco/,True,57,True,201,True,201
+post,1098,flickr-upload-limits-increased,Flickr Upload Limits Increased,https://kriskrug.co/2006/12/22/flickr-upload-limits-increased/,True,42,True,201,True,201
+post,1099,you-witness-news,You Witness News,https://kriskrug.co/2006/12/22/you-witness-news/,True,28,True,158,True,158
+post,1100,flickr-pickr-morning-do,FLICKR PICKR / Morning do,https://kriskrug.co/2006/12/22/flickr-pickr-morning-do/,True,37,True,129,True,129
+post,1101,continuous-partial-attention-if-youre-lucky,Continuous Partial Attention (if you&#8217;re lucky),https://kriskrug.co/2006/12/21/continuous-partial-attention-if-youre-lucky/,True,58,True,132,True,132
+post,1102,lee-and-sachis-rockin-panorama-photos,Lee and Sachiâ€™s Rockinâ€™ Panorama Photos,https://kriskrug.co/2006/12/21/lee-and-sachis-rockin-panorama-photos/,True,55,True,155,True,155
+post,1103,community-wireless-in-vancouver-fon-meraki-something-else,"Community Wireless in Vancouver &#8211; FON, Meraki, Something Else? |",https://kriskrug.co/2006/12/21/community-wireless-in-vancouver-fon-meraki-something-else/,False,0,True,201,True,201
+post,1104,mybloglog-is-distributed-social-networking,MyBlogLog is Distributed Social Networking,https://kriskrug.co/2006/12/21/mybloglog-is-distributed-social-networking/,True,54,True,111,True,111
+post,1105,using-open-source-software-to-design-develop-and-deploy-a-collaborative-web-site-part-12-hosting-and-deploying,"Using open source software to design, develop, and deploy a collaborative Web site, Part 12: Hosting and deploying",https://kriskrug.co/2006/12/21/using-open-source-software-to-design-develop-and-deploy-a-collaborative-web-site-part-12-hosting-and-deploying/,False,0,True,200,True,200
+post,1106,nowpublic-flirts-with-abc-news,NowPublic flirts with ABC News,https://kriskrug.co/2006/12/19/nowpublic-flirts-with-abc-news/,True,42,True,201,True,201
+post,1107,happy-birthday-from-mickipedia,Happy Birthday from Mickipedia,https://kriskrug.co/2006/12/18/happy-birthday-from-mickipedia/,True,42,True,46,True,46
+post,1108,how-to-become-a-fashion-photographer,How to become a fashion photographer,https://kriskrug.co/2006/12/12/how-to-become-a-fashion-photographer/,True,48,True,184,True,184
+post,1109,organic-denim-for-the-sustainable-fashionista,Organic Denim for the Sustainable Fashionista,https://kriskrug.co/2006/12/12/organic-denim-for-the-sustainable-fashionista/,True,57,True,146,True,146
+post,1110,how-we-did-it-stewart-butterfield-and-caterina-fake-co-founders-flickr-buying-a-business-or-franchise-article,"How We Did It: Stewart Butterfield and Caterina Fake, Co-founders, Flickr, Buying a Business or Franchise Article",https://kriskrug.co/2006/12/11/how-we-did-it-stewart-butterfield-and-caterina-fake-co-founders-flickr-buying-a-business-or-franchise-article/,False,0,True,166,True,166
+post,1111,web-directions-north,Web Directions North,https://kriskrug.co/2006/12/07/web-directions-north/,True,32,True,148,True,148
+post,1112,vancouver-fashion-finds-in-unexpected-places,Vancouver Fashion Finds in Unexpected Places,https://kriskrug.co/2006/12/07/vancouver-fashion-finds-in-unexpected-places/,True,56,True,201,True,201
+post,1113,photography-christmas-gift-ideas-fotoclips,Photography Christmas Gift Ideas &#8211; Fotoclips,https://kriskrug.co/2006/12/07/photography-christmas-gift-ideas-fotoclips/,True,56,True,170,True,170
+post,1114,the-7-deadly-myths-of-internet-copyright-in-regard-to-photography,The 7 Deadly Myths of Internet Copyright in Regard to Photography,https://kriskrug.co/2006/12/07/the-7-deadly-myths-of-internet-copyright-in-regard-to-photography/,False,0,True,173,True,173
+post,1115,welcome-to-our-three-new-northern-voice-organizers,Welcome to Our Three New Northern Voice Organizers,https://kriskrug.co/2006/12/06/welcome-to-our-three-new-northern-voice-organizers/,False,0,True,176,True,176
+post,1116,kris-krug-of-bryght-represents-web-20-at-2010-new-media-day,Kris Krug of Bryght Represents Web 2.0 at 2010 New Media Day,https://kriskrug.co/2006/12/06/kris-krug-of-bryght-represents-web-20-at-2010-new-media-day/,False,0,True,201,True,201
+post,1117,uber-babe-awards-acknowledge-captains-of-consciousness-shun-stalled-sheep,"uber babe awards acknowledge captains of consciousness, shun stalled sheep",https://kriskrug.co/2006/12/05/uber-babe-awards-acknowledge-captains-of-consciousness-shun-stalled-sheep/,False,0,True,182,True,182
+post,1091,jpg-photography-magazine-issue-8-voting,JPG Photography Magazine &#8211; Issue 8 Voting,https://kriskrug.co/2006/12/04/jpg-photography-magazine-issue-8-voting/,True,53,True,128,True,128
+post,1069,vancouver-christmas-shopping-discollection-gift-cards,Vancouver Christmas Shopping &#8211; Discollection Gift Cards,https://kriskrug.co/2006/12/01/vancouver-christmas-shopping-discollection-gift-cards/,False,0,True,201,True,201
+post,1070,flickr-faves-self-portraits-by-laura-kicey,Flickr Faves: Self-Portraits by Laura Kicey,https://kriskrug.co/2006/12/01/flickr-faves-self-portraits-by-laura-kicey/,True,55,True,201,True,201
+post,1071,rebagliati-positive-about-2010%e2%80%b3-in-heads-magazine,"â€œRebagliati Positive about 2010â€³ in Heads, Magazine",https://kriskrug.co/2006/12/01/rebagliati-positive-about-2010%e2%80%b3-in-heads-magazine/,False,0,True,149,True,149
+post,1072,celebrating-canadian-social-media-innovation,Celebrating Canadian Social Media Innovation,https://kriskrug.co/2006/12/01/celebrating-canadian-social-media-innovation/,True,56,True,188,True,188
+post,1073,a-flurry-of-vancouver-web-20-startups,A Flurry of Vancouver Web 2.0 Startups,https://kriskrug.co/2006/11/30/a-flurry-of-vancouver-web-20-startups/,True,50,True,200,True,200
+post,1074,who-can-resist-a-moose-with-an-ipod,Who can resist a moose with an iPod&#8230;,https://kriskrug.co/2006/11/30/who-can-resist-a-moose-with-an-ipod/,True,50,True,199,True,199
+post,1068,important-northern-voice-updates-registration-open-and-speaker-submissions-closing,Important Northern Voice Updates &#8211; Registration Open and Speaker Submissions Closing,https://kriskrug.co/2006/11/29/important-northern-voice-updates-registration-open-and-speaker-submissions-closing/,False,0,True,141,True,141
+post,1075,threads-of-gastown-fashion-show,threads of gastown fashion show,https://kriskrug.co/2006/11/28/threads-of-gastown-fashion-show/,True,43,True,197,True,197
+post,1076,got-hats-changeeverythingca,got hats? | ChangeEverything.ca,https://kriskrug.co/2006/11/28/got-hats-changeeverythingca/,True,43,True,163,True,163
+post,1077,francois-brunelles-doppelgangers,Francois Brunelleâ€™s Doppelgangers,https://kriskrug.co/2006/11/24/francois-brunelles-doppelgangers/,True,47,True,164,True,164
+post,1078,summary-of-the-violent-acts-and-punishments-inflicted-by-god-according-to-the-bible,"Summary of the violent acts and punishments inflicted by God, according to the Bible",https://kriskrug.co/2006/11/24/summary-of-the-violent-acts-and-punishments-inflicted-by-god-according-to-the-bible/,False,0,True,144,True,144
+post,1079,aperture-vs-lightroom,Aperture vs Lightroom,https://kriskrug.co/2006/11/24/aperture-vs-lightroom/,True,33,True,186,True,186
+post,1080,social-media-club-vancouver-at-bryght-offices,Social Media Club Vancouver at Bryght Offices,https://kriskrug.co/2006/11/23/social-media-club-vancouver-at-bryght-offices/,True,57,True,201,True,201
+post,1081,fighting-comment-spam-with-drupal,Fighting comment spam with Drupal,https://kriskrug.co/2006/11/23/fighting-comment-spam-with-drupal/,True,45,True,152,True,152
+post,1082,the-flickr-camera-guide,The Flickr Camera Guide,https://kriskrug.co/2006/11/22/the-flickr-camera-guide/,True,35,True,178,True,178
+post,1083,lomokev-your-flickr-superstars-interviewed,"lomokev &#8211; Your flickr superstars, interviewed.",https://kriskrug.co/2006/11/21/lomokev-your-flickr-superstars-interviewed/,True,58,True,156,True,156
+post,1084,use-your-photographic-skills-to-show-your-support-for-creative-commons,Use your photographic skills to show your support for Creative Commons!,https://kriskrug.co/2006/11/20/use-your-photographic-skills-to-show-your-support-for-creative-commons/,False,0,True,184,True,184
+post,1085,discollections-designer-vintage-and-kdon-photoshoot,Discollectionâ€™s Designer Vintage and kdon Photoshoot,https://kriskrug.co/2006/11/20/discollections-designer-vintage-and-kdon-photoshoot/,False,0,True,201,True,201
+post,1086,how-we-do-it-video-blogging-as-we-travel,How We Do It Video: Blogging as We Travel,https://kriskrug.co/2006/11/17/how-we-do-it-video-blogging-as-we-travel/,True,53,True,158,True,158
+post,1087,basic-photographic-lighting-techniques,Basic Photographic Lighting Techniques,https://kriskrug.co/2006/11/16/basic-photographic-lighting-techniques/,True,50,True,135,True,135
+post,1088,lighting-for-still-photography,Lighting for Still Photography,https://kriskrug.co/2006/11/16/lighting-for-still-photography/,True,42,True,170,True,170
+post,1089,wtb-photography-light-kit-and-tripod,WTB: Photography Light Kit and Tripod,https://kriskrug.co/2006/11/16/wtb-photography-light-kit-and-tripod/,True,49,True,201,True,201
+post,1067,hardcore-superstar-photoshoot,Hardcore Superstar Photoshoot,https://kriskrug.co/2006/11/15/hardcore-superstar-photoshoot/,True,41,True,148,True,148
+post,1066,desmogblog-photoshoot,DeSmogBlog Photoshoot,https://kriskrug.co/2006/11/15/desmogblog-photoshoot/,True,33,True,200,True,200
+post,1065,nitobi-photoshoot,Nitobi Photoshoot,https://kriskrug.co/2006/11/15/nitobi-photoshoot/,True,29,True,165,True,165
+post,1064,raincity-studios-photoshoot,Raincity Studios Photoshoot,https://kriskrug.co/2006/11/15/raincity-studios-photoshoot/,True,39,True,151,True,151
+post,1090,nick-douglas-leaving-valleywag,Nick Douglas Leaving Valleywag,https://kriskrug.co/2006/11/13/nick-douglas-leaving-valleywag/,True,42,True,201,True,201
+post,1063,made-in-vancouver-photoshoot,&#8220;Made in Vancouver&#8221; Photoshoot,https://kriskrug.co/2006/11/13/made-in-vancouver-photoshoot/,True,42,True,170,True,170
+post,1062,evan-biddell-photoshoot,Evan Biddell Photoshoot,https://kriskrug.co/2006/11/13/evan-biddell-photoshoot/,True,35,True,158,True,158
+post,1061,denyss-halo-photoshoot,Denyss Halo Photoshoot,https://kriskrug.co/2006/11/13/denyss-halo-photoshoot/,True,34,True,191,True,191
+post,1060,discollection-photoshoot,Discollection Photoshoot,https://kriskrug.co/2006/11/13/discollection-photoshoot/,True,36,True,197,True,197
+post,1032,vancouver-designer-vintage-clothes,Vancouver designer vintage clothes.,https://kriskrug.co/2006/11/12/vancouver-designer-vintage-clothes/,True,47,True,136,True,136
+post,1033,whats-zo-wearing,What&#8217;s Zo Wearing?,https://kriskrug.co/2006/11/12/whats-zo-wearing/,True,30,True,201,True,201
+post,1031,movember-update-its-on,Movember Update &#8211; It&#8217;s On!,https://kriskrug.co/2006/11/08/movember-update-its-on/,True,38,True,129,True,129
+post,1034,superhappydevhouse-13-on-flickr,SuperHappyDevHouse 13 on Flickr,https://kriskrug.co/2006/11/07/superhappydevhouse-13-on-flickr/,True,43,True,139,True,139
+post,1035,the-definitive-guide-to-cell-phone-no-nos,The Definitive Guide to Cell Phone No-No&#8217;s,https://kriskrug.co/2006/11/07/the-definitive-guide-to-cell-phone-no-nos/,True,54,True,159,True,159
+post,1036,your-guide-to-wikis,Your Guide to Wikis,https://kriskrug.co/2006/11/07/your-guide-to-wikis/,True,31,True,201,True,201
+post,1030,photobooth-pictures-workspace,Photobooth Pictures @ Workspace,https://kriskrug.co/2006/11/07/photobooth-pictures-workspace/,True,43,True,130,True,130
+post,1037,november-drupal-training-update-new-drupal-for-consultants,November Drupal Training Update &#8211; new Drupal for Consultants,https://kriskrug.co/2006/11/06/november-drupal-training-update-new-drupal-for-consultants/,False,0,True,201,True,201
+post,1038,deconstructing-flickrs-interestingness,Deconstructing Flickrâ€™s â€œInterestingness!â€,https://kriskrug.co/2006/11/06/deconstructing-flickrs-interestingness/,True,60,True,201,True,201
+post,1039,interestingness-is-to-flickr-as-pagerank-is-to-google,Interestingness Is to Flickr As PageRank Is to Google,https://kriskrug.co/2006/11/06/interestingness-is-to-flickr-as-pagerank-is-to-google/,False,0,True,201,True,201
+post,1040,the-interesting-economy,The Interesting Economy,https://kriskrug.co/2006/11/06/the-interesting-economy/,True,35,True,201,True,201
+post,1041,flickr-interestingness-rankings-patents-released,Flickr Interestingness Rankings Patents Released,https://kriskrug.co/2006/11/06/flickr-interestingness-rankings-patents-released/,True,60,True,201,True,201
+post,1029,new-jpg-magazine-photography-magazine,New JPG Magazine Photography Magazine,https://kriskrug.co/2006/11/03/new-jpg-magazine-photography-magazine/,True,49,True,180,True,180
+post,1042,a-tale-of-three-communities,A Tale of Three Communities,https://kriskrug.co/2006/11/03/a-tale-of-three-communities/,True,39,True,157,True,157
+post,1043,middle-finger-olympics,"Middle Finger, Olympics!",https://kriskrug.co/2006/11/03/middle-finger-olympics/,True,36,True,201,True,201
+post,1044,worldchanging-tour-vancouver-november-5-2006,"Worldchanging Tour: Vancouver November 5, 2006",https://kriskrug.co/2006/11/02/worldchanging-tour-vancouver-november-5-2006/,True,58,True,144,True,144
+post,1045,office-has-more-than-a-stunning-view,Office has more than a stunning view.,https://kriskrug.co/2006/11/02/office-has-more-than-a-stunning-view/,True,49,True,89,True,89
+post,1046,jumptv-using-drupal,Jump.TV using Drupal,https://kriskrug.co/2006/11/02/jumptv-using-drupal/,True,32,True,201,True,201
+post,1047,south-by-northwest-at-iron-cactus-monday-march-12-2007,"South by Northwest at Iron Cactus (Monday, March 12, 2007)",https://kriskrug.co/2006/10/31/south-by-northwest-at-iron-cactus-monday-march-12-2007/,False,0,True,200,True,200
+post,1048,how-to-geekify-your-halloween,How to Geekify Your Halloween,https://kriskrug.co/2006/10/31/how-to-geekify-your-halloween/,True,41,True,200,True,200
+post,1049,drupal-50-beta-1-announced,Drupal 5.0 beta 1 Announced,https://kriskrug.co/2006/10/31/drupal-50-beta-1-announced/,True,39,True,190,True,190
+post,1050,online-participation-for-every-regular-contributor-nine-occasionals-and-ninety-nine-lurkers,"Online participation: for every regular contributor, nine occasionals and ninety-nine lurkers",https://kriskrug.co/2006/10/31/online-participation-for-every-regular-contributor-nine-occasionals-and-ninety-nine-lurkers/,False,0,True,201,True,201
+post,1051,vancouver-league-of-drupalers-october-2006,Vancouver League of Drupalers October 2006,https://kriskrug.co/2006/10/27/vancouver-league-of-drupalers-october-2006/,True,54,True,114,True,114
+post,1052,the-paradox-of-registering-bloggers-real-names-in-china,The Paradox of Registering Bloggers&#8217; Real Names in China,https://kriskrug.co/2006/10/26/the-paradox-of-registering-bloggers-real-names-in-china/,False,0,True,201,True,201
+post,1028,movember-and-i-got-a-head-start,Movember &#8211; And I Got A Head Start!,https://kriskrug.co/2006/10/26/movember-and-i-got-a-head-start/,True,46,True,156,True,156
+post,1053,china-bans-partying-and-other-innapropriate-behaviour-on-the-great-wall,China bans &#8220;partying&#8221; and other innapropriate behaviour on the Great Wall,https://kriskrug.co/2006/10/25/china-bans-partying-and-other-innapropriate-behaviour-on-the-great-wall/,False,0,True,119,True,119
+post,1054,one-in-three-read-blogs-environics,One in three read blogs: Environics,https://kriskrug.co/2006/10/25/one-in-three-read-blogs-environics/,True,47,True,157,True,157
+post,1055,elika-designs,Elika Designs,https://kriskrug.co/2006/10/23/elika-designs/,True,25,True,183,True,183
+post,1056,kk-on-modelmayhemcom,kk+ on ModelMayhem.com,https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/,True,34,True,174,True,174
+post,1057,more-on-flickr-and-creative-commons,More on Flickr and Creative Commons,https://kriskrug.co/2006/10/20/more-on-flickr-and-creative-commons/,True,47,True,142,True,142
+post,1058,a-new-default-theme-for-drupal,A new default theme for Drupal?,https://kriskrug.co/2006/10/20/a-new-default-theme-for-drupal/,True,43,True,200,True,200
+post,1059,they-representation-inc,THEY Representation Inc.,https://kriskrug.co/2006/10/20/they-representation-inc/,True,36,True,176,True,176
+post,1009,get-your-moose-on-this-is-your-mothers-conference-bmann-consulting,Get your Moose on: This IS your mother&#8217;s conference | B.Mann Consulting,https://kriskrug.co/2006/10/20/get-your-moose-on-this-is-your-mothers-conference-bmann-consulting/,False,0,True,145,True,145
+post,1008,northern-voice-2007,Northern Voice 2007,https://kriskrug.co/2006/10/20/northern-voice-2007/,True,31,True,152,True,152
+post,1010,head-down-to-the-morrissey-tonight-for-some-roundtable-china-chat-and-pints,Head Down To The Morrissey Tonight For Some Roundtable China Chat and Pints,https://kriskrug.co/2006/10/20/head-down-to-the-morrissey-tonight-for-some-roundtable-china-chat-and-pints/,False,0,True,199,True,199
+post,1011,giving-away-the-photo-store,Giving away the photo store,https://kriskrug.co/2006/10/19/giving-away-the-photo-store/,True,39,True,122,True,122
+post,1012,creative-commons-flickr-22-million-sharable-photos,Creative Commons + Flickr = 22 Million Sharable Photos,https://kriskrug.co/2006/10/18/creative-commons-flickr-22-million-sharable-photos/,False,0,True,155,True,155
+post,1013,drupal-training-by-raincity-studios-and-bryght,Drupal Training by Raincity Studios and Bryght,https://kriskrug.co/2006/10/16/drupal-training-by-raincity-studios-and-bryght/,True,58,True,201,True,201
+post,1014,sxsw-panel-idea-the-ultimate-music-recommendation-smackdown,SXSW panel idea: The Ultimate Music Recommendation Smackdown,https://kriskrug.co/2006/10/16/sxsw-panel-idea-the-ultimate-music-recommendation-smackdown/,False,0,True,129,True,129
+post,1015,victoria-bc-drupal-users-meetup,Victoria BC Drupal Users Meetup,https://kriskrug.co/2006/10/16/victoria-bc-drupal-users-meetup/,True,43,True,92,True,92
+post,1016,vancouver-sculpture-biennale-photo-contest-winner,Vancouver Sculpture Biennale Photo Contest Winner,https://kriskrug.co/2006/10/10/vancouver-sculpture-biennale-photo-contest-winner/,False,0,True,141,True,141
+post,1017,why-smart-people-love-battlestar-galactica,Why Smart People Love &#8216;Battlestar Galactica&#8217;,https://kriskrug.co/2006/10/05/why-smart-people-love-battlestar-galactica/,True,56,True,201,True,201
+post,1018,sxsw-2007,SXSW 2007,https://kriskrug.co/2006/10/03/sxsw-2007/,True,21,True,122,True,122
+post,1019,the-100-best-skate-photos-on-flickr,The 100 Best Skate Photos on Flickr!,https://kriskrug.co/2006/10/03/the-100-best-skate-photos-on-flickr/,True,48,True,36,True,36
+post,1007,discollection-rocks-the-vancouver-flea-market,Discollection Rocks the Vancouver Flea Market,https://kriskrug.co/2006/09/17/discollection-rocks-the-vancouver-flea-market/,True,57,True,127,True,127
+post,1006,my-beijing-peeps,My Beijing Peeps,https://kriskrug.co/2006/09/17/my-beijing-peeps/,True,28,True,200,True,200
+post,1005,martin-bloom-china-access-2008-in-beijing,Martin Bloom @ China Access 2008 in Beijing,https://kriskrug.co/2006/09/17/martin-bloom-china-access-2008-in-beijing/,True,55,True,153,True,153
+post,1004,harmonica-armada,Harmonica Armada,https://kriskrug.co/2006/09/16/harmonica-armada/,True,28,True,25,True,25
+post,1003,back-to-china,Back to China!,https://kriskrug.co/2006/09/14/back-to-china/,True,26,True,201,True,201
+post,1020,what-news-corp-doesnt-want-you-to-know-about-myspace,What News Corp doesn&#8217;t want you to know about MySpace,https://kriskrug.co/2006/09/11/what-news-corp-doesnt-want-you-to-know-about-myspace/,False,0,True,201,True,201
+post,1021,the-new-tastemakers,The New Tastemakers,https://kriskrug.co/2006/09/11/the-new-tastemakers/,True,31,True,201,True,201
+post,1022,8-more-ways-to-stay-single,8 more ways to stay single,https://kriskrug.co/2006/09/08/8-more-ways-to-stay-single/,True,38,True,126,True,126
+post,1023,my-two-years-at-bryght,My Two Years At Bryght,https://kriskrug.co/2006/09/08/my-two-years-at-bryght/,True,34,True,182,True,182
+post,1024,peace-and-hate-the-submarines,Peace and Hate &#8211; The Submarines,https://kriskrug.co/2006/09/07/peace-and-hate-the-submarines/,True,43,True,100,True,100
+post,1025,the-next-version-of-drupal-will-be-50,The Next Version of Drupal Will Be 5.0!,https://kriskrug.co/2006/09/01/the-next-version-of-drupal-will-be-50/,True,51,True,123,True,123
+post,1026,tv-free-burning-man,TV Free Burning Man,https://kriskrug.co/2006/09/01/tv-free-burning-man/,True,31,True,154,True,154
+post,972,copycamp-2,CopyCamp,https://kriskrug.co/2006/09/01/copycamp-2/,True,20,True,86,True,86
+post,973,cheatsheet-what-is-digg,Cheatsheet: What is Digg?,https://kriskrug.co/2006/08/31/cheatsheet-what-is-digg/,True,37,True,144,True,144
+post,974,event-photography-inspriation-ted,Event Photography Inspriation: Ted,https://kriskrug.co/2006/08/31/event-photography-inspriation-ted/,True,46,True,150,True,150
+post,975,tara-hunt-kris-krug-and-mike-arrington-at-gnomedex-6-the-chris-pirillo-show,"Tara Hunt, Kris Krug and Mike Arrington at Gnomedex 6 ~ The Chris Pirillo Show",https://kriskrug.co/2006/08/31/tara-hunt-kris-krug-and-mike-arrington-at-gnomedex-6-the-chris-pirillo-show/,False,0,True,162,True,162
+post,976,blogging-for-change-contest-changeeverythingca,Blogging for Change Contest | ChangeEverything.ca,https://kriskrug.co/2006/08/31/blogging-for-change-contest-changeeverythingca/,False,0,True,180,True,180
+post,977,is-myspace-safe,Is MySpace Safe?,https://kriskrug.co/2006/08/29/is-myspace-safe/,True,28,True,201,True,201
+post,978,open-hack-day-at-yahoo,Open hack day at Yahoo!,https://kriskrug.co/2006/08/29/open-hack-day-at-yahoo/,True,35,True,154,True,154
+post,979,the-best-canon-eos-lenses,The Best Canon EOS Lenses,https://kriskrug.co/2006/08/29/the-best-canon-eos-lenses/,True,37,True,97,True,97
+post,980,new-canon-50mm-lens,New Canon 50mm Lens,https://kriskrug.co/2006/08/29/new-canon-50mm-lens/,True,31,True,185,True,185
+post,981,laughs-abound-below-the-belt,Laughs abound below the belt,https://kriskrug.co/2006/08/29/laughs-abound-below-the-belt/,True,40,True,201,True,201
+post,982,senator-tim-ryan-kicks-bushs-ass,Senator Tim Ryan kicks Bush&#8217;s Ass,https://kriskrug.co/2006/08/29/senator-tim-ryan-kicks-bushs-ass/,True,45,True,201,True,201
+post,983,barcampearth-a-local-report,BarCampEarth: a local report,https://kriskrug.co/2006/08/28/barcampearth-a-local-report/,True,40,True,201,True,201
+post,984,steppin-dirty,STEPPIN&#8217; DIRTY?,https://kriskrug.co/2006/08/28/steppin-dirty/,True,27,True,126,True,126
+post,985,photo-camp,Photo Camp,https://kriskrug.co/2006/08/28/photo-camp/,True,22,True,201,True,201
+post,971,midnight-vancouver-photowalk,Vancouver Photographers Unite &#8211; Midnight Gastown Photowalk,https://kriskrug.co/2006/08/25/midnight-vancouver-photowalk/,False,0,True,201,True,201
+post,970,barcamp-vancouver,Barcamp Vancouver,https://kriskrug.co/2006/08/21/barcamp-vancouver/,True,29,True,201,True,201
+post,986,something-awful,Something Awful,https://kriskrug.co/2006/08/15/something-awful/,True,27,True,172,True,172
+post,987,music-20-the-coming-revolution,Music 2.0: The Coming Revolution,https://kriskrug.co/2006/08/09/music-20-the-coming-revolution/,True,44,True,201,True,201
+post,988,free-e-book-how-to-pitch-the-media,Free e-book: How to Pitch the Media,https://kriskrug.co/2006/08/09/free-e-book-how-to-pitch-the-media/,True,47,True,177,True,177
+post,989,design-inside-yahoo-george-oates,Design Inside Yahoo!: George Oates,https://kriskrug.co/2006/08/09/design-inside-yahoo-george-oates/,True,46,True,129,True,129
+post,990,a-wwwwake-up,A www.wake-upâ€¦,https://kriskrug.co/2006/08/08/a-wwwwake-up/,True,28,True,168,True,168
+post,991,how-kevin-corazzas-actions-will-follow-him-online-for-a-long-long-time,"How Kevin Corazza&#8217;s Actions Will Follow Him Online For a Long, Long Time",https://kriskrug.co/2006/08/08/how-kevin-corazzas-actions-will-follow-him-online-for-a-long-long-time/,False,0,True,133,True,133
+post,992,things-to-know-when-you-do-fashion-show-shoot,Things to know when you do fashion show shoot.,https://kriskrug.co/2006/08/07/things-to-know-when-you-do-fashion-show-shoot/,True,58,True,119,True,119
+post,993,reason-why-gays-smoke-so-much,Reason Why Gays Smoke So Much,https://kriskrug.co/2006/08/04/reason-why-gays-smoke-so-much/,True,41,True,147,True,147
+post,994,digg-vs-slashdot-or-traffic-vs-influence,"Digg vs. Slashdot (or, traffic vs. influence)",https://kriskrug.co/2006/08/04/digg-vs-slashdot-or-traffic-vs-influence/,True,57,True,124,True,124
+post,995,web-20-strategies-and-lessons-for-business-leaders,Web 2.0: Strategies and Lessons for Business Leaders,https://kriskrug.co/2006/08/04/web-20-strategies-and-lessons-for-business-leaders/,False,0,True,200,True,200
+post,996,photographer-sued-by-plagiarist,Photographer Sued By Plagiarist?,https://kriskrug.co/2006/08/04/photographer-sued-by-plagiarist/,True,44,True,175,True,175
+post,997,welkom-steven,Welkom Steven!,https://kriskrug.co/2006/08/03/welkom-steven/,True,26,True,166,True,166
+post,998,how-to-dj-your-first-set-without-knowing-how,How to DJ your first set without knowing how,https://kriskrug.co/2006/08/03/how-to-dj-your-first-set-without-knowing-how/,True,56,True,200,True,200
+post,999,maxwells-demon,Maxwell&#8217;s Demon,https://kriskrug.co/2006/08/03/maxwells-demon/,True,27,True,201,True,201
+post,1000,communicopia-is-hiring-a-web-producer,Communicopia is Hiring A Web Producer,https://kriskrug.co/2006/08/02/communicopia-is-hiring-a-web-producer/,True,49,True,127,True,127
+post,1001,style-profiles-kris-krug-one-cool-geek,"Style Profiles &#8211; Kris Krug, One Cool Geek",https://kriskrug.co/2006/08/01/style-profiles-kris-krug-one-cool-geek/,True,53,True,200,True,200
+post,969,vancouver-sculpture-biennale-contestcommunity,Vancouver Sculpture Biennale (Contest/Community),https://kriskrug.co/2006/08/01/vancouver-sculpture-biennale-contestcommunity/,True,60,True,201,True,201
+post,1002,web-20-and-the-letter-e-the-interview,Web 2.0 and The Letter â€œeâ€: The Interview,https://kriskrug.co/2006/07/31/web-20-and-the-letter-e-the-interview/,True,57,True,201,True,201
+post,968,only-27-spots-left-for-barcamp-vancouver,Only 23 Spots Left for Barcamp Vancouver (and PhotoCamp),https://kriskrug.co/2006/07/28/only-27-spots-left-for-barcamp-vancouver/,False,0,True,165,True,165
+post,967,workspace-photo-contest,Workspace Photo Contest,https://kriskrug.co/2006/07/25/workspace-photo-contest/,True,35,True,157,True,157
+post,966,flickr-war,Flickr War,https://kriskrug.co/2006/07/24/flickr-war/,True,22,True,201,True,201
+post,965,george-oates-from-flickr,George Oates from Flickr,https://kriskrug.co/2006/07/24/george-oates-from-flickr/,True,36,True,192,True,192
+post,964,kriscollection-v1,Kriscollection v.1,https://kriskrug.co/2006/07/18/kriscollection-v1/,True,30,True,201,True,201
+post,933,kexp-suggests-cut-chemist,KEXP Suggests &#8211; Cut Chemist!,https://kriskrug.co/2006/07/13/kexp-suggests-cut-chemist/,True,40,True,134,True,134
+post,934,scout-find-your-photographs-in-flickrs-explore,Scout: Find your photographs in Flickr&#8217;s Explore,https://kriskrug.co/2006/07/13/scout-find-your-photographs-in-flickrs-explore/,True,60,True,48,True,48
+post,935,webkinz-second-life-for-kids,Webkinz &#8211; Second Life for kids,https://kriskrug.co/2006/07/13/webkinz-second-life-for-kids/,True,42,True,186,True,186
+post,936,geek-entertainment-tv-sells-out-to-podtech,Geek Entertainment TV Sells Out To PodTech,https://kriskrug.co/2006/07/13/geek-entertainment-tv-sells-out-to-podtech/,True,54,True,42,True,42
+post,937,discollection,Discollection,https://kriskrug.co/2006/07/12/discollection/,True,25,True,54,True,54
+post,938,paralyzed-man-moves-computer-cursor-with-thoughts,Paralyzed Man Moves Computer Cursor With Thoughts,https://kriskrug.co/2006/07/12/paralyzed-man-moves-computer-cursor-with-thoughts/,False,0,True,201,True,201
+post,939,desert-to-dream-a-decade-of-burning-man-photography,Burning Man Photography,https://kriskrug.co/2006/07/11/desert-to-dream-a-decade-of-burning-man-photography/,True,35,True,201,True,201
+post,932,amazing-flickr-testimonial,Amazing Flickr Testimonial,https://kriskrug.co/2006/07/11/amazing-flickr-testimonial/,True,38,True,146,True,146
+post,940,heres-a-slightly-less-than-entirely-random-sampling-of-my-portrait-work,Here&#8217;s a slightly-less-than-entirely-random sampling of my portrait work.,https://kriskrug.co/2006/07/10/heres-a-slightly-less-than-entirely-random-sampling-of-my-portrait-work/,False,0,True,148,True,148
+post,931,drupalcamp-seattle-2006,DrupalCamp Seattle 2006,https://kriskrug.co/2006/07/10/drupalcamp-seattle-2006/,True,35,True,151,True,151
+post,941,bolloxed-a-play-by-darren-barefoot,Bolloxed &#8211;  A Play By Darren Barefoot,https://kriskrug.co/2006/07/10/bolloxed-a-play-by-darren-barefoot/,True,49,True,144,True,144
+post,930,gnomedex-6,Gnomedex 6,https://kriskrug.co/2006/07/07/gnomedex-6/,True,22,True,179,True,179
+post,942,lip-gloss-and-laptops-episode-019,Lip Gloss and Laptops Episode 019,https://kriskrug.co/2006/07/05/lip-gloss-and-laptops-episode-019/,True,45,True,200,True,200
+post,943,were-considering-going-carless,We&#8217;re Considering Going Carless,https://kriskrug.co/2006/07/04/were-considering-going-carless/,True,43,True,124,True,124
+post,944,digg-technology,digg / Technology,https://kriskrug.co/2006/07/04/digg-technology/,True,29,True,17,True,17
+post,945,upcoming-event-rapidly-evolving-strategies-for-china,Upcoming event: Rapidly Evolving Strategies for China,https://kriskrug.co/2006/07/04/upcoming-event-rapidly-evolving-strategies-for-china/,False,0,True,201,True,201
+post,946,public-speakers-from-a-photographers-view,Public Speakers from a Photographer&#8217;s View,https://kriskrug.co/2006/07/04/public-speakers-from-a-photographers-view/,True,54,True,136,True,136
+post,947,conference-photography-shooting-gnomedex,Conference Photography: Shooting Gnomedex,https://kriskrug.co/2006/07/04/conference-photography-shooting-gnomedex/,True,53,True,127,True,127
+post,948,bloglines,Bloglines,https://kriskrug.co/2006/07/04/bloglines/,True,21,True,9,True,9
+post,949,gnomedex-wall-of-love-on-flickr,Gnomedex Wall of Love on Flickr,https://kriskrug.co/2006/07/04/gnomedex-wall-of-love-on-flickr/,True,43,True,197,True,197
+post,950,educate-the-us-senate-on-copyright-issues,Educate the US Senate on Copyright Issues,https://kriskrug.co/2006/07/04/educate-the-us-senate-on-copyright-issues/,True,53,True,186,True,186
+post,951,copycamp,CopyCamp,https://kriskrug.co/2006/07/04/copycamp/,True,20,True,86,True,86
+post,929,checkin-in-from-gnomedex,Checkin&#8217; In From Gnomedex,https://kriskrug.co/2006/07/01/checkin-in-from-gnomedex/,True,37,True,115,True,115
+post,952,sex-longing-web-20,Sex &#038; Longing &#038; Web 2.0,https://kriskrug.co/2006/06/29/sex-longing-web-20/,True,35,True,201,True,201
+post,953,a-funny-podcast-about-a-sad-girl,A Funny Podcast About a Sad Girl,https://kriskrug.co/2006/06/29/a-funny-podcast-about-a-sad-girl/,True,44,True,78,True,78
+post,954,drupal-camp-seattle-underway,Drupal Camp Seattle Underway,https://kriskrug.co/2006/06/28/drupal-camp-seattle-underway/,True,40,True,133,True,133
+post,955,hi-there-were-cosmic-cubes,"Hi there, We&#8217;re Cosmic Cubes",https://kriskrug.co/2006/06/27/hi-there-were-cosmic-cubes/,True,40,True,188,True,188
+post,956,definition-boil-the-ocean,Definition: Boil the Ocean,https://kriskrug.co/2006/06/26/definition-boil-the-ocean/,True,38,True,131,True,131
+post,957,naked-on-the-great-wall-canadian-stunt-cute-or-arrogant,Naked On The Great Wall: Canadian Stunt Cute or Arrogant?,https://kriskrug.co/2006/06/26/naked-on-the-great-wall-canadian-stunt-cute-or-arrogant/,False,0,True,201,True,201
+post,958,podcasting-on-your-bryght-site,Podcasting on Your Bryght Site,https://kriskrug.co/2006/06/21/podcasting-on-your-bryght-site/,True,42,True,133,True,133
+post,928,videoblogs-from-china,Videoblogs from China!,https://kriskrug.co/2006/06/21/videoblogs-from-china/,True,34,True,201,True,201
+post,959,another-bryght-guy-djun-kim,Another Bryght Guy: Djun Kim,https://kriskrug.co/2006/06/21/another-bryght-guy-djun-kim/,True,40,True,128,True,128
+post,960,vidfest-kicks-off-with-the-international-partnering-forum,VIDFEST Kicks Off with the International Partnering Forum,https://kriskrug.co/2006/06/20/vidfest-kicks-off-with-the-international-partnering-forum/,False,0,True,201,True,201
+post,961,design-guru-joshua-davis-vidfest,Design Guru Joshua Davis @ VIDFEST,https://kriskrug.co/2006/06/20/design-guru-joshua-davis-vidfest/,True,46,True,201,True,201
+post,962,emo-hits-uno-on-youtube,EMO Hits UNO on YouTube,https://kriskrug.co/2006/06/20/emo-hits-uno-on-youtube/,True,35,True,200,True,200
+post,963,the-whole-is-greater-than-the-sum-of-the-parts-2,The whole is greater than the sum of the parts.,https://kriskrug.co/2006/06/19/the-whole-is-greater-than-the-sum-of-the-parts-2/,True,59,True,146,True,146
+post,927,checking-in-from-china-access-2008-conference-in-beijing,Checking in From China Access 2008 Conference in Beijing,https://kriskrug.co/2006/05/28/checking-in-from-china-access-2008-conference-in-beijing/,False,0,True,201,True,201
+post,926,china-access-2008-business-forum-reflections,China Access 2008 Business Forum Reflections,https://kriskrug.co/2006/05/24/china-access-2008-business-forum-reflections/,True,56,True,201,True,201
+post,925,beijing-trip-mentioned-in-vancouver-sun-article-about-business-opportunities-in-china,Beijing Trip Mentioned in Vancouver Sun Article About Business Opportunities in China,https://kriskrug.co/2006/05/23/beijing-trip-mentioned-in-vancouver-sun-article-about-business-opportunities-in-china/,False,0,True,201,True,201
+post,924,interview-on-kootenay-co-op-radio-with-jill-boland-of-tech-village,Interview on Kootenay Co-op Radio with Jill Boland of Tech Village,https://kriskrug.co/2006/05/18/interview-on-kootenay-co-op-radio-with-jill-boland-of-tech-village/,False,0,True,185,True,185
+post,923,m%c3%b8tley-krug,MÃ¸tley KrÃ¼g,https://kriskrug.co/2006/05/17/m%c3%b8tley-krug/,True,25,True,176,True,176
+post,922,e3-wrap-up,E3 Wrap-Up,https://kriskrug.co/2006/05/15/e3-wrap-up/,True,22,True,135,True,135
+post,921,the-emerald-used-my-photos-on-their-website,The Emeralds Used My Photos on Their Website,https://kriskrug.co/2006/05/15/the-emerald-used-my-photos-on-their-website/,True,56,True,190,True,190
+post,920,heading-to-beijing-china,I&#8217;m Going to Beijing China!,https://kriskrug.co/2006/05/04/heading-to-beijing-china/,True,39,True,201,True,201
+post,919,get-funded-by-google-to-work-on-drupal-with-bryght,Get Funded By Google to Work on Drupal With Bryght,https://kriskrug.co/2006/05/01/get-funded-by-google-to-work-on-drupal-with-bryght/,False,0,True,201,True,201
+post,918,918,Glencora Twigg of Twigg &#038; Hottie at Vancouver&#8217;s Glad Rags Party,https://kriskrug.co/2006/04/27/918/,False,0,True,201,True,201
+post,917,carpooling-to-work-and-buyin-a-bike,Carpooling to Work and Buyin&#8217; a Bike,https://kriskrug.co/2006/04/26/carpooling-to-work-and-buyin-a-bike/,True,48,True,201,True,201
+post,916,burnkit-office-grand-tour,Burnkit Office Grand Tour,https://kriskrug.co/2006/04/25/burnkit-office-grand-tour/,True,37,True,198,True,198
+post,908,a-couple-more-kk-and-mc-videoblogs,A Couple of kk+ and MC VideoBlogs,https://kriskrug.co/2006/04/25/a-couple-more-kk-and-mc-videoblogs/,True,45,True,135,True,135
+post,909,thomas-jefferson-was-a-badass,Thomas Jefferson Was a Badass,https://kriskrug.co/2006/04/25/thomas-jefferson-was-a-badass/,True,41,True,79,True,79
+post,910,workspace-future-home-of-yoga-for-geeks,Workspace &#8211; Future Home of Yoga for Geeks,https://kriskrug.co/2006/04/25/workspace-future-home-of-yoga-for-geeks/,True,53,True,152,True,152
+post,911,drupals-aggregator2-and-social-signal-blogged-on-worldchanging,Drupal&#8217;s Aggregator2 and Social Signal Blogged on WorldChanging,https://kriskrug.co/2006/04/24/drupals-aggregator2-and-social-signal-blogged-on-worldchanging/,False,0,True,189,True,189
+post,912,prioritized-cms-requirements-for-greenpeace-uk,Prioritized CMS Requirements for Greenpeace UK,https://kriskrug.co/2006/04/24/prioritized-cms-requirements-for-greenpeace-uk/,True,58,True,176,True,176
+post,913,how-to-prioritize-requirements-part-ii,HOW TO Prioritize Requirements (Part II),https://kriskrug.co/2006/04/24/how-to-prioritize-requirements-part-ii/,True,52,True,201,True,201
+post,914,nextbillionnet-nominated-for-a-webby,NextBillion.net Nominated For A Webby,https://kriskrug.co/2006/04/24/nextbillionnet-nominated-for-a-webby/,True,49,True,201,True,201
+post,915,onenorthwest-receives-salesforcecom-foundation-grant,ONE/Northwest Receives Salesforce.com Foundation Grant,https://kriskrug.co/2006/04/24/onenorthwest-receives-salesforcecom-foundation-grant/,False,0,True,201,True,201
+post,876,what-citizen-journalism-means-to-corporate-communications,What Citizen Journalism Means to Corporate Communications,https://kriskrug.co/2006/04/21/what-citizen-journalism-means-to-corporate-communications/,False,0,True,200,True,200
+post,877,social-tech-brewing-vancouver-may-4-at-the-whip,Social Tech Brewing Vancouver: May 4 at the Whip,https://kriskrug.co/2006/04/20/social-tech-brewing-vancouver-may-4-at-the-whip/,True,60,True,201,True,201
+post,878,comvu-talks-community,ComVu talks community,https://kriskrug.co/2006/04/20/comvu-talks-community/,True,33,True,201,True,201
+post,879,back-like-lazarus,Back Like Lazarus&#8230;,https://kriskrug.co/2006/04/20/back-like-lazarus/,True,32,True,109,True,109
+post,880,musicians-should-have-feeds,Musicians should have feeds.,https://kriskrug.co/2006/04/19/musicians-should-have-feeds/,True,40,True,198,True,198
+post,881,mollyguard,Mollyguard,https://kriskrug.co/2006/04/19/mollyguard/,True,22,True,139,True,139
+post,882,ten-video-sharing-services-compared,Ten Video Sharing Services Compared,https://kriskrug.co/2006/04/18/ten-video-sharing-services-compared/,True,47,True,180,True,180
+post,883,hacking-a-more-tasteful-myspace,Hacking A More Tasteful MySpace,https://kriskrug.co/2006/04/18/hacking-a-more-tasteful-myspace/,True,43,True,139,True,139
+post,884,official-2010-olympics-protest-site,&#8220;Official&#8221; 2010 Olympics Protest Site,https://kriskrug.co/2006/04/13/official-2010-olympics-protest-site/,True,49,True,177,True,177
+post,875,workspace-awesome-shared-office-space-for-creatives-and-techies-in-vancouver,Workspace: Awesome Shared Office Space for Creatives and Techies in Vancouver,https://kriskrug.co/2006/04/11/workspace-awesome-shared-office-space-for-creatives-and-techies-in-vancouver/,False,0,True,182,True,182
+post,885,what-web-20-means-for-your-church,What Web 2.0 Means for Your Church,https://kriskrug.co/2006/04/11/what-web-20-means-for-your-church/,True,46,True,161,True,161
+post,874,hangin-raincity-studios,Hangin&#8217; @ Raincity Studios,https://kriskrug.co/2006/04/11/hangin-raincity-studios/,True,38,True,201,True,201
+post,886,openmute,OpenMute,https://kriskrug.co/2006/04/10/openmute/,True,20,True,201,True,201
+post,887,how-to-prioritize-requirements-part-i,HOW TO Prioritize Requirements (Part I),https://kriskrug.co/2006/04/10/how-to-prioritize-requirements-part-i/,True,51,True,201,True,201
+post,888,the-cost-of-bootstrapping-your-app-the-figures-behind-dropsend-part-one,The Cost of Bootstrapping Your App: The Figures Behind DropSend (part one),https://kriskrug.co/2006/04/06/the-cost-of-bootstrapping-your-app-the-figures-behind-dropsend-part-one/,False,0,True,140,True,140
+post,889,video-on-the-net-is-a-solved-problem-many-times-over,"Video on the Net is a Solved Problem, Many Times Over",https://kriskrug.co/2006/04/06/video-on-the-net-is-a-solved-problem-many-times-over/,False,0,True,156,True,156
+post,890,the-dark-secrets-of-the-organic-food-movement,The dark secrets of the organic-food movement.,https://kriskrug.co/2006/04/06/the-dark-secrets-of-the-organic-food-movement/,True,58,True,72,True,72
+post,891,greenpeace-uk-is-looking-for-an-open-source-cms-possibly-a-vendor,Greenpeace UK is Looking for an Open Source CMS &#038; Possibly a Vendor,https://kriskrug.co/2006/04/06/greenpeace-uk-is-looking-for-an-open-source-cms-possibly-a-vendor/,False,0,True,145,True,145
+post,892,newbies-guide-to-the-wide-wonderful-world-of-rss,Newbie&#8217;s Guide to the Wide Wonderful World of RSS.,https://kriskrug.co/2006/04/06/newbies-guide-to-the-wide-wonderful-world-of-rss/,False,0,True,201,True,201
+post,893,a-directory-of-the-best-in-web-20-applications,A directory of the best in Web 2.0 applications,https://kriskrug.co/2006/04/05/a-directory-of-the-best-in-web-20-applications/,True,59,True,201,True,201
+post,894,civic-minded,Civic Mindedâ„¢,https://kriskrug.co/2006/04/05/civic-minded/,True,27,True,201,True,201
+post,895,man-took-40000-ecstasy-tablets,"Man &#8216;took 40,000 ecstasy tablets&#8217;",https://kriskrug.co/2006/04/04/man-took-40000-ecstasy-tablets/,True,45,True,169,True,169
+post,873,bridge-vancouver-networking-young-professionals-doing-business-in-asia-pacific,Bridge Vancouver &#8211; Networking Young Professionals Doing Business in Asia-Pacific,https://kriskrug.co/2006/04/04/bridge-vancouver-networking-young-professionals-doing-business-in-asia-pacific/,False,0,True,183,True,183
+post,896,canadaonrails-afterparty-sponsored-by-raincity-studios,CanadaOnRails Afterparty &#8211; Sponsored by Raincity Studios,https://kriskrug.co/2006/04/04/canadaonrails-afterparty-sponsored-by-raincity-studios/,False,0,True,201,True,201
+post,872,872,"Walk the Web 2.0 Ricepaper, Grasshoppa",https://kriskrug.co/2006/04/04/872/,True,50,True,181,True,181
+post,897,web-20-for-good,Web 2.0 for Good,https://kriskrug.co/2006/04/04/web-20-for-good/,True,28,True,201,True,201
+post,898,greenpeace-uk-cms-project,Greenpeace UK CMS Project,https://kriskrug.co/2006/04/04/greenpeace-uk-cms-project/,True,37,True,201,True,201
+post,899,unique-partnership-augments-venture-capital-with-product-design,Unique Partnership Augments Venture Capital With Product Design,https://kriskrug.co/2006/04/04/unique-partnership-augments-venture-capital-with-product-design/,False,0,True,171,True,171
+post,900,more-bangs-for-the-buck-ben-brown-imterview,More bangs for the buck: Ben Brown IMterview,https://kriskrug.co/2006/04/03/more-bangs-for-the-buck-ben-brown-imterview/,True,56,True,200,True,200
+post,901,megan-cole-starts-at-raincity-studios,Megan Cole Starts At Raincity Studios,https://kriskrug.co/2006/04/03/megan-cole-starts-at-raincity-studios/,True,49,True,182,True,182
+post,902,sustainability-business-centre,Sustainability Business Centre,https://kriskrug.co/2006/04/03/sustainability-business-centre/,True,42,True,101,True,101
+post,903,youtube-the-web-at-its-best,YouTube &#8211; The web at its best?,https://kriskrug.co/2006/04/03/youtube-the-web-at-its-best/,True,42,True,201,True,201
+post,904,7-ways-nonprofits-can-use-podcasts,7 Ways Nonprofits Can Use Podcasts,https://kriskrug.co/2006/03/31/7-ways-nonprofits-can-use-podcasts/,True,46,True,168,True,168
+post,905,culture-jamming-the-chevy-tahoe,Culture Jamming the Chevy Tahoe,https://kriskrug.co/2006/03/31/culture-jamming-the-chevy-tahoe/,True,43,True,201,True,201
+post,906,10-ways-nonprofits-can-use-blogs,10 Ways Nonprofits Can Use Blogs,https://kriskrug.co/2006/03/31/10-ways-nonprofits-can-use-blogs/,True,44,True,168,True,168
+post,907,the-changing-world-of-web-design-an-interview-with-dan-saffer,The changing world of web design: an interview with Dan Saffer,https://kriskrug.co/2006/03/31/the-changing-world-of-web-design-an-interview-with-dan-saffer/,False,0,True,176,True,176
+post,871,tech-village-switch-on-event-with-communicopia,Tech Village Switch On Event With Communicopia,https://kriskrug.co/2006/03/30/tech-village-switch-on-event-with-communicopia/,True,58,True,201,True,201
+post,870,ntc-and-penguin-day,NTC and Penguin Day,https://kriskrug.co/2006/03/25/ntc-and-penguin-day/,True,31,True,201,True,201
+post,869,sxsw-wrap-up,SXSW Wrap-Up,https://kriskrug.co/2006/03/25/sxsw-wrap-up/,True,24,True,201,True,201
+post,868,sxsw-travelling-videos,SXSW Travelling Videos,https://kriskrug.co/2006/03/21/sxsw-travelling-videos/,True,34,True,201,True,201
+post,867,lomo-lc-a,Lomo LC-A,https://kriskrug.co/2006/03/08/lomo-lc-a/,True,21,True,112,True,112
+post,866,sxsw-2006,SXSW 2006,https://kriskrug.co/2006/03/07/sxsw-2006/,True,21,True,167,True,167
+post,865,checkin-in-from-massive-techvibes-2006,Checkin&#8217; in from Massive Techvibes 2006,https://kriskrug.co/2006/02/28/checkin-in-from-massive-techvibes-2006/,True,51,True,108,True,108
+post,864,mile-high-club,Mile High Club,https://kriskrug.co/2006/02/25/mile-high-club/,True,26,True,201,True,201
+post,863,interviews-with-canadian-olympic-snowboard-team-and-a-team-canada-skiier-too,Interviews With Canadian Olympic Snowboard Team (and a Team Canada Skiier Too),https://kriskrug.co/2006/02/22/interviews-with-canadian-olympic-snowboard-team-and-a-team-canada-skiier-too/,False,0,True,200,True,200
+post,862,canada-kicks-ass-olympic-hockey-afterparty,Canada Kicks Ass &#8211; Olympic Hockey Afterparty,https://kriskrug.co/2006/02/17/canada-kicks-ass-olympic-hockey-afterparty/,True,56,True,181,True,181
+post,861,w00t-i-got-flickr-blogged,w00t! I Got Flickr Blogged. :),https://kriskrug.co/2006/02/17/w00t-i-got-flickr-blogged/,True,42,True,146,True,146
+post,860,torino-2006-winter-olympics-check-in,Torino 2006 Winter Olympics Check-In,https://kriskrug.co/2006/02/16/torino-2006-winter-olympics-check-in/,True,48,True,201,True,201
+post,859,happy-valentines-day,kk + sfp,https://kriskrug.co/2006/02/14/happy-valentines-day/,True,20,True,201,True,201
+post,858,858,"Sono affamato, non ho Internet ed il mio italiano succhia",https://kriskrug.co/2006/02/14/858/,False,0,True,201,True,201
+post,857,does-my-creative-commons-liscence-cover-this,Does My Creative Commons Liscence Cover This Kevin Corazza?,https://kriskrug.co/2006/02/10/does-my-creative-commons-liscence-cover-this/,False,0,True,125,True,125
+post,856,were-planning-a-party,We&#8217;re Planning A Party,https://kriskrug.co/2006/02/08/were-planning-a-party/,True,34,True,177,True,177
+post,855,ridiculosity,Ridiculosity,https://kriskrug.co/2006/02/08/ridiculosity/,True,24,True,201,True,201
+post,854,gettin-my-ass-kicked,Gettin&#8217; My Ass Kicked!,https://kriskrug.co/2006/02/08/gettin-my-ass-kicked/,True,34,True,161,True,161
+post,853,butchrpaprcom,Butchrpapr.com Launch,https://kriskrug.co/2006/02/08/butchrpaprcom/,True,33,True,83,True,83
+post,852,os-cms-setup-patrol,OS CMS Setup Patrol,https://kriskrug.co/2006/02/08/os-cms-setup-patrol/,True,31,True,79,True,79
+post,851,driving-and-listening-to-madonna,Driving and Listening to Madonna,https://kriskrug.co/2006/02/08/driving-and-listening-to-madonna/,True,44,True,179,True,179
+post,850,kk-rockin-6am,kk+ Rockin 6am,https://kriskrug.co/2006/02/08/kk-rockin-6am/,True,26,True,62,True,62
+post,849,hello-the-internets,"Hello, the Internets.",https://kriskrug.co/2006/02/06/hello-the-internets/,True,33,True,201,True,201
+post,847,frenchie-mcdoesnttalkalot-and-kk-rock-bcit-tv,Frenchie McDoesn&#8217;tTalkAlot and kk+ Rock BCIT TV,https://kriskrug.co/2006/02/02/frenchie-mcdoesnttalkalot-and-kk-rock-bcit-tv/,True,59,True,144,True,144
+post,846,i-broke-down-today-and-bought-the-canon-5d,I Broke Down Today and Bought the Canon 5d,https://kriskrug.co/2006/01/31/i-broke-down-today-and-bought-the-canon-5d/,True,54,True,180,True,180
+post,845,a-rendition-of-happy-birthday-by-will-pate-with-a-bad-cold,A Rendition of Happy Birthday by Will Pate With a Bad Cold,https://kriskrug.co/2006/01/31/a-rendition-of-happy-birthday-by-will-pate-with-a-bad-cold/,False,0,True,101,True,101
+post,844,my-four-things,My Four Things,https://kriskrug.co/2006/01/31/my-four-things/,True,26,True,177,True,177
+post,842,rollin-the-vancouver-streets,Rollin The Vancouver Streets,https://kriskrug.co/2006/01/27/rollin-the-vancouver-streets/,True,40,True,180,True,180
+post,841,recursive-infinite-loops-meta-vlog-vlog-with-boris-mann,Recursive Infinite Loops &#8211; Meta Vlog Vlog With Boris Mann,https://kriskrug.co/2006/01/25/recursive-infinite-loops-meta-vlog-vlog-with-boris-mann/,False,0,True,186,True,186
+post,840,canadian-politics-101,Canadian Politics 101 Vlog,https://kriskrug.co/2006/01/24/canadian-politics-101/,True,38,True,124,True,124
+post,839,trophies-and-cleansing,Trophies and Cleansing,https://kriskrug.co/2006/01/23/trophies-and-cleansing/,True,34,True,159,True,159
+post,838,geekin-out-bryght,Geekin Out @ Bryght,https://kriskrug.co/2006/01/19/geekin-out-bryght/,True,31,True,201,True,201
+post,837,837,Chillaxin in Vancouver,https://kriskrug.co/2006/01/18/837/,True,34,True,108,True,108
+post,806,break-free,Break Free,https://kriskrug.co/2006/01/18/break-free/,True,22,True,174,True,174
+post,807,adobe-project-lightroom-beta-1,Adobe: Project Lightroom Beta 1,https://kriskrug.co/2006/01/17/adobe-project-lightroom-beta-1/,True,43,True,167,True,167
+post,808,help-redesign-our-new-corporate-site,Help Redesign Our New Corporate Site,https://kriskrug.co/2006/01/17/help-redesign-our-new-corporate-site/,True,48,True,165,True,165
+post,809,wired-up-plugged-in-zoned-out,"WIRED UP, PLUGGED IN, ZONED OUT",https://kriskrug.co/2006/01/16/wired-up-plugged-in-zoned-out/,True,43,True,164,True,164
+post,810,bryght-is-going-to-the-olympics-in-torino,Bryght is going to the Olympics in Torino,https://kriskrug.co/2006/01/16/bryght-is-going-to-the-olympics-in-torino/,True,53,True,201,True,201
+post,811,podcast-hotel-seattle-lets-get-famous,Podcast Hotel Seattle: Let&#8217;s Get Famous,https://kriskrug.co/2006/01/16/podcast-hotel-seattle-lets-get-famous/,True,51,True,201,True,201
+post,812,northern-voice-2006-photocamp,Northern Voice 2006 &#8211; PhotoCamp,https://kriskrug.co/2006/01/13/northern-voice-2006-photocamp/,True,43,True,200,True,200
+post,813,photography-in-cold-weather-conditions,Photography in Cold Weather Conditions,https://kriskrug.co/2006/01/12/photography-in-cold-weather-conditions/,True,50,True,201,True,201
+post,814,zaadz-do-we-need-another-social-networking-tool,Zaadz &#8211; Do We Need Another Social Networking Tool!?,https://kriskrug.co/2006/01/11/zaadz-do-we-need-another-social-networking-tool/,False,0,True,189,True,189
+post,815,mobile-monday-vancouver-meeting-1-3-words,Mobile Monday Vancouver Meeting #1 &#8211; 3 words,https://kriskrug.co/2006/01/11/mobile-monday-vancouver-meeting-1-3-words/,True,56,True,189,True,189
+post,804,i-guess-im-a-video-blogger-now-too,I Guess I&#8217;m A Video Blogger Now Too.,https://kriskrug.co/2006/01/10/i-guess-im-a-video-blogger-now-too/,True,48,True,176,True,176
+post,803,im-a-sexual-7,I&#8217;m A Sexual 7,https://kriskrug.co/2006/01/09/im-a-sexual-7/,True,26,True,201,True,201
+post,816,intention-7-photos-on-flickr,Intention 7 Photos on Flickr,https://kriskrug.co/2006/01/06/intention-7-photos-on-flickr/,True,40,True,113,True,113
+post,817,photoblog-or-blog-about-photography,Photoblog or blog about photography?,https://kriskrug.co/2006/01/06/photoblog-or-blog-about-photography/,True,48,True,201,True,201
+post,818,tips-for-photographing-children,Tips for Photographing Children,https://kriskrug.co/2006/01/06/tips-for-photographing-children/,True,43,True,200,True,200
+post,819,diy-podcasting,DIY: Podcasting,https://kriskrug.co/2006/01/04/diy-podcasting/,True,27,True,201,True,201
+post,802,802,Photography Tips and Resolutions for 2006,https://kriskrug.co/2006/01/04/802/,True,53,True,150,True,150
+post,820,new-years-resolutions-for-photographers,New Years Resolutions for Photographers,https://kriskrug.co/2006/01/04/new-years-resolutions-for-photographers/,True,51,True,136,True,136
+post,821,static-photography-represents-northern-voice-2006-in-vancouver,Static Photography Represents @ Northern Voice 2006 in Vancouver,https://kriskrug.co/2006/01/04/static-photography-represents-northern-voice-2006-in-vancouver/,False,0,True,132,True,132
+post,822,guadec-logo-and-drupal-theme-contest,GUADEC Logo and Drupal Theme Contest,https://kriskrug.co/2006/01/04/guadec-logo-and-drupal-theme-contest/,True,48,True,201,True,201
+post,823,win-a-free-pass-to-sxsw-interactive,Win a Free Pass to SXSW Interactive!,https://kriskrug.co/2006/01/04/win-a-free-pass-to-sxsw-interactive/,True,48,True,171,True,171
+post,801,hippie-20,Hippie Camp &#8211; Intention 7 by Tribal Harmonix,https://kriskrug.co/2006/01/03/hippie-20/,True,56,True,123,True,123
+post,824,integral-naked-podcasts,Integral Naked Podcasts,https://kriskrug.co/2006/01/03/integral-naked-podcasts/,True,35,True,200,True,200
+post,825,a-new-year-in-photography,A New Year in Photography,https://kriskrug.co/2006/01/03/a-new-year-in-photography/,True,37,True,94,True,94
+post,826,top-five-products-of-2005,Top Five Products of 2005,https://kriskrug.co/2006/01/03/top-five-products-of-2005/,True,37,True,110,True,110
+post,827,show-our-northern-voice-sponsors-some-love,Show Our Northern Voice Sponsors Some Love,https://kriskrug.co/2006/01/03/show-our-northern-voice-sponsors-some-love/,True,54,True,145,True,145
+post,828,2006-nonprofit-technology-conference-agenda,2006 Nonprofit Technology Conference Agenda,https://kriskrug.co/2006/01/03/2006-nonprofit-technology-conference-agenda/,True,55,True,201,True,201
+post,829,hubble-uncovers-smallest-moons-yet-seen-around-uranus,Hubble Uncovers Smallest Moons Yet Seen Around Uranus,https://kriskrug.co/2005/12/26/hubble-uncovers-smallest-moons-yet-seen-around-uranus/,False,0,True,132,True,132
+post,830,however-you-want-to-say-it,However you want to say it&#8230;,https://kriskrug.co/2005/12/24/however-you-want-to-say-it/,True,41,True,201,True,201
+post,831,drupal-developerbusiness-meetup,Drupal Developer/Business Meetup,https://kriskrug.co/2005/12/23/drupal-developerbusiness-meetup/,True,44,True,167,True,167
+post,832,ocd-tech-dreams,OCD Tech Dreams,https://kriskrug.co/2005/12/23/ocd-tech-dreams/,True,27,True,201,True,201
+post,833,canon-ef-50mm-f14-vs-f18-mk-ii,Canon EF 50mm â€“ F1.4 vs F1.8 MK II,https://kriskrug.co/2005/12/23/canon-ef-50mm-f14-vs-f18-mk-ii/,True,48,True,188,True,188
+post,834,identity-questions,Identity Questions,https://kriskrug.co/2005/12/23/identity-questions/,True,30,True,201,True,201
+post,835,online-rights-canada-bill-c-60-and-what-it-means-for-photographers,Online Rights Canada: Bill C-60 and What It Means for Photographers,https://kriskrug.co/2005/12/23/online-rights-canada-bill-c-60-and-what-it-means-for-photographers/,False,0,True,200,True,200
+post,836,what-happens-when-web20-is-down,what happens when web2.0 is down?,https://kriskrug.co/2005/12/22/what-happens-when-web20-is-down/,True,45,True,150,True,150
+post,769,drupal-girls-kick-ass,Drupal Girls Kick Ass!,https://kriskrug.co/2005/12/20/drupal-girls-kick-ass/,True,34,True,97,True,97
+post,770,intention-retreat-enters-its-7th-cycle,Intention Retreat enters its 7th cycle,https://kriskrug.co/2005/12/20/intention-retreat-enters-its-7th-cycle/,True,50,True,152,True,152
+post,771,the-are-you-a-hippy-test,The Are You A Hippy Test,https://kriskrug.co/2005/12/20/the-are-you-a-hippy-test/,True,36,True,121,True,121
+post,772,drupal-girls-kick-ass-2,Drupal Girls Kick Ass!,https://kriskrug.co/2005/12/20/drupal-girls-kick-ass-2/,True,34,True,53,True,53
+post,773,gettin-things-done,Gettin&#8217; Things Done!,https://kriskrug.co/2005/12/20/gettin-things-done/,True,32,True,201,True,201
+post,774,2005-was-93-worth-living,2005 was 93% worth living.,https://kriskrug.co/2005/12/16/2005-was-93-worth-living/,True,38,True,118,True,118
+post,775,if-news-is-not-in-english-did-it-happen,"If news is not in English, did it happen?",https://kriskrug.co/2005/12/16/if-news-is-not-in-english-did-it-happen/,True,53,True,187,True,187
+post,776,photography-books-for-your-coffee-table,Photography Books for your Coffee Table,https://kriskrug.co/2005/12/16/photography-books-for-your-coffee-table/,True,51,True,201,True,201
+post,777,quickie-folksonomy-screencast,Quickie Folksonomy Screencast,https://kriskrug.co/2005/12/15/quickie-folksonomy-screencast/,True,41,True,201,True,201
+post,778,online-photography-rights-are-you-allowed-to-link-to-me,Online Photography Rights: Are You Allowed to Link to Me?,https://kriskrug.co/2005/12/15/online-photography-rights-are-you-allowed-to-link-to-me/,False,0,True,165,True,165
+post,779,colette-fisheye-by-lomo,Colette Fisheye by Lomo,https://kriskrug.co/2005/12/13/colette-fisheye-by-lomo/,True,35,True,178,True,178
+post,780,reality-bytes-eight-myths-about-video-games-debunked,Reality Bytes: Eight Myths About Video Games Debunked,https://kriskrug.co/2005/12/13/reality-bytes-eight-myths-about-video-games-debunked/,False,0,True,198,True,198
+post,781,sleep-debt-time-for-more-shut-eye,Sleep Debt &#8211; Time for More Shut-Eye,https://kriskrug.co/2005/12/13/sleep-debt-time-for-more-shut-eye/,True,47,True,201,True,201
+post,768,fu-h2,FU H2,https://kriskrug.co/2005/12/13/fu-h2/,True,17,True,201,True,201
+post,782,family-picture-christmas-cards,Family Picture Christmas Cards,https://kriskrug.co/2005/12/13/family-picture-christmas-cards/,True,42,True,201,True,201
+post,767,blogging-for-artists-and-creatives,Blogging for Independent Artists and Creatives,https://kriskrug.co/2005/12/12/blogging-for-artists-and-creatives/,True,58,True,169,True,169
+post,783,the-best-web-20-software-of-2005,The Best Web 2.0 Software of 2005,https://kriskrug.co/2005/12/12/the-best-web-20-software-of-2005/,True,45,True,145,True,145
+post,784,moving-on-some-words-that-i-would-love-to-see-retired-from-my-existence-for-quite-some-time,Moving On &#8211; Some words that I would love to see retired from my existence for quite some time:,https://kriskrug.co/2005/12/12/moving-on-some-words-that-i-would-love-to-see-retired-from-my-existence-for-quite-some-time/,False,0,True,201,True,201
+post,785,recovering-from-blog-verload,Recovering from Blog-Verload,https://kriskrug.co/2005/12/11/recovering-from-blog-verload/,True,40,True,201,True,201
+post,786,blogging-for-the-creative-crew,Blogging for the creative crew,https://kriskrug.co/2005/12/11/blogging-for-the-creative-crew/,True,42,True,201,True,201
+post,787,bold-predictions-for-the-savvy-designer-2006-edition,"Bold predictions for the savvy designer, 2006 edition",https://kriskrug.co/2005/12/09/bold-predictions-for-the-savvy-designer-2006-edition/,False,0,True,168,True,168
+post,788,web-design-and-development-trends-for-2006,Web Design and Development Trends for 2006,https://kriskrug.co/2005/12/09/web-design-and-development-trends-for-2006/,True,54,True,201,True,201
+post,766,beercasting-from-the-props-pub-blogs-n-dogs-in-banff-alberta,"BeerCasting from the Props Pub @ Blogs N Dogs in Banff, Alberta",https://kriskrug.co/2005/12/07/beercasting-from-the-props-pub-blogs-n-dogs-in-banff-alberta/,False,0,True,188,True,188
+post,789,canadacom-redesigns-without-rss-feeds,Canada.com Redesigns Without RSS Feeds,https://kriskrug.co/2005/12/07/canadacom-redesigns-without-rss-feeds/,True,50,True,201,True,201
+post,790,things-i-didnt-know-before-yesterday,Things I Didn&#8217;t Know Before Yesterday,https://kriskrug.co/2005/12/07/things-i-didnt-know-before-yesterday/,True,49,True,201,True,201
+post,791,why-we-love-jpg-magazine-photography-is-not-a-crime,Why We Love JPG Magazine: Photography is Not a Crime,https://kriskrug.co/2005/12/06/why-we-love-jpg-magazine-photography-is-not-a-crime/,False,0,True,199,True,199
+post,792,the-dogs-part-of-the-equation,The Dogs Part of the Equation,https://kriskrug.co/2005/12/06/the-dogs-part-of-the-equation/,True,41,True,200,True,200
+post,765,i-feel-like-the-prom-king,I Feel Like the Prom King,https://kriskrug.co/2005/12/05/i-feel-like-the-prom-king/,True,37,True,120,True,120
+post,764,rhonda-fasts-photography-opening-wicked-cafe-in-vancouver,Rhonda Fast&#8217;s Photography Opening @ Wicked Cafe in Vancouver,https://kriskrug.co/2005/12/05/rhonda-fasts-photography-opening-wicked-cafe-in-vancouver/,False,0,True,200,True,200
+post,793,greetings-from-banff,Greetings from Banff,https://kriskrug.co/2005/12/04/greetings-from-banff/,True,32,True,164,True,164
+post,794,welcome-to-blogsndogs,Welcome to BlogsnDogs,https://kriskrug.co/2005/12/04/welcome-to-blogsndogs/,True,33,True,131,True,131
+post,795,the-quest-to-acheive-buzzword-compliancy,The Quest to Acheive Buzzword Compliancy,https://kriskrug.co/2005/12/04/the-quest-to-acheive-buzzword-compliancy/,True,52,True,185,True,185
+post,796,blogs-n-dogs-geeking-out-in-kks-room,Blogs n Dogs &#8211; Geeking out in kk&#8217;s room,https://kriskrug.co/2005/12/04/blogs-n-dogs-geeking-out-in-kks-room/,True,51,True,115,True,115
+post,797,testing-odeo-blogs-and-dogs-banff,"Testing Odeo &#8211; Blogs and Dogs, Banff",https://kriskrug.co/2005/12/04/testing-odeo-blogs-and-dogs-banff/,True,48,True,166,True,166
+post,798,blogs-n-dogs-faculty-geeking-out,Blogs n Dogs &#8211; Faculty Geeking out,https://kriskrug.co/2005/12/04/blogs-n-dogs-faculty-geeking-out/,True,46,True,62,True,62
+post,799,off-to-blogs-and-dogs,Off to Blogs and Dogs,https://kriskrug.co/2005/12/04/off-to-blogs-and-dogs/,True,33,True,137,True,137
+post,800,currently-13-f-but-real-feel-is-24-f,"Currently -13 F, but Real Feel is -24 F",https://kriskrug.co/2005/12/03/currently-13-f-but-real-feel-is-24-f/,True,51,True,186,True,186
+post,763,10-web-moments-that-changed-the-world,10 Web Moments That Changed the World,https://kriskrug.co/2005/12/02/10-web-moments-that-changed-the-world/,True,49,True,201,True,201
+post,737,the-rights-of-photographers-when-shooting-in-public-places,The Right&#8217;s of Photographers (when shooting in public places),https://kriskrug.co/2005/11/23/the-rights-of-photographers-when-shooting-in-public-places/,False,0,True,201,True,201
+post,738,flickr-favourites-why-why-why,Flickr Favourites: Why? Why? Why?,https://kriskrug.co/2005/11/23/flickr-favourites-why-why-why/,True,45,True,190,True,190
+post,739,remixing-the-web-for-social-change,Remixing the Web for Social Change,https://kriskrug.co/2005/11/22/remixing-the-web-for-social-change/,True,46,True,201,True,201
+post,736,upcoming-events-im-involved-with,Upcoming Events I&#8217;m Involved With,https://kriskrug.co/2005/11/22/upcoming-events-im-involved-with/,True,45,True,139,True,139
+post,740,announcement-open-source-cms-and-blogging-tools-summit-vancouver-february-7-9-2006,"Announcement: Open Source CMS and Blogging Tools Summit, Vancouver, February 7 &#8211; 9, 2006",https://kriskrug.co/2005/11/22/announcement-open-source-cms-and-blogging-tools-summit-vancouver-february-7-9-2006/,False,0,True,190,True,190
+post,741,fairsource-model-for-sustainable-trade-in-services,FairSource: Model for Sustainable Trade in Services,https://kriskrug.co/2005/11/22/fairsource-model-for-sustainable-trade-in-services/,False,0,True,201,True,201
+post,742,green-business-go-carbon-neutral,Green Business? Go Carbon Neutral!!!,https://kriskrug.co/2005/11/22/green-business-go-carbon-neutral/,True,48,True,201,True,201
+post,743,a-delicious-tagsgiving-dinner,A del.icio.us Tagsgiving dinner,https://kriskrug.co/2005/11/21/a-delicious-tagsgiving-dinner/,True,43,True,142,True,142
+post,744,floatleft-design-and-web-development-for-non-profits,FloatLeft &#8211; Design and Web Development for Non-Profits,https://kriskrug.co/2005/11/16/floatleft-design-and-web-development-for-non-profits/,False,0,True,167,True,167
+post,745,xml-conference-2005-presentin-and-representin,XML Conference 2005 &#8211; Presentin&#8217; and Representin&#8217;,https://kriskrug.co/2005/11/16/xml-conference-2005-presentin-and-representin/,False,0,True,129,True,129
+post,734,in-a-moment-of-jet-lagged-weakness,In A Moment of Jet-Lagged Weakness,https://kriskrug.co/2005/11/11/in-a-moment-of-jet-lagged-weakness/,True,46,True,24,True,24
+post,746,50-flavorful-affordable-wines,"50 flavorful, affordable wines",https://kriskrug.co/2005/11/11/50-flavorful-affordable-wines/,True,42,True,181,True,181
+post,747,from-cells-to-bells-10-things-the-chinese-do-far-better-than-we-do,"From cells to bells, 10 things the Chinese do far better than we do.",https://kriskrug.co/2005/11/11/from-cells-to-bells-10-things-the-chinese-do-far-better-than-we-do/,False,0,True,173,True,173
+post,748,when-do-you-use-a-forum-a-blog-jotspot-writely-a-wiki-or-a-full-web-20-platform,"When do you use a forum, a blog, Jotspot, Writely, a wiki, or a full web 2.0 platform?",https://kriskrug.co/2005/11/10/when-do-you-use-a-forum-a-blog-jotspot-writely-a-wiki-or-a-full-web-20-platform/,False,0,True,201,True,201
+post,749,new-black-tories-ep-coming-soon,New Black Tories E.P. Coming Soon,https://kriskrug.co/2005/11/10/new-black-tories-ep-coming-soon/,True,45,True,186,True,186
+post,750,church-1-lust-0,"Church: 1, Lust: 0",https://kriskrug.co/2005/11/10/church-1-lust-0/,True,30,True,135,True,135
+post,751,zen-and-the-art-of-powerpoint,Zen and the Art of Powerpoint,https://kriskrug.co/2005/11/10/zen-and-the-art-of-powerpoint/,True,41,True,201,True,201
+post,752,speak-at-northern-voice-2006,Speak at Northern Voice 2006,https://kriskrug.co/2005/11/10/speak-at-northern-voice-2006/,True,40,True,192,True,192
+post,753,opportunities-people-and-tools,"Opportunities, people, and tools",https://kriskrug.co/2005/11/10/opportunities-people-and-tools/,True,44,True,150,True,150
+post,754,blackcombs-opening-day,Blackcomb&#8217;s Opening Day,https://kriskrug.co/2005/11/10/blackcombs-opening-day/,True,35,True,186,True,186
+post,755,lomography-the-rules-the-society-and-why-i-want-one-so-badly-static-photography,"Lomography: The Rules, The Society and Why I Want One So Badly! | static photography",https://kriskrug.co/2005/11/10/lomography-the-rules-the-society-and-why-i-want-one-so-badly-static-photography/,False,0,True,201,True,201
+post,756,google-maps-on-your-website,Google Maps on Your Website,https://kriskrug.co/2005/10/28/google-maps-on-your-website/,True,39,True,178,True,178
+post,733,captain-ajax-presents-at-vancouver-film-school,Captain AJAX Presents at Vancouver Film School,https://kriskrug.co/2005/10/28/captain-ajax-presents-at-vancouver-film-school/,True,58,True,147,True,147
+post,732,yvr-lhr-lgw-edi-lhr-yvr,Breaking The Curse,https://kriskrug.co/2005/10/28/yvr-lhr-lgw-edi-lhr-yvr/,True,30,True,179,True,179
+post,757,the-whole-is-greater-than-the-sum-of-the-parts,The whole is greater than the sum of the parts.,https://kriskrug.co/2005/10/27/the-whole-is-greater-than-the-sum-of-the-parts/,True,59,True,146,True,146
+post,758,bryght-and-early,Bryght and Early,https://kriskrug.co/2005/10/27/bryght-and-early/,True,28,True,63,True,63
+post,759,static-takes-photos-for-vancouver-dj-jay-parsons,Static takes photos for Vancouver DJ &#8211; Jay Parsons,https://kriskrug.co/2005/10/26/static-takes-photos-for-vancouver-dj-jay-parsons/,False,0,True,180,True,180
+post,731,other-places-on-the-web-i-hang-out,Other Places on the Web I Hang Out,https://kriskrug.co/2005/10/26/other-places-on-the-web-i-hang-out/,True,46,True,161,True,161
+post,760,arctics-amazed-recorded-live-on-the-scotfree,Arctic&#8217;s &#8220;Amazed&#8221; Recorded Live on the ScotFree,https://kriskrug.co/2005/10/26/arctics-amazed-recorded-live-on-the-scotfree/,True,59,True,163,True,163
+post,761,multi-user-blog-tools-overall-ratings-and-reviews,Multi User Blog Tools &#8211; Overall Ratings and Reviews,https://kriskrug.co/2005/10/25/multi-user-blog-tools-overall-ratings-and-reviews/,False,0,True,201,True,201
+post,762,pig-roast-2005,Pig Roast 2005,https://kriskrug.co/2005/10/25/pig-roast-2005/,True,26,True,151,True,151
+post,699,vancouver-user-guide-blog-feeds,Vancouver User Guide Blog Feeds,https://kriskrug.co/2005/10/22/vancouver-user-guide-blog-feeds/,True,43,True,164,True,164
+post,700,why-self-portraiture,Why Self Portraiture?,https://kriskrug.co/2005/10/22/why-self-portraiture/,True,33,True,200,True,200
+post,698,sam-sullivan-photo-used-for-the-cover-of-the-terminal-city-news,Sam Sullivan Photo Used for the Cover of the Terminal City News,https://kriskrug.co/2005/10/22/sam-sullivan-photo-used-for-the-cover-of-the-terminal-city-news/,False,0,True,159,True,159
+post,701,truck-you-video-podcasting-second-life-slackstreet-and-more,"Truck you! Video Podcasting, Second Life, Slackstreet and more",https://kriskrug.co/2005/10/21/truck-you-video-podcasting-second-life-slackstreet-and-more/,False,0,True,200,True,200
+post,702,gastown-graffiti-project,Gastown Graffiti Project,https://kriskrug.co/2005/10/21/gastown-graffiti-project/,True,36,True,139,True,139
+post,703,please-go-and-vote-for-our-web-20-manifesto-over-at-changethis,Please go and vote for our Web 2.0 Manifesto over at ChangeThis!,https://kriskrug.co/2005/10/21/please-go-and-vote-for-our-web-20-manifesto-over-at-changethis/,False,0,True,153,True,153
+post,704,min-jung-kim-interview,Min Jung Kim Interview,https://kriskrug.co/2005/10/21/min-jung-kim-interview/,True,34,True,160,True,160
+post,705,book-review-bittorrent-for-dummies-by-susannah-gardner-and-kris-krug,Book Review &#8211; BitTorrent For Dummies by Susannah Gardner and Kris Krug,https://kriskrug.co/2005/10/19/book-review-bittorrent-for-dummies-by-susannah-gardner-and-kris-krug/,False,0,True,201,True,201
+post,706,a-neo-techies-morning,A Neo-Techie&#8217;s Morning,https://kriskrug.co/2005/10/17/a-neo-techies-morning/,True,34,True,92,True,92
+post,710,flickr-photos-from-kk,Flickr: Photos from kk+,https://kriskrug.co/2005/10/17/flickr-photos-from-kk/,True,35,True,23,True,23
+post,709,change-culture-creativity-communication-moderate-comments-wordpress,"â€˜Change, Culture, Creativity, Communicationâ€™ â€º Moderate comments â€” WordPress",https://kriskrug.co/2005/10/17/change-culture-creativity-communication-moderate-comments-wordpress/,False,0,True,84,True,84
+post,708,the-black-tories-black-tories-militia-unite,tHE bLACK tORIES*** | bLACK tORIES mILITIA uNITE***,https://kriskrug.co/2005/10/17/the-black-tories-black-tories-militia-unite/,False,0,True,51,True,51
+post,712,flock,Flock,https://kriskrug.co/2005/10/14/flock/,True,17,True,5,True,5
+post,711,getting-started,Getting Started,https://kriskrug.co/2005/10/14/getting-started/,True,27,True,15,True,15
+post,713,guess-what-arrived-today,Guess What Arrived Today?,https://kriskrug.co/2005/10/14/guess-what-arrived-today/,True,37,True,156,True,156
+post,697,expired-slide-film,Expired Slide Film and Cross-Processing,https://kriskrug.co/2005/10/14/expired-slide-film/,True,51,True,176,True,176
+post,714,brent-holliday-with-web-20-anti-hype-and-get-ready-for-vancouver-enterprise-forum-20,Brent Holliday with Web 2.0 anti-hype (and get ready for Vancouver Enterprise Forum 2.0),https://kriskrug.co/2005/10/12/brent-holliday-with-web-20-anti-hype-and-get-ready-for-vancouver-enterprise-forum-20/,False,0,True,200,True,200
+post,715,social-signal-is-hiring,Social Signal is hiring!,https://kriskrug.co/2005/10/12/social-signal-is-hiring/,True,36,True,201,True,201
+post,716,remix-is-active-consumption-not-production-when-media-becomes-culture,remix is active consumption not production (when media becomes culture),https://kriskrug.co/2005/10/10/remix-is-active-consumption-not-production-when-media-becomes-culture/,False,0,True,159,True,159
+post,696,colors-of-web-20-party,Colors of Web 2.0 Party,https://kriskrug.co/2005/10/10/colors-of-web-20-party/,True,35,True,194,True,194
+post,695,web-20-conference-photos,Web 2.0 Conference Photos,https://kriskrug.co/2005/10/10/web-20-conference-photos/,True,37,True,201,True,201
+post,694,quickie-web-20-conference-post,Quickie Web 2.0 Conference Post,https://kriskrug.co/2005/10/05/quickie-web-20-conference-post/,True,43,True,154,True,154
+post,717,bittorrent-for-dummies,BitTorrent For Dummies,https://kriskrug.co/2005/10/04/bittorrent-for-dummies/,True,34,True,167,True,167
+post,718,customized-code-and-free-hosting-for-grassroots-media-activists,Customized Code and Free Hosting for Grassroots Media Activists,https://kriskrug.co/2005/10/04/customized-code-and-free-hosting-for-grassroots-media-activists/,False,0,True,201,True,201
+post,719,raised-voices,Raised Voices,https://kriskrug.co/2005/09/29/raised-voices/,True,25,True,100,True,100
+post,720,playlist-module-released,Playlist Module Released,https://kriskrug.co/2005/09/29/playlist-module-released/,True,36,True,152,True,152
+post,721,is-fix-it-in-photoshop-a-valid-statement,Is &#8220;Fix it in Photoshop&#8221; A Valid Statement?,https://kriskrug.co/2005/09/29/is-fix-it-in-photoshop-a-valid-statement/,True,55,True,200,True,200
+post,722,blue-flavor-is-open-for-business,Blue Flavor is Open for Business,https://kriskrug.co/2005/09/29/blue-flavor-is-open-for-business/,True,44,True,130,True,130
+post,723,bittorrents-grab-at-respectability,BitTorrent&#8217;s Grab at Respectability,https://kriskrug.co/2005/09/28/bittorrents-grab-at-respectability/,True,47,True,170,True,170
+post,693,bit-torrent-for-dummies-chapter-1-and-table-of-contents-online-and-available,BitTorrent for Dummies Chapter 1 and Table of Contents Online and Available,https://kriskrug.co/2005/09/28/bit-torrent-for-dummies-chapter-1-and-table-of-contents-online-and-available/,False,0,True,151,True,151
+post,724,lead-generation-via-myspace,Lead Generation via Myspace,https://kriskrug.co/2005/09/28/lead-generation-via-myspace/,True,39,True,169,True,169
+post,725,open-source-cms-evalation-part-iii-implementation,Open Source CMS Evalation &#8211; Part III: Implementation,https://kriskrug.co/2005/09/28/open-source-cms-evalation-part-iii-implementation/,False,0,True,137,True,137
+post,726,building-a-website-with-an-open-source-cms,Building a website with an Open Source CMS,https://kriskrug.co/2005/09/28/building-a-website-with-an-open-source-cms/,True,54,True,176,True,176
+post,728,open-source-cms-evaluation-part-i-installation,Open Source CMS Evaluation &#8211; Part I: Installation,https://kriskrug.co/2005/09/28/open-source-cms-evaluation-part-i-installation/,False,0,True,201,True,201
+post,727,open-source-cms-evaluation-part-ii-customization,Open Source CMS Evaluation &#8211; Part II: Customization,https://kriskrug.co/2005/09/28/open-source-cms-evaluation-part-ii-customization/,False,0,True,143,True,143
+post,729,raincity-studios-party,Raincity Studios Party!,https://kriskrug.co/2005/09/28/raincity-studios-party/,True,35,True,129,True,129
+post,692,web-of-change-photos-on-flickr,Web of Change Photos on Flickr,https://kriskrug.co/2005/09/24/web-of-change-photos-on-flickr/,True,42,True,170,True,170
+post,690,cheetah-sighting,Cheetah Sighting,https://kriskrug.co/2005/09/22/cheetah-sighting/,True,28,True,50,True,50
+post,689,top-10-marketing-initiatives-for-civic-space,Top 10 Marketing Initiatives for Civic Space,https://kriskrug.co/2005/09/22/top-10-marketing-initiatives-for-civic-space/,True,56,True,150,True,150
+post,688,688,G&#8217;Morning from Hollyhock &#8211; Web of Change on Cortes Island,https://kriskrug.co/2005/09/22/688/,False,0,True,170,True,170
+post,687,cortes-island,Cortes Island,https://kriskrug.co/2005/09/21/cortes-island/,True,25,True,201,True,201
+post,686,web-of-change,Web of Change,https://kriskrug.co/2005/09/19/web-of-change/,True,25,True,201,True,201
+post,685,northern-voice-2006-the-moose-is-loose,Northern Voice + Moose Camp,https://kriskrug.co/2005/09/16/northern-voice-2006-the-moose-is-loose/,True,39,True,181,True,181
+post,653,so-opus-goes-live-silently,So&#8230;. Opus goes live silently,https://kriskrug.co/2005/09/12/so-opus-goes-live-silently/,True,42,True,194,True,194
+post,684,podcast-hotel-presentation-and-photos,PodCast Hotel Presentation and Photos,https://kriskrug.co/2005/09/12/podcast-hotel-presentation-and-photos/,True,49,True,194,True,194
+post,652,sneak-preview-of-drupalbryght-flickr-module,Sneak Preview of Drupal Flickr Module,https://kriskrug.co/2005/09/12/sneak-preview-of-drupalbryght-flickr-module/,True,49,True,199,True,199
+post,654,hurricane-katrina-and-the-power-of-photography,Hurricane Katrina and the Power of Photography,https://kriskrug.co/2005/09/11/hurricane-katrina-and-the-power-of-photography/,True,58,True,201,True,201
+post,655,eric-rice-gets-funding-to-launch-podcast-and-videoblog-service-and-portal-in-japan-korea-and-china,"Eric Rice gets funding to launch podcast and videoblog service and portal in Japan, Korea and China",https://kriskrug.co/2005/09/06/eric-rice-gets-funding-to-launch-podcast-and-videoblog-service-and-portal-in-japan-korea-and-china/,False,0,True,201,True,201
+post,656,bandnewsorg,Bandnews.org,https://kriskrug.co/2005/09/03/bandnewsorg/,True,24,True,167,True,167
+post,657,scratching-at-fidos-door,Scratching at Fidoâ€™s door,https://kriskrug.co/2005/08/29/scratching-at-fidos-door/,True,39,True,164,True,164
+post,658,evolution-and-intuition,Evolution and Intuition,https://kriskrug.co/2005/08/29/evolution-and-intuition/,True,35,True,126,True,126
+post,659,kk-opening-wicked-cafe,KK  opening @ Wicked Cafe,https://kriskrug.co/2005/08/29/kk-opening-wicked-cafe/,True,37,True,123,True,123
+post,660,ty-west-performs-on-the-scot-free,Ty West Performs on the Scot Free,https://kriskrug.co/2005/08/25/ty-west-performs-on-the-scot-free/,True,45,True,161,True,161
+post,661,drupal-for-education-crushes-webct,Drupal for Education Crushes WebCT,https://kriskrug.co/2005/08/24/drupal-for-education-crushes-webct/,True,46,True,201,True,201
+post,651,bruise,"bruise &#8211; photography show, 7pm friday @ wicked cafe &#8211; vancouver",https://kriskrug.co/2005/08/24/bruise/,False,0,True,191,True,191
+post,650,taylor-the-paratrooper,Taylor The ParaTrooper,https://kriskrug.co/2005/08/23/taylor-the-paratrooper/,True,34,True,183,True,183
+post,662,want-to-start-a-company,Want to start a company?,https://kriskrug.co/2005/08/23/want-to-start-a-company/,True,36,True,174,True,174
+post,663,flock-rocks-or-chris-messina-is-a-demo-god,Flock rocks (or Chris Messina is a demo god)!,https://kriskrug.co/2005/08/22/flock-rocks-or-chris-messina-is-a-demo-god/,True,57,True,201,True,201
+post,664,rebel,Rebel,https://kriskrug.co/2005/08/22/rebel/,True,17,True,125,True,125
+post,665,event-blogging-with-drupal,Event blogging with Drupal,https://kriskrug.co/2005/08/22/event-blogging-with-drupal/,True,38,True,201,True,201
+post,666,bootyliscious-west-coast-style,Bootyliscious West Coast Style,https://kriskrug.co/2005/08/22/bootyliscious-west-coast-style/,True,42,True,132,True,132
+post,667,canon-5d-2,Canon 5d,https://kriskrug.co/2005/08/19/canon-5d-2/,True,20,True,95,True,95
+post,668,booty-callshould-i-answer,Booty Call&#8230;Should I Answer?,https://kriskrug.co/2005/08/19/booty-callshould-i-answer/,True,41,True,201,True,201
+post,649,canon-5d,Canon 5d,https://kriskrug.co/2005/08/18/canon-5d/,True,20,True,173,True,173
+post,648,just-another-soldier-a-year-on-the-ground-in-iraq,Just Another Soldier: A Year on the Ground in Iraq,https://kriskrug.co/2005/08/16/just-another-soldier-a-year-on-the-ground-in-iraq/,False,0,True,147,True,147
+post,669,10-hours-in-the-life-of-andy,10 Hours In The Life Of Andy,https://kriskrug.co/2005/08/15/10-hours-in-the-life-of-andy/,True,40,True,58,True,58
+post,647,new-canon-digital-camera-canon-5d-dslr,New Canon Digital Camera &#8211; Canon 5D DSLR,https://kriskrug.co/2005/08/10/new-canon-digital-camera-canon-5d-dslr/,True,52,True,176,True,176
+post,670,choosing-a-platform-for-the-telecentreorg-distributed-network,Choosing a Platform For The Telecentre.org Distributed Network,https://kriskrug.co/2005/08/10/choosing-a-platform-for-the-telecentreorg-distributed-network/,False,0,True,201,True,201
+post,671,choosing-drupal,Choosing Drupal,https://kriskrug.co/2005/08/10/choosing-drupal/,True,27,True,143,True,143
+post,672,evaluating-specific-cms-options,Evaluating Specific CMS Options,https://kriskrug.co/2005/08/09/evaluating-specific-cms-options/,True,43,True,31,True,31
+post,673,our-goal-a-platform-with-community-dna,Our Goal: A  Platform With Community DNA,https://kriskrug.co/2005/08/09/our-goal-a-platform-with-community-dna/,True,52,True,39,True,39
+post,674,envisioning-a-rss-based-distributed-network,Envisioning A RSS-Based Distributed Network,https://kriskrug.co/2005/08/09/envisioning-a-rss-based-distributed-network/,True,55,True,43,True,43
+post,675,oscon-aggregator-at-eventbloggingcom,OSCON Aggregator at EventBlogging.com,https://kriskrug.co/2005/08/02/oscon-aggregator-at-eventbloggingcom/,True,49,True,37,True,37
+post,646,drupal-geeks-at-oscon-2005-in-portland,My CMS Can Kick Your CMS&#8217;s Ass &#8211; Drupal Geeks at OSCON 2005 in Portland,https://kriskrug.co/2005/08/02/drupal-geeks-at-oscon-2005-in-portland/,False,0,True,130,True,130
+post,676,kk-clusters-on-flickr,kk Clusters on Flickr,https://kriskrug.co/2005/08/02/kk-clusters-on-flickr/,True,33,True,89,True,89
+post,677,interestingness,Interestingness!,https://kriskrug.co/2005/08/02/interestingness/,True,28,True,123,True,123
+post,645,oscon-pdx,OSCON &#8211; PDX,https://kriskrug.co/2005/08/01/oscon-pdx/,True,23,True,124,True,124
+post,678,grouphugus,GroupHug.us,https://kriskrug.co/2005/07/30/grouphugus/,True,23,True,52,True,52
+post,679,branding-blogging-mexican-and-a-rant-on-selling-out,"Branding, Blogging, Mexican and a Rant on Selling Out",https://kriskrug.co/2005/07/30/branding-blogging-mexican-and-a-rant-on-selling-out/,False,0,True,162,True,162
+post,680,the-misadventures-of-cross-processing-film,The Misadventures Of Cross-Processing Film,https://kriskrug.co/2005/07/28/the-misadventures-of-cross-processing-film/,True,54,True,201,True,201
+post,681,the-flickys,The Flickyâ€™s,https://kriskrug.co/2005/07/28/the-flickys/,True,26,True,62,True,62
+post,682,graphic-design-vancouver,Graphic Design Vancouver,https://kriskrug.co/2005/07/28/graphic-design-vancouver/,True,36,True,115,True,115
+post,683,lomography-ego-trip-photography-contest,Lomography Ego Trip Photography Contest,https://kriskrug.co/2005/07/28/lomography-ego-trip-photography-contest/,True,51,True,201,True,201
+post,613,top-10-must-have-gadgets-for-2005,Top 10 Must-Have Gadgets for 2005,https://kriskrug.co/2005/07/27/top-10-must-have-gadgets-for-2005/,True,45,True,182,True,182
+post,614,national-belgian-day-dinner-2005-at-chambar-in-vancouver-podcast,National Belgian Day Dinner 2005 at Chambar in Vancouver &#8211; Podcast,https://kriskrug.co/2005/07/27/national-belgian-day-dinner-2005-at-chambar-in-vancouver-podcast/,False,0,True,201,True,201
+post,615,the-zen-of-white-balance,The Zen of White Balance,https://kriskrug.co/2005/07/24/the-zen-of-white-balance/,True,36,True,188,True,188
+post,616,misanthropy-art-gallery-in-vancouver-closing-show,Misanthropy Art Gallery in Vancouver Closing Show,https://kriskrug.co/2005/07/23/misanthropy-art-gallery-in-vancouver-closing-show/,False,0,True,156,True,156
+post,617,community-business-minded-ness,Community Business Minded Ness,https://kriskrug.co/2005/07/23/community-business-minded-ness/,True,42,True,190,True,190
+post,618,the-future-of-publishing-conference,The Future of Publishing Conference,https://kriskrug.co/2005/07/22/the-future-of-publishing-conference/,True,47,True,201,True,201
+post,619,portrait-photography-tips,Portrait Photography Tips,https://kriskrug.co/2005/07/22/portrait-photography-tips/,True,37,True,201,True,201
+post,620,champ-krug-powazek-turingan,"Champ, Krug, Powazek, Turingan",https://kriskrug.co/2005/07/21/champ-krug-powazek-turingan/,True,42,True,186,True,186
+post,621,sajax-simple-ajax-toolkit,SAJAX &#8211; Simple Ajax Toolkit,https://kriskrug.co/2005/07/19/sajax-simple-ajax-toolkit/,True,39,True,188,True,188
+post,622,ajax-resources,Ajax Resources,https://kriskrug.co/2005/07/19/ajax-resources/,True,26,True,126,True,126
+post,612,usable-content-manifesto,Usable Content Manifesto,https://kriskrug.co/2005/07/19/usable-content-manifesto/,True,36,True,139,True,139
+post,623,beyond-robson-the-site-for-vancouver,Beyond Robson &#8211; the site for Vancouver,https://kriskrug.co/2005/07/18/beyond-robson-the-site-for-vancouver/,True,50,True,162,True,162
+post,611,eventblogging-webvisions-2005-in-portland,EventBlogging @ WebVisions 2005 in Portland,https://kriskrug.co/2005/07/15/eventblogging-webvisions-2005-in-portland/,True,55,True,147,True,147
+post,610,t-minus-7-hours-til-webvisions-2005,T Minus 7 Hours &#8216;Til WebVisions 2005,https://kriskrug.co/2005/07/14/t-minus-7-hours-til-webvisions-2005/,True,48,True,180,True,180
+post,624,losability-vs-usability,Losability vs. Usability,https://kriskrug.co/2005/07/11/losability-vs-usability/,True,36,True,196,True,196
+post,625,flickrbits,FlickrBits,https://kriskrug.co/2005/07/11/flickrbits/,True,22,True,49,True,49
+post,626,drupal-hosting-options,Drupal Hosting Options,https://kriskrug.co/2005/07/11/drupal-hosting-options/,True,34,True,130,True,130
+post,627,minimalist-photography-as-an-artform,Minimalist Photography As An Artform.,https://kriskrug.co/2005/07/11/minimalist-photography-as-an-artform/,True,49,True,184,True,184
+post,628,stencilrevolution-the-dark,stencilrevolution &#8211; the dark,https://kriskrug.co/2005/07/11/stencilrevolution-the-dark/,True,40,True,55,True,55
+post,629,stencilrevolution-nokin-gallery,stencilrevolution &#8211; nokin Gallery,https://kriskrug.co/2005/07/11/stencilrevolution-nokin-gallery/,True,45,True,61,True,61
+post,630,dodging-and-burning-in-the-digital-darkroom,Dodging and Burning in the Digital Darkroom,https://kriskrug.co/2005/07/10/dodging-and-burning-in-the-digital-darkroom/,True,55,True,146,True,146
+post,609,boris-mann-speaks-geek-to-michelle-mill-of-global-tv,Boris Mann Speaks Geek to Michelle Mill of Global TV,https://kriskrug.co/2005/07/08/boris-mann-speaks-geek-to-michelle-mill-of-global-tv/,False,0,True,159,True,159
+post,631,ourmedia-nominated-for-global-award,Ourmedia Nominated for Global Award,https://kriskrug.co/2005/07/08/ourmedia-nominated-for-global-award/,True,47,True,200,True,200
+post,632,magnificent-seven-bryght-gets-a-music-czar,Magnificent Seven: Bryght gets a Music Czar,https://kriskrug.co/2005/07/08/magnificent-seven-bryght-gets-a-music-czar/,True,55,True,163,True,163
+post,633,8-simple-rules-for-making-those-big-ticket-photography-purchases,8 Simple Rules for Making Those Big-Ticket Photography Purchases,https://kriskrug.co/2005/07/07/8-simple-rules-for-making-those-big-ticket-photography-purchases/,False,0,True,140,True,140
+post,634,steve-ballmer-on-evangelism-innovation-and-maybe-halo-3,"Steve Ballmer on Evangelism, Innovation and Maybe Halo 3",https://kriskrug.co/2005/07/07/steve-ballmer-on-evangelism-innovation-and-maybe-halo-3/,False,0,True,194,True,194
+post,635,leanne-chan-rory-richards-and-kris-krug-podcast-from-the-bryght-office,"Leanne Chan, Rory Richards and Kris Krug Podcast from the Bryght Office",https://kriskrug.co/2005/07/07/leanne-chan-rory-richards-and-kris-krug-podcast-from-the-bryght-office/,False,0,True,201,True,201
+post,636,im-cd-swapping,I&#8217;m CD Swapping,https://kriskrug.co/2005/07/07/im-cd-swapping/,True,27,True,77,True,77
+post,637,good-blog-consultants-are-definitely-more-than-just-implementers,Good Blog Consultants are Definitely More Than Just Implementers.,https://kriskrug.co/2005/07/07/good-blog-consultants-are-definitely-more-than-just-implementers/,False,0,True,201,True,201
+post,638,drupal-ajax-usability,Drupal Ajax Usability,https://kriskrug.co/2005/07/07/drupal-ajax-usability/,True,33,True,119,True,119
+post,639,web-20-definition-from-wikipedia,Web 2.0 Definition From Wikipedia,https://kriskrug.co/2005/07/06/web-20-definition-from-wikipedia/,True,45,True,201,True,201
+post,640,design-for-web-20,Design for Web 2.0,https://kriskrug.co/2005/07/06/design-for-web-20/,True,30,True,153,True,153
+post,641,150-things-you-can-do-to-build-social-capital,150 Things You Can Do To Build Social Capital,https://kriskrug.co/2005/07/05/150-things-you-can-do-to-build-social-capital/,True,57,True,131,True,131
+post,642,eamonns-home-flickring-families,Eamonn&#8217;s Home: Flickring Families,https://kriskrug.co/2005/07/05/eamonns-home-flickring-families/,True,45,True,149,True,149
+post,643,top-20-most-downloaded-drupal-projects,Top-20 Most Downloaded Drupal projects,https://kriskrug.co/2005/07/04/top-20-most-downloaded-drupal-projects/,True,50,True,192,True,192
+post,644,sonic-heart-magazine-new-englands-electronic-music-magazine,Sonic Heart Magazine | New England&#8217;s Electronic Music Magazine,https://kriskrug.co/2005/07/04/sonic-heart-magazine-new-englands-electronic-music-magazine/,False,0,True,166,True,166
+post,579,web-20-for-events-aggregating-content-around-events,Web 2.0 For Events: Aggregating Content Around Events,https://kriskrug.co/2005/06/30/web-20-for-events-aggregating-content-around-events/,False,0,True,166,True,166
+post,580,dogma-radio-interviews-richard-macmanus,Dogma Radio Interviews Richard MacManus,https://kriskrug.co/2005/06/30/dogma-radio-interviews-richard-macmanus/,True,51,True,156,True,156
+post,581,develop-your-own-location-based-services-using-google-maps,Develop Your Own Location-Based Services Using Google Maps,https://kriskrug.co/2005/06/29/develop-your-own-location-based-services-using-google-maps/,False,0,True,152,True,152
+post,582,thoughts-on-digital-photography,Thoughts on Digital Photography,https://kriskrug.co/2005/06/29/thoughts-on-digital-photography/,True,43,True,188,True,188
+post,583,calendar-swamp,Calendar Swamp,https://kriskrug.co/2005/06/29/calendar-swamp/,True,26,True,133,True,133
+post,578,photos-from-gnomedex,Photos From Gnomedex,https://kriskrug.co/2005/06/28/photos-from-gnomedex/,True,32,True,184,True,184
+post,577,flickr-photographr-badge,Flickr Photographr Badge,https://kriskrug.co/2005/06/28/flickr-photographr-badge/,True,36,False,0,False,0
+post,584,bugmenot-on-steriods,BugMeNot on Steriods,https://kriskrug.co/2005/06/28/bugmenot-on-steriods/,True,32,True,167,True,167
+post,576,the-11-layers-of-citizen-journalism,The 11 Layers of Citizen Journalism,https://kriskrug.co/2005/06/28/the-11-layers-of-citizen-journalism/,True,47,True,198,True,198
+post,585,knowing-full-well-that-anybody-who-wanted-to-read-the-site-could,Knowing Full Well That Anybody Who Wanted to Read the Site Could,https://kriskrug.co/2005/06/26/knowing-full-well-that-anybody-who-wanted-to-read-the-site-could/,False,0,True,201,True,201
+post,575,bryght-crew-going-into-gnomedex-50,Bryght Crew going into Gnomedex 5.0,https://kriskrug.co/2005/06/26/bryght-crew-going-into-gnomedex-50/,True,47,True,55,True,55
+post,586,drupal-goes-to-11-projects-on-googles-summer-of-code-project,Drupal Goes to 11 Projects On Google&#8217;s Summer of Code Project,https://kriskrug.co/2005/06/25/drupal-goes-to-11-projects-on-googles-summer-of-code-project/,False,0,True,127,True,127
+post,574,browse-search-subscribe-longhorn-loves-rss,Browse. Search. Subscribe. Microsoft Longhorn Loves RSS.,https://kriskrug.co/2005/06/24/browse-search-subscribe-longhorn-loves-rss/,False,0,True,146,True,146
+post,573,top-ten-signs-you-spend-too-much-time-thinking-about-web-20,Top Ten Signs You Spend Too Much Time Thinking About Web 2.0,https://kriskrug.co/2005/06/24/top-ten-signs-you-spend-too-much-time-thinking-about-web-20/,False,0,True,199,True,199
+post,587,joe-kraus-joined-the-board-of-the-electronic-frontier-foundation-eff,Joe Kraus joined the board of the Electronic Frontier Foundation (EFF).,https://kriskrug.co/2005/06/23/joe-kraus-joined-the-board-of-the-electronic-frontier-foundation-eff/,False,0,True,167,True,167
+post,588,raincity-studios-disinfomercial,RainCity Studios Disinfomercial,https://kriskrug.co/2005/06/23/raincity-studios-disinfomercial/,True,43,True,130,True,130
+post,589,does-this-count-as-podcasting,Does This Count as Podcasting?,https://kriskrug.co/2005/06/23/does-this-count-as-podcasting/,True,42,True,50,True,50
+post,590,an-isp-and-government-controlled-monopoly-in-the-united-arab-emirates-has-decided-to-ban-access-to-flickr-for-its-citizens,An ISP (and government controlled monopoly) in the United Arab Emirates has decided to ban access to Flickr for it&#8217;s citizens,https://kriskrug.co/2005/06/23/an-isp-and-government-controlled-monopoly-in-the-united-arab-emirates-has-decided-to-ban-access-to-flickr-for-its-citizens/,False,0,True,201,True,201
+post,591,bundled-feed-for-gnomedex,&#8216;Bundled Feed&#8217; for Gnomedex,https://kriskrug.co/2005/06/23/bundled-feed-for-gnomedex/,True,39,True,165,True,165
+post,592,google-adsense-is-my-business-model,Google Adsense is My Business Model,https://kriskrug.co/2005/06/23/google-adsense-is-my-business-model/,True,47,True,185,True,185
+post,572,you-gotta-set-it-to-forget-it,"You Gotta Set It, To Forget it",https://kriskrug.co/2005/06/23/you-gotta-set-it-to-forget-it/,True,42,True,41,True,41
+post,593,bill-gates-to-make-microsoft-podcasting-announcment-at-gnomedex,Bill Gates to make Microsoft podcasting announcment at Gnomedex?,https://kriskrug.co/2005/06/22/bill-gates-to-make-microsoft-podcasting-announcment-at-gnomedex/,False,0,True,201,True,201
+post,594,really-delicious-easy-shared-bookmarks,Really del.icio.us &#8211; Easy Shared Bookmarks,https://kriskrug.co/2005/06/22/really-delicious-easy-shared-bookmarks/,True,54,True,181,True,181
+post,595,hey-have-you-heard-the-one-about-the-new-buddhist-vaccum-cleaner,"Hey, have you heard the one about the new Buddhist vaccum cleaner?",https://kriskrug.co/2005/06/21/hey-have-you-heard-the-one-about-the-new-buddhist-vaccum-cleaner/,False,0,True,100,True,100
+post,596,the-guide-on-learning-styles-and-style-discovery-test,The Guide on Learning Styles and Style Discovery Test,https://kriskrug.co/2005/06/21/the-guide-on-learning-styles-and-style-discovery-test/,False,0,True,185,True,185
+post,597,odeo-launches,Odeo Launches!,https://kriskrug.co/2005/06/21/odeo-launches/,True,26,True,192,True,192
+post,598,bram-cohen-says-microsofts-torrent-killer-avalanche-is-nothing-but-vaporware,Bram Cohen Says Microsoftâ€™s Torrent Killer Avalanche is Nothing But Vaporware,https://kriskrug.co/2005/06/21/bram-cohen-says-microsofts-torrent-killer-avalanche-is-nothing-but-vaporware/,False,0,True,171,True,171
+post,599,introducing-theopen-media-100,Introducing theOpen Media 100,https://kriskrug.co/2005/06/21/introducing-theopen-media-100/,True,41,True,201,True,201
+post,600,what-are-microformats,What Are MicroFormats?,https://kriskrug.co/2005/06/21/what-are-microformats/,True,34,True,171,True,171
+post,601,10-steps-to-rsstocracy-with-bloglines,10 steps to RSStocracy with Bloglines,https://kriskrug.co/2005/06/21/10-steps-to-rsstocracy-with-bloglines/,True,49,True,116,True,116
+post,602,digital-web-magazinewebvisions-scavanger-hunt,Digital-Web Magazine/WebVisions Scavanger Hunt,https://kriskrug.co/2005/06/20/digital-web-magazinewebvisions-scavanger-hunt/,True,58,True,201,True,201
+post,603,rss-and-news-aggregators-opportunity-or-threat,RSS and News Aggregators: Opportunity or Threat?,https://kriskrug.co/2005/06/20/rss-and-news-aggregators-opportunity-or-threat/,True,60,True,200,True,200
+post,604,shifting-paradigms-the-mental-evolutionary-process-of-moving-from-web-10-to-web-20-in-17-steps,Shifting Paradigms: The Mental Evolutionary Process of Moving from Web 1.0 to Web 2.0 in 17 Steps,https://kriskrug.co/2005/06/20/shifting-paradigms-the-mental-evolutionary-process-of-moving-from-web-10-to-web-20-in-17-steps/,False,0,True,201,True,201
+post,605,marc-canter-is-announcing-reblgcom,Marc Canter is Announcing ReBlg.com,https://kriskrug.co/2005/06/20/marc-canter-is-announcing-reblgcom/,True,47,True,161,True,161
+post,606,vancouver-alternative-center-for-web-20-business,Vancouver &#8211; Alternative Center for Web 2.0 Business?,https://kriskrug.co/2005/06/20/vancouver-alternative-center-for-web-20-business/,False,0,True,199,True,199
+post,570,dave-call-my-friend-donald-at-rethreads,"Dave, Call My Friend Donald At Rethreads",https://kriskrug.co/2005/06/20/dave-call-my-friend-donald-at-rethreads/,True,52,True,166,True,166
+post,607,whirlwind-podcast-between-roland-boris-and-marc-canter,"Whirlwind podcast between Roland, Boris and Marc Canter",https://kriskrug.co/2005/06/20/whirlwind-podcast-between-roland-boris-and-marc-canter/,False,0,True,201,True,201
+post,608,better-digital-photography-market-your-photography-business,Better Digital Photography: Market Your Photography Business,https://kriskrug.co/2005/06/20/better-digital-photography-market-your-photography-business/,False,0,True,167,True,167
+post,569,this-is-my-canon-20d-falling-off-its-tripod,This is My Canon 20d&#8230; Falling Off Its Tripod. :(,https://kriskrug.co/2005/06/19/this-is-my-canon-20d-falling-off-its-tripod/,False,0,True,195,True,195
+post,568,summer-street-portraits,Summer Street Portraits,https://kriskrug.co/2005/06/17/summer-street-portraits/,True,35,True,139,True,139
+post,562,lightweight-user-generated-business-models,LightWeight User Generated Business Models,https://kriskrug.co/2005/06/09/lightweight-user-generated-business-models/,True,54,True,131,True,131
+post,563,less-cursing-better-pictures-10-suggestions,"Less Cursing, Better Pictures: 10 Suggestions",https://kriskrug.co/2005/06/09/less-cursing-better-pictures-10-suggestions/,True,57,True,131,True,131
+post,564,flickr-schwag-10-baby,"Flickr Schwag 1.0, baby!",https://kriskrug.co/2005/06/07/flickr-schwag-10-baby/,True,36,True,140,True,140
+post,565,paper-airplane-and-the-two-way-web-a-collaborative-and-decentralized-world-wide-web,Paper Airplane and The Two Way Web: A Collaborative and Decentralized World Wide Web,https://kriskrug.co/2005/06/06/paper-airplane-and-the-two-way-web-a-collaborative-and-decentralized-world-wide-web/,False,0,True,201,True,201
+post,566,wwjdt-what-would-jesus-dance-to,WWJDT: What Would Jesus Dance To?,https://kriskrug.co/2005/06/06/wwjdt-what-would-jesus-dance-to/,True,45,True,201,True,201
+post,567,progressive-u,Progressive U,https://kriskrug.co/2005/06/06/progressive-u/,True,25,True,85,True,85
+post,61,blogging-grows-up,Blogging Grows Up,https://kriskrug.co/2004/08/19/blogging-grows-up/,True,29,True,201,True,201
+post,63,cubicles-suck-not-just-for-hackers,Cubicles Suck &#8211; Not Just for Hackers,https://kriskrug.co/2004/08/09/cubicles-suck-not-just-for-hackers/,True,48,True,144,True,144
+post,64,syndicate-this-site-news-feeds-rss-xml-and-atom,"Syndicate this site! News feeds, RSS, XML, and Atom.",https://kriskrug.co/2004/08/02/syndicate-this-site-news-feeds-rss-xml-and-atom/,False,0,True,182,True,182
+post,65,michael-c-place-build-design-interview,"Michael C. Place,  Build Design &#8211;  Interview",https://kriskrug.co/2004/08/02/michael-c-place-build-design-interview/,True,56,True,168,True,168
+post,50,jeremy-crowle-interview,Jeremy Crowle  &#8211; Interview,https://kriskrug.co/2004/07/30/jeremy-crowle-interview/,True,38,True,158,True,158
+post,51,look-at-me-everyone-im-pretending-im-hardcore,Look at Me Everyone&#8230; I&#8217;m Pretending I&#8217;m Hardcore!,https://kriskrug.co/2004/07/28/look-at-me-everyone-im-pretending-im-hardcore/,False,0,True,140,True,140
+post,53,blog-search-engines-directories-and-listings,"Blog Search Engines, Directories, and Listings",https://kriskrug.co/2004/07/23/blog-search-engines-directories-and-listings/,True,58,True,174,True,174
+post,54,spark-online-version-20-brainstorming,*spark-online Version 2.0 Brainstorming,https://kriskrug.co/2004/07/23/spark-online-version-20-brainstorming/,True,51,True,160,True,160
+post,55,design-and-your-strategy,Design and your strategy,https://kriskrug.co/2004/07/23/design-and-your-strategy/,True,36,True,190,True,190
+post,56,web-design-the-usual-suspects,Web Design: The Usual Suspects,https://kriskrug.co/2004/07/22/web-design-the-usual-suspects/,True,42,True,198,True,198
+post,57,george-w-bush-negative-capability,George W. Bush &#8211; Negative Capability,https://kriskrug.co/2004/07/17/george-w-bush-negative-capability/,True,48,True,169,True,169
+post,58,mcsweeneys-lists,McSweeney&#8217;s Lists,https://kriskrug.co/2004/07/16/mcsweeneys-lists/,True,29,True,201,True,201
+post,59,shout-outs-vancouver-edition,Shout-outs. Vancouver Edition.,https://kriskrug.co/2004/07/13/shout-outs-vancouver-edition/,True,42,True,163,True,163
+post,60,nightmare-job-marcom-for-chevrontexaco,Nightmare Job &#8211; MarCom for ChevronTexaco,https://kriskrug.co/2004/07/09/nightmare-job-marcom-for-chevrontexaco/,True,52,True,201,True,201
+post,41,omg,OMG!!!,https://kriskrug.co/2004/06/29/omg/,True,18,True,69,True,69
+post,42,supermodel-personal-ads,Supermodel Personal Ads,https://kriskrug.co/2004/06/14/supermodel-personal-ads/,True,35,True,192,True,192
+post,43,some-big-ass-comanies,Some Big-Ass Comanies!,https://kriskrug.co/2004/06/11/some-big-ass-comanies/,True,34,True,91,True,91
+post,44,gmail-invitation-prices-crash,Gmail Invitation Prices Crash,https://kriskrug.co/2004/06/11/gmail-invitation-prices-crash/,True,41,True,198,True,198
+post,45,redwood-coast-roadtrip,Redwood Coast &#8211; ROADTRIP,https://kriskrug.co/2004/06/08/redwood-coast-roadtrip/,True,36,True,201,True,201
+post,47,michael-moores-new-film-fahrenheit-911,Michael Moore&#8217;s New Film Fahrenheit 9/11,https://kriskrug.co/2004/06/03/michael-moores-new-film-fahrenheit-911/,True,52,True,201,True,201
+post,48,transcendent-materialist,Transcendent Materialist,https://kriskrug.co/2004/06/02/transcendent-materialist/,True,36,True,130,True,130
+post,49,lexicon,Lexicon,https://kriskrug.co/2004/06/01/lexicon/,True,19,True,200,True,200
+post,34,purveyor-of-cool,Purveyor of Cool?,https://kriskrug.co/2004/05/28/purveyor-of-cool/,True,29,True,188,True,188
+post,35,the-lord-of-the-rings-drinking-game,The Lord of the Rings Drinking Game,https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/,True,47,True,166,True,166
+post,37,the-business-of-design,The Business of Design,https://kriskrug.co/2004/05/26/the-business-of-design/,True,34,True,201,True,201
+post,38,spring-bling,Spring Bling!,https://kriskrug.co/2004/05/20/spring-bling/,True,25,True,201,True,201
+post,39,losing-the-war,Losing the War?,https://kriskrug.co/2004/05/13/losing-the-war/,True,27,True,151,True,151
+post,40,gmail-plaxo-and-linkedin,"Gmail, Plaxo, and LinkedIn",https://kriskrug.co/2004/05/11/gmail-plaxo-and-linkedin/,True,38,True,187,True,187
+post,32,five-and-dime,five and dime,https://kriskrug.co/2004/04/29/five-and-dime/,True,25,True,161,True,161
+post,33,120-gigs-and-counting,120 Gigs and Counting,https://kriskrug.co/2004/04/02/120-gigs-and-counting/,True,33,True,138,True,138
+post,25,testing-testing-1-2-1-2-3-4,Testing Testing 1 2&#8230; 1 2 3 4.,https://kriskrug.co/2003/10/14/testing-testing-1-2-1-2-3-4/,True,43,True,4,True,4
+page,12322,indigenous-ai,Indigenous &#038; Reconciliation in Tech,https://kriskrug.co/indigenous-ai/,True,47,True,144,False,0
+page,12321,ai-tools,Generative AI Tools,https://kriskrug.co/ai-tools/,True,43,True,156,False,0
+page,12320,ai-for-journalists,AI for Journalism &#038; Media,https://kriskrug.co/ai-for-journalists/,True,43,True,148,False,0
+page,12319,ai-conversations,Conversations &#038; Interviews,https://kriskrug.co/ai-conversations/,True,41,True,146,False,0
+page,12318,ai-ethics,AI Ethics &#038; Philosophy,https://kriskrug.co/ai-ethics/,True,61,True,156,False,0
+page,12317,ai-events,AI Events &#038; Recaps,https://kriskrug.co/ai-events/,True,51,True,155,False,0
+page,12316,ai-for-creatives,AI for Creatives,https://kriskrug.co/ai-for-creatives/,True,50,True,155,False,0
+page,12315,vancouver-ai,Vancouver AI Ecosystem,https://kriskrug.co/vancouver-ai/,True,58,True,149,False,0
+page,12013,photography,Photography,https://kriskrug.co/photography/,False,0,False,0,False,0
+page,11914,responsible-ai-professional,Responsible AI Professional Certification,https://kriskrug.co/responsible-ai-professional/,False,0,False,0,False,0
+page,7764,cinematic-podcasts-hollywood-grade-storytelling-meets-generative-ai,Cinematic Podcasts: Hollywood-Grade Storytelling Meets Generative AI,https://kriskrug.co/cinematic-podcasts-hollywood-grade-storytelling-meets-generative-ai/,False,0,False,0,False,0
+page,7610,ai-upgrade-for-modern-media-leaders,AI Upgrade for Modern Media Leaders,https://kriskrug.co/ai-upgrade-for-modern-media-leaders/,False,0,False,0,False,0
+page,6770,ai-upgrade-for-creative-professionals,AI Upgrade for Creative Professionals,https://kriskrug.co/ai-upgrade-for-creative-professionals/,False,0,False,0,False,0
+page,6755,ai-upgrade-community-coaching-w-kris-krug-peter-bittner,AI Upgrade Community Coaching w/ Kris Krug &amp; Peter Bittner,https://kriskrug.co/ai-upgrade-community-coaching-w-kris-krug-peter-bittner/,False,0,False,0,False,0
+page,3609,podcast-guesting-page-epk,"Podcast Guest, AI Commentator, Event Host",https://kriskrug.co/podcast-guesting-page-epk/,True,53,True,153,False,0
+page,3974,product-review-policy-instructions,Product Review Policy &amp; Instructions,https://kriskrug.co/product-review-policy-instructions/,False,0,False,0,False,0
+page,3969,sponsor-cyberpunk-chronicles-newsletter,Cyberpunk Chronicles Newsletter Sponsor Guide,https://kriskrug.co/sponsor-cyberpunk-chronicles-newsletter/,False,0,False,0,False,0
+page,3948,the-kk-worldview,The KK Worldview,https://kriskrug.co/the-kk-worldview/,False,0,False,0,False,0
+page,3899,reconciliation-indigenous-land-acknowledgement,Reconciliation &#038; Indigenous Land Acknowledgement,https://kriskrug.co/reconciliation-indigenous-land-acknowledgement/,False,0,False,0,False,0
+page,3930,empowering-events-organizations-for-the-ai-age,"{'raw': '', 'rendered': ''}",https://kriskrug.co/,False,0,True,155,False,0
+page,3696,urdu-language-introduction-kris-krug,Urdu Language Introduction &#8211; Kris Krüg,https://kriskrug.co/urdu-language-introduction-kris-krug/,True,26,True,254,False,0
+page,3600,russian-introduction-kristofor-kruglov,Russian Introduction &#8211; Kristofor Kruglov,https://kriskrug.co/russian-introduction-kristofor-kruglov/,True,29,True,254,False,0
+page,3603,swahili-introduction-kintu-krowfeather-karibu-kwenye-kabila-la-kidijitali-la-dunia-la-kris-krug-kuunganisha-dunia-kupitia-lugha-na-teknolojia,Swahili Introduction &#8211; Kintu Krowfeather &#8211; Karibu kwenye Kabila la Kidijitali la Dunia la Kris Krüg: Kuunganisha Dunia Kupitia Lugha na Teknolojia,https://kriskrug.co/swahili-introduction-kintu-krowfeather-karibu-kwenye-kabila-la-kidijitali-la-dunia-la-kris-krug-kuunganisha-dunia-kupitia-lugha-na-teknolojia/,True,20,True,205,False,0
+page,3595,japanese-introduction-page-kaykaysan,Japanese Introduction Page &#8211; KayKaySan,https://kriskrug.co/japanese-introduction-page-kaykaysan/,False,0,False,0,False,0
+page,3606,hindi-introduction-krishna-vishwanathapriyadhanvanshi,Hindi Introduction &#8211; Krishna Vishwanathapriyadhanvanshi,https://kriskrug.co/hindi-introduction-krishna-vishwanathapriyadhanvanshi/,False,0,False,0,False,0
+page,3598,chinese-introduction-kang-jia,Chinese Introduction &#8211; Kang Jia,https://kriskrug.co/chinese-introduction-kang-jia/,False,0,False,0,False,0
+page,3601,farsi-introduction-khalil-khalifa,Farsi Introduction &#8211; Khalil Khalifa,https://kriskrug.co/farsi-introduction-khalil-khalifa/,False,0,False,0,False,0
+page,3623,karibu-kwenye-kabila-la-kidijitali-la-dunia-la-kris-krug-kuunganisha-dunia-kupitia-lugha-na-teknolojia-swahili-welcome-page,Karibu kwenye Kabila la Kidijitali la Dunia la Kris Krüg: Kuunganisha Dunia Kupitia Lugha na Teknolojia &#8211; Swahili Welcome Page,https://kriskrug.co/karibu-kwenye-kabila-la-kidijitali-la-dunia-la-kris-krug-kuunganisha-dunia-kupitia-lugha-na-teknolojia-swahili-welcome-page/,False,0,False,0,False,0
+page,2985,privacy-policy,KK Pledge to Privacy,https://kriskrug.co/privacy-policy/,False,0,False,0,False,0
+page,2672,recent-projects-include,Work,https://kriskrug.co/recent-projects-include/,True,16,True,153,False,0
+page,2828,motleykrug-podcast,Kris Krüg&#8217;s MØTLEYKRÜG Podcast,https://kriskrug.co/motleykrug-podcast/,False,0,False,0,False,0
+page,2808,subscribe,"{'raw': '', 'rendered': ''}",https://kriskrug.co/subscribe/,True,46,True,177,False,0
+page,2666,generative-ai-services,Generative AI Creative Services &amp; Strategy,https://kriskrug.co/generative-ai-services/,False,0,True,158,False,0
+page,2603,generative-ai-workshop-for-artists-creatives,Generative AI &#038; Creative Potential Workshops,https://kriskrug.co/generative-ai-workshop-for-artists-creatives/,False,0,False,0,False,0
+page,2543,art-island-perspectives-from-a-creative-community,Art Island: Perspectives from a Creative Community,https://kriskrug.co/art-island-perspectives-from-a-creative-community/,False,0,False,0,False,0
+page,2418,contact,Contact Kris Krüg,https://kriskrug.co/contact/,False,0,True,152,False,0
+page,2409,testimonials,Testimonials,https://kriskrug.co/testimonials/,False,0,False,0,False,0
+page,2389,news,News,https://kriskrug.co/news/,False,0,False,0,False,0
+page,2316,blog,Blog,https://kriskrug.co/blog/,False,0,True,154,False,0
+page,2315,home,Recent Posts &amp; Updates:,https://kriskrug.co/home/,False,0,False,0,False,0
+page,2250,events,Events,https://kriskrug.co/events/,False,0,False,0,False,0
+page,1895,publications,Publications,https://kriskrug.co/publications/,True,52,True,127,False,0
+page,1887,speaking,AI Keynote Speaker Kris Krüg,https://kriskrug.co/speaking/,True,68,True,150,False,0
+page,1208,about,About Kris Krüg,https://kriskrug.co/about/,True,71,True,158,False,0

--- a/docs/current-state/reports/seo-backfill-20260617-160047Z.md
+++ b/docs/current-state/reports/seo-backfill-20260617-160047Z.md
@@ -1,0 +1,20 @@
+# SEO metadata backfill report — dry-run
+
+- Generated: 2026-06-17T16:00:47Z
+- Mode: **dry-run** · kind: post · fields: meta_desc
+- Filters: order=idlist limit=all since=- ids=yes
+- Probe: n/a (dry-run)
+- Backup: n/a (dry-run)
+
+## Counts
+- candidates: 1
+- **written: 0**  (dry-run — nothing written)
+- planned (dry-run): 1
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 577 | flickr-photographr-badge | planned | advanced_seo_description |  |  |

--- a/docs/current-state/reports/seo-backfill-20260617-160053Z.md
+++ b/docs/current-state/reports/seo-backfill-20260617-160053Z.md
@@ -1,0 +1,41 @@
+# SEO metadata backfill report — dry-run
+
+- Generated: 2026-06-17T16:00:53Z
+- Mode: **dry-run** · kind: page · fields: meta_desc
+- Filters: order=idlist limit=all since=- ids=yes
+- Probe: n/a (dry-run)
+- Backup: n/a (dry-run)
+
+## Counts
+- candidates: 22
+- **written: 0**  (dry-run — nothing written)
+- planned (dry-run): 22
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 12013 | photography | planned | advanced_seo_description |  |  |
+| 11914 | responsible-ai-professional | planned | advanced_seo_description |  |  |
+| 7764 | cinematic-podcasts-hollywood-grade-story | planned | advanced_seo_description |  |  |
+| 7610 | ai-upgrade-for-modern-media-leaders | planned | advanced_seo_description |  |  |
+| 6770 | ai-upgrade-for-creative-professionals | planned | advanced_seo_description |  |  |
+| 6755 | ai-upgrade-community-coaching-w-kris-kru | planned | advanced_seo_description |  |  |
+| 3974 | product-review-policy-instructions | planned | advanced_seo_description |  |  |
+| 3969 | sponsor-cyberpunk-chronicles-newsletter | planned | advanced_seo_description |  |  |
+| 3948 | the-kk-worldview | planned | advanced_seo_description |  |  |
+| 3899 | reconciliation-indigenous-land-acknowled | planned | advanced_seo_description |  |  |
+| 3595 | japanese-introduction-page-kaykaysan | planned | advanced_seo_description |  |  |
+| 3606 | hindi-introduction-krishna-vishwanathapr | planned | advanced_seo_description |  |  |
+| 3598 | chinese-introduction-kang-jia | planned | advanced_seo_description |  |  |
+| 3601 | farsi-introduction-khalil-khalifa | planned | advanced_seo_description |  |  |
+| 3623 | karibu-kwenye-kabila-la-kidijitali-la-du | planned | advanced_seo_description |  |  |
+| 2985 | privacy-policy | planned | advanced_seo_description |  |  |
+| 2828 | motleykrug-podcast | planned | advanced_seo_description |  |  |
+| 2603 | generative-ai-workshop-for-artists-creat | planned | advanced_seo_description |  |  |
+| 2543 | art-island-perspectives-from-a-creative- | planned | advanced_seo_description |  |  |
+| 2409 | testimonials | planned | advanced_seo_description |  |  |
+| 2389 | news | planned | advanced_seo_description |  |  |
+| 2250 | events | planned | advanced_seo_description |  |  |

--- a/docs/current-state/reports/seo-backfill-20260617-160130Z.md
+++ b/docs/current-state/reports/seo-backfill-20260617-160130Z.md
@@ -1,0 +1,20 @@
+# SEO metadata backfill report — live
+
+- Generated: 2026-06-17T16:01:30Z
+- Mode: **live** · kind: post · fields: meta_desc
+- Filters: order=idlist limit=all since=- ids=yes
+- Probe: PASS on post 11878
+- Backup: NONE — additive meta-only write; every change recorded below for trivial revert (set field back to empty). KK acknowledged pilot-without-backup.
+
+## Counts
+- candidates: 1
+- **written: 1**
+- planned (dry-run): 0
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 577 | flickr-photographr-badge | written | advanced_seo_description |  |  |

--- a/docs/current-state/reports/seo-backfill-20260617-160229Z.md
+++ b/docs/current-state/reports/seo-backfill-20260617-160229Z.md
@@ -1,0 +1,41 @@
+# SEO metadata backfill report — live
+
+- Generated: 2026-06-17T16:02:29Z
+- Mode: **live** · kind: page · fields: meta_desc
+- Filters: order=idlist limit=all since=- ids=yes
+- Probe: PASS on post 11878
+- Backup: NONE — additive meta-only write; every change recorded below for trivial revert (set field back to empty). KK acknowledged pilot-without-backup.
+
+## Counts
+- candidates: 22
+- **written: 22**
+- planned (dry-run): 0
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 12013 | photography | written | advanced_seo_description |  |  |
+| 11914 | responsible-ai-professional | written | advanced_seo_description |  |  |
+| 7764 | cinematic-podcasts-hollywood-grade-story | written | advanced_seo_description |  |  |
+| 7610 | ai-upgrade-for-modern-media-leaders | written | advanced_seo_description |  |  |
+| 6770 | ai-upgrade-for-creative-professionals | written | advanced_seo_description |  |  |
+| 6755 | ai-upgrade-community-coaching-w-kris-kru | written | advanced_seo_description |  |  |
+| 3974 | product-review-policy-instructions | written | advanced_seo_description |  |  |
+| 3969 | sponsor-cyberpunk-chronicles-newsletter | written | advanced_seo_description |  |  |
+| 3948 | the-kk-worldview | written | advanced_seo_description |  |  |
+| 3899 | reconciliation-indigenous-land-acknowled | written | advanced_seo_description |  |  |
+| 3595 | japanese-introduction-page-kaykaysan | written | advanced_seo_description |  |  |
+| 3606 | hindi-introduction-krishna-vishwanathapr | written | advanced_seo_description |  |  |
+| 3598 | chinese-introduction-kang-jia | written | advanced_seo_description |  |  |
+| 3601 | farsi-introduction-khalil-khalifa | written | advanced_seo_description |  |  |
+| 3623 | karibu-kwenye-kabila-la-kidijitali-la-du | written | advanced_seo_description |  |  |
+| 2985 | privacy-policy | written | advanced_seo_description |  |  |
+| 2828 | motleykrug-podcast | written | advanced_seo_description |  |  |
+| 2603 | generative-ai-workshop-for-artists-creat | written | advanced_seo_description |  |  |
+| 2543 | art-island-perspectives-from-a-creative- | written | advanced_seo_description |  |  |
+| 2409 | testimonials | written | advanced_seo_description |  |  |
+| 2389 | news | written | advanced_seo_description |  |  |
+| 2250 | events | written | advanced_seo_description |  |  |

--- a/docs/current-state/reports/seo-overwrite-20260617-160047Z.md
+++ b/docs/current-state/reports/seo-overwrite-20260617-160047Z.md
@@ -1,0 +1,20 @@
+# SEO metadata backfill report — dry-run (overwrite from seo-crafted-approved-2026-06-17-pages.json)
+
+- Generated: 2026-06-17T16:00:47Z
+- Mode: **dry-run (overwrite from seo-crafted-approved-2026-06-17-pages.json)** · kind: page · fields: approved
+- Filters: from-file=seo-crafted-approved-2026-06-17-pages.json
+- Probe: n/a
+- Backup: overwrite — prior values recorded per-item for rollback
+
+## Counts
+- candidates: 1
+- **written: 0**
+- planned (dry-run): 1
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 2315 | home | planned | advanced_seo_description |  |  |

--- a/docs/current-state/reports/seo-overwrite-20260617-160739Z.md
+++ b/docs/current-state/reports/seo-overwrite-20260617-160739Z.md
@@ -1,0 +1,25 @@
+# SEO metadata backfill report — live (overwrite from seo-crafted-approved-2026-06-17-pages.json)
+
+- Generated: 2026-06-17T16:07:39Z
+- Mode: **live (overwrite from seo-crafted-approved-2026-06-17-pages.json)** · kind: page · fields: approved
+- Filters: from-file=seo-crafted-approved-2026-06-17-pages.json
+- Probe: n/a
+- Backup: overwrite — prior values recorded per-item for rollback
+
+## Counts
+- candidates: 1
+- **written: 1**
+- planned (dry-run): 0
+- skipped: 0
+- **failed: 0**
+
+## Per-item
+
+| id | slug | status | fields | flags | reason |
+|---|---|---|---|---|---|
+| 2315 | home | written | advanced_seo_description |  |  |
+
+## Prior values (rollback record — overwrite mode)
+
+- **2315** home:
+    - `advanced_seo_description`: was “∅empty”

--- a/docs/current-state/reports/wp-post-ia-media-rollout-20260617-dry-run.md
+++ b/docs/current-state/reports/wp-post-ia-media-rollout-20260617-dry-run.md
@@ -1,0 +1,46 @@
+# Single-Post IA + Media Rollout Report (2026-06-17)
+
+- Generated: 2026-06-17 09:10:51
+- Cohort: published posts since `2025-01-01`
+- Mode: dry-run
+- Pilot slug: `make-culture-not-content`
+- Pilot media ID: `11264`
+
+## Before/After Counts
+
+| Metric | Before | After |
+| --- | --- | --- |
+| Published posts audited | 38 | 38 |
+| Missing manual excerpt | 0 | 0 |
+| Missing featured image | 4 | 4 |
+| Missing featured-image alt | 0 | 0 |
+
+## Pilot Status
+
+| Pilot check | Result |
+| --- | --- |
+| Post ID | 10594 |
+| Slug | make-culture-not-content |
+| Has excerpt | yes |
+| Featured media ID | 11264 |
+| Featured alt non-empty | yes |
+| Live featured img alt non-empty | yes |
+| Live OG image alt non-empty | yes |
+| Live H1 -> dek -> content order | yes |
+| Live hardcoded Field note present | no |
+| Live Article schema includes image | yes |
+
+## Remediations Applied
+
+- Featured-image alt updates: **0**
+- Manual excerpt updates: **0**
+- Posts still needing manual featured image decision: **4**
+
+### Manual Featured-image Queue
+
+| Post ID | Slug | URL |
+| --- | --- | --- |
+| 8786 | a-creative-technologists-ai-age-manifesto | https://kriskrug.co/2025/03/30/a-creative-technologists-ai-age-manifesto/ |
+| 8856 | how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada | https://kriskrug.co/2025/04/08/how-indigenomics-ai-is-flipping-the-script-on-economic-power-in-canada/ |
+| 11014 | vancouver-tech-journal-isnt-journalism | https://kriskrug.co/2025/12/11/vancouver-tech-journal-isnt-journalism/ |
+| 12184 | canada-ai-for-all-strategy-skeptical-guide | https://kriskrug.co/2026/06/04/canada-ai-for-all-strategy-skeptical-guide/ |

--- a/scripts/seo-backfill/backfill_lib.py
+++ b/scripts/seo-backfill/backfill_lib.py
@@ -45,6 +45,13 @@ def strip_html(value: str) -> str:
     return _WS_RE.sub(" ", html.unescape(_TAG_RE.sub(" ", value or ""))).strip()
 
 
+def purge_em_dashes(text: str) -> str:
+    if not text:
+        return text
+    text = re.sub(r"\s*—\s*", ", ", text)
+    return re.sub(r"(?<!\d)\s*–\s*(?!\d)", "-", text)
+
+
 def title_text(item: dict) -> str:
     """Prefer the raw title (context=edit), fall back to unescaped rendered."""
     t = item.get("title") or {}
@@ -66,6 +73,7 @@ def _rendered(item: dict, key: str) -> str:
 def derive_seo_title(title: str, max_chars: int = 60) -> str:
     """Append ' | Kris Krüg' if it fits; otherwise the title alone (truncated).
     Same rule as the Notion publisher's derive_seo_title."""
+    title = purge_em_dashes(title)
     suffix = " | Kris Krüg"
     if len(title) + len(suffix) <= max_chars:
         return title + suffix
@@ -88,18 +96,18 @@ def derive_meta_description(item: dict, max_chars: int = 200) -> tuple[str, str]
     of the content. Returns ('', 'none') when nothing usable exists."""
     excerpt = strip_html(_rendered(item, "excerpt"))
     if excerpt:
-        return _trim_to_sentence(excerpt, max_chars), "excerpt"
+        return purge_em_dashes(_trim_to_sentence(excerpt, max_chars)), "excerpt"
     content_html = _rendered(item, "content")
     for chunk in re.split(r"</p>|<br\s*/?>|\n", content_html):
         text = strip_html(chunk)
         if len(text) >= 40:  # skip headings, captions, single links
-            return _trim_to_sentence(text, max_chars), "first_paragraph"
+            return purge_em_dashes(_trim_to_sentence(text, max_chars)), "first_paragraph"
     return "", "none"
 
 
 def derive_social_message(text: str, max_chars: int = 280) -> str:
     """Same trimming as the publisher's derive_social_message."""
-    return _trim_to_sentence(text or "", max_chars)
+    return purge_em_dashes(_trim_to_sentence(text or "", max_chars))
 
 
 _CAPTION_RE = re.compile(r"^(photo|image|figure|fig\.|caption|credit)\b", re.I)

--- a/scripts/seo-backfill/backfill_meta.py
+++ b/scripts/seo-backfill/backfill_meta.py
@@ -47,8 +47,12 @@ def _utcnow() -> dt.datetime:
     return dt.datetime.now(dt.timezone.utc)
 
 
+def endpoint_for_kind(kind: str) -> str:
+    return "posts" if kind == "post" else "pages"
+
+
 def fetch_candidates(wp: WordPress, kind: str, since: str | None) -> list[dict]:
-    endpoint = "posts" if kind == "post" else "pages"
+    endpoint = endpoint_for_kind(kind)
     page, items = 1, []
     while True:
         params = {
@@ -74,9 +78,10 @@ def fetch_candidates(wp: WordPress, kind: str, since: str | None) -> list[dict]:
     return items
 
 
-def readback(wp: WordPress, post_id: int) -> dict:
+def readback(wp: WordPress, post_id: int, kind: str = "post") -> dict:
+    endpoint = endpoint_for_kind(kind)
     r = wp.s.get(
-        f"{wp.base}/wp-json/wp/v2/posts/{post_id}",
+        f"{wp.base}/wp-json/wp/v2/{endpoint}/{post_id}",
         params={"context": "edit", "_fields": READBACK_FIELDS},
         timeout=30,
     )
@@ -133,7 +138,7 @@ def apply_one(wp: WordPress, item: dict, kind: str, fields, *, live: bool) -> di
         return out
 
     # --- live path: re-verify identity on a fresh GET before writing ---
-    fresh = readback(wp, pid)
+    fresh = readback(wp, pid, kind)
     if int(fresh.get("id", -1)) != pid:
         out["status"] = "failed"; out["reason"] = "id mismatch on readback"; return out
     list_title = title_text(item)
@@ -152,10 +157,11 @@ def apply_one(wp: WordPress, item: dict, kind: str, fields, *, live: bool) -> di
         out["reason"] = "fields filled since enumeration"; return out
 
     payload = build_meta_payload(planned)  # raises if any key not allowlisted
-    wp.s.post(f"{wp.base}/wp-json/wp/v2/posts/{pid}", json=payload, timeout=60).raise_for_status()
+    endpoint = endpoint_for_kind(kind)
+    wp.s.post(f"{wp.base}/wp-json/wp/v2/{endpoint}/{pid}", json=payload, timeout=60).raise_for_status()
 
     # --- post-write verification ---
-    verify = readback(wp, pid)
+    verify = readback(wp, pid, kind)
     vmeta = verify.get("meta") or {}
     mismatched = [k for k, v in planned.items() if not meta_values_match(v, vmeta.get(k))]
     slug_changed = verify.get("slug") != fresh.get("slug")
@@ -170,7 +176,7 @@ def apply_one(wp: WordPress, item: dict, kind: str, fields, *, live: bool) -> di
     return out
 
 
-def apply_from_file_one(wp: WordPress, entry: dict, *, live: bool) -> dict:
+def apply_from_file_one(wp: WordPress, entry: dict, kind: str, *, live: bool) -> dict:
     """Write KK-approved OVERWRITE values for one post. Unlike the additive path
     this MAY overwrite non-empty fields — but only the 3 allowlisted meta keys,
     only the exact approved values, and only after a slug-identity guard. Records
@@ -178,7 +184,7 @@ def apply_from_file_one(wp: WordPress, entry: dict, *, live: bool) -> dict:
     pid, slug, meta = parse_approved_entry(entry)  # raises on bad shape
     out = {"id": pid, "slug": slug, "status": "skipped", "written": [], "flags": [], "reason": "", "old": {}}
 
-    fresh = readback(wp, pid)
+    fresh = readback(wp, pid, kind)
     if int(fresh.get("id", -1)) != pid:
         out["status"] = "failed"; out["reason"] = "id mismatch on readback"; return out
     if fresh.get("slug") != slug:
@@ -191,9 +197,10 @@ def apply_from_file_one(wp: WordPress, entry: dict, *, live: bool) -> dict:
         out["status"] = "planned"; out["written"] = sorted(meta); out["preview"] = meta; return out
 
     payload = build_meta_payload(meta)  # allowlist assert
-    wp.s.post(f"{wp.base}/wp-json/wp/v2/posts/{pid}", json=payload, timeout=60).raise_for_status()
+    endpoint = endpoint_for_kind(kind)
+    wp.s.post(f"{wp.base}/wp-json/wp/v2/{endpoint}/{pid}", json=payload, timeout=60).raise_for_status()
 
-    verify = readback(wp, pid)
+    verify = readback(wp, pid, kind)
     vmeta = verify.get("meta") or {}
     mismatched = [k for k, v in meta.items() if not meta_values_match(v, vmeta.get(k))]
     if mismatched or verify.get("slug") != slug or title_text(verify) != title_text(fresh):
@@ -202,7 +209,7 @@ def apply_from_file_one(wp: WordPress, entry: dict, *, live: bool) -> dict:
     return out
 
 
-def run_from_file(wp: WordPress, path: Path, *, live: bool) -> list[dict]:
+def run_from_file(wp: WordPress, path: Path, kind: str, *, live: bool) -> list[dict]:
     data = json.loads(path.read_text(encoding="utf-8"))
     entries = data["items"] if isinstance(data, dict) and "items" in data else data
     if isinstance(entries, dict):  # {"123": {...}} form
@@ -210,7 +217,7 @@ def run_from_file(wp: WordPress, path: Path, *, live: bool) -> list[dict]:
     outcomes = []
     for entry in entries:
         try:
-            out = apply_from_file_one(wp, entry, live=live)
+            out = apply_from_file_one(wp, entry, kind, live=live)
         except ValueError as e:
             out = {"id": entry.get("id"), "slug": entry.get("slug", ""), "status": "failed",
                    "written": [], "flags": [], "reason": f"validation: {e}", "old": {}}
@@ -300,10 +307,10 @@ def main() -> int:
     if args.from_file:
         path = Path(args.from_file)
         log(f"{mode} (from-file overwrite): {path}")
-        outcomes = run_from_file(wp, path, live=args.execute)
+        outcomes = run_from_file(wp, path, args.kind, live=args.execute)
         ts = _utcnow().strftime("%Y%m%d-%H%M%SZ")
         report = REPO_ROOT / args.report_dir / f"seo-overwrite-{ts}.md"
-        write_report(report, mode=f"{mode} (overwrite from {path.name})", kind="post",
+        write_report(report, mode=f"{mode} (overwrite from {path.name})", kind=args.kind,
                      fields=("approved",), filters=f"from-file={path.name}",
                      probe_result="n/a", backup_note="overwrite — prior values recorded per-item for rollback",
                      outcomes=outcomes)
@@ -317,8 +324,9 @@ def main() -> int:
     if args.ids:
         want = [int(x) for x in args.ids.split(",") if x.strip()]
         candidates = []
+        endpoint = endpoint_for_kind(args.kind)
         for pid in want:
-            r = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts/{pid}",
+            r = wp.s.get(f"{wp.base}/wp-json/wp/v2/{endpoint}/{pid}",
                          params={"context": "edit", "_fields": LIST_FIELDS}, timeout=30)
             if r.status_code == 200:
                 candidates.append(r.json())

--- a/scripts/seo-backfill/tests/test_backfill_lib.py
+++ b/scripts/seo-backfill/tests/test_backfill_lib.py
@@ -12,6 +12,7 @@ from backfill_lib import (  # noqa: E402
     build_meta_payload,
     derive_meta_description,
     derive_seo_title,
+    derive_social_message,
     parse_approved_entry,
     plan_meta_for_item,
     reconcile_with_fresh_meta,
@@ -73,6 +74,13 @@ def test_meta_desc_prefers_excerpt():
     desc, source = derive_meta_description(item(excerpt="The excerpt.", content="<p>Body paragraph here.</p>"))
     assert desc == "The excerpt."
     assert source == "excerpt"
+
+
+def test_derived_text_purges_em_dashes():
+    desc, _ = derive_meta_description(item(excerpt="A strong excerpt — with a dash."))
+    assert desc == "A strong excerpt, with a dash."
+    assert derive_social_message("Share this — now.") == "Share this, now."
+    assert derive_seo_title("Short — Title") == "Short, Title | Kris Krüg"
 
 
 def test_meta_desc_falls_back_to_first_real_paragraph():


### PR DESCRIPTION
## Summary
- Fix SEO backfill page handling so `KIND=page IDS=...` and approved page overwrite files use the WordPress pages endpoint.
- Purge em/en dashes from generated SEO title, description, and social text before write, with regression coverage.
- Add the approved home-page SEO override plus the leftover-lanes evidence reports.

## Review Notes
- This PR uses `Refs`, not `Closes`, because several linked issue lanes still have human/admin blockers.
- No plugin deploy, bulk media mutation, PII export, or risky title overwrite is included here.

Refs #222 #219 #36 #40 #4 #174 #128 #197

## Verification
- `make morning-truth`
- `make test`
- `make docs-truth-check`
- `python3 -m pytest scripts/seo-backfill/tests -q`
- `FORMAT=json make seo-audit`
- `git diff --cached --check`
