### PR TITLE
Swarm ready docs, feed discovery, and static checks

### DIFF
--- a/content/drafts/swarm-ready-pages/ai-glossary-page-v1.md
+++ b/content/drafts/swarm-ready-pages/ai-glossary-page-v1.md
@@ -1,0 +1,226 @@
+---
+title: "AI Glossary"
+slug: glossary
+status: draft-only
+post_type: page
+issue: 44
+github_issue: https://github.com/WalksWithASwagger/kriskrug-wp/issues/44
+audience:
+  - Newcomers learning AI terminology
+  - Clients and event audiences who need plain-language definitions
+  - Editors maintaining accessible AI content on KrisKrug.co
+primary_cta: "Book an AI literacy workshop"
+secondary_cta: "Explore Vancouver AI community resources"
+seo:
+  meta_title: "AI Glossary | Plain-Language AI Terms"
+  meta_description: "A plain-language AI glossary for newcomers, teams, educators, and community organizers who want practical definitions without hype or jargon."
+notes:
+  draft_scope: "Content artifact only. No WordPress writes or publishing."
+  related_issue: "#44 - [CONTENT] Create Glossary Page for AI Terminology"
+---
+
+# AI Glossary
+
+AI conversations can get exclusionary fast.
+
+This glossary is for people who want to understand the practical language around artificial intelligence without being buried in hype, math, vendor jargon, or inside-baseball acronyms.
+
+The goal is not to make everyone a machine learning engineer. The goal is to help people ask better questions, spot sloppy claims, and participate in AI decisions that affect their work, culture, communities, and organizations.
+
+## How To Use This Glossary
+
+- Start with the term you keep hearing.
+- Read the plain-language definition first.
+- Use the "Why it matters" line to connect the term to real decisions.
+- Follow related links for deeper context when they are available.
+
+Future implementation note: if this becomes a live page, add on-page search or an alphabetical jump list once the glossary grows beyond this v1 set.
+
+## Terms
+
+### Agent
+
+An AI system that can take steps toward a goal, often by using tools, checking results, and deciding what to do next.
+
+Why it matters: Agents can be useful for research, coding, operations, and support workflows, but they need clear boundaries because they can act across systems.
+
+### AI Ethics
+
+The practice of asking what an AI system should do, who it affects, what harms it may create, and who is accountable when something goes wrong.
+
+Why it matters: Ethics is not a decoration after launch. It belongs in design, data choices, deployment, review, and governance.
+
+### AI Literacy
+
+The practical ability to understand what AI can do, what it cannot do, where it might fail, and how to use it responsibly.
+
+Why it matters: AI literacy helps teams move past panic and hype into better decisions.
+
+### Alignment
+
+The challenge of making an AI system behave in ways that match human goals, constraints, and values.
+
+Why it matters: A system can be technically impressive and still optimize for the wrong thing.
+
+### Bias
+
+A pattern where an AI system produces unfair, skewed, or harmful results for certain people, groups, languages, cultures, or contexts.
+
+Why it matters: Bias can come from data, design choices, measurement, deployment context, or the assumptions of the people building the system.
+
+### Chatbot
+
+An interface that lets people interact with software through conversation.
+
+Why it matters: A chatbot may look simple, but the quality depends on the model, instructions, tools, data access, and safety rules behind it.
+
+### Context Window
+
+The amount of text, data, or conversation an AI model can consider at one time.
+
+Why it matters: When important context falls outside the window, the model may miss details or answer from incomplete information.
+
+### Data Governance
+
+The policies and practices that define how data is collected, stored, accessed, shared, corrected, and deleted.
+
+Why it matters: AI systems often amplify existing data practices. Weak governance becomes a bigger risk when automation enters the room.
+
+### Dataset
+
+A collection of examples used to train, test, evaluate, or operate an AI system.
+
+Why it matters: The quality, source, consent, and representativeness of a dataset shape what the system learns and who it may harm.
+
+### Evaluation
+
+The process of testing whether an AI system performs well enough for its intended use.
+
+Why it matters: A few impressive demos are not enough. Useful evaluations test real tasks, edge cases, safety, and failure modes.
+
+### Fine-Tuning
+
+Training an existing model further on a narrower set of examples so it behaves better for a specific use case.
+
+Why it matters: Fine-tuning can improve consistency, but it is not always the right answer. Better prompts, retrieval, or workflow design may be simpler.
+
+### Foundation Model
+
+A large general-purpose AI model that can be adapted to many tasks, such as writing, coding, image understanding, search, or analysis.
+
+Why it matters: Foundation models are powerful building blocks, but they still need context, evaluation, and governance before serious deployment.
+
+### Generative AI
+
+AI that creates new text, images, audio, video, code, or other outputs based on patterns learned from data.
+
+Why it matters: Generative AI changes creative, educational, business, and civic workflows because it can produce plausible work very quickly.
+
+### Guardrails
+
+Rules, checks, permissions, or design choices that limit what an AI system can do.
+
+Why it matters: Guardrails help reduce risk, but they are not magic. They need testing, monitoring, and human accountability.
+
+### Hallucination
+
+When an AI system produces information that sounds confident but is wrong, unsupported, or invented.
+
+Why it matters: Hallucinations are especially risky in journalism, law, health, finance, education, and public-sector work.
+
+### Human In The Loop
+
+A workflow where a person reviews, approves, corrects, or supervises an AI system before important actions are taken.
+
+Why it matters: Human review is most useful when the reviewer has enough context, authority, and time to catch problems.
+
+### Indigenous Data Sovereignty
+
+The right of Indigenous Peoples to govern the collection, ownership, access, interpretation, and use of data about their communities, lands, cultures, and knowledge.
+
+Why it matters: AI work that touches Indigenous data, knowledge, or communities requires relationship, consent, protocol, and governance beyond generic data policy.
+
+### Large Language Model
+
+An AI model trained on large amounts of text that can generate and transform language.
+
+Why it matters: LLMs power many chatbots, writing tools, coding assistants, summarizers, and research workflows.
+
+### Model
+
+The part of an AI system that has learned patterns from data and uses those patterns to make predictions or generate outputs.
+
+Why it matters: "The model" is only one part of the system. The surrounding data, prompts, tools, interface, and human process matter too.
+
+### Multimodal AI
+
+AI that can work across more than one kind of input or output, such as text, images, audio, video, or code.
+
+Why it matters: Multimodal systems are useful for creative and accessibility workflows, but they also raise new consent, attribution, and interpretation questions.
+
+### Prompt
+
+The instruction, question, context, or examples given to an AI system.
+
+Why it matters: Better prompts can improve results, but prompts are not a substitute for good judgment, good data, or proper review.
+
+### Retrieval-Augmented Generation
+
+A pattern where an AI system searches approved sources and uses that retrieved context to answer.
+
+Why it matters: RAG can make answers more grounded, but only if the source material is current, relevant, and correctly retrieved.
+
+### Synthetic Media
+
+Media created or altered with AI, including images, audio, video, avatars, and generated voices.
+
+Why it matters: Synthetic media can be creative and useful, but it also raises consent, disclosure, provenance, and misinformation concerns.
+
+### Token
+
+A small unit of text that an AI model processes. A token can be a word, part of a word, punctuation, or another text fragment.
+
+Why it matters: Tokens affect cost, context limits, and how much information a model can handle at once.
+
+### Training Data
+
+The data used to teach an AI model patterns before it is used.
+
+Why it matters: Training data shapes what the model can do, what it misses, and what harms or assumptions it may reproduce.
+
+### Workflow Automation
+
+Using software, sometimes with AI, to move tasks through a process with less manual effort.
+
+Why it matters: Automation can save time, but bad workflows scale mistakes faster.
+
+## Suggested Related CTAs And Internal Links
+
+- Primary CTA: [Book an AI keynote or workshop](https://kriskrug.co/speaking/).
+- Supporting link: [Current AI ecosystem work](https://kriskrug.co/recent-projects-include/).
+- Supporting link: [Vancouver AI community page](https://kriskrug.co/community/vancouver-ai/) after issue #18 is published.
+- Supporting link: [Blog](https://kriskrug.co/blog/).
+- Supporting link: [About Kris Krug](https://kriskrug.co/about/).
+
+## SEO Meta Draft
+
+| Field | Draft |
+|---|---|
+| Visible title | AI Glossary |
+| SEO title | AI Glossary \| Plain-Language AI Terms |
+| Slug | `glossary` |
+| Meta description | A plain-language AI glossary for newcomers, teams, educators, and community organizers who want practical definitions without hype or jargon. |
+| Primary keyword | AI glossary |
+| Secondary keywords | AI terminology, plain-language AI definitions, generative AI glossary, AI literacy |
+| Suggested category | AI Literacy |
+
+## Maintenance Notes
+
+- Reference issue: #44.
+- This v1 contains 26 practical terms, matching the current draft-only acceptance target of 20-30 terms. The original issue asks for 50+ terms, so treat this as a first publishable slice and expand in later passes.
+- Keep definitions plain-language and audience-centered.
+- Revisit terms quarterly because AI language changes quickly.
+- Add source links for terms that become policy-sensitive, legal, technical, or culturally specific.
+- Ask a qualified Indigenous data governance reviewer before expanding Indigenous terminology beyond the short definition above.
+- Add alphabetical jump links or search before publishing a larger version.
+- Check all CTAs and internal links before WordPress publication.

--- a/content/drafts/swarm-ready-pages/vancouver-ai-community-page-v1.md
+++ b/content/drafts/swarm-ready-pages/vancouver-ai-community-page-v1.md
@@ -1,0 +1,151 @@
+---
+title: "Vancouver AI Community"
+slug: community/vancouver-ai
+status: draft-only
+post_type: page
+issue: 18
+github_issue: https://github.com/WalksWithASwagger/kriskrug-wp/issues/18
+audience:
+  - Vancouver and BC people learning AI in public
+  - Event organizers and civic partners looking for trusted local AI programming
+  - Founders, artists, educators, students, and operators looking for practical AI peers
+primary_cta: "Join the next Vancouver AI gathering"
+secondary_cta: "Book Kris for an AI keynote or workshop"
+seo:
+  meta_title: "Vancouver AI Community | Kris Krug"
+  meta_description: "A practical guide to Vancouver's AI community: meetups, learning spaces, recordings, resources, and ways to participate in BC's growing AI ecosystem."
+notes:
+  draft_scope: "Content artifact only. No WordPress writes or publishing."
+  related_issue: "#18 - [CONTENT] Create Vancouver AI Community Page"
+---
+
+# Vancouver AI Community
+
+Vancouver's AI scene is not one thing.
+
+It is researchers, creative technologists, startup builders, public-sector people, artists, educators, students, nonprofit leaders, Indigenous knowledge workers, policy folks, and curious professionals trying to understand what these tools mean in real life.
+
+This page is the front door for people who want to find that community, learn what happens in the room, and decide where they can plug in.
+
+## Purpose
+
+The Vancouver AI Community page should make the local ecosystem easier to find, easier to understand, and easier to join.
+
+It should not overclaim. It should not turn the community into a trophy case. It should explain why the gatherings matter: they create practical learning space before the stakes get higher.
+
+## Who This Is For
+
+- People in Vancouver and across BC who are AI-curious but do not know where to start.
+- Builders who want honest feedback beyond startup demo theater.
+- Artists, designers, writers, filmmakers, photographers, and media workers adapting their practice.
+- Educators and students looking for plain-language AI learning spaces.
+- Civic, nonprofit, and public-sector teams trying to understand trustworthy AI adoption.
+- Event organizers looking for speakers, workshops, panels, or community partnerships.
+
+## Suggested Page Body
+
+### A Place To Learn In Public
+
+AI is moving too quickly for everyone to wait until they feel ready.
+
+The Vancouver AI community gives people a room where they can bring prototypes, questions, warnings, workflows, creative experiments, policy concerns, and lessons from real deployments. The value is not only the speaker lineup. It is the shared language that forms when different kinds of people compare notes in public.
+
+The best nights have a practical texture: what worked, what broke, what surprised us, and what we should be more careful about next time.
+
+### What Happens At A Vancouver AI Gathering
+
+The exact format can change by event, but the community page should set expectations around:
+
+- Talks and demos from people building or using AI in the region.
+- Practical examples from creative, civic, education, startup, nonprofit, and industry contexts.
+- Time for questions, hallway conversations, and peer learning.
+- Links to recordings, slides, notes, or related resources when they are available.
+- Clear participation norms that make the room useful for newcomers and experienced practitioners.
+
+### Why Vancouver Matters
+
+Vancouver and BC have a distinctive AI conversation because the region sits at the overlap of technology, culture, education, public trust, and creative production.
+
+This is not only a lab story. It is also a film, VFX, games, journalism, climate, design, Indigenous protocol, public-interest technology, and community-learning story.
+
+That mix matters. AI tools do not land in a vacuum. They land in classrooms, production studios, local governments, small businesses, arts organizations, newsrooms, and communities that need both imagination and accountability.
+
+### How To Participate
+
+Use this section as the practical conversion area.
+
+- Join the next Vancouver AI meetup or event.
+- Bring a demo, case study, question, workflow, or hard-earned lesson.
+- Invite your team if they need a grounded introduction to AI.
+- Share a resource or recording that would help other people learn.
+- Reach out about a talk, workshop, panel, or community partnership.
+
+### Events And Recordings
+
+This section should become a lightweight index rather than a static brag list.
+
+Suggested fields for each event:
+
+- Event title.
+- Date.
+- Venue or host.
+- Topic.
+- Recording link, if public.
+- Slides or notes, if public.
+- Related posts on KrisKrug.co.
+
+Do not add attendee counts unless they are verified from a current source and the number is useful to the reader.
+
+### Community Resources
+
+Suggested resource groups:
+
+- Upcoming events.
+- Past talks and recordings.
+- AI learning guides.
+- Responsible AI and AI ethics resources.
+- Vancouver and BC ecosystem links.
+- Speaker and workshop booking links.
+
+### Testimonials And Partner Notes
+
+Issue #18 asks for member testimonials and academic partnerships. Keep this section empty or marked "pending" until quotes, approvals, and partner names are verified.
+
+Possible future modules:
+
+- Short attendee quotes with explicit permission.
+- Partner logos only after approval.
+- University or college collaborations only when the relationship is current and source-backed.
+- A privacy note for photos, recordings, and names.
+
+## Suggested Internal Links And CTAs
+
+- Primary CTA: `Join the next Vancouver AI gathering` pointing to the current event or events page once confirmed.
+- Secondary CTA: [Book Kris for an AI keynote](https://kriskrug.co/speaking/).
+- Supporting link: [Current projects](https://kriskrug.co/recent-projects-include/).
+- Supporting link: [About Kris Krug](https://kriskrug.co/about/).
+- Supporting link: [Blog](https://kriskrug.co/blog/).
+- External ecosystem link: BC + AI, if the current public URL and context are confirmed before publish.
+
+## SEO Meta Draft
+
+| Field | Draft |
+|---|---|
+| Visible title | Vancouver AI Community |
+| SEO title | Vancouver AI Community \| Kris Krug |
+| Slug | `community/vancouver-ai` |
+| Meta description | A practical guide to Vancouver's AI community: meetups, learning spaces, recordings, resources, and ways to participate in BC's growing AI ecosystem. |
+| Primary keyword | Vancouver AI community |
+| Secondary keywords | Vancouver AI meetup, BC AI ecosystem, AI events Vancouver, responsible AI Vancouver |
+| Suggested category | Vancouver AI Ecosystem |
+
+## Implementation Notes
+
+- Reference issue: #18.
+- Treat this as a page draft, not a post draft.
+- Do not publish attendee numbers from the original issue body until they are verified against a current source.
+- Add event dates only from a current calendar or public event listing.
+- Add testimonials only with explicit permission and final quote approval.
+- Add partner names only when the relationship is current, public, and relevant.
+- Make the future page mobile-friendly with short sections, clear headings, and accessible link text.
+- If the page becomes `/community/vancouver-ai`, add redirects or menu placement only after publisher approval.

--- a/docs/current-state/marketing/community-advocate-program-v1-2026-06-17.md
+++ b/docs/current-state/marketing/community-advocate-program-v1-2026-06-17.md
@@ -1,0 +1,130 @@
+# Community Advocate Program V1 - 2026-06-17
+
+**Status:** V1 review draft. No public launch, recruitment send, form, CRM setup, private member-data handling, or advocate onboarding system is implemented by this document.
+
+**Issue:** GitHub #54 - `[MARKETING] Create Community Advocate Program`
+
+## Goal
+
+Create a clear, safe, human-centered advocate program that helps trusted community members share KK's work, host or co-host useful gatherings, and bring new people into the ecosystem without turning community participation into extractive growth labor.
+
+Issue #54 names a 3-tier program, 30-40 advocates, 300-1000 new contacts/month, recognition, and monthly support. For this repo-safe V1, those remain targets to validate after a small pilot.
+
+## Advocate Profile
+
+Good-fit advocates are people who already demonstrate:
+
+- Trust in KK's work and alignment with practical, creative, ethical AI adoption.
+- A real local, professional, creator, event, education, or civic network.
+- A habit of sharing useful material without spamming.
+- Good judgment around consent, privacy, cultural context, and community safety.
+- Willingness to represent the work accurately and send people to opt-in channels.
+
+Not a fit for V1:
+
+- Anyone expected to scrape contacts, mass-message friends, or add people to lists.
+- Anyone who needs aggressive commissions to participate.
+- Anyone who cannot respect moderation, attribution, or safety guidelines.
+
+## Roles And Tiers
+
+Start as an invite-only pilot with a small cohort before scaling to the issue #54 targets.
+
+| Tier | Profile | Expected role | Pilot size | Issue #54 scale target |
+|---|---|---|---|---|
+| Bronze | Lightweight signal booster | Share one approved post, event, or resource per week when relevant | 5-10 | 20-30 advocates |
+| Silver | Community host | Host or convene one small meetup, salon, office-hours session, or local conversation per month | 2-4 | 5-10 advocates |
+| Gold | Program partner | Co-host a quarterly event, workshop, or campaign with KK | 1-2 | 2-3 advocates |
+
+Advocates should be able to pause any month without penalty. V1 should value consistency, judgment, and fit over volume.
+
+## Enablement Materials
+
+Prepare these as review-ready assets before recruiting:
+
+- One-page advocate brief: purpose, who the work serves, what to share, what not to promise.
+- Approved message bank: newsletter share, event invite, workshop note, speaking intro, and thank-you reply.
+- Link pack: kriskrug.co, newsletter signup, speaking/work page, public events, selected evergreen posts.
+- Visual pack: headshot, logo/wordmark guidance if approved, event image options, social crop guidance.
+- Host kit for Silver advocates: sample event description, run-of-show, consent reminder, accessibility notes, feedback prompt.
+- Co-host kit for Gold advocates: planning timeline, responsibilities, promotion windows, moderation plan, and post-event recap path.
+- Safety card: consent, privacy, anti-harassment, no scraping, no unauthorized claims, and escalation contact.
+
+Do not publish or distribute these until KK approves the program language and boundaries.
+
+## Recognition Model
+
+V1 recognition should reinforce trust and contribution instead of leaderboard pressure.
+
+Suggested recognition:
+
+- Private thank-you notes after useful introductions, shares, or hosted sessions.
+- Quarterly public appreciation only with explicit consent.
+- Early access to public resources, notes, or small-group briefings.
+- Optional profile mention in recap posts for hosts and co-hosts who opt in.
+- Non-cash perks such as event priority, office-hours access, or workshop guest spots.
+
+Avoid in V1:
+
+- Public rankings by number of contacts or referrals.
+- Recognition that reveals private community participation.
+- Rewards that encourage spam, performative posting, or unsafe claims.
+
+## Community Safety Guidelines
+
+Advocates should agree to these before participating:
+
+- Consent first: invite people to opt in; do not add anyone to lists.
+- No scraping, bulk DMs, purchased lists, or surprise introductions.
+- No promises about pricing, access, jobs, investment, client outcomes, or speaking availability unless KK has approved the language.
+- Attribute KK's work accurately and do not imply formal employment, agency, or exclusive representation.
+- Keep event spaces inclusive, accessible, and harassment-free.
+- Respect Indigenous, cultural, creator, and community context when discussing AI adoption.
+- Escalate safety concerns, conflicts, press inquiries, sponsorship questions, and high-stakes partnership leads to KK.
+- Stop outreach immediately if someone says no, unsubscribes, or signals discomfort.
+
+## Metrics
+
+Track only aggregate, low-risk signals during V1:
+
+| Metric | Why it matters | V1 method |
+|---|---|---|
+| Active advocates | Shows whether the program has real participation | Manual monthly count by tier. |
+| Qualified shares or intros | Separates useful advocacy from noise | Advocate self-report or KK log, no contact harvesting. |
+| Opt-ins or inquiries attributed to advocates | Connects effort to outcomes | Manual source notes from opt-in forms or direct conversations only after consent. |
+| Hosted sessions | Measures Silver/Gold contribution | Event count, rough attendance, qualitative notes. |
+| Safety issues | Protects the community | Manual incident/escalation log with minimal details. |
+| Advocate satisfaction | Checks whether the program feels worthwhile | Short private check-in, optional responses. |
+
+Report monthly by tier and channel. Do not create contact-growth claims until a compliant measurement path exists. Treat the issue #54 target of 300-1000 new contacts/month as a V2/V3 ambition, not a V1 promise.
+
+## Launch Checklist
+
+- [ ] Confirm the pilot size and whether it is invite-only.
+- [ ] Approve tier names, expectations, and pause/off-ramp rules.
+- [ ] Draft the advocate brief, message bank, link pack, host kit, and safety card.
+- [ ] Confirm who can approve public recognition and profile mentions.
+- [ ] Define the escalation path for safety, press, sponsorship, and high-stakes partnership leads.
+- [ ] Choose the monthly support format: group call, office hours, async note, or event-prep session.
+- [ ] Decide the minimum viable metrics for pilot review.
+- [ ] Run a privacy and community-safety review before collecting any advocate reports.
+- [ ] Recruit a small pilot cohort only after materials are approved.
+- [ ] After the pilot, compare actual results against issue #54 targets: 30-40 advocates and 300-1000 new contacts/month.
+
+## Decisions Needed
+
+1. Should V1 use the Bronze/Silver/Gold tier names from issue #54 or softer community language?
+2. Who should be invited into the pilot cohort first?
+3. What are advocates allowed to say about KK's services, availability, rates, and upcoming programs?
+4. What recognition is appropriate for people who prefer not to be public?
+5. Who owns monthly advocate support?
+6. What safety or moderation standard should apply to advocate-hosted gatherings?
+7. What outcome threshold justifies scaling beyond the pilot?
+
+## Out Of Scope For This V1
+
+- Public launch or recruitment campaign.
+- Advocate forms, CRM/list setup, automations, dashboards, or private contact uploads.
+- Outreach sends.
+- Paid ambassador contracts or commission structure.
+- Event creation, venue booking, sponsor outreach, or partner commitments.

--- a/docs/current-state/marketing/community-referral-program-v1-2026-06-17.md
+++ b/docs/current-state/marketing/community-referral-program-v1-2026-06-17.md
@@ -1,0 +1,107 @@
+# Community Referral Program V1 - 2026-06-17
+
+**Status:** V1 review draft. No public launch, form, CRM, automation, tracking dashboard, outreach send, or private member-data handling is implemented by this document.
+
+**Issue:** GitHub #53 - `[MARKETING] Build Community Referral Program`
+
+## Goal
+
+Turn existing community goodwill into a simple, permission-based referral lane that helps the kriskrug.co / KK ecosystem grow through trusted introductions, without creating a live system before the offer, privacy model, and fulfillment path are approved.
+
+Issue #53 names a 10-20% growth acceleration target, 20-30 active referrers, a tracking dashboard, and automated rewards. For this repo-safe V1, those remain validation targets, not implementation claims.
+
+## Audience
+
+Primary referrers:
+
+- Existing community members who already share KK's work, events, workshops, newsletter, and speaking.
+- Past clients, collaborators, event hosts, and workshop participants with credible networks.
+- Newsletter readers who regularly click, reply, or forward.
+
+Primary referred audiences:
+
+- People interested in practical AI literacy, creative technology, community events, ethical AI adoption, or speaking/workshop bookings.
+- Organizations considering KK for talks, facilitation, advisory, or training.
+- People likely to join the newsletter or attend public community programming.
+
+## Offer And Mechanics
+
+The program should start with four referral lanes, each with a small manual proof path:
+
+| Lane | Referral action | Suggested offer | Fulfillment note |
+|---|---|---|---|
+| Membership / community | Refer someone into a public community program or paid membership if one is approved later | VIP access, early registration, or member-only recap | Do not promise a membership tier until KK confirms the membership product exists and the benefit is fulfillable. |
+| Newsletter | Refer a new newsletter subscriber | Exclusive notes, behind-the-scenes recap, or early access to a public resource | Use aggregate counts only until a compliant signup/referral tool is selected. |
+| Course / workshop | Refer someone to a paid workshop or cohort | 20% discount for the referred participant, optional thank-you credit for the referrer | Requires pricing, refund, discount-code, and tax/accounting approval before use. |
+| Speaking | Introduce a qualified event or organization lead | $500-$1000 thank-you per booked engagement, or a non-cash recognition option | Requires written eligibility rules, payment approval, and anti-spam guardrails before use. |
+
+Recommended V1 flow:
+
+1. KK publishes or sends a short invitation only after approval.
+2. Referrer uses one approved share link or intro template per lane.
+3. Referred person opts in directly through the existing public newsletter/contact path or a later approved form.
+4. KK or a delegated operator records the referral source manually in a review sheet.
+5. Rewards are fulfilled only after the referred person opts in and any sale or booking is complete.
+
+## Tracking Model Without Live Systems
+
+Use a manual planning ledger before adopting any live system:
+
+| Field | Purpose | Privacy stance |
+|---|---|---|
+| Referral lane | Newsletter, membership/community, workshop, or speaking | No private data. |
+| Referrer code | Human-readable code such as `KK-REF-FIRSTNAME-01` | Avoid email addresses or full personal identifiers in codes. |
+| Source channel | Newsletter, event, social, direct intro, partner | Aggregate reporting only. |
+| Referred action | Opt-in, inquiry, paid registration, booked call, booked speaking | Track action status, not unnecessary personal details. |
+| Reward status | Pending, approved, fulfilled, declined | Manual review before fulfillment. |
+| Notes | Eligibility or context needed for review | No sensitive details, no private member records. |
+
+V1 reporting should answer:
+
+- How many people actively shared at least once?
+- Which lanes created qualified conversations or opt-ins?
+- Which offers were easy to fulfill?
+- Which mechanics caused confusion, support load, or privacy risk?
+
+Do not create referral links, dashboards, discount codes, Zapier workflows, CRM fields, member lists, or email automations until the decisions below are made.
+
+## Privacy Safeguards
+
+- Use opt-in only. A referrer may introduce someone, but the referred person must choose to subscribe, inquire, register, or book.
+- Do not upload community/member lists into a new tool for this V1.
+- Do not expose who referred whom in public recognition.
+- Keep reporting aggregate by lane and channel unless a person has explicitly agreed to be named.
+- Avoid reward mechanics that pressure people to disclose contacts or send bulk invites.
+- Review any paid reward, discount, or affiliate-like language before launch so expectations are clear and compliant.
+- Keep manual notes minimal and delete rejected or stale referral records on an agreed cadence.
+
+## Launch Checklist
+
+- [ ] Confirm the first referral lane to pilot; do not launch all four at once unless KK explicitly approves the operational load.
+- [ ] Approve the exact offer, eligibility rules, and reward limits.
+- [ ] Confirm whether paid rewards are allowed for speaking referrals and who approves payouts.
+- [ ] Draft the public invitation copy and one private intro template.
+- [ ] Choose a temporary manual ledger owner and review cadence.
+- [ ] Confirm opt-in language for referred people.
+- [ ] Define what counts as an active referrer, qualified referral, and fulfilled reward.
+- [ ] Decide whether the pilot is invite-only, newsletter-wide, or event-specific.
+- [ ] Run a privacy review before any form, CRM, tracking link, or automation is added.
+- [ ] After a small pilot, compare actual results against issue #53 targets: 20-30 active referrers and 10-20% growth acceleration.
+
+## Decisions Needed
+
+1. Which lane launches first: newsletter, membership/community, workshop, or speaking?
+2. What is the first approved offer that KK can fulfill without new infrastructure?
+3. Are cash rewards acceptable for speaking referrals, or should V1 use non-cash recognition?
+4. Who owns the manual ledger and reward approval?
+5. What data-retention window should apply to unconverted referrals?
+6. What is the smallest pilot audience: 5 trusted referrers, one event cohort, or a newsletter segment?
+7. What success threshold makes V2 worth building into a real system?
+
+## Out Of Scope For This V1
+
+- Public launch.
+- Forms, CRM fields, referral dashboards, automation, discount-code setup, or payment processing.
+- Private member-data exports or contact-list uploads.
+- Outreach sends.
+- Affiliate/legal/tax finalization.

--- a/docs/current-state/marketing/content-syndication-strategy-v1-2026-06-17.md
+++ b/docs/current-state/marketing/content-syndication-strategy-v1-2026-06-17.md
@@ -1,0 +1,133 @@
+# Content Syndication Strategy v1 - 2026-06-17
+
+**Lane:** Track A marketing/content strategy
+**Scope:** docs-only v1 for GitHub issue #52. No public posting, account setup, API configuration, outbound messages, private data handling, or production deploy.
+**Issue:** [#52 - [MARKETING] Create Content Syndication Strategy](https://github.com/WalksWithASwagger/kriskrug-wp/issues/52)
+
+## Assumptions and Success Criteria
+
+- `kriskrug.co` remains the canonical home for original long-form posts.
+- Syndication expands reach only after a post is already published, QA'd, and intentionally selected for reuse.
+- This v1 defines the operating system; it does not claim that Medium, LinkedIn, Dev.to, or Substack accounts are configured.
+- Success for issue #52 means future publishers have channel rules, SEO safeguards, a packaging workflow, measurement, and stop conditions before any public reposting begins.
+
+## Channels and Surfaces
+
+| Surface | Best fit | Default format | Publish timing | Required safeguards |
+|---|---|---|---|---|
+| Medium | Narrative essays, culture/AI field notes, travel/photo essays with broad audience appeal | Full or lightly edited republication | 7-14 days after canonical post | Canonical link back to `kriskrug.co`, original-post note, no unverified claims added |
+| LinkedIn Articles | Professional AI strategy, facilitation, speaking, community leadership, case-study posts | Edited article or excerpt with CTA to original | 3-10 days after canonical post | Link to canonical original, remove private/client-sensitive details, factual proofread |
+| Dev.to | Practical AI workflow, tooling, web, automation, and maker notes | Technical adaptation with code/process focus | 7-21 days after canonical post | Canonical URL if supported, developer-first headline, no duplicate low-fit essays |
+| Substack | Newsletter-style dispatches, curated reflections, subscriber updates | Excerpt plus commentary or newsletter edition | Weekly or biweekly batch | Link to canonical post, avoid paywalling the canonical article, preserve consent on media |
+| Internal cross-link surfaces | Related `kriskrug.co` posts, Work/Speaking/About references | Contextual internal links | Same day as canonical publish or during content QA | Slug/ID verification before any WordPress edit |
+
+## Republishing Rules
+
+1. Publish on `kriskrug.co` first.
+2. Wait at least 72 hours before any duplicate full-text republication unless there is a campaign-specific reason.
+3. Prefer excerpts or adapted versions when the target platform has a different reader intent.
+4. Keep the canonical URL visible near the top or bottom of every syndicated copy.
+5. Do not syndicate posts with unresolved editorial review, draft claims, private event context, unapproved sponsor/client references, or media-rights uncertainty.
+6. Do not rewrite the factual substance for a platform unless the edited version gets its own approval pass.
+7. Do not use automation to post publicly until account ownership, preview rendering, and rollback/delete access are confirmed.
+
+## Canonical-Link and SEO Safeguards
+
+- Canonical source: the final public `kriskrug.co` post URL.
+- Required note for full republication:
+
+```text
+Originally published at kriskrug.co: [canonical URL]
+```
+
+- Use a platform canonical URL field when available. If a platform does not support canonical metadata, use the visible original-publication note.
+- Do not change the WordPress slug, title, excerpt, or metadata as part of syndication packaging.
+- Do not publish the same full article to all platforms on the same day. Staggering supports measurement and reduces duplicate-content confusion.
+- Use UTM-tagged links only for outbound links from syndicated copies back to `kriskrug.co`; never replace the canonical URL itself with a tracking redirect.
+- Suggested UTM pattern:
+
+```text
+?utm_source=<platform>&utm_medium=syndication&utm_campaign=<post-slug>
+```
+
+## Packaging Workflow
+
+### 1. Select
+
+- Confirm the canonical post is public and stable.
+- Confirm the post fits at least one syndication surface.
+- Capture the canonical URL, title, excerpt, publish date, primary image, and owner-approved CTA.
+
+### 2. Screen
+
+- Check for private names, emails, event attendee details, unpublished client details, sponsor claims, or media where publicity rights are unclear.
+- Check for claims that need current numbers or external proof.
+- Confirm the post does not rely on site-specific embeds that will break on another platform.
+
+### 3. Adapt
+
+- Create one platform package at a time.
+- Adjust headline, deck, intro, CTA, and tags for the platform.
+- Keep the core argument intact.
+- Preserve image alt text where the platform supports it.
+
+### 4. Approve
+
+- Reviewer verifies: canonical link, original-publication note, privacy screen, factual claims, media rights, CTA, and platform fit.
+- KK or delegated publisher gives explicit go/no-go before any public posting.
+
+### 5. Publish and Log
+
+- Publish manually for v1.
+- Record platform URL, date, canonical URL, UTM campaign, post owner, and any edits made from the canonical version.
+- Add performance metrics after 7, 30, and 90 days.
+
+## Measurement Plan
+
+| Metric | Source | Cadence | Notes |
+|---|---|---|---|
+| Syndicated posts shipped | Manual log | Monthly | Target from issue #52: 2-3 reposts/month after pilot approval |
+| Referral sessions to `kriskrug.co` | Analytics/UTM reports | 7, 30, 90 days | Track per platform and per post |
+| Leads or inquiries | Contact/source notes | Monthly | Attribute only when source is clear |
+| Backlinks | SEO/backlink tool or manual search | Monthly | Count live links back to canonical source |
+| Platform reach | Native platform analytics | 7 and 30 days | Treat issue #52's 100K+ reach as an aspirational benchmark, not a v1 proof claim |
+| Subscriber/follower growth | Native platform analytics | Monthly | Keep Substack growth separate from social reach |
+
+## Pilot Plan
+
+Start with four already-public, low-risk posts:
+
+1. One AI/community strategy post for LinkedIn Articles.
+2. One practical AI/tooling post for Dev.to if it has genuine technical substance.
+3. One broad narrative essay for Medium.
+4. One newsletter-friendly dispatch for Substack.
+
+The pilot is complete when each platform has one approved package, one manual publish decision, and one 30-day metric readback.
+
+## Stop Conditions
+
+Pause syndication if any of these occur:
+
+- Canonical link cannot be represented clearly on the target platform.
+- A platform package includes private, client, sponsor, attendee, or media-rights-sensitive material without explicit approval.
+- The adapted version introduces unverified claims or stale numbers.
+- Referral traffic is low and bounce/engagement quality is poor for two consecutive monthly cycles.
+- A platform account, permissions model, or deletion/rollback path is unclear.
+- Duplicate-content or indexing issues appear for canonical posts.
+- The workflow starts cannibalizing editorial quality on `kriskrug.co`.
+
+## Launch Gate Checklist
+
+- [ ] Canonical `kriskrug.co` post URL verified.
+- [ ] Platform selected and rationale noted.
+- [ ] Privacy/publicity screen passed.
+- [ ] Canonical/original-publication link included.
+- [ ] CTA and UTM links reviewed.
+- [ ] Media rights and alt text reviewed.
+- [ ] Platform preview checked.
+- [ ] Publisher approval captured.
+- [ ] Public URL and metric dates logged after posting.
+
+## Closeout Criteria for #52
+
+Issue #52 can be treated as strategy-complete when this doc is accepted as the v1 playbook and a future execution issue or checklist owns account setup, first-package approval, and pilot measurement.

--- a/docs/current-state/marketing/email-onboarding-v1-2026-06-17.md
+++ b/docs/current-state/marketing/email-onboarding-v1-2026-06-17.md
@@ -1,0 +1,349 @@
+# Email Onboarding Draft v1 - 2026-06-17
+
+**Issue lane:** child issue #230, split from parent issue #51.
+**Status:** Draft-only, repo-safe planning artifact.
+**Scope:** Sequence structure, email-by-email purpose, subject options, draft body copy, conceptual trigger/tag map, and required decisions before sending.
+**Out of scope:** ESP/CRM setup, contact import, subscriber data handling, form publishing, tracking pixels, automation activation, public launch, and email sending.
+
+## Working Assumptions
+
+- Parent #51 remains the full production email onboarding system.
+- Child #230 is satisfied when v1 copy and a non-executing automation map are ready for human review.
+- This draft prioritizes one shared lead-magnet nurture sequence because #229 is the active child lane for lead-magnet content.
+- The broader parent #51 sequence set remains parked until platform, consent, and audience decisions are made.
+- All copy below requires brand, legal/privacy, and deliverability review before use.
+
+## Sequence Structure
+
+### V1 Sequence: Lead Magnet Download
+
+**Use case:** A visitor requests one of the five guides from #229.
+
+**Length:** 7 emails over 21 days.
+
+**Goal:** Deliver the guide, build trust, segment the reader by interest, and invite the right next action without pretending an email sequence is a relationship.
+
+**Cadence:**
+
+| Email | Timing | Purpose |
+|---|---:|---|
+| 1 | Immediate | Deliver the guide and set expectations. |
+| 2 | Day 2 | Share Kris's human-first AI frame and ask for the reader's context. |
+| 3 | Day 5 | Offer a practical worksheet or exercise from the guide. |
+| 4 | Day 8 | Show applied proof through a story, case study, or field note. |
+| 5 | Day 12 | Route by segment and invite a specific next step. |
+| 6 | Day 16 | Address skepticism, risk, and trust directly. |
+| 7 | Day 21 | Make the clear ask: book, reply, attend, or keep reading. |
+
+### Later Parent #51 Sequences
+
+These remain conceptual until the full parent issue is resumed:
+
+- New subscriber: 5 emails over 14 days.
+- Lead magnet download: 7-10 emails over 21-30 days.
+- Event attendee: 5 emails over 30 days.
+- Workshop inquiry: 7 emails over 14 days.
+- Blog subscriber: weekly editorial dispatch.
+- Re-engagement: 4 emails to inactive subscribers.
+
+## Email 1: Guide Delivery
+
+**Purpose:** Deliver the requested guide, acknowledge the reader's interest, and set a low-pressure expectation for follow-up.
+
+**Subject options:**
+
+- Your guide is here: {{guide_title}}
+- Here is the {{guide_title}} field guide
+- Download: {{guide_title}}
+
+**Body copy:**
+
+Hi {{first_name}},
+
+Here is the guide you asked for:
+
+{{guide_download_link}}
+
+I made this for people who want to work with AI without surrendering their judgment, voice, community, or ethics to the tool stack.
+
+Over the next couple of weeks, I will send a few short notes that help you turn the guide into something practical: a conversation with your team, a workshop idea, a safer workflow, or a clearer next decision.
+
+No breathless hype. No fake certainty. Just useful field notes from the messy middle of creative technology, community building, and responsible AI adoption.
+
+Start here: read the first section and write down one AI question your team keeps circling but has not named clearly yet.
+
+Kris
+
+**Primary CTA:** Download the guide
+
+**Secondary CTA:** Reply with the AI question your team is circling.
+
+## Email 2: The Human-First Frame
+
+**Purpose:** Establish Kris's point of view and encourage the reader to define their context.
+
+**Subject options:**
+
+- The better AI question
+- Start with people, not tools
+- Before you pick a tool
+
+**Body copy:**
+
+Hi {{first_name}},
+
+Most AI conversations start in the wrong place.
+
+People ask: "Which tool should we use?"
+
+The better question is: "What human work are we trying to support, and what would make that work more trustworthy, creative, accessible, or useful?"
+
+That question changes the room.
+
+It moves the conversation away from demos and toward people: staff, artists, students, members, audiences, communities, clients, sources, partners, and the folks who carry the risk when a system goes sideways.
+
+Try this with your guide:
+
+1. Pick one workflow or decision your team cares about.
+2. Name the people affected by it.
+3. Name one thing AI might improve.
+4. Name one thing AI could make worse.
+5. Decide who needs to be in the conversation before anything ships.
+
+That is the start of a better AI strategy.
+
+Kris
+
+**Primary CTA:** Bring this conversation to your team.
+
+## Email 3: One Practical Exercise
+
+**Purpose:** Move the reader from passive download to action.
+
+**Subject options:**
+
+- A 15-minute AI exercise
+- Try this before your next AI meeting
+- The smallest useful AI audit
+
+**Body copy:**
+
+Hi {{first_name}},
+
+Here is a simple exercise you can run in 15 minutes.
+
+Open a blank page and make three columns:
+
+- Work we repeat
+- Work that needs judgment
+- Work that creates trust
+
+Now list five tasks under each column.
+
+The first column is where AI may save time.
+
+The second column is where AI may help with drafts, options, or synthesis, but humans still own the decision.
+
+The third column is where you move slowly. Trust work needs consent, context, relationship, and accountability. Automation can support it, but it should not quietly replace it.
+
+If you only do one thing after reading the guide, do this map. It will tell you more than another tool demo.
+
+Kris
+
+**Primary CTA:** Book a working session.
+
+## Email 4: Field Proof
+
+**Purpose:** Show how Kris turns ideas into practice without exposing private client details.
+
+**Subject options:**
+
+- What practical AI work looks like
+- From messy notes to useful systems
+- The work behind the workshop
+
+**Body copy:**
+
+Hi {{first_name}},
+
+The most useful AI work I do rarely starts with a model.
+
+It starts with source material: interviews, workshops, event notes, transcripts, photos, messy docs, half-formed strategy, and the lived context that never fits neatly inside a prompt box.
+
+From there, the job is to build a system that helps people think better:
+
+- Turn scattered knowledge into a usable archive.
+- Make the language sound like the humans behind the work.
+- Build reusable assets instead of one-off campaigns.
+- Keep review, consent, and accountability visible.
+- Use automation to support trust, not bypass it.
+
+That is the pattern behind the strongest projects: the knowledge is the asset, the tools are the scaffolding, and the humans still own the meaning.
+
+Kris
+
+**Primary CTA:** See how this could apply to your team.
+
+## Email 5: Segment Routing
+
+**Purpose:** Invite the reader to self-identify and route future follow-up by interest.
+
+**Subject options:**
+
+- Which AI conversation are you actually having?
+- Pick your lane
+- What brought you here?
+
+**Body copy:**
+
+Hi {{first_name}},
+
+People arrive at AI from very different doors.
+
+Some are trying to lead a team through uncertainty. Some are artists trying to protect their voice while learning new tools. Some are community organizers trying to build trust. Some are media people trying to move faster without breaking verification. Some are working through sovereignty, consent, and governance questions that deserve more care than a vendor deck can provide.
+
+Which conversation are you having right now?
+
+Choose the closest fit:
+
+- I am leading a team or organization.
+- I am building creative workflows.
+- I am organizing community or ecosystem work.
+- I work in media, journalism, or communications.
+- I am focused on Indigenous AI, governance, sovereignty, or partnership.
+
+Your answer helps shape what I send next and where a real conversation might be useful.
+
+Kris
+
+**Primary CTA:** Reply with your lane.
+
+**Implementation note:** In a live ESP, these choices should become tracked links or preference-center options only after consent and platform decisions are approved.
+
+## Email 6: Trust and Risk
+
+**Purpose:** Address the reader's likely objections and reinforce a careful operating model.
+
+**Subject options:**
+
+- The AI risk nobody fixes with a prompt
+- Trust is the adoption layer
+- Move slower where trust is involved
+
+**Body copy:**
+
+Hi {{first_name}},
+
+The hardest AI problems are not prompt problems.
+
+They are trust problems.
+
+Does the team understand what the system is doing? Did people consent to how their material is being used? Can someone explain the decision? Is there a rollback path? Are we making work better, or just making bad process move faster?
+
+That is why I like small, legible pilots.
+
+Pick a real workflow. Limit the blast radius. Keep humans in the loop. Make review visible. Write down what is allowed and what is not. Test the output against reality. Then decide whether it deserves more responsibility.
+
+AI adoption works better when people can see the guardrails.
+
+Kris
+
+**Primary CTA:** Plan a safer AI pilot.
+
+## Email 7: Clear Next Ask
+
+**Purpose:** Convert attention into a next step while leaving a respectful non-buyer path.
+
+**Subject options:**
+
+- Want help turning this into a plan?
+- The next useful step
+- Bring Kris into the room
+
+**Body copy:**
+
+Hi {{first_name}},
+
+If the guide helped, there are a few good next steps.
+
+If your team needs shared language, bring me in for a keynote.
+
+If you need practical momentum, book a workshop.
+
+If you are already experimenting and want safer systems, start with a workflow audit.
+
+If you are building community around AI, I can help design the room, facilitate the conversation, document the learning, and turn the work into assets that keep serving people after the event ends.
+
+And if now is not the moment, that is fine too. Keep the guide, share it with the person who keeps asking the hard questions, and stay close to the work.
+
+Kris
+
+**Primary CTA:** Book a conversation.
+
+**Secondary CTA:** Keep reading the blog.
+
+## Conceptual Trigger and Tag Map
+
+This is a planning map only. Do not configure these tags or triggers until the platform, consent model, and privacy language are approved.
+
+### Entry Triggers
+
+| Trigger | Source | Intended Action |
+|---|---|---|
+| `form_submit_lead_magnet_general` | Humanizing Tech landing page | Send guide, enter lead-magnet sequence, tag general AI. |
+| `form_submit_lead_magnet_creative` | Creative Technologist landing page | Send guide, enter lead-magnet sequence, tag creative workflow. |
+| `form_submit_lead_magnet_community` | Community Building landing page | Send guide, enter lead-magnet sequence, tag community builder. |
+| `form_submit_lead_magnet_media` | AI for Media landing page | Send guide, enter lead-magnet sequence, tag media professional. |
+| `form_submit_lead_magnet_indigenous_ai` | Indigenous AI landing page | Send guide, enter lead-magnet sequence, tag Indigenous AI interest. |
+
+### Conceptual Tags
+
+| Tag | Meaning |
+|---|---|
+| `source:kriskrug_site` | Subscriber came through kriskrug.co. |
+| `intent:lead_magnet` | Subscriber requested a guide. |
+| `segment:general_ai` | Interested in human-first AI leadership. |
+| `segment:creative_tech` | Interested in creative AI workflows. |
+| `segment:community_building` | Interested in community, ecosystem, or event work. |
+| `segment:media_ai` | Interested in journalism, media, production, or communications. |
+| `segment:indigenous_ai` | Interested in Indigenous AI, governance, sovereignty, or partnership. |
+| `interest:keynote` | Clicked keynote or speaking CTA. |
+| `interest:workshop` | Clicked workshop CTA. |
+| `interest:strategy` | Clicked strategy or audit CTA. |
+| `status:needs_human_reply` | Replied or requested contact; requires manual handling. |
+
+### Suppression and Safety Rules
+
+- Never enroll a contact without clear consent.
+- Never import old contacts into this sequence without a separate consent and list-hygiene decision.
+- Suppress unsubscribed, bounced, complained, or manually excluded contacts.
+- Do not send Indigenous AI follow-up that implies endorsement, authority, or partnership without human review.
+- Do not infer sensitive identity from guide interest. Treat segment tags as content-interest signals only.
+- Stop automation if a person replies with a direct inquiry, complaint, correction, or consent concern.
+
+## Required Decisions Before Sending
+
+- ESP/CRM platform owner and implementation path.
+- Consent language for each form.
+- Privacy-policy alignment and data retention expectations.
+- Physical mailing address and sender identity requirements.
+- From name, reply-to address, and monitored inbox owner.
+- Unsubscribe and preference-center behavior.
+- Whether old newsletter subscribers can receive any part of this sequence.
+- Which guide download files exist and where they are hosted.
+- Whether each guide has its own thank-you page.
+- Whether link tracking, open tracking, UTM tags, or analytics events are acceptable.
+- Accessibility and plain-language review.
+- Review owner for Indigenous AI language.
+- Manual response workflow for replies and high-intent clicks.
+- Rollback process for pausing sends, disabling forms, and removing public CTAs.
+
+## Ready-for-Implementation Checklist
+
+- [ ] KK approves the sequence length and cadence.
+- [ ] KK approves subject lines and body copy direction.
+- [ ] #229 guide titles and landing-page CTAs are approved.
+- [ ] ESP/CRM platform is selected.
+- [ ] Consent, privacy, unsubscribe, and data-retention language is approved.
+- [ ] Sender identity and monitored reply workflow are confirmed.
+- [ ] No automation or send occurs until the above decisions are complete.

--- a/docs/current-state/marketing/lead-magnets-v1-2026-06-17.md
+++ b/docs/current-state/marketing/lead-magnets-v1-2026-06-17.md
@@ -1,0 +1,188 @@
+# Lead Magnet Drafts v1 - 2026-06-17
+
+**Issue lane:** child issue #229, split from parent issue #49.
+**Status:** Draft-only, repo-safe planning artifact.
+**Scope:** Audience segmentation, guide positioning, guide outlines, landing-page requirements, CTA options, and launch decisions.
+**Out of scope:** Production WordPress writes, email capture configuration, CRM/list setup, form embeds, automations, analytics wiring, public launch, and collection or handling of lead data.
+
+## Working Assumptions
+
+- Parent #49 remains the full production lead-magnet system.
+- Child #229 is satisfied when the v1 content architecture is ready for human review and later implementation.
+- The five guide titles below preserve the parent issue's recommended lead-magnet set.
+- Each guide is intended to become a short 10-15 page PDF or web-first guide after subject-matter review.
+- Landing pages should be drafted before any form, list, CRM, or tracking setup is touched.
+
+## Audience Segments and Guide Set
+
+| Segment | Reader Need | Proposed Guide Title | Primary Offer |
+|---|---|---|---|
+| General AI-curious leaders | Understand AI without hype, panic, or vendor fog. | Humanizing Tech in the AI Age | A grounded field guide for making AI feel useful, ethical, and human. |
+| Creative professionals | Turn AI from novelty into a repeatable creative workflow. | Creative Technologist's Toolkit | Practical workflows for artists, producers, designers, photographers, and storytellers. |
+| Community organizers | Build trust, participation, and momentum around technology change. | Community Building Playbook | A community-first playbook for convening people around AI without extractive hype. |
+| Journalists and media professionals | Use AI responsibly in reporting, research, production, and newsroom workflows. | AI for Media Professionals | A working guide to AI-assisted media work with verification and editorial integrity. |
+| Indigenous leaders and allied partners | Evaluate AI through sovereignty, consent, data governance, and cultural context. | Indigenous AI Sovereignty Framework | A decision framework for responsible AI conversations in Indigenous contexts. |
+
+## Guide 1: Humanizing Tech in the AI Age
+
+**Audience:** Executives, educators, nonprofit leaders, civic staff, founders, and community members who need a plainspoken AI orientation.
+
+**Promise:** Readers leave with a practical way to talk about AI that centers people, trust, context, and real work.
+
+**Concise outline:**
+
+1. The problem: AI is arriving faster than shared understanding.
+2. What "humanizing tech" means in practical terms.
+3. The three-question filter: who benefits, who is affected, who decides.
+4. How to spot hype, fear, and magical thinking.
+5. Where AI helps today: drafts, synthesis, search, translation, operations, prototyping.
+6. Where humans must stay accountable: judgment, consent, privacy, safety, taste, public trust.
+7. A meeting-room worksheet for evaluating an AI idea.
+8. Next step: bring Kris in for a keynote, workshop, or strategy session.
+
+**Landing-page angle:** "A plain-English AI guide for leaders who care about people as much as tools."
+
+## Guide 2: Creative Technologist's Toolkit
+
+**Audience:** Artists, filmmakers, photographers, designers, producers, writers, educators, and creative directors.
+
+**Promise:** Readers get a useful starter kit for adding AI to creative work without flattening voice, taste, authorship, or craft.
+
+**Concise outline:**
+
+1. The creative shift: AI as studio assistant, not artistic replacement.
+2. Capture first: notes, voice memos, sketches, transcripts, references, and archives.
+3. Build a personal creative knowledge base.
+4. Prompting from taste: references, constraints, audience, and desired emotional effect.
+5. Workflow recipes: concept boards, proposal drafts, interview prep, edit logs, captions, pitch decks.
+6. Responsible boundaries: consent, attribution, source material, client expectations, and disclosure.
+7. The "75 percent rule" for keeping human judgment in charge.
+8. Next step: book a creative AI workshop or workflow design session.
+
+**Landing-page angle:** "A practical AI workflow kit for people whose taste is the product."
+
+## Guide 3: Community Building Playbook
+
+**Audience:** Meetup hosts, nonprofit operators, ecosystem builders, association leaders, civic innovators, and grassroots organizers.
+
+**Promise:** Readers learn how to build community trust around AI adoption without turning community into a marketing costume.
+
+**Concise outline:**
+
+1. The problem: people do not adopt what they do not trust.
+2. Community before campaign: convening as infrastructure.
+3. How to define the real audience: members, partners, skeptics, funders, practitioners.
+4. Designing events that create belonging, not just attendance.
+5. Turning recaps, photos, notes, and questions into reusable knowledge assets.
+6. Partnership maps: who already has trust with the people you want to serve.
+7. Guardrails for volunteer labor, consent, photos, and representation.
+8. Next step: invite Kris to advise, host, photograph, or facilitate a community AI program.
+
+**Landing-page angle:** "A field-tested guide for turning AI curiosity into trusted local participation."
+
+## Guide 4: AI for Media Professionals
+
+**Audience:** Journalists, editors, newsroom leaders, producers, podcasters, documentary teams, and communications staff.
+
+**Promise:** Readers get a newsroom-safe way to use AI for research and production while protecting verification, sources, and editorial trust.
+
+**Concise outline:**
+
+1. The media trust problem: speed is not the same as truth.
+2. Useful AI tasks: transcript analysis, research maps, timelines, interview prep, versioning, accessibility support.
+3. Verification workflow: source traceability, quote checks, claim logs, and human approval.
+4. What not to automate: final facts, sensitive source handling, editorial judgment, community harm assessment.
+5. Building a newsroom prompt pack.
+6. Disclosure and policy basics for teams without an AI policy yet.
+7. A pre-publication AI-use checklist.
+8. Next step: book a newsroom workshop, editorial keynote, or workflow audit.
+
+**Landing-page angle:** "A practical guide to using AI in media without giving up editorial trust."
+
+## Guide 5: Indigenous AI Sovereignty Framework
+
+**Audience:** Indigenous leaders, Indigenous-serving organizations, technology partners, public-sector teams, funders, and allied practitioners.
+
+**Promise:** Readers get a respectful starting framework for AI conversations shaped by sovereignty, consent, governance, relationship, and local context.
+
+**Concise outline:**
+
+1. The starting point: AI is not neutral infrastructure.
+2. Why data governance, consent, and jurisdiction come first.
+3. Questions to ask before any AI pilot touches Indigenous data, stories, language, images, or knowledge.
+4. Risk map: extraction, misrepresentation, dependency, surveillance, procurement pressure, model opacity.
+5. Opportunity map: language support, archive access, community services, youth learning, admin relief, cultural continuity.
+6. Partnership terms that protect trust: ownership, review, opt-out, benefit sharing, and long-term stewardship.
+7. A decision worksheet for boards, councils, staff, and partners.
+8. Next step: start with a listening session or facilitated strategy workshop.
+
+**Landing-page angle:** "A practical starting framework for AI decisions rooted in sovereignty, consent, and trust."
+
+## Landing-Page Requirements
+
+Each guide landing page should include:
+
+- One clear audience-specific headline.
+- One short promise statement that names the reader and the transformation.
+- A three-to-five bullet "what you will learn" section.
+- A preview of guide contents without over-explaining the whole PDF.
+- One primary CTA above the fold and repeated near the bottom.
+- One secondary CTA for high-intent visitors who want to book Kris instead of downloading.
+- Trust markers relevant to the segment: speaking, BC + AI, The Upgrade AI, responsible AI work, media/community experience, photography/documentary background, or Indigenous partnership experience where appropriate and approved.
+- A short privacy note explaining what happens after signup before any form goes live.
+- Accessibility-ready copy: descriptive link text, no image-only instructions, concise headings, and plain-language labels.
+- SEO basics for the future implementation: proposed slug, meta title, meta description, social title, social description, and featured image brief.
+- Implementation notes for later: form provider, consent language, thank-you destination, email sequence, file delivery method, analytics events, and rollback path.
+
+## CTA Copy Options
+
+### General CTA Set
+
+- Download the free guide
+- Get the guide
+- Send me the field guide
+- Read the practical AI guide
+- Start with the free framework
+
+### Segment-Specific CTA Set
+
+- Humanizing Tech in the AI Age: "Get the human-first AI guide"
+- Creative Technologist's Toolkit: "Download the creative AI toolkit"
+- Community Building Playbook: "Get the community AI playbook"
+- AI for Media Professionals: "Download the newsroom-safe AI guide"
+- Indigenous AI Sovereignty Framework: "Get the sovereignty-first AI framework"
+
+### High-Intent Secondary CTAs
+
+- Book Kris for a keynote
+- Plan a workshop
+- Talk through your AI strategy
+- Bring this conversation to your team
+- Invite Kris to facilitate
+
+## Follow-Up Launch Decisions
+
+Before public launch, decide:
+
+- Which guide ships first and why.
+- Whether all five guides use one shared download template or distinct landing-page layouts.
+- Which ESP/CRM owns forms, tags, delivery emails, and unsubscribe management.
+- Whether the guides are PDF-only, web-first, or both.
+- Who reviews claims, examples, and sensitive language for each guide.
+- Who approves Indigenous AI positioning and partnership language before publication.
+- What consent language appears on each form.
+- What thank-you page or confirmation experience follows each signup.
+- What email sequence from #230 each guide should enter.
+- What minimal analytics are acceptable before launch.
+- What conversion target is realistic for v1 before the parent #49 growth goals are reintroduced.
+- What rollback path removes forms, files, automations, and landing pages if something is wrong.
+
+## Ready-for-Implementation Checklist
+
+- [ ] KK approves the five segments and titles.
+- [ ] KK chooses the first guide to draft in full.
+- [ ] Segment-specific proof points are selected.
+- [ ] Form provider, data owner, and privacy language are approved.
+- [ ] Email follow-up path from #230 is approved.
+- [ ] Landing-page slugs and CTAs are approved.
+- [ ] No production write occurs until the above decisions are complete.

--- a/docs/current-state/marketing/social-amplification-system-v1-2026-06-17.md
+++ b/docs/current-state/marketing/social-amplification-system-v1-2026-06-17.md
@@ -1,0 +1,236 @@
+# Social Amplification System v1 - 2026-06-17
+
+**Lane:** Track A marketing/content strategy
+**Scope:** docs-only v1 for GitHub issue #56. No public posting, account setup, API configuration, outbound messages, private data handling, or production deploy.
+**Issue:** [#56 - [MARKETING] Social Media Amplification System](https://github.com/WalksWithASwagger/kriskrug-wp/issues/56)
+
+## Assumptions and Success Criteria
+
+- Every amplification package starts from a published, approved `kriskrug.co` post.
+- The system creates reusable assets and approval gates, not automatic public distribution.
+- Buffer, Canva, or equivalent tooling may be used later, but this doc does not configure tools or accounts.
+- Success for issue #56 means future publishers have a platform-by-platform workflow, templates, gates, privacy constraints, metrics, and a checklist for turning one post into 10-15 derivative assets.
+
+## Platform Workflow
+
+| Platform | Output per canonical post | Best use | Timing | Review focus |
+|---|---|---|---|---|
+| LinkedIn feed | 3-4 short posts | Professional framing, lessons, event/community proof, service relevance | Publish over 1-2 weeks | Claims, tone, CTA, no private client details |
+| LinkedIn article | 1 adapted article or excerpt | High-signal long-form professional reuse | After canonical post and before or during feed run | Canonical link, overlap with syndication plan #52 |
+| X/Twitter | 1 thread of 5-10 posts plus optional single quote post | Sharp thesis, useful list, event recap, link back | Same week as canonical post | Thread coherence, no context collapse, no stale handles |
+| Instagram feed | 1 carousel or image post | Visual storytelling, event/photo context, concise takeaways | Same week or weekend | Image rights, captions, alt text, tags |
+| Instagram Stories | 3-5 frames | Lightweight reminders, behind-the-scenes, recap prompts | 24-72 hours after publish | Publicity consent, no private screenshots |
+| TikTok/Reels | 1-3 short clips | Spoken insight, field note, one practical takeaway | Within 2 weeks if video source exists | Consent, captions, no unapproved music/media |
+| Pinterest | 2-3 pins | Evergreen visuals, photography, keynote/resource content | Within 2 weeks | Destination URL, image ownership, title readability |
+| Email snippet | 1 short newsletter block | Curated note and canonical link | Next newsletter cycle | Subscriber relevance, no overclaiming |
+
+## v1 Tool Roles
+
+| Tool | Role | v1 boundary |
+|---|---|---|
+| Canva | Design reusable visual templates for carousels, story frames, quote cards, short-video covers, and Pinterest pins | Use only approved source media and reviewed copy; no account setup in this doc |
+| Buffer or equivalent scheduler | Hold approved posts in a visible calendar and prevent same-day platform pileups | Schedule only after explicit approval; no account/API configuration in this doc |
+| Campaign log | Track canonical URL, derivative asset, platform URL, publish date, UTM, owner, and metrics | Can start as a spreadsheet or repo-safe markdown table before any tool migration |
+
+## Asset Packaging Workflow
+
+### 1. Source
+
+- Confirm canonical URL, title, excerpt, publish date, hero/primary image, author, and target CTA.
+- Pull 3-5 core ideas, 2-3 quotable lines, and any proof points from the post.
+- Note any source media, people, clients, venues, or sponsors that require approval.
+
+### 2. Split
+
+- Turn the post into:
+  - one thesis post,
+  - one practical lesson post,
+  - one personal/context post,
+  - one visual/carousel concept,
+  - one thread outline,
+  - one email snippet,
+  - optional short-video prompts if source footage exists.
+
+### 3. Design
+
+- Use Canva or existing brand templates only after the visual claim, image rights, and platform dimensions are checked.
+- Keep text overlays short enough to read on mobile.
+- Preserve alt text or write fresh alt text for each image asset.
+
+### 4. Schedule
+
+- Keep a 4-week working calendar with statuses: `drafted`, `review`, `approved`, `scheduled`, `published`, `measured`.
+- Do not schedule public posts before approval.
+- Avoid posting every derivative on the same day; let each platform breathe.
+
+### 5. Measure
+
+- Capture native analytics after 48 hours, 7 days, and 30 days.
+- Keep platform URL, canonical URL, asset type, date, CTA, and metrics in the campaign log.
+
+## Reusable Post Templates
+
+### LinkedIn Thesis Post
+
+```text
+I used to think [common assumption].
+
+After [event/project/post context], I think the sharper question is:
+[core thesis].
+
+Three things this changes:
+1. [point]
+2. [point]
+3. [point]
+
+Full note: [canonical URL with UTM]
+```
+
+### LinkedIn Practical Lesson
+
+```text
+One practical takeaway from [post topic]:
+
+[specific lesson in 1-2 sentences]
+
+What worked:
+- [detail]
+- [detail]
+- [detail]
+
+What I would watch next:
+[risk/open question]
+
+Source note: [canonical URL with UTM]
+```
+
+### X/Twitter Thread
+
+```text
+1/ [Hook: specific claim, tension, or lesson]
+
+2/ [Context]
+
+3/ [Point one]
+
+4/ [Point two]
+
+5/ [Point three]
+
+6/ [Concrete example or useful step]
+
+7/ [Why it matters]
+
+8/ Full post: [canonical URL with UTM]
+```
+
+### Instagram Carousel
+
+```text
+Slide 1: [short title]
+Slide 2: [problem/tension]
+Slide 3: [lesson one]
+Slide 4: [lesson two]
+Slide 5: [lesson three]
+Slide 6: [question or CTA]
+
+Caption:
+[2-4 sentence setup]
+
+Read the full piece at kriskrug.co: [canonical URL or profile-link instruction]
+```
+
+### Short-Video Prompt
+
+```text
+Opening line: [one sentence hook]
+Middle: [one story, example, or lesson]
+Close: [one question or CTA]
+Caption: [canonical URL or profile-link instruction]
+Required on-screen text: [short phrase]
+Required captions: yes
+```
+
+### Pinterest Pin
+
+```text
+Pin title: [clear evergreen title]
+Pin description: [1-2 sentence summary with search phrase]
+Destination URL: [canonical URL with UTM]
+Image: [owned/approved visual]
+Alt text: [specific visual description]
+```
+
+### Email Snippet
+
+```text
+Subject/section line: [short topic label]
+
+[One paragraph that frames why this post matters now.]
+
+Read: [post title] - [canonical URL with UTM]
+```
+
+## Approval Gates
+
+Public amplification may proceed only when all gates pass:
+
+- Canonical post is public and stable.
+- Platform package uses a reviewed CTA and canonical URL.
+- Any names, faces, venues, client references, sponsor references, or attendee context are approved for public reuse.
+- Images, clips, logos, screenshots, and music are owned, licensed, or explicitly approved.
+- Claims, numbers, dates, and affiliations are current or clearly time-bound.
+- Accessibility basics are complete: captions for video, alt text for images, readable text overlays.
+- Platform preview has been checked manually.
+- KK or delegated publisher approves the final package before scheduling.
+
+## Privacy and Publicity Constraints
+
+- Do not expose attendee identities, private conversations, emails, DMs, Slack/Notion screenshots, form submissions, or unpublished client material.
+- Do not imply sponsor, employer, client, or community endorsement unless the relationship is explicit and approved.
+- Do not reuse event photos where a person is the subject without checking consent or public-event expectations.
+- Do not use platform-native AI expansion tools on private source material.
+- Do not post AI-generated imagery as event documentation or factual proof.
+- Do not publish crisis, legal, health, or personally sensitive material through this workflow without a separate human review path.
+
+## Metrics
+
+| Metric | Goal signal | Cadence |
+|---|---|---|
+| Assets created per canonical post | Issue #56 target: 10-15 pieces when the post warrants it | Per package |
+| Social reach | Directional target: 3-5x baseline reach after pilot | 7 and 30 days |
+| Engagement rate | Saves, comments, replies, shares, profile clicks | 48 hours, 7 days |
+| Referral sessions | Clicks to canonical `kriskrug.co` post | 7 and 30 days |
+| Leads or inquiries | Clear-source contact, reply, booking, or newsletter signal | Monthly |
+| Calendar health | 4 weeks of reviewed or scheduled content, not just drafts | Weekly |
+| Quality guardrails | Corrections, takedowns, privacy flags, negative feedback | Continuous |
+
+## Launch Checklist
+
+- [ ] Canonical post URL verified.
+- [ ] Source facts, quotes, and media extracted.
+- [ ] Privacy/publicity screen passed.
+- [ ] Platform package drafted.
+- [ ] Image/video rights checked.
+- [ ] Alt text and captions prepared.
+- [ ] CTA and UTM links reviewed.
+- [ ] Platform preview checked.
+- [ ] Approval captured before scheduling.
+- [ ] Calendar status updated.
+- [ ] Published URLs logged.
+- [ ] 48-hour, 7-day, and 30-day metric readbacks scheduled.
+
+## Stop Conditions
+
+Pause amplification for a post or platform if:
+
+- Approval is missing or ambiguous.
+- A package depends on private or consent-sensitive context.
+- Public comments reveal factual confusion that needs correction.
+- Platform reach is improving only through low-quality engagement or off-brand framing.
+- The calendar is full of drafts but lacks review capacity.
+- Tool access, account ownership, or delete/rollback ability is unclear.
+
+## Closeout Criteria for #56
+
+Issue #56 can be treated as strategy-complete when this doc is accepted as the v1 playbook and a future execution issue owns tool selection, template implementation, calendar setup, first package approval, and metric logging.

--- a/docs/current-state/portal/constellation-navigation-design-v1-2026-06-17.md
+++ b/docs/current-state/portal/constellation-navigation-design-v1-2026-06-17.md
@@ -1,0 +1,283 @@
+# Constellation Navigation Design V1 - 2026-06-17
+
+**Status:** V1 design/spec artifact. No theme implementation, WordPress writes, deploy, analytics instrumentation, external integration, or private source handling is implemented by this document.
+
+**Issue:** GitHub #63 - `[PORTAL] Beautiful Constellation Navigation Design`
+
+**Lane:** Track B-ready design/spec, docs-only.
+
+## Goal
+
+Give issue #63 a practical implementation target: a beautiful but usable project-network navigation surface that shows how Kris's major bodies of work connect, without replacing the site's primary navigation or creating a heavy custom app.
+
+The constellation should help visitors understand the ecosystem quickly, then move toward the right next step: hire, invite, read, attend, explore a project, or contact Kris.
+
+## Assumptions
+
+1. `kriskrug.co` remains the home base for Kris's identity, services, writing, speaking, and project proof.
+2. The constellation is a guided discovery module, not the site's only navigation system.
+3. Aurora remains the likely implementation lane because this requires theme-level interaction, responsive layout, motion rules, and accessibility checks.
+4. Production URLs stay stable unless KK separately approves a redirect or IA change.
+5. The six project nodes named in issue #63 are the starting set, but labels and targets need final content approval before implementation.
+
+## Target Users And Use Cases
+
+Primary users:
+
+- Event organizers evaluating Kris for a keynote, workshop, moderation, or advisory role.
+- AI, culture, and community leaders trying to understand how BC + AI, Vancouver AI, Indigenomics, The Upgrade AI, photography, and thought leadership relate.
+- Readers who arrive through a post and need a quick map of Kris's broader work.
+- Collaborators, sponsors, and partners looking for the right project doorway.
+- Returning followers who know one project but not the full network.
+
+Primary use cases:
+
+| Use case | Desired outcome |
+|---|---|
+| "Who is Kris and what is he building?" | Understand the ecosystem in under 20 seconds. |
+| "Which project is relevant to me?" | Select one node and get a concise description plus a clear link. |
+| "Can I hire or invite him?" | Move from project context to Speaking, Services, or Contact. |
+| "Where does BC + AI fit?" | See it as a major community and industry node without making it the only story. |
+| "I cannot use animation or pointer hover." | Use the same content through keyboard, screen reader, reduced-motion, and mobile list paths. |
+
+## Information Architecture
+
+The constellation should sit below the first brand/offer signal, not above it. It works best as a homepage or Work-page section after the visitor already sees "Kris Krug" and the primary role promise.
+
+Recommended placement options:
+
+| Surface | Recommendation | Reason |
+|---|---|---|
+| Homepage | Optional V1 placement after hero/proof chips | Strongest orientation moment, but must not delay first contentful paint. |
+| Work page | Preferred first implementation target | Visitors expect project relationships here, and it keeps the experiment away from the global header. |
+| About page | Secondary compact version | Useful as "Current Work" context, but avoid making About too visually busy. |
+| Header/global nav | Do not implement in V1 | Too much risk for core navigation, mobile usability, and accessibility. |
+| Footer | Text fallback only | Good for durable links, not the animated concept. |
+
+Recommended node set for V1:
+
+| Node | Role in the network | Likely target |
+|---|---|---|
+| BC + AI | Community and industry association work in British Columbia | External `bc-ai.ca` or internal BC + AI role page if approved |
+| Indigenomics | AI, technology, and Indigenous economic future work | Work/project detail or external property if approved |
+| The Upgrade AI | AI literacy, training, and media/product work | Internal Services/Work section or external property if approved |
+| Vancouver AI | Local events, community learning, and practical AI adoption | Events, Vancouver AI pillar, or BC + AI context page |
+| Photography | Documentary, event, portrait, and visual culture proof | Photography page/archive teaser |
+| Thought Leadership | Writing, talks, podcasts, and public ideas | Blog/Writing, Speaking, and selected pillar posts |
+
+Secondary links should remain outside the constellation: Newsletter, Contact, Services, Speaking, Events, Blog/Writing, Podcast, Publications, Testimonials, policies.
+
+## Constellation Metaphor Boundaries
+
+Use the metaphor as a spatial aid, not as a literal interface that obscures content.
+
+The constellation may include:
+
+- Six stable nodes, each with a label, short description, and target link.
+- Thin connection lines showing relationship types.
+- A subtle idle drift, pulse, or draw-in effect.
+- Focus/hover detail panels.
+- Optional "path" highlighting from one node to related nodes.
+
+The constellation should not include:
+
+- Starfields, particle storms, or decorative backgrounds that compete with text.
+- Hidden unlabeled points that look clickable but do nothing.
+- Motion that is required to understand the relationships.
+- Physics simulation as the default layout.
+- Canvas-only text or links.
+- More than six primary nodes in V1.
+- A global navigation replacement.
+
+Relationship line types:
+
+| Relationship | Example | Visual treatment |
+|---|---|---|
+| Community | BC + AI to Vancouver AI | Solid line, strongest weight. |
+| Practice | Photography to Thought Leadership | Fine line, medium weight. |
+| Platform | The Upgrade AI to Thought Leadership | Dashed or low-opacity line. |
+| Partnership/proof | Indigenomics to BC + AI or Thought Leadership | Solid line, medium weight. |
+
+Line labels are optional and should be hidden by default. If added, they appear only in the detail panel or as accessible text, not as tiny floating labels.
+
+## Interaction Model
+
+Default desktop state:
+
+- Six nodes arranged in a stable radial or asymmetric cluster.
+- Each node shows a plain-language label.
+- One node may be featured by default if the module is placed on a page with strong context, but no node should be visually "selected" in a way that hides the others.
+- Connection lines are visible but restrained.
+
+Pointer behavior:
+
+- Hovering a node highlights it, strengthens related lines, dims unrelated lines slightly, and opens a detail panel.
+- Clicking a node opens the same detail panel first if the panel is not already open.
+- A second click on the primary CTA inside the panel navigates to the target.
+- Node labels and CTA text must be real HTML, not image text.
+
+Keyboard behavior:
+
+- The constellation is introduced by a semantic heading and short text.
+- Tab order follows the visible node order, then the active detail panel CTA.
+- Each node is a real `button` or link with a clear accessible name.
+- Arrow-key navigation may be added only if it is fully documented and does not replace normal Tab behavior.
+- `Enter` or `Space` opens the node detail.
+- `Escape` closes the detail panel and returns focus to the active node.
+- Focus indicators are visible against all background states.
+
+Touch/mobile behavior:
+
+- Do not depend on hover.
+- Default mobile presentation is a vertical or two-column "project map" list with small connection hints.
+- Tapping a node expands an inline detail panel with description and CTA.
+- The animated constellation can appear as a static visual header above the list if it does not add load or confusion.
+- Hit targets are at least 44 by 44 CSS pixels.
+- The mobile list must preserve the same six nodes, descriptions, and targets as desktop.
+
+Reduced-motion behavior:
+
+- No idle animation.
+- No line drawing animation.
+- State changes use instant or very short opacity changes.
+- The static layout still communicates the project relationships.
+
+## Navigation States
+
+| State | Requirements |
+|---|---|
+| Loading | Show the semantic heading and text/list content immediately. Enhancement can follow after CSS/JS loads. |
+| Ready | All nodes are visible, labeled, and reachable. No required content is hidden behind animation. |
+| Hover | Active node, related lines, and detail summary become clearer within 150 ms. |
+| Focus | Same clarity as hover, plus a visible focus ring. |
+| Selected/open | Detail panel shows title, one-sentence description, relationship hints, and one primary CTA. |
+| Visited | Optional subtle visited style on node CTA; do not make visited nodes look disabled. |
+| Error/no JS | Render as a normal HTML list of project cards with links. |
+| Reduced motion | Render as static or near-static module. |
+| High contrast/forced colors | Preserve labels, links, and focus order; do not rely on line color alone. |
+
+## Visual Constraints
+
+- Use the Aurora direction: editorial black, photographic depth, restrained glass, cyan/teal as an interaction signal, and real project proof where available.
+- Avoid a one-note blue/purple gradient system. Constellation lines can be cool-toned, but project nodes should have distinct non-color cues such as icon shape, label, metadata, or line pattern.
+- Do not place cards inside cards. The detail panel may be a single framed surface; the constellation itself should feel like a section, not a nested dashboard.
+- Do not use decorative orbit blobs or particle clouds.
+- Keep labels readable at normal text sizes. No tiny labels on curved paths.
+- Connection lines should never run through body copy or CTA buttons.
+- Use real photos or project thumbnails near the module if available; do not let the constellation become abstract clip art.
+- Keep animation subtle enough that the module still feels like navigation, not a splash screen.
+
+## Accessibility Criteria
+
+V1 must meet WCAG 2.1 AA for the module before any production rollout:
+
+- Semantic heading precedes the module.
+- All nodes have accessible names matching visible labels.
+- Each node detail has programmatic relationship to its trigger, such as `aria-expanded` and `aria-controls` where appropriate.
+- Color contrast passes 4.5:1 for normal text and 3:1 for large text and focus indicators.
+- Focus order matches reading/visual order.
+- Keyboard-only users can open details, follow links, and close panels without trapping focus.
+- Screen reader users receive the same project names, descriptions, relationship hints, and CTAs.
+- Motion respects `prefers-reduced-motion`.
+- The module remains usable at 320 px width, 200% browser zoom, and with forced colors/high contrast.
+- No essential information is conveyed by color, line position, or animation alone.
+
+Manual QA checklist:
+
+- [ ] Keyboard smoke: Tab, Shift+Tab, Enter, Space, Escape.
+- [ ] Screen reader smoke: VoiceOver on macOS or iOS, at minimum.
+- [ ] Reduced motion smoke.
+- [ ] Mobile touch smoke at 320 px and 390 px.
+- [ ] Desktop smoke at 1280 px and 1440 px.
+- [ ] Contrast check for all node, line, panel, and focus states.
+
+## Performance Constraints
+
+- Default HTML fallback must be useful before JavaScript runs.
+- No WebGL, Three.js, or physics engine in V1 unless KK explicitly approves a heavier prototype.
+- Prefer CSS/SVG/HTML for nodes and lines.
+- If SVG is used, text and links should remain in HTML or be mirrored with accessible HTML controls.
+- JavaScript enhancement budget target: under 10 KB gzipped for this module.
+- Animation uses transform and opacity only.
+- No autoplay media inside the module.
+- Do not block page rendering on analytics, external APIs, or remote project data.
+- Lazy-load any supporting images below the first viewport.
+
+## Rollout Phases
+
+| Phase | Scope | Exit criteria |
+|---|---|---|
+| Phase 0 - Spec approval | Review this document against issue #63 and current IA docs | KK approves node labels, targets, and first placement surface. |
+| Phase 1 - Static content map | Build a no-JS HTML section/list in a Track B branch or block pattern | Six nodes, descriptions, targets, and fallback layout reviewed. |
+| Phase 2 - Visual prototype | Add SVG/CSS constellation layout as progressive enhancement | Desktop and mobile screenshots show readable, stable layout. |
+| Phase 3 - Interaction/a11y pass | Add focus/hover/open states and reduced-motion behavior | Manual keyboard, screen reader, mobile, contrast, and no-JS checks pass. |
+| Phase 4 - Staging measurement | Test on real Aurora staging pages | Lighthouse/performance and manual QA evidence captured. |
+| Phase 5 - Production decision | Decide whether to ship on Work page, homepage, or hold | No deploy unless Track B release gate and KK approval are satisfied. |
+
+## Metrics
+
+The module should be judged by navigation clarity, not novelty alone.
+
+Launch-readiness metrics:
+
+- Time to understand the six-project network during review: under 20 seconds for a first-time reviewer.
+- Keyboard completion: reviewer can open each node and follow a CTA without pointer input.
+- Mobile completion: reviewer can identify all six nodes and expand details without horizontal scrolling.
+- Performance: no meaningful regression to Core Web Vitals on the placement page.
+- Accessibility: WCAG 2.1 AA checklist passes before production.
+
+Post-launch metrics if analytics are approved:
+
+- Node CTA click-through by project.
+- Work/Speaking/Contact assisted paths after constellation interaction.
+- Scroll depth through the module.
+- Mobile interaction rate versus desktop interaction rate.
+- Rage-click or quick-back signals if available.
+- Qualitative feedback from at least three target users.
+
+Do not add analytics for V1 without a separate instrumentation/privacy decision.
+
+## Acceptance Criteria For Issue #63
+
+This design/spec artifact satisfies the repo-safe design phase of issue #63 when:
+
+- [x] Target users and use cases are defined.
+- [x] Information architecture and placement recommendations are defined.
+- [x] The constellation metaphor has boundaries and relationship rules.
+- [x] Navigation states are documented.
+- [x] Keyboard, touch/mobile, no-JS, and reduced-motion behavior are specified.
+- [x] Visual constraints are tied to the Aurora design direction.
+- [x] Accessibility criteria and manual QA checks are defined.
+- [x] Performance constraints are defined.
+- [x] Rollout phases and metrics are defined.
+- [x] Implementation stop rules are defined.
+
+The issue should not be closed by this artifact alone unless KK decides the requested deliverable was design/spec only. A later Track B implementation PR should reference this file and use `Refs #63`, not `Closes #63`, until the interactive module is built and verified.
+
+## Implementation Stop Rules
+
+Stop and ask KK before implementation if any of these are true:
+
+- A proposed change touches `theme/kk-aurora/`, production WordPress, redirects, live menus, snippets, plugins, analytics, or external services outside an approved Track B branch.
+- Node labels, targets, or project inclusion are uncertain.
+- The design requires private data, private member lists, unpublished source material, or non-public project details.
+- The implementation would replace primary navigation.
+- The prototype requires WebGL, a physics engine, heavy animation libraries, or persistent client-side state.
+- Mobile behavior depends on hover or tiny spatial targets.
+- Accessibility fallback would be materially different from the visual experience.
+- Performance evidence shows the module harms the placement page.
+
+## Open Decisions
+
+1. First placement surface: Work page, homepage, or About page compact version?
+2. Final labels: "BC + AI" versus "BC+AI", "Vancouver AI" versus "Vancouver AI Community", and "Thought Leadership" versus "Writing + Talks"?
+3. Final targets for each node: internal pages first, external properties first, or mixed?
+4. Should Indigenomics and The Upgrade AI be represented as external projects, Kris role pages, or Work-page anchors?
+5. Should Photography be a full node in V1 or a supporting proof layer?
+6. Should lines communicate relationship types visually, or stay decorative and let detail copy explain the relationships?
+7. Is the module allowed on the homepage before Aurora's broader header/nav QA is complete?
+8. What is the minimum evidence package required before a production deploy: screenshots only, Lighthouse plus screenshots, or full browser/a11y notes?
+
+## Recommended Next Step
+
+If KK approves this spec, create a Track B issue or branch for Phase 1 only: a static HTML/CSS project map on the Work page with the exact six nodes, descriptions, and links. Do not start with animation. Make the content and fallback right first, then layer the constellation treatment on top.

--- a/fixes/issue-43-twitter-cards.md
+++ b/fixes/issue-43-twitter-cards.md
@@ -48,7 +48,7 @@ done
 
 ## Close Criteria Remaining
 
-- Live `twitter:site` and `twitter:creator` read `@kriskrug`.
+- Live `twitter:site` and `twitter:creator` read `@feelmoreplants`, matching the current footer/social metadata source of truth.
 - `/blog/` has a `summary_large_image` card or is explicitly split to a blog-index SEO follow-up.
 - Representative page, post, and blog-index card images resolve to 1200x630.
 - X Card Validator preview is manually checked after cache purge because X validation requires the live crawler.

--- a/fixes/issue-43-twitter-cards.php
+++ b/fixes/issue-43-twitter-cards.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'KK_ISSUE_43_TWITTER_HANDLE', '@kriskrug' );
+define( 'KK_ISSUE_43_TWITTER_HANDLE', '@feelmoreplants' );
 define( 'KK_ISSUE_43_CARD_WIDTH', 1200 );
 define( 'KK_ISSUE_43_CARD_HEIGHT', 630 );
 define( 'KK_ISSUE_43_FALLBACK_IMAGE_ID', 7548 );

--- a/scripts/tests/test_swarm_ready_static_checks.py
+++ b/scripts/tests/test_swarm_ready_static_checks.py
@@ -1,0 +1,40 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SwarmReadyStaticChecks(unittest.TestCase):
+    def test_aurora_search_blocks_get_accessible_names(self):
+        functions = (ROOT / "theme/kk-aurora/functions.php").read_text()
+
+        self.assertIn("function enhance_search_block_accessibility", functions)
+        self.assertIn("set_attribute('role', 'search')", functions)
+        self.assertIn("set_attribute('aria-label', $label)", functions)
+        self.assertIn("Submit search", functions)
+
+    def test_writing_archive_exposes_category_feed_discovery(self):
+        functions = (ROOT / "theme/kk-aurora/functions.php").read_text()
+        home_template = (ROOT / "theme/kk-aurora/templates/home.html").read_text()
+
+        self.assertIn("function writing_archive_category_feed_discovery", functions)
+        self.assertIn("get_category_feed_link", functions)
+        self.assertIn("rel=\\\"alternate\\\" type=\\\"application/rss+xml\\\"", functions)
+
+        feed_links = re.findall(r'href=\"/category/[^\"]+/feed/\"', home_template)
+        self.assertGreaterEqual(len(feed_links), 8)
+        self.assertIn('aria-label="Category RSS feeds"', home_template)
+
+    def test_twitter_card_snippet_uses_current_site_handle(self):
+        snippet = (ROOT / "fixes/issue-43-twitter-cards.php").read_text()
+        note = (ROOT / "fixes/issue-43-twitter-cards.md").read_text()
+
+        self.assertIn("KK_ISSUE_43_TWITTER_HANDLE', '@feelmoreplants'", snippet)
+        self.assertNotIn("@YourTwitterHandle", snippet)
+        self.assertIn("@feelmoreplants", note)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/github-workflow-automation/scripts/run_tests.sh
+++ b/skills/github-workflow-automation/scripts/run_tests.sh
@@ -173,6 +173,26 @@ if [ -d "scripts/notion-to-wp/tests" ]; then
     echo
 fi
 
+# Detect and run root-level script tests
+if [ -d "scripts/tests" ]; then
+    TESTS_DETECTED=true
+    echo "Detected: repo script tests"
+
+    if command -v python3 >/dev/null 2>&1; then
+        echo "Running unittest for scripts/tests..."
+        if [ "$VERBOSE" = true ]; then
+            python3 -m unittest discover -s scripts/tests -v
+        else
+            python3 -m unittest discover -s scripts/tests
+        fi
+        echo -e "${GREEN}✓ repo script tests passed${NC}"
+        echo
+    else
+        echo -e "${YELLOW}⚠ scripts/tests found but python3 is not installed${NC}"
+        echo
+    fi
+fi
+
 # Detect and run Node.js tests
 if [ -f "package.json" ]; then
     TESTS_DETECTED=true

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.18');
+define('KK_AURORA_VERSION', '1.3.19');
 
 /**
  * Theme setup
@@ -549,3 +549,33 @@ function writing_archive_open_graph_fallback(array $tags): array {
     return $tags;
 }
 add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\writing_archive_open_graph_fallback');
+
+/**
+ * Expose high-signal category feeds to feed readers on the Writing archive.
+ */
+function writing_archive_category_feed_discovery(): void {
+    if (!is_home() || is_front_page()) {
+        return;
+    }
+
+    $categories = get_categories([
+        'hide_empty' => true,
+        'number'     => 8,
+        'orderby'    => 'count',
+        'order'      => 'DESC',
+    ]);
+
+    foreach ($categories as $category) {
+        $feed_url = get_category_feed_link((int) $category->term_id);
+        if (!$feed_url) {
+            continue;
+        }
+
+        printf(
+            "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"%s\" href=\"%s\" />\n",
+            esc_attr(sprintf('%s category feed - Kris Krug', wp_strip_all_tags($category->name))),
+            esc_url($feed_url)
+        );
+    }
+}
+add_action('wp_head', __NAMESPACE__ . '\\writing_archive_category_feed_discovery', 12);

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1533,6 +1533,61 @@ a {
   color: var(--aurora-ink);
 }
 
+.aurora-feed-links {
+  border-top: 1px solid var(--aurora-line);
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  margin: 0 auto clamp(2rem, 5vw, 4rem);
+  max-width: var(--aurora-max);
+  padding: clamp(1.25rem, 3vw, 2rem) 0 0;
+  width: min(calc(100% - clamp(2rem, 6vw, 4rem)), var(--aurora-max));
+}
+
+.aurora-feed-links-copy {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.aurora-feed-links-copy h2 {
+  color: var(--aurora-ink);
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  line-height: 1.05;
+  margin: 0;
+}
+
+.aurora-feed-links-copy p:not(.aurora-kicker) {
+  color: var(--aurora-ink-soft);
+  margin: 0;
+}
+
+.aurora-feed-link-grid {
+  align-content: start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.aurora-feed-link-grid a {
+  align-items: center;
+  border: 1px solid var(--aurora-line);
+  border-radius: var(--aurora-radius-control);
+  color: var(--aurora-ink-soft);
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 760;
+  min-height: 36px;
+  padding: 0.42rem 0.6rem;
+  text-decoration: none;
+}
+
+.aurora-feed-link-grid a:hover,
+.aurora-feed-link-grid a:focus-visible {
+  background: rgba(200, 255, 61, 0.08);
+  border-color: rgba(200, 255, 61, 0.35);
+  color: var(--aurora-ink);
+}
+
 .aurora-writing-dispatch {
   align-items: center;
   background:
@@ -2845,6 +2900,10 @@ a {
 
   .aurora-writing-dispatch .aurora-action-row {
     justify-content: start;
+  }
+
+  .aurora-feed-links {
+    grid-template-columns: 1fr;
   }
 
   .aurora-signal-strip,

--- a/theme/kk-aurora/templates/home.html
+++ b/theme/kk-aurora/templates/home.html
@@ -62,6 +62,24 @@
   <!-- /wp:query -->
 
   <!-- wp:html -->
+  <section class="aurora-feed-links" aria-labelledby="aurora-feed-links-title">
+    <div class="aurora-feed-links-copy">
+      <p class="aurora-kicker">RSS by topic</p>
+      <h2 id="aurora-feed-links-title">Subscribe to the lanes you actually read.</h2>
+      <p>Native category feeds for the recurring KrisKrug.co themes: AI practice, community field notes, events, photography, ethics, and the older web archive.</p>
+    </div>
+    <nav class="aurora-feed-link-grid" aria-label="Category RSS feeds">
+      <a href="/category/vancouver-ai-ecosystem/feed/">Vancouver AI Ecosystem</a>
+      <a href="/category/ai-creatives/feed/">AI for Creatives</a>
+      <a href="/category/events-reports/feed/">Events and Reports</a>
+      <a href="/category/photography-visual-storytelling/feed/">Photography and Visual Storytelling</a>
+      <a href="/category/ai-ethics-philosophy/feed/">AI Ethics and Philosophy</a>
+      <a href="/category/field-notes/feed/">Field Notes</a>
+      <a href="/category/conversations-interviews/feed/">Conversations and Interviews</a>
+      <a href="/category/web-early-blog/feed/">Web and Early Blog</a>
+    </nav>
+  </section>
+
   <section class="aurora-dispatch-band aurora-writing-dispatch" aria-labelledby="aurora-writing-dispatch-title">
     <p class="aurora-kicker">Get the dispatch</p>
     <h2 id="aurora-writing-dispatch-title">The dispatch from the edge.</h2>


### PR DESCRIPTION
## Summary

This PR ships the first autonomous `swarm-ready` wave from the cleaned queue.

- Adds draft-only content/page artifacts for #18 and #44.
- Adds repo-safe marketing/community strategy artifacts for #52, #53, #54, #56, #229, and #230.
- Adds the #63 constellation navigation design/spec artifact without theme implementation.
- Adds category RSS feed discovery on the Aurora Writing archive for #45.
- Aligns the dormant #43 Twitter/X card snippet with the currently verified `@feelmoreplants` site handle.
- Adds root-level `scripts/tests` discovery to `make test` plus static regression checks for #9/#43/#45 surfaces.

## Issue Links

Closes #229.
Closes #230.
Refs #18, #44, #52, #53, #54, #56, #63, #9, #43, #45, #49, #51.

## Safety Notes

- No production WordPress writes.
- No public publishing.
- No private inbox/mailbox reads.
- No outbound sends.
- No form, CRM, lead-capture, analytics, or automation setup.
- Theme change is branch/PR only and still needs normal review/deploy handling before live closeout.

## Verification

- `python3 -m unittest discover -s scripts/tests -v`
- `make test`
- `make docs-truth-check`
- `make validate`
- `php -l theme/kk-aurora/functions.php`
- `php -l fixes/issue-43-twitter-cards.php`
- `git diff --check`
- ASCII check for new docs and static test artifacts

## Remaining Gates

- #9 still needs live keyboard/screen-reader proof after any deployed search/a11y surface is active.
- #43 still needs cache-purged public readback and X/Twitter card validation after deployment.
- #45 needs live readback after theme deploy to confirm feed discovery links render publicly.
- #18/#44 remain draft-only until KK approves publishing and WordPress page creation.
- #52/#53/#54/#56 are v1 strategy/doc artifacts; live systems remain explicitly out of scope.
- #63 is design/spec only; Track B implementation should be a separate branch.
