### PR TITLE
Close deployment SEO and feed workdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit seo-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
+.PHONY: help test plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
 
 # Default target
 .DEFAULT_GOAL := help
@@ -155,6 +155,12 @@ seo-backfill: ## Additive-only SEO meta backfill (default DRY-RUN). Live: EXECUT
 		$${LIMIT:+--limit $${LIMIT}} $${SINCE:+--since $${SINCE}} $${IDS:+--ids $${IDS}} \
 		$${PROBE_ID:+--probe-id $${PROBE_ID}} $${BACKUP_DIR:+--backup-dir $${BACKUP_DIR}} \
 		$${FROM_FILE:+--from-file $${FROM_FILE}}
+
+public-image-audit: ## Audit public-rendered images (dry-run). Args: IDS URLS DEFAULT_URLS=1 CHECK_URLS=1 FORMAT OUTPUT
+	@python3 scripts/public_image_audit.py \
+		--kind "$${KIND:-post,page}" --limit "$${LIMIT:-50}" --since "$${SINCE:-2025-01-01}" \
+		$${IDS:+--ids "$${IDS}"} $${URLS:+--urls "$${URLS}"} $${DEFAULT_URLS:+--default-urls} \
+		$${CHECK_URLS:+--check-urls} --timeout "$${TIMEOUT:-20}" --format "$${FORMAT:-markdown}" $${OUTPUT:+--output "$${OUTPUT}"}
 
 jetpack-feedback-audit: ## Run PII-safe read-only Jetpack Forms feedback counts/routing audit (FORMAT=json)
 	@if [ "$${FORMAT:-human}" = "json" ]; then \

--- a/docs/current-state/reports/issue-workdown-20260618.md
+++ b/docs/current-state/reports/issue-workdown-20260618.md
@@ -1,0 +1,90 @@
+# Issue Workdown Deploy Readback — 2026-06-18
+
+## Scope
+
+Deployment/readback closure lane for #9, #36, #43, and #45, plus image-audit narrowing evidence for #4/#40.
+
+No plugin deploys, bulk media mutation, private inbox reads, or WordPress title writes were performed.
+
+## Baseline
+
+- `make status-readonly` passed before live writes.
+- `make test` passed after local changes.
+- `make docs-truth-check` passed before live deploy work.
+- `make seo-audit` reported `Missing meta description: 0`.
+- `make jetpack-feedback-audit FORMAT=json` ran PII-safe metadata-only checks:
+  - Jetpack forms available.
+  - Feedback inbox count: `547`.
+  - Spam count: `104`.
+  - `/contact/` page ID `2418` contains one Jetpack contact form.
+  - No message bodies, names, emails, attachments, or CSV exports were requested.
+
+## Live Writes
+
+### Jetpack SEO setting
+
+Updated only `advanced_seo_front_page_description` through `/wp-json/jetpack/v4/settings`.
+
+- Before length: `246`
+- After length: `153`
+- After value: `Kris Krüg is an AI keynote speaker and creative technologist building community-first tools, talks, training, and media across BC+AI and Both Hands Full.`
+- REST write status: `200`
+- Readback: matched exact value.
+
+Rollback: restore the previous `advanced_seo_front_page_description` value through the same Jetpack settings endpoint.
+
+### Aurora theme
+
+Uploaded through WordPress admin Appearance → Add Themes → Upload Theme, choosing only the bounded `Replace installed with uploaded` action.
+
+- Final package: `/Users/kk/Desktop/kk-aurora-1.3.21.zip`
+- SHA-256: `969f8d4ad366904d5619cf578b6a722054c5a749978954bac0cd140ce46a1bc3`
+- `unzip -t`: no errors.
+- WordPress confirmation: `Theme updated successfully.`
+- PressCACHE admin purge: `Cache Purge: Success`.
+
+Rollback: upload the prior `kk-aurora` package through the same theme replacement flow, then purge PressCACHE.
+
+## Public Readback
+
+Cache-busted readback with `Codex issue-workdown readback/1.0` user agent.
+
+- `https://kriskrug.co/wp-content/themes/kk-aurora/style.css`: `Version: 1.3.21`.
+- `/`: standard and Open Graph descriptions both match the new 153-character homepage description; Twitter Card is `summary_large_image`; `twitter:site` is `@feelmoreplants`; Twitter title/description now present.
+- `/blog/`: standard, Open Graph, and Twitter descriptions all match the posts-page description; Twitter Card is `summary_large_image`; `twitter:site` is `@feelmoreplants`; `twitter:image:alt` length `66`.
+- Latest post sample `sovereign-ai-for-whom`: standard/Open Graph/Twitter descriptions present; Twitter Card is `summary_large_image`; `twitter:site` is `@feelmoreplants`; Twitter title/description/image/alt present.
+- `/blog/` exposes the visible `aurora-feed-links` section and 10 RSS discovery links.
+- Category feeds returned `200` with RSS/XML content:
+  - `/category/artificial-intelligence/feed/`
+  - `/category/ai-tools/feed/`
+  - `/category/speaking/feed/`
+  - `/category/community/feed/`
+- 404 search form readback:
+  - HTTP status `404`.
+  - `wp-block-search` present.
+  - `Search kriskrug.co` visible label present.
+  - `aria-label="Search kriskrug.co"` present.
+  - `aria-label="Submit search"` present.
+
+## Image Audit
+
+Command:
+
+```sh
+make public-image-audit DEFAULT_URLS=1 CHECK_URLS=1 TIMEOUT=8 OUTPUT=docs/current-state/reports/public-image-audit-20260618-default.md
+```
+
+Result:
+
+- Pages scanned: `8`.
+- Images discovered: `89`.
+- Missing `alt` attribute: `8`, all Facebook noscript tracking pixels.
+- Empty non-decorative alt: `0`.
+- Decorative empty alt: `8`.
+- Filename-style alt: `0`.
+- Images with `srcset`: `28`.
+- Images with lazy loading: `64`.
+- Broken checked image URLs: `1`, a legacy Flickr/Jetpack proxy on `/flickr-photographr-badge/` returning `429`.
+- Oversized checked image URLs: `28`.
+
+#4/#40 should remain open as a narrowed image-performance/follow-up lane unless the team decides the public-default sample is enough to split and close the broad original scope.

--- a/docs/current-state/reports/public-image-audit-20260618-default.md
+++ b/docs/current-state/reports/public-image-audit-20260618-default.md
@@ -1,0 +1,54 @@
+# Public Image Audit
+
+- Pages scanned: 8
+- Images found: 89
+- Missing alt attribute: 8
+- Empty non-decorative alt: 0
+- Decorative empty alt: 8
+- Filename-style alt: 0
+- Images with srcset: 28
+- Lazy-loaded images: 64
+- Broken checked image URLs: 1
+- Checked images over 500 KB response size: 28
+
+## Flagged Images
+
+| Page | Media ID | State | Status | Bytes | Alt | Source |
+|---|---:|---|---:|---:|---|---|
+| https://kriskrug.co/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/ |  | ok oversize | 200 | 2831396 | Indigenomics AI visual from Kris Krug's public writing | https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&ssl=1 |
+| https://kriskrug.co/blog/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 5468369 | Sovereign AI for Whom? | https://s5102.pcdn.co/wp-content/uploads/2026/05/01-sovereign-ai-for-whom-scaled.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 1154318 | Speak It Into Existence: Voice-First AI Workflows | https://s5102.pcdn.co/wp-content/uploads/2026/05/03-both-hands-full-thesis.jpg |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 1967306 | AI Keynote Slides Need Taste Before Prompts | https://s5102.pcdn.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 739199 | Agent Orchestrators, Creative Insurgents & The New Stack | https://s5102.pcdn.co/wp-content/uploads/2026/05/12-ai-is-a-mirror.jpg |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 3910616 | The Long Road to Futureproof | https://s5102.pcdn.co/wp-content/uploads/2026/06/vanai21-kris-jonny-stage.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 613573 | The AI Mindset: Adapting to the New Creative Paradigm | https://s5102.pcdn.co/wp-content/uploads/2024/08/IMG_8053-scaled.jpg |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 1937929 | Make Culture, Not Content | https://s5102.pcdn.co/wp-content/uploads/2026/02/06-mycelial-action-network.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 896153 | Punk Rock AI | https://s5102.pcdn.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 3843372 | Applied Ethical AI: Responsible AI Professional Certification (RAP) | https://s5102.pcdn.co/wp-content/uploads/2026/04/rap-faces.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 2001911 | Name the Bias | https://s5102.pcdn.co/wp-content/uploads/2026/02/01-the-word-bias-dissolving.png |
+| https://kriskrug.co/blog/ |  | ok oversize | 200 | 1267350 | Both Hands Full | https://s5102.pcdn.co/wp-content/uploads/2026/01/MASTER-Blog-header.png |
+| https://kriskrug.co/home/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/home/ |  | ok oversize | 200 | 1048255 | BC + AI illustration with forests, mountains, DNA strands, microscopes, communit | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/01-sovereign-ai-for-whom-scaled.png?fit=1024%2C573&ssl=1 |
+| https://kriskrug.co/speaking/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/speaking/ |  | ok oversize | 200 | 878826 | Punk Rock AI CreativeMornings Vancouver keynote banner | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&ssl=1 |
+| https://kriskrug.co/speaking/ |  | ok oversize | 200 | 754744 | CBC AI Sandbox with Kris Krug graphic | https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/2024-recap-cbc.png?w=1200&ssl=1 |
+| https://kriskrug.co/speaking/ |  | ok oversize | 200 | 878826 | CreativeMornings Vancouver Punk Rock AI keynote visual | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&ssl=1 |
+| https://kriskrug.co/speaking/ |  | ok oversize | 200 | 828784 | Vancouver AI Community Meetup visual | https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/MASTER-Youtube-Thumbs-1280-x-420-px-1.png?w=1280&ssl=1 |
+| https://kriskrug.co/generative-ai-services/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/generative-ai-services/ |  | ok oversize | 200 | 2831396 | Indigenomics AI visual from Kris Krug's public writing | https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&ssl=1 |
+| https://kriskrug.co/contact/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/photography/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 643516 | Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jp |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 758316 | A Gulf of Mexico oil rig, documented on the TEDxOilSpill expedition by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-a-gulf-oil-rig.jpg?ssl=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 563034 | Journey to Midway Island — documenting the most remote place on Earth and its oc | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554916809329-1.jpg?ssl=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 544071 | Journey to Midway Island, Pacific — environmental documentary by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554917413729.jpg?ssl=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 643516 | Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jp |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 765252 | Jack White of the Raconteurs, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-jack-white-of-the-raconteurs-shot-by-kris-krug-scaled |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 563535 | Billy Bragg, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-billy-bragg-shot-by-kris-krug.jpg?ssl=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 895589 | President George W. Bush at the 2008 Beijing Olympics, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-george-bush-at-the-2008-beijing-olympics-2827525797-1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 552759 | Jake Gyllenhaal at SXSW 2011, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-jake-gyllenhaal-sxsw-2011.jpg?ssl=1 |
+| https://kriskrug.co/photography/ |  | ok oversize | 200 | 590690 | Grace Park on the set of Battlestar Galactica, photographed by Kris Krüg | https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-grace-park-28boomer29-on-battlestar-galactica-flic-1- |
+| https://kriskrug.co/flickr-photographr-badge/ |  | missing-attr |  |  |  | https://www.facebook.com/tr?id=1720755522050230&ev=PageView&noscript=1 |
+| https://kriskrug.co/flickr-photographr-badge/ |  | ok | 429 |  | Vintage Flickr badge image from Kris Krug's early photoblogging archive | https://i0.wp.com/photos16.flickr.com/22181199_f3857c8ca6_o.jpg?resize=400%2C300 |

--- a/scripts/public_image_audit.py
+++ b/scripts/public_image_audit.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Audit public-rendered images on kriskrug.co posts/pages.
+
+Default mode is read-only. Live media alt writes require --execute plus an exact
+media-alt JSON file; crawl findings are never auto-applied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import dataclasses
+import html
+import json
+import os
+import re
+import sys
+import time
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_PATH = REPO_ROOT / "scripts" / "notion-to-wp" / ".env"
+DEFAULT_BASE_URL = "https://kriskrug.co"
+DEFAULT_URLS = (
+    "/",
+    "/blog/",
+    "/home/",
+    "/speaking/",
+    "/generative-ai-services/",
+    "/contact/",
+    "/photography/",
+    "/flickr-photographr-badge/",
+)
+IMAGE_EXT_RE = re.compile(r"\.(?:avif|gif|jpe?g|png|svg|webp)(?:$|[?#])", re.I)
+MEDIA_ID_RE = re.compile(r"\bwp-image-(\d+)\b")
+
+
+@dataclasses.dataclass
+class RenderedImage:
+    page_url: str
+    page_kind: str
+    page_id: int | None
+    page_slug: str
+    src: str
+    alt: str | None
+    media_id: int | None
+    loading: str
+    has_srcset: bool
+    classes: str
+    role: str
+    width: str
+    height: str
+    status: int | None = None
+    content_length: int | None = None
+
+    @property
+    def alt_state(self) -> str:
+        if self.is_decorative:
+            return "decorative-empty"
+        if self.alt is None:
+            return "missing-attr"
+        if self.alt.strip() == "":
+            return "empty"
+        if is_filename_style_alt(self.alt, self.src):
+            return "filename-style"
+        return "ok"
+
+    @property
+    def is_decorative(self) -> bool:
+        if self.alt is None or self.alt.strip() != "":
+            return False
+        haystack = f"{self.classes} {self.role} {self.src}".lower()
+        decorative_markers = (
+            "aurora-brand-logo",
+            "custom-logo",
+            "site-logo",
+            "pixel",
+            "tracking",
+            "transparent",
+            "spacer",
+        )
+        return any(marker in haystack for marker in decorative_markers)
+
+    @property
+    def oversize(self) -> bool:
+        return bool(self.content_length and self.content_length > 500_000)
+
+
+class ImageParser(HTMLParser):
+    def __init__(self, page_url: str):
+        super().__init__()
+        self.page_url = page_url
+        self.images: list[dict[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "img":
+            return
+        data = {k.lower(): (v or "") for k, v in attrs}
+        if data.get("src"):
+            self.images.append(data)
+
+
+def parse_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def auth_session(base_url: str) -> requests.Session:
+    env = parse_env(ENV_PATH)
+    user = env.get("WP_USER") or os.environ.get("WP_USER")
+    password = (env.get("WP_APP_PASSWORD") or os.environ.get("WP_APP_PASSWORD") or "").replace(" ", "")
+    if not user or not password:
+        raise SystemExit(f"Missing WP credentials in {ENV_PATH} or environment")
+    session = requests.Session()
+    token = base64.b64encode(f"{user}:{password}".encode("utf-8")).decode("utf-8")
+    session.headers.update({"Authorization": f"Basic {token}"})
+    session.headers.update({"User-Agent": "KrisKrugPublicImageAudit/1.0"})
+    session.base_url = base_url.rstrip("/")  # type: ignore[attr-defined]
+    return session
+
+
+def public_session() -> requests.Session:
+    session = requests.Session()
+    session.headers.update({"User-Agent": "KrisKrugPublicImageAudit/1.0"})
+    return session
+
+
+def normalize_filenameish(value: str) -> str:
+    value = html.unescape(value).lower()
+    value = re.sub(r"\.[a-z0-9]{2,5}$", "", value)
+    return re.sub(r"[^a-z0-9]+", "", value)
+
+
+def image_basename(src: str) -> str:
+    path = urlsplit(html.unescape(src)).path.rstrip("/")
+    return Path(path).name
+
+
+def is_filename_style_alt(alt: str, src: str) -> bool:
+    alt_raw = html.unescape(alt).strip()
+    if not IMAGE_EXT_RE.search(alt_raw) and "-" not in alt_raw and "_" not in alt_raw:
+        return False
+    alt_norm = normalize_filenameish(alt)
+    base_norm = normalize_filenameish(image_basename(src))
+    if not alt_norm or not base_norm or len(alt_norm) < 8:
+        return False
+    return alt_norm == base_norm or alt_norm in base_norm or base_norm in alt_norm
+
+
+def cachebust_url(url: str) -> str:
+    split = urlsplit(url)
+    query = dict(parse_qsl(split.query, keep_blank_values=True))
+    query["cachebust"] = str(int(time.time()))
+    return urlunsplit((split.scheme, split.netloc, split.path, urlencode(query), split.fragment))
+
+
+def fetch_html(session: requests.Session, url: str, timeout: int, max_bytes: int = 2_000_000) -> str:
+    response = session.get(url, stream=True, timeout=(timeout, timeout))
+    response.raise_for_status()
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=65536):
+        if not chunk:
+            continue
+        chunks.append(chunk)
+        total += len(chunk)
+        if total >= max_bytes:
+            break
+    encoding = response.encoding or "utf-8"
+    return b"".join(chunks).decode(encoding, "replace")
+
+
+def absolute_url(base_url: str, url: str) -> str:
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    if url.startswith("//"):
+        return "https:" + url
+    return base_url.rstrip("/") + "/" + url.lstrip("/")
+
+
+def media_id_from_class(classes: str) -> int | None:
+    match = MEDIA_ID_RE.search(classes)
+    return int(match.group(1)) if match else None
+
+
+def image_probe(session: requests.Session, src: str, timeout: int) -> tuple[int | None, int | None]:
+    try:
+        response = session.head(src, allow_redirects=True, timeout=timeout)
+        if response.status_code in (405, 429) or response.status_code >= 500:
+            response = session.get(src, stream=True, timeout=timeout)
+        length_raw = response.headers.get("content-length")
+        length = int(length_raw) if length_raw and length_raw.isdigit() else None
+        return response.status_code, length
+    except requests.RequestException:
+        return None, None
+
+
+def fetch_public_items(base_url: str, kinds: list[str], ids: list[int], limit: int, since: str) -> list[dict[str, Any]]:
+    session = public_session()
+    items: list[dict[str, Any]] = []
+    for kind in kinds:
+        endpoint = "posts" if kind == "post" else "pages"
+        if ids:
+            for item_id in ids:
+                response = session.get(
+                    f"{base_url}/wp-json/wp/v2/{endpoint}/{item_id}",
+                    params={"_fields": "id,slug,link,title,type,date"},
+                    timeout=30,
+                )
+                if response.status_code == 200:
+                    items.append(response.json())
+            continue
+
+        page = 1
+        while len([i for i in items if i.get("type") == kind]) < limit:
+            params: dict[str, Any] = {
+                "status": "publish",
+                "per_page": min(100, limit),
+                "page": page,
+                "_fields": "id,slug,link,title,type,date",
+            }
+            if kind == "post" and since:
+                params["after"] = f"{since}T00:00:00"
+            response = session.get(f"{base_url}/wp-json/wp/v2/{endpoint}", params=params, timeout=30)
+            if response.status_code != 200:
+                break
+            batch = response.json()
+            if not batch:
+                break
+            items.extend(batch)
+            if page >= int(response.headers.get("X-WP-TotalPages", "1")):
+                break
+            page += 1
+    return items[: limit * max(1, len(kinds))]
+
+
+def item_title(item: dict[str, Any]) -> str:
+    title = item.get("title") or {}
+    if isinstance(title, dict):
+        return re.sub(r"\s+", " ", html.unescape(title.get("rendered", ""))).strip()
+    return str(title)
+
+
+def collect_urls(args: argparse.Namespace) -> list[dict[str, Any]]:
+    base_url = args.base_url.rstrip("/")
+    if args.urls:
+        return [
+            {
+                "id": None,
+                "slug": urlsplit(url).path.strip("/") or "home",
+                "link": absolute_url(base_url, url),
+                "type": "url",
+                "title": {"rendered": url},
+            }
+            for url in args.urls
+        ]
+    if not args.ids and args.default_urls:
+        return [
+            {
+                "id": None,
+                "slug": path.strip("/") or "home",
+                "link": absolute_url(base_url, path),
+                "type": "url",
+                "title": {"rendered": path},
+            }
+            for path in DEFAULT_URLS
+        ]
+    return fetch_public_items(base_url, args.kind, args.ids, args.limit, args.since)
+
+
+def audit_images(args: argparse.Namespace) -> list[RenderedImage]:
+    session = public_session()
+    rows: list[RenderedImage] = []
+    for item in collect_urls(args):
+        page_url = str(item["link"])
+        try:
+            html_text = fetch_html(session, cachebust_url(page_url), args.timeout)
+        except requests.RequestException:
+            continue
+        parser = ImageParser(page_url)
+        parser.feed(html_text)
+        for attrs in parser.images:
+            src = absolute_url(args.base_url, attrs.get("src", ""))
+            status = None
+            content_length = None
+            if args.check_urls and IMAGE_EXT_RE.search(src):
+                status, content_length = image_probe(session, src, args.timeout)
+            rows.append(
+                RenderedImage(
+                    page_url=page_url,
+                    page_kind=str(item.get("type") or "url"),
+                    page_id=item.get("id"),
+                    page_slug=str(item.get("slug") or ""),
+                    src=src,
+                    alt=attrs.get("alt") if "alt" in attrs else None,
+                    media_id=media_id_from_class(attrs.get("class", "")),
+                    loading=attrs.get("loading", ""),
+                    has_srcset=bool(attrs.get("srcset")),
+                    classes=attrs.get("class", ""),
+                    role=attrs.get("role", ""),
+                    width=attrs.get("width", ""),
+                    height=attrs.get("height", ""),
+                    status=status,
+                    content_length=content_length,
+                )
+            )
+    return rows
+
+
+def summarize(rows: list[RenderedImage]) -> dict[str, int]:
+    return {
+        "pages": len({r.page_url for r in rows}),
+        "images": len(rows),
+        "missing_attr": sum(1 for r in rows if r.alt_state == "missing-attr"),
+        "empty_alt": sum(1 for r in rows if r.alt_state == "empty"),
+        "decorative_empty": sum(1 for r in rows if r.alt_state == "decorative-empty"),
+        "filename_style": sum(1 for r in rows if r.alt_state == "filename-style"),
+        "srcset": sum(1 for r in rows if r.has_srcset),
+        "lazy": sum(1 for r in rows if r.loading.lower() == "lazy"),
+        "broken": sum(1 for r in rows if r.status is not None and r.status >= 400),
+        "oversize": sum(1 for r in rows if r.oversize),
+    }
+
+
+def row_dict(row: RenderedImage) -> dict[str, Any]:
+    return {
+        "page_url": row.page_url,
+        "page_kind": row.page_kind,
+        "page_id": row.page_id,
+        "page_slug": row.page_slug,
+        "media_id": row.media_id,
+        "alt_state": row.alt_state,
+        "alt": row.alt or "",
+        "src": row.src,
+        "loading": row.loading,
+        "has_srcset": row.has_srcset,
+        "status": row.status,
+        "content_length": row.content_length,
+        "oversize": row.oversize,
+    }
+
+
+def render_markdown(rows: list[RenderedImage]) -> str:
+    stats = summarize(rows)
+    flagged = [r for r in rows if r.alt_state not in ("ok", "decorative-empty") or r.oversize or (r.status and r.status >= 400)]
+    lines = [
+        "# Public Image Audit",
+        "",
+        f"- Pages scanned: {stats['pages']}",
+        f"- Images found: {stats['images']}",
+        f"- Missing alt attribute: {stats['missing_attr']}",
+        f"- Empty non-decorative alt: {stats['empty_alt']}",
+        f"- Decorative empty alt: {stats['decorative_empty']}",
+        f"- Filename-style alt: {stats['filename_style']}",
+        f"- Images with srcset: {stats['srcset']}",
+        f"- Lazy-loaded images: {stats['lazy']}",
+        f"- Broken checked image URLs: {stats['broken']}",
+        f"- Checked images over 500 KB response size: {stats['oversize']}",
+        "",
+        "## Flagged Images",
+        "",
+        "| Page | Media ID | State | Status | Bytes | Alt | Source |",
+        "|---|---:|---|---:|---:|---|---|",
+    ]
+    for row in flagged[:200]:
+        alt = (row.alt or "").replace("|", "\\|")[:80]
+        src = row.src.replace("|", "%7C")[:120]
+        lines.append(
+            f"| {row.page_url} | {row.media_id or ''} | {row.alt_state}{' oversize' if row.oversize else ''} | "
+            f"{row.status or ''} | {row.content_length or ''} | {alt} | {src} |"
+        )
+    if not flagged:
+        lines.append("| - | - | - | - | - | - | - |")
+    return "\n".join(lines) + "\n"
+
+
+def write_output(args: argparse.Namespace, rows: list[RenderedImage]) -> None:
+    if args.format == "json":
+        output = json.dumps({"summary": summarize(rows), "images": [row_dict(r) for r in rows]}, indent=2)
+    elif args.format == "csv":
+        import io
+
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=list(row_dict(rows[0]).keys()) if rows else ["page_url"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row_dict(row))
+        output = buffer.getvalue()
+    else:
+        output = render_markdown(rows)
+
+    if args.output:
+        path = Path(args.output)
+        if not path.is_absolute():
+            path = REPO_ROOT / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(output, encoding="utf-8")
+        print(f"report={path}")
+    else:
+        print(output)
+
+
+def execute_media_alt_file(args: argparse.Namespace) -> None:
+    if not args.media_alt_file:
+        raise SystemExit("--execute requires --media-alt-file with exact media_id/alt_text entries")
+    data = json.loads(Path(args.media_alt_file).read_text(encoding="utf-8"))
+    entries = data.get("items", data)
+    if not isinstance(entries, list):
+        raise SystemExit("media alt file must be a list or {'items': [...]}")
+    session = auth_session(args.base_url)
+    updates = []
+    for entry in entries:
+        media_id = int(entry["media_id"])
+        alt_text = str(entry["alt_text"]).strip()
+        if not alt_text:
+            raise SystemExit(f"media {media_id} alt_text is empty")
+        before = session.get(f"{session.base_url}/wp-json/wp/v2/media/{media_id}", params={"context": "edit", "_fields": "id,alt_text"}, timeout=30)  # type: ignore[attr-defined]
+        before.raise_for_status()
+        old_alt = before.json().get("alt_text", "")
+        response = session.post(f"{session.base_url}/wp-json/wp/v2/media/{media_id}", json={"alt_text": alt_text}, timeout=60)  # type: ignore[attr-defined]
+        response.raise_for_status()
+        after = session.get(f"{session.base_url}/wp-json/wp/v2/media/{media_id}", params={"context": "edit", "_fields": "id,alt_text"}, timeout=30)  # type: ignore[attr-defined]
+        after.raise_for_status()
+        new_alt = after.json().get("alt_text", "")
+        if new_alt != alt_text:
+            raise SystemExit(f"media {media_id} readback mismatch")
+        updates.append({"media_id": media_id, "old_alt": old_alt, "new_alt": new_alt})
+    print(json.dumps({"updated": updates}, indent=2))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--kind", default="post,page", type=lambda value: [v.strip() for v in value.split(",") if v.strip()])
+    parser.add_argument("--ids", default="", type=lambda value: [int(v) for v in value.split(",") if v.strip()])
+    parser.add_argument("--urls", default="", type=lambda value: [v.strip() for v in value.split(",") if v.strip()])
+    parser.add_argument("--default-urls", action="store_true", help="Scan the high-visibility default URL set.")
+    parser.add_argument("--since", default="2025-01-01")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument("--check-urls", action="store_true")
+    parser.add_argument("--format", choices=("markdown", "json", "csv"), default="markdown")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--media-alt-file", default="")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.execute:
+        execute_media_alt_file(args)
+        return
+    rows = audit_images(args)
+    write_output(args, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_public_image_audit.py
+++ b/scripts/tests/test_public_image_audit.py
@@ -1,0 +1,41 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from public_image_audit import ImageParser, is_filename_style_alt, media_id_from_class, summarize
+
+
+class PublicImageAuditTests(unittest.TestCase):
+    def test_parser_classifies_decorative_and_problem_alt_states(self):
+        parser = ImageParser("https://kriskrug.co/example/")
+        parser.feed(
+            """
+            <img class="aurora-brand-logo" src="/logo.png" alt="">
+            <img class="wp-image-123" src="/wp-content/uploads/flickr-photographr-badge.jpg" alt="flickr-photographr-badge.jpg" srcset="x 1x" loading="lazy">
+            <img src="/missing.jpg">
+            """
+        )
+
+        self.assertEqual(len(parser.images), 3)
+        self.assertEqual(media_id_from_class(parser.images[1]["class"]), 123)
+        self.assertTrue(is_filename_style_alt(parser.images[1]["alt"], parser.images[1]["src"]))
+
+    def test_summary_counts_alt_states(self):
+        from public_image_audit import RenderedImage
+
+        rows = [
+            RenderedImage("u", "url", None, "home", "/logo.png", "", None, "", False, "aurora-brand-logo", "", "", ""),
+            RenderedImage("u", "url", None, "home", "/flickr-photographr-badge.jpg", "flickr-photographr-badge.jpg", 123, "lazy", True, "", "", "", ""),
+            RenderedImage("u", "url", None, "home", "/missing.jpg", None, None, "", False, "", "", "", ""),
+        ]
+
+        stats = summarize(rows)
+
+        self.assertEqual(stats["decorative_empty"], 1)
+        self.assertEqual(stats["filename_style"], 1)
+        self.assertEqual(stats["missing_attr"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_swarm_ready_static_checks.py
+++ b/scripts/tests/test_swarm_ready_static_checks.py
@@ -20,6 +20,11 @@ class SwarmReadyStaticChecks(unittest.TestCase):
         home_template = (ROOT / "theme/kk-aurora/templates/home.html").read_text()
 
         self.assertIn("function writing_archive_category_feed_discovery", functions)
+        self.assertIn("function writing_archive_seo_meta_tags", functions)
+        self.assertIn("jetpack_seo_meta_tags", functions)
+        self.assertIn("function twitter_card_tag_fallbacks", functions)
+        self.assertIn("twitter_card_tag_fallbacks', 120", functions)
+        self.assertIn("advanced_seo_description", functions)
         self.assertIn("get_category_feed_link", functions)
         self.assertIn("rel=\\\"alternate\\\" type=\\\"application/rss+xml\\\"", functions)
 

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.19');
+define('KK_AURORA_VERSION', '1.3.21');
 
 /**
  * Theme setup
@@ -519,6 +519,32 @@ function work_page_open_graph_fallback(array $tags): array {
 }
 add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\work_page_open_graph_fallback');
 
+function writing_archive_meta_description(): string {
+    $fallback = 'Read Kris Krug field notes on responsible AI, creative technology, community building, Indigenous tech, media, culture, practical workflows, and events.';
+    $posts_page_id = (int) get_option('page_for_posts');
+    if ($posts_page_id <= 0) {
+        return $fallback;
+    }
+
+    $description = get_post_meta($posts_page_id, 'advanced_seo_description', true);
+    if (!is_string($description) || trim($description) === '') {
+        return $fallback;
+    }
+
+    return wp_strip_all_tags($description);
+}
+
+function writing_archive_seo_meta_tags(array $tags): array {
+    if (!is_home() || is_front_page()) {
+        return $tags;
+    }
+
+    $tags['description'] = writing_archive_meta_description();
+
+    return $tags;
+}
+add_filter('jetpack_seo_meta_tags', __NAMESPACE__ . '\\writing_archive_seo_meta_tags', 99);
+
 /**
  * Set archive-specific social metadata for the Writing landing page.
  *
@@ -531,7 +557,7 @@ function writing_archive_open_graph_fallback(array $tags): array {
     }
 
     $image = 'https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/02/06-mycelial-action-network.png?fit=1200%2C686&ssl=1';
-    $description = 'Essays on AI, culture, community, creative practice, consent, taste, and what stays human when the tools get loud.';
+    $description = writing_archive_meta_description();
 
     $tags['og:title'] = 'Writing — Kris Krug';
     $tags['og:description'] = $description;
@@ -548,7 +574,62 @@ function writing_archive_open_graph_fallback(array $tags): array {
 
     return $tags;
 }
-add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\writing_archive_open_graph_fallback');
+add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\writing_archive_open_graph_fallback', 99);
+
+/**
+ * Mirror available Open Graph metadata into missing Twitter Card fields.
+ *
+ * @param array<string, string> $tags Existing Open Graph/Twitter tags.
+ * @return array<string, string>
+ */
+function twitter_card_tag_fallbacks(array $tags): array {
+    if (empty($tags['twitter:site'])) {
+        $tags['twitter:site'] = '@feelmoreplants';
+    }
+
+    if (empty($tags['twitter:title'])) {
+        $title = '';
+        if (!empty($tags['og:title']) && is_string($tags['og:title'])) {
+            $title = $tags['og:title'];
+        } else {
+            $title = wp_get_document_title();
+        }
+
+        if ($title !== '') {
+            $tags['twitter:title'] = wp_strip_all_tags($title);
+        }
+    }
+
+    if (empty($tags['twitter:description'])) {
+        $description = '';
+        if (!empty($tags['og:description']) && is_string($tags['og:description'])) {
+            $description = $tags['og:description'];
+        } elseif (!empty($tags['description']) && is_string($tags['description'])) {
+            $description = $tags['description'];
+        } elseif (is_singular()) {
+            $description = get_the_excerpt();
+        }
+
+        if ($description !== '') {
+            $tags['twitter:description'] = wp_strip_all_tags($description);
+        }
+    }
+
+    if (empty($tags['twitter:image']) && !empty($tags['og:image']) && is_string($tags['og:image'])) {
+        $tags['twitter:image'] = $tags['og:image'];
+    }
+
+    if (empty($tags['twitter:image:alt']) && !empty($tags['og:image:alt']) && is_string($tags['og:image:alt'])) {
+        $tags['twitter:image:alt'] = $tags['og:image:alt'];
+    }
+
+    if (empty($tags['twitter:card'])) {
+        $tags['twitter:card'] = empty($tags['twitter:image']) ? 'summary' : 'summary_large_image';
+    }
+
+    return $tags;
+}
+add_filter('jetpack_open_graph_tags', __NAMESPACE__ . '\\twitter_card_tag_fallbacks', 120);
 
 /**
  * Expose high-signal category feeds to feed readers on the Writing archive.

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,16 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.21 =
+* Added late Twitter Card fallbacks so missing title, description, image, and site fields mirror available Open Graph metadata.
+
+= 1.3.20 =
+* Forced Writing archive Jetpack metadata overrides to late priority so archive Open Graph descriptions cannot inherit a post excerpt.
+
+= 1.3.19 =
+* Added Writing archive category feed discovery links and search accessibility regression coverage (PR #231).
+* Aligned Writing archive Jetpack standard, Open Graph, and Twitter descriptions to the posts-page SEO description.
+
 = 1.3.18 =
 * Fixed stagger-reveal sections rendering invisible (found in visual QA).
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.18
+Version: 1.3.21
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary
- deploy Aurora 1.3.21 metadata/feed/search fixes that are already live on kriskrug.co
- add late Twitter Card fallbacks and Writing archive SEO/Open Graph overrides
- add a dry-run-default public image audit helper plus evidence reports

## Live Readback
- WP admin theme replacement confirmed Theme updated successfully for kk-aurora-1.3.21.zip
- PressCACHE reported Cache Purge: Success
- public style.css readback reports Version: 1.3.21
- / and /blog/ public metadata readbacks are green
- latest post sample has Twitter Card title/description/image/site fields
- category feeds return 200 RSS/XML and /blog/ exposes feed discovery links
- 404 search form includes visible label and aria labels

## Verification
- make test
- make docs-truth-check
- make seo-audit
- git diff --check
- make public-image-audit DEFAULT_URLS=1 CHECK_URLS=1 TIMEOUT=8 OUTPUT=docs/current-state/reports/public-image-audit-20260618-default.md

## Issue Notes
- closed #9, #36, #43, and #45 with evidence comments
- commented #4 and #40 with narrowed image-audit follow-up
- commented #128, #174, and #222 with privacy-safe blocker/status updates