### PR TITLE
content: harden glossary and Vancouver AI drafts

### DIFF
--- a/content/drafts/2026-06-11-vancouver-ai-community-page/post.html
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/post.html
@@ -1,185 +1,147 @@
-<!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading">Vancouver AI Community</h1>
-<!-- /wp:heading -->
+<!-- wp:html -->
+<style>
+.kk-vancouver-ai { --kk-ink:#171717; --kk-muted:#57534e; --kk-line:#d8d4cc; --kk-paper:#fffaf0; --kk-card:#ffffff; --kk-accent:#0f766e; --kk-hot:#b91c1c; color:var(--kk-ink); }
+.kk-vancouver-ai a { font-weight:700; }
+.kk-vancouver-ai-hero { padding:1.35rem 0 1.6rem; border-bottom:1px solid var(--kk-line); }
+.kk-vancouver-ai-kicker { margin:0 0 .5rem; text-transform:uppercase; letter-spacing:.08em; font-size:.78rem; color:var(--kk-hot); font-weight:800; }
+.kk-vancouver-ai-display { margin:.15rem 0 .8rem; max-width:58rem; font-size:2rem; line-height:1.16; }
+.kk-vancouver-ai-lead { max-width:58rem; font-size:1.14rem; line-height:1.65; color:var(--kk-muted); }
+.kk-vancouver-ai-actions { display:flex; flex-wrap:wrap; gap:.75rem; margin:1.25rem 0 0; }
+.kk-vancouver-ai-button { display:inline-block; padding:.72rem 1rem; border:2px solid var(--kk-ink); border-radius:4px; text-decoration:none; background:var(--kk-ink); color:#fff !important; }
+.kk-vancouver-ai-button.secondary { background:#fff; color:var(--kk-ink) !important; }
+.kk-vancouver-ai-section { padding:2rem 0; border-bottom:1px solid var(--kk-line); }
+.kk-vancouver-ai-section-intro { max-width:58rem; margin-bottom:1rem; color:var(--kk-muted); }
+.kk-vancouver-ai-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:1rem; }
+.kk-vancouver-ai-card { border:1px solid var(--kk-line); border-radius:6px; padding:1rem; background:var(--kk-card); }
+.kk-vancouver-ai-card h3 { margin-top:0; margin-bottom:.45rem; font-size:1.12rem; }
+.kk-vancouver-ai-card p { margin:.45rem 0; color:var(--kk-muted); }
+.kk-vancouver-ai-card ul { margin:.55rem 0 .2rem 1.1rem; }
+.kk-vancouver-ai-card li { margin:.25rem 0; }
+.kk-vancouver-ai-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:.75rem; margin-top:1.1rem; }
+.kk-vancouver-ai-proof div { border:1px solid var(--kk-line); border-radius:6px; padding:.9rem; background:#fff; }
+.kk-vancouver-ai-proof strong { display:block; font-size:1.35rem; line-height:1.1; }
+.kk-vancouver-ai-proof span { display:block; color:var(--kk-muted); margin-top:.25rem; }
+.kk-vancouver-ai-two { display:grid; grid-template-columns:minmax(0,1fr) minmax(260px,.82fr); gap:1.25rem; align-items:start; }
+.kk-vancouver-ai-callout { background:var(--kk-paper); border:1px solid var(--kk-line); border-radius:6px; padding:1rem; }
+.kk-vancouver-ai-media { margin:1rem 0 0; }
+.kk-vancouver-ai-video { position:relative; padding-bottom:56.25%; height:0; overflow:hidden; border-radius:6px; background:#111; border:1px solid var(--kk-line); }
+.kk-vancouver-ai-video iframe { position:absolute; inset:0; width:100%; height:100%; border:0; }
+.kk-vancouver-ai-links { columns:2 16rem; padding-left:1.2rem; }
+.kk-vancouver-ai-note { color:var(--kk-muted); font-size:.95rem; }
+@media (max-width:760px){ .kk-vancouver-ai-display{font-size:1.5rem;} .kk-vancouver-ai-two{grid-template-columns:1fr;} .kk-vancouver-ai-actions{display:block;} .kk-vancouver-ai-actions a{margin:.35rem 0;} .kk-vancouver-ai-links{columns:1;} }
+</style>
 
-<!-- wp:paragraph -->
-<p>Vancouver AI is a public room for people who want to understand AI without pretending it is simple.</p>
-<!-- /wp:paragraph -->
+<div class="kk-vancouver-ai">
+  <section class="kk-vancouver-ai-hero" aria-labelledby="kk-vancouver-ai-title">
+    <p class="kk-vancouver-ai-kicker">Vancouver AI community</p>
+    <h1 id="kk-vancouver-ai-title" class="kk-vancouver-ai-display">A public room for the people building, questioning, and metabolizing AI in Vancouver.</h1>
+    <p class="kk-vancouver-ai-lead">Vancouver AI is where artists, founders, educators, researchers, policy people, students, technologists, organizers, and the AI-curious can wrestle with the technology together instead of swallowing the hype alone.</p>
+    <p class="kk-vancouver-ai-lead">Kris Krüg helps convene that field through BC+AI: community gatherings, keynote rooms, practical learning, member infrastructure, partner pathways, and a stubborn insistence that AI should be discussed in public with the people it affects.</p>
+    <div class="kk-vancouver-ai-actions">
+      <a class="kk-vancouver-ai-button" href="https://luma.com/vancouver-ai">See upcoming Vancouver AI events</a>
+      <a class="kk-vancouver-ai-button secondary" href="https://bc-ai.ca/membership/">Join BC+AI</a>
+      <a class="kk-vancouver-ai-button secondary" href="/speaking/">Book Kris for a talk</a>
+    </div>
+    <div class="kk-vancouver-ai-proof" aria-label="BC+AI public community markers">
+      <div><strong>250+</strong><span>BC+AI members</span></div>
+      <div><strong>3,000+</strong><span>event attendees</span></div>
+      <div><strong>94+</strong><span>events hosted</span></div>
+      <div><strong>4</strong><span>BC regions represented</span></div>
+      <div><strong>Est. 2023</strong><span>community founded</span></div>
+    </div>
+  </section>
 
-<!-- wp:paragraph -->
-<p>Artists, founders, educators, researchers, students, policy people, technologists, organizers, and the AI-curious all need somewhere to compare notes. Not a sales funnel. Not a doom circle. A real room where people can ask better questions together.</p>
-<!-- /wp:paragraph -->
+  <section class="kk-vancouver-ai-section">
+    <div class="kk-vancouver-ai-two">
+      <div>
+        <h2>Why This Room Exists</h2>
+        <p>AI is changing work, art, education, media, government, climate decisions, and community life faster than most institutions can explain it. Vancouver needs places where people can ask better questions in public and compare lived experience before the next platform, policy, or procurement decision hardens into default.</p>
+        <p>The point is not to cheerlead or doom-scroll. The point is to build shared language, practical literacy, and enough trust for honest disagreement. Vancouver AI works best when the room stays mixed: builders beside skeptics, artists beside engineers, policy beside practice, beginners beside people deep in the stack.</p>
+      </div>
+      <aside class="kk-vancouver-ai-callout">
+        <h3>Good fit if you need</h3>
+        <ul>
+          <li>A credible entry point into Vancouver's AI community</li>
+          <li>Public learning that does not flatten ethics into branding</li>
+          <li>Partner, sponsor, or speaker pathways through BC+AI</li>
+          <li>A community-tested AI keynote or workshop</li>
+        </ul>
+      </aside>
+    </div>
+  </section>
 
-<!-- wp:paragraph -->
-<p>Kris helps convene that room through BC+AI, public talks, practical learning sessions, member pathways, and a steady commitment to keeping AI conversations grounded in people, place, and community.</p>
-<!-- /wp:paragraph -->
+  <section class="kk-vancouver-ai-section">
+    <h2>What Happens Here</h2>
+    <p class="kk-vancouver-ai-section-intro">The community is not one format. It is a stack of gatherings, talks, experiments, and follow-up loops that help people keep learning after the room ends.</p>
+    <div class="kk-vancouver-ai-grid">
+      <article class="kk-vancouver-ai-card">
+        <h3>Meetups and public learning rooms</h3>
+        <p>Recurring Vancouver AI gatherings give people a place to see demos, hear field reports, ask direct questions, and meet others working through the same messy transition.</p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Both Hands Full conversations</h3>
+        <p>Kris's community-stage AI talks hold both truths at once: the tools are compromised and powerful, extractive and useful, exhausting and creatively explosive.</p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Partner and member pathways</h3>
+        <p>BC+AI gives companies, civic groups, researchers, creatives, and public-interest teams ways to show up with more than a logo: membership, partnerships, events, and practical collaboration.</p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Regional and civic connective tissue</h3>
+        <p>The work starts in Vancouver but points wider: British Columbia needs AI capacity that is place-rooted, culturally literate, and accountable to more than the loudest market signal.</p>
+      </article>
+    </div>
+  </section>
 
-<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://luma.com/vancouver-ai">See upcoming Vancouver AI events</a></div>
-<!-- /wp:button -->
+  <section class="kk-vancouver-ai-section">
+    <h2>A Community-Tested Talk</h2>
+    <p class="kk-vancouver-ai-section-intro">The March 2026 Vancouver AI talk is a useful proof point for the tone of the room: candid about stolen work, bias, labor pressure, environmental cost, and platform power, while still making space for creative agency and practical experimentation.</p>
+    <div class="kk-vancouver-ai-media">
+      <div class="kk-vancouver-ai-video">
+        <iframe src="https://www.youtube.com/embed/T5ANAthZewE" title="We Trained AI on Stolen Work and I Am More Creative Than Ever at Vancouver AI Meetup March 2026" loading="lazy" allowfullscreen></iframe>
+      </div>
+    </div>
+    <p class="kk-vancouver-ai-note">Source: public Vancouver AI YouTube video, uploaded 2026-04-22. Final WordPress draft should keep audience references general unless a person is separately approved or publicly credited.</p>
+  </section>
 
-<!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://bc-ai.ca/membership/">Join BC+AI</a></div>
-<!-- /wp:button -->
+  <section class="kk-vancouver-ai-section">
+    <h2>How To Plug In</h2>
+    <div class="kk-vancouver-ai-grid">
+      <article class="kk-vancouver-ai-card">
+        <h3>Attend</h3>
+        <p>Start with the public Vancouver AI event calendar. Bring the real question you are trying to answer, even if it is still half-formed.</p>
+        <p><a href="https://luma.com/vancouver-ai">View Vancouver AI events</a></p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Become a member</h3>
+        <p>BC+AI membership is the clearest next step for people who want ongoing community, ecosystem signal, member pathways, and a stronger local network.</p>
+        <p><a href="https://bc-ai.ca/membership/">Join BC+AI</a></p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Partner or sponsor</h3>
+        <p>Useful partners bring space, resources, platforms, expertise, and care for the public-interest side of AI adoption. The best fit is aligned action, not generic brand placement.</p>
+        <p><a href="https://bc-ai.ca/">Start with BC+AI</a></p>
+      </article>
+      <article class="kk-vancouver-ai-card">
+        <h3>Bring Kris into your room</h3>
+        <p>If your team, conference, school, board, or community needs a high-signal AI talk, workshop, host, or moderator, start with Kris's speaking page.</p>
+        <p><a href="/speaking/">Explore AI keynote speaking</a></p>
+      </article>
+    </div>
+  </section>
 
-<!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="/speaking/">Book Kris for a talk</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">Why This Page Exists</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>AI is changing work, art, education, media, government, climate decisions, and community life faster than most institutions can explain it.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Vancouver needs public learning spaces where people can stay curious without being naive, stay critical without becoming frozen, and build enough shared language to make better decisions.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>The best Vancouver AI rooms are mixed on purpose. Builders sit beside skeptics. Artists sit beside engineers. Policy meets practice. Beginners are allowed to ask the obvious question. People deep in the stack are asked to explain why the work matters.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">What Happens In The Community</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Public Meetups</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Vancouver AI gatherings give people a place to see demos, hear field reports, ask direct questions, and meet others working through the same messy transition.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Use the public event calendar for the current schedule and next gathering.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Talks And Recordings</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Kris's Vancouver AI talks tend to hold both hands full: the tools are compromised and powerful, extractive and useful, exhausting and creatively explosive.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>The March 2026 Vancouver AI talk is a useful public proof point for that tone. It addresses stolen work, creative agency, environmental cost, bias, labor pressure, and why community matters when the technology gets loud.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:embed {"url":"https://www.youtube.com/watch?v=T5ANAthZewE","type":"video","providerNameSlug":"youtube","responsive":true} -->
-<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">
-https://www.youtube.com/watch?v=T5ANAthZewE
-</div></figure>
-<!-- /wp:embed -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Member Pathways</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>BC+AI membership is the clearest next step for people who want ongoing community, ecosystem signal, member pathways, and a stronger local network.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Membership details, benefits, and pricing should come from the current BC+AI membership page, not from this local draft.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Partner Pathways</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Useful partners bring space, resources, platforms, expertise, and care for the public-interest side of AI adoption.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>The best fit is aligned action, not generic brand placement.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">How To Plug In</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Attend</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Start with the public Vancouver AI event calendar. Bring the real question you are trying to answer, even if it is still half-formed.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><a href="https://luma.com/vancouver-ai">View Vancouver AI events</a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Join</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Join BC+AI if you want a more durable connection to the ecosystem.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><a href="https://bc-ai.ca/membership/">Explore BC+AI membership</a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Partner</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Start with BC+AI if your organization wants to support a more public, local, and community-accountable AI ecosystem.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><a href="https://bc-ai.ca/">Visit BC+AI</a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading {"level":3} -->
-<h3 class="wp-block-heading">Bring Kris Into Your Room</h3>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>If your team, conference, school, board, or community needs a high-signal AI talk, workshop, host, or moderator, start with Kris's speaking page.</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p><a href="/speaking/">Explore AI keynote speaking</a></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">Resources And Recordings</h2>
-<!-- /wp:heading -->
-
-<!-- wp:list -->
-<ul class="wp-block-list"><!-- wp:list-item -->
-<li><a href="https://luma.com/vancouver-ai">Vancouver AI events on Luma</a></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><a href="https://bc-ai.ca/">BC+AI</a></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><a href="https://bc-ai.ca/membership/">BC+AI membership</a></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><a href="https://www.bothhandsfull.com/">Both Hands Full</a></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><a href="/speaking/">Kris's AI keynote speaking</a></li>
-<!-- /wp:list-item -->
-
-<!-- wp:list-item -->
-<li><a href="/recent-projects-include/">Kris's work</a></li>
-<!-- /wp:list-item --></ul>
-<!-- /wp:list -->
+  <section class="kk-vancouver-ai-section">
+    <h2>Related Starting Points</h2>
+    <ul class="kk-vancouver-ai-links">
+      <li><a href="https://bc-ai.ca/">BC+AI Ecosystem</a></li>
+      <li><a href="https://bc-ai.ca/membership/">BC+AI membership</a></li>
+      <li><a href="https://luma.com/vancouver-ai">Vancouver AI events on Luma</a></li>
+      <li><a href="https://vancouver.bc-ai.net/">Vancouver AI community page</a></li>
+      <li><a href="https://www.bothhandsfull.com/">Both Hands Full</a></li>
+      <li><a href="/speaking/">AI keynote speaking</a></li>
+      <li><a href="/recent-projects-include/">Kris's work</a></li>
+      <li><a href="/contact/">Contact Kris</a></li>
+    </ul>
+  </section>
+</div>
+<!-- /wp:html -->

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/post.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/post.md
@@ -30,6 +30,18 @@ Kris helps convene that room through BC+AI, public talks, practical learning ses
 [Join BC+AI](https://bc-ai.ca/membership/)
 [Book Kris for a talk](/speaking/)
 
+## Community Proof
+
+Public BC+AI markers checked in the earlier issue #18 verification pass:
+
+- 250+ BC+AI members
+- 3,000+ event attendees
+- 94+ events hosted
+- 4 BC regions represented
+- Established in 2023
+
+These stats should be rechecked immediately before WordPress draft creation or publication.
+
 ## Why This Page Exists
 
 AI is changing work, art, education, media, government, climate decisions, and community life faster than most institutions can explain it.
@@ -44,7 +56,7 @@ The best Vancouver AI rooms are mixed on purpose. Builders sit beside skeptics. 
 
 Vancouver AI gatherings give people a place to see demos, hear field reports, ask direct questions, and meet others working through the same messy transition.
 
-Use the public event calendar for the current schedule and next gathering.
+Use the public event calendar for the current schedule, frequency, venue details, and next gathering.
 
 ### Talks And Recordings
 
@@ -97,6 +109,7 @@ If your team, conference, school, board, or community needs a high-signal AI tal
 - [Vancouver AI events on Luma](https://luma.com/vancouver-ai)
 - [BC+AI](https://bc-ai.ca/)
 - [BC+AI membership](https://bc-ai.ca/membership/)
+- [Vancouver AI community page](https://vancouver.bc-ai.net/)
 - [Both Hands Full](https://www.bothhandsfull.com/)
 - [Kris's AI keynote speaking](/speaking/)
 - [Kris's work](/recent-projects-include/)

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/publish-gate.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/publish-gate.md
@@ -25,12 +25,13 @@ Status: local draft package only. No WordPress draft was created. No live site w
 - Existing issue #18 source-pack payload used as context: `content/source-packs/keynotes-2026/wp-payloads/vancouver-ai-community.html`.
 - Existing issue #18 verification note used as context: `content/source-packs/keynotes-2026/verification/ISSUE-18-VANCOUVER-AI-COMMUNITY-VERIFICATION-2026-05-21.md`.
 - March 2026 public talk context used from `content/drafts/2026-05-19-both-hands-full-vancouver-ai-march-2026/post.md`.
+- Canonical `post.html` has been reconciled to the stronger source-pack payload that includes the public BC+AI proof markers from the 2026-05-21 verification pass.
 
 ## Acceptance Coverage
 
 - Dedicated page path: packaged for `/community/vancouver-ai/`, blocked on parent page confirmation.
-- Meetup schedule and frequency: linked to Luma, cadence gated.
-- Attendee numbers and growth: gated pending current verification.
+- Meetup schedule and frequency: linked to Luma as the source of truth.
+- Attendee numbers and growth: staged with previously verified public BC+AI markers; recheck immediately before WordPress draft creation or publish.
 - How to join or participate: included.
 - Events calendar: linked.
 - Resources and recordings: included with public YouTube talk.

--- a/content/drafts/2026-06-11-vancouver-ai-community-page/seo-meta.md
+++ b/content/drafts/2026-06-11-vancouver-ai-community-page/seo-meta.md
@@ -13,7 +13,7 @@
 
 ## Claim Gates
 
-- Do not publish member counts, attendance numbers, growth numbers, or event cadence until checked against current public sources or KK approval.
+- Recheck member counts, attendance numbers, growth numbers, and event cadence against current public sources immediately before draft creation or publish. The local draft currently carries the 2026-05-21 public BC+AI markers from the issue #18 verification pass.
 - Do not add testimonials until the quote, name, title, and permission are explicit.
 - Do not add academic partnership names until the relationship is confirmed by a current public source or KK approval.
 - Keep the page as a WordPress draft until preview, mobile review, accessibility review, and link checks pass.

--- a/content/drafts/ai-glossary-2026-05/README.md
+++ b/content/drafts/ai-glossary-2026-05/README.md
@@ -13,12 +13,14 @@ Current acceptance coverage:
 
 - 50+ terms: met with 69 draft terms.
 - Alphabetical: met by letter sections and terms sorted within each section.
-- Searchable: content is structured for an accessible in-page filter; implementation is still a publisher task.
+- Searchable: met in `post.html` with a visible labelled filter, keyboard-usable input, `aria-live` result count, no-results state, and no-JS fallback with all terms visible.
 - Internal links: draft includes a related-reading module and post-publication link map.
 - Mobile: draft avoids tables and long multi-column layouts.
 - SEO: title, meta description, slug, excerpt, and schema notes are drafted below.
 
 ## Draft Page Copy
+
+`post.html` is now the canonical Gutenberg-ready body for WordPress preview. It preserves the 69 draft terms from `post.md` and adds the accessible in-page glossary filter required by issue #44.
 
 # AI Glossary
 

--- a/content/drafts/ai-glossary-2026-05/post.html
+++ b/content/drafts/ai-glossary-2026-05/post.html
@@ -1,0 +1,456 @@
+<!-- wp:html -->
+<style>
+.kk-glossary { --kk-ink:#f7f2e8; --kk-muted:#c9bda8; --kk-line:rgba(247,242,232,.22); --kk-panel:rgba(255,255,255,.055); --kk-panel-strong:rgba(255,255,255,.09); --kk-accent:#b7f36d; color:var(--kk-ink); }
+.kk-glossary a { color:var(--kk-accent); font-weight:700; }
+.kk-glossary-intro { max-width:62rem; padding:1rem 0 1.35rem; border-bottom:1px solid var(--kk-line); }
+.kk-glossary-intro p { color:var(--kk-muted); font-size:1.08rem; line-height:1.72; }
+.kk-glossary-tools { margin:1.4rem 0; display:grid; gap:.8rem; max-width:42rem; }
+.kk-glossary-tools label { font-weight:800; }
+.kk-glossary-tools input { width:100%; min-height:48px; border:2px solid var(--kk-line); border-radius:6px; padding:.75rem .9rem; background:#fff; color:#171717; font:inherit; }
+.kk-glossary-count { color:var(--kk-muted); font-size:.96rem; }
+.kk-glossary-no-results { border:1px solid var(--kk-line); border-radius:6px; padding:1rem; background:var(--kk-panel); color:var(--kk-muted); }
+.kk-glossary-letter-nav { display:flex; flex-wrap:wrap; gap:.45rem; margin:1.3rem 0 1.7rem; }
+.kk-glossary-letter-nav a { display:inline-flex; align-items:center; justify-content:center; min-width:2.2rem; min-height:2.2rem; border:1px solid var(--kk-line); border-radius:4px; text-decoration:none; background:var(--kk-panel); }
+.kk-glossary-related { margin:1.5rem 0; padding:1rem 0 1.3rem; border-bottom:1px solid var(--kk-line); }
+.kk-glossary-related ul { columns:2 18rem; padding-left:1.1rem; }
+.kk-glossary-related li { break-inside:avoid; margin:.35rem 0; }
+.kk-glossary-section { padding:1.45rem 0; border-top:1px solid var(--kk-line); }
+.kk-glossary-section h2 { margin:0 0 .9rem; }
+.kk-glossary-term-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:.9rem; }
+.kk-glossary-term { border:1px solid var(--kk-line); border-radius:6px; padding:1rem; background:var(--kk-panel); overflow-wrap:anywhere; }
+.kk-glossary-term h3 { margin:0 0 .45rem; font-size:1.08rem; }
+.kk-glossary-term p { margin:0; color:var(--kk-muted); line-height:1.62; }
+.kk-glossary-term mark { background:transparent; color:inherit; }
+@media (max-width:680px) { .kk-glossary-term-grid { grid-template-columns:1fr; } .kk-glossary-related ul { columns:1; } }
+</style>
+
+<div class="kk-glossary" data-kk-glossary>
+  <section class="kk-glossary-intro" aria-labelledby="glossary-title">
+    <h1 id="glossary-title">AI Glossary</h1>
+    <p>AI conversations get hard to enter when every sentence assumes you already know the vocabulary. This glossary is a plain-language bridge for readers of KrisKrug.co, especially people arriving through posts about creative AI, local AI, data centres, Indigenous governance, public-interest technology, and community accountability.</p>
+    <p>The goal is not to flatten complex ideas. The goal is to give newcomers enough context to keep reading, ask better questions, and notice when a term is being used too loosely.</p>
+    <div class="kk-glossary-tools" role="search">
+      <label for="kk-glossary-search">Search glossary terms</label>
+      <input id="kk-glossary-search" type="search" autocomplete="off" data-glossary-search aria-describedby="kk-glossary-count" placeholder="Try data, rights, RAG, water, prompt">
+      <p id="kk-glossary-count" class="kk-glossary-count" aria-live="polite" data-glossary-count>69 terms visible.</p>
+    </div>
+    <p class="kk-glossary-no-results" data-glossary-no-results hidden>No matching glossary terms. Clear the search to browse the full list.</p>
+    <nav class="kk-glossary-letter-nav" aria-label="Browse glossary by letter"><a href="#glossary-A">A</a> <a href="#glossary-B">B</a> <a href="#glossary-C">C</a> <a href="#glossary-D">D</a> <a href="#glossary-E">E</a> <a href="#glossary-F">F</a> <a href="#glossary-G">G</a> <a href="#glossary-H">H</a> <a href="#glossary-I">I</a> <a href="#glossary-L">L</a> <a href="#glossary-M">M</a> <a href="#glossary-O">O</a> <a href="#glossary-P">P</a> <a href="#glossary-R">R</a> <a href="#glossary-S">S</a> <a href="#glossary-T">T</a> <a href="#glossary-U">U</a> <a href="#glossary-V">V</a> <a href="#glossary-W">W</a></nav>
+  </section>
+
+  <section class="kk-glossary-related" aria-labelledby="glossary-related-title">
+    <h2 id="glossary-related-title">Related Reading</h2>
+    <ul>
+      <li><a href="/generative-ai-services/">AI Services, Training &amp; Strategy</a></li>
+      <li><a href="/about/">About Kris Krug</a></li>
+      <li><a href="/2026/05/07/web-summit-vancouver-2026/">Web Summit Vancouver 2026</a></li>
+      <li><a href="/2026/05/14/calling-us-all-in/">Calling Us All In</a></li>
+      <li><a href="/reconciliation-indigenous-land-acknowledgement/">Reconciliation &amp; Indigenous Land Acknowledgement</a> - include only after the sensitive-term review is complete.</li>
+    </ul>
+  </section>
+
+<section class="kk-glossary-section" id="glossary-A" data-glossary-section>
+  <h2>A</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-agent" data-glossary-term data-glossary-search-text="agent an ai system that can take multiple steps toward a goal, often using tools, files, web search, or other software along the way.">
+      <h3>Agent</h3>
+      <p>An AI system that can take multiple steps toward a goal, often using tools, files, web search, or other software along the way.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-ai-alignment" data-glossary-term data-glossary-search-text="ai alignment the work of making ai systems behave in ways that match human goals, safety needs, and social values. alignment is not only a technical problem; it also depends on whose goals and values are being centered.">
+      <h3>AI alignment</h3>
+      <p>The work of making AI systems behave in ways that match human goals, safety needs, and social values. Alignment is not only a technical problem; it also depends on whose goals and values are being centered.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-ai-ethics" data-glossary-term data-glossary-search-text="ai ethics the practice of asking whether ai systems are fair, accountable, understandable, safe, consent-based, and worth building in the first place.">
+      <h3>AI ethics</h3>
+      <p>The practice of asking whether AI systems are fair, accountable, understandable, safe, consent-based, and worth building in the first place.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-algorithm" data-glossary-term data-glossary-search-text="algorithm a set of instructions for solving a problem or making a decision. in ai, algorithms help systems find patterns, rank options, generate content, or make predictions.">
+      <h3>Algorithm</h3>
+      <p>A set of instructions for solving a problem or making a decision. In AI, algorithms help systems find patterns, rank options, generate content, or make predictions.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-artificial-intelligence-ai" data-glossary-term data-glossary-search-text="artificial intelligence (ai) software that performs tasks people often associate with intelligence, such as recognizing patterns, generating language or images, planning, translating, summarizing, or making recommendations.">
+      <h3>Artificial intelligence (AI)</h3>
+      <p>Software that performs tasks people often associate with intelligence, such as recognizing patterns, generating language or images, planning, translating, summarizing, or making recommendations.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-automation" data-glossary-term data-glossary-search-text="automation using software or machines to do work that people otherwise do manually. automation can save time, but it can also hide decisions, remove context, or shift power away from workers and communities.">
+      <h3>Automation</h3>
+      <p>Using software or machines to do work that people otherwise do manually. Automation can save time, but it can also hide decisions, remove context, or shift power away from workers and communities.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-B" data-glossary-section>
+  <h2>B</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-benchmark" data-glossary-term data-glossary-search-text="benchmark a test used to compare ai systems. benchmarks can be useful, but they rarely capture the full social, cultural, or local impact of a tool.">
+      <h3>Benchmark</h3>
+      <p>A test used to compare AI systems. Benchmarks can be useful, but they rarely capture the full social, cultural, or local impact of a tool.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-bias" data-glossary-term data-glossary-search-text="bias a pattern that causes a system to treat people, groups, languages, places, or ideas unevenly. bias can come from training data, design choices, deployment context, or the assumptions of the people building the system.">
+      <h3>Bias</h3>
+      <p>A pattern that causes a system to treat people, groups, languages, places, or ideas unevenly. Bias can come from training data, design choices, deployment context, or the assumptions of the people building the system.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-C" data-glossary-section>
+  <h2>C</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-chatbot" data-glossary-term data-glossary-search-text="chatbot a conversational interface for software. modern chatbots often use large language models to answer questions, draft text, summarize files, or help with tasks.">
+      <h3>Chatbot</h3>
+      <p>A conversational interface for software. Modern chatbots often use large language models to answer questions, draft text, summarize files, or help with tasks.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-chatgpt" data-glossary-term data-glossary-search-text="chatgpt openai&#x27;s conversational ai product. it is a product built around ai models, not the same thing as the underlying model itself.">
+      <h3>ChatGPT</h3>
+      <p>OpenAI's conversational AI product. It is a product built around AI models, not the same thing as the underlying model itself.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-claude" data-glossary-term data-glossary-search-text="claude anthropic&#x27;s conversational ai product. like chatgpt, it is a product experience wrapped around underlying models and safety systems.">
+      <h3>Claude</h3>
+      <p>Anthropic's conversational AI product. Like ChatGPT, it is a product experience wrapped around underlying models and safety systems.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-community-benefits-agreement" data-glossary-term data-glossary-search-text="community benefits agreement a negotiated agreement that spells out how a project will benefit local communities, often including jobs, infrastructure, training, environmental safeguards, or accountability measures.">
+      <h3>Community benefits agreement</h3>
+      <p>A negotiated agreement that spells out how a project will benefit local communities, often including jobs, infrastructure, training, environmental safeguards, or accountability measures.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-compute" data-glossary-term data-glossary-search-text="compute the processing power needed to train or run ai systems. compute often depends on specialized chips, energy, cooling, networking, and data centre infrastructure.">
+      <h3>Compute</h3>
+      <p>The processing power needed to train or run AI systems. Compute often depends on specialized chips, energy, cooling, networking, and data centre infrastructure.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-consent" data-glossary-term data-glossary-search-text="consent clear permission from people or communities before their data, stories, likeness, cultural knowledge, or creative work is used. consent should be informed, specific, and revocable where possible.">
+      <h3>Consent</h3>
+      <p>Clear permission from people or communities before their data, stories, likeness, cultural knowledge, or creative work is used. Consent should be informed, specific, and revocable where possible.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-consultation" data-glossary-term data-glossary-search-text="consultation a process for asking affected people or communities for input. consultation is not the same as consent, shared governance, or decision-making power.">
+      <h3>Consultation</h3>
+      <p>A process for asking affected people or communities for input. Consultation is not the same as consent, shared governance, or decision-making power.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-corpus" data-glossary-term data-glossary-search-text="corpus a collection of text, images, audio, video, code, or other material used for search, research, analysis, or ai training.">
+      <h3>Corpus</h3>
+      <p>A collection of text, images, audio, video, code, or other material used for search, research, analysis, or AI training.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-D" data-glossary-section>
+  <h2>D</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-data-centre" data-glossary-term data-glossary-search-text="data centre a building or campus that houses servers, networking, storage, cooling, and power systems. ai data centres can have major effects on electricity demand, water use, land, labour, and local infrastructure.">
+      <h3>Data centre</h3>
+      <p>A building or campus that houses servers, networking, storage, cooling, and power systems. AI data centres can have major effects on electricity demand, water use, land, labour, and local infrastructure.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-data-governance" data-glossary-term data-glossary-search-text="data governance the rules, responsibilities, and decision-making processes for collecting, storing, using, sharing, and deleting data.">
+      <h3>Data governance</h3>
+      <p>The rules, responsibilities, and decision-making processes for collecting, storing, using, sharing, and deleting data.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-data-sovereignty" data-glossary-term data-glossary-search-text="data sovereignty the idea that data should be governed by the laws, rights, values, and decision-making authority of the people, communities, or nations it comes from.">
+      <h3>Data sovereignty</h3>
+      <p>The idea that data should be governed by the laws, rights, values, and decision-making authority of the people, communities, or nations it comes from.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-digital-colonialism" data-glossary-term data-glossary-search-text="digital colonialism a pattern where technology systems extract data, labour, knowledge, attention, or value from communities without meaningful consent, benefit, or governance power.">
+      <h3>Digital colonialism</h3>
+      <p>A pattern where technology systems extract data, labour, knowledge, attention, or value from communities without meaningful consent, benefit, or governance power.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-E" data-glossary-section>
+  <h2>E</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-embedding" data-glossary-term data-glossary-search-text="embedding a mathematical representation of text, images, audio, or other data that helps ai systems compare meaning and similarity.">
+      <h3>Embedding</h3>
+      <p>A mathematical representation of text, images, audio, or other data that helps AI systems compare meaning and similarity.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-explainability" data-glossary-term data-glossary-search-text="explainability the ability to understand why an ai system produced a result or recommendation. some ai systems are hard to explain, which can make accountability harder.">
+      <h3>Explainability</h3>
+      <p>The ability to understand why an AI system produced a result or recommendation. Some AI systems are hard to explain, which can make accountability harder.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-extractive-technology" data-glossary-term data-glossary-search-text="extractive technology technology that takes more value from people, communities, workers, creators, or environments than it returns.">
+      <h3>Extractive technology</h3>
+      <p>Technology that takes more value from people, communities, workers, creators, or environments than it returns.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-F" data-glossary-section>
+  <h2>F</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-fine-tuning" data-glossary-term data-glossary-search-text="fine-tuning additional training that adapts a model for a specific style, task, domain, or dataset.">
+      <h3>Fine-tuning</h3>
+      <p>Additional training that adapts a model for a specific style, task, domain, or dataset.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-foundation-model" data-glossary-term data-glossary-search-text="foundation model a large model trained on broad data that can be adapted to many tasks, such as writing, coding, image generation, search, or analysis.">
+      <h3>Foundation model</h3>
+      <p>A large model trained on broad data that can be adapted to many tasks, such as writing, coding, image generation, search, or analysis.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-free-prior-and-informed-consent-fpic" data-glossary-term data-glossary-search-text="free, prior and informed consent (fpic) a standard in indigenous rights that means consent should be given freely, before a project proceeds, and with enough information for communities to make a real decision.">
+      <h3>Free, prior and informed consent (FPIC)</h3>
+      <p>A standard in Indigenous rights that means consent should be given freely, before a project proceeds, and with enough information for communities to make a real decision.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-frontier-model" data-glossary-term data-glossary-search-text="frontier model a model at or near the leading edge of ai capability. the term is often used for powerful systems from major ai labs.">
+      <h3>Frontier model</h3>
+      <p>A model at or near the leading edge of AI capability. The term is often used for powerful systems from major AI labs.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-G" data-glossary-section>
+  <h2>G</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-generative-ai" data-glossary-term data-glossary-search-text="generative ai ai that creates new text, images, audio, video, code, or other outputs from prompts, examples, or source material.">
+      <h3>Generative AI</h3>
+      <p>AI that creates new text, images, audio, video, code, or other outputs from prompts, examples, or source material.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-gpu" data-glossary-term data-glossary-search-text="gpu a graphics processing unit. gpus are chips that are especially useful for the parallel calculations behind modern ai.">
+      <h3>GPU</h3>
+      <p>A graphics processing unit. GPUs are chips that are especially useful for the parallel calculations behind modern AI.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-guardrails" data-glossary-term data-glossary-search-text="guardrails rules, filters, prompts, policies, or product design choices meant to reduce harmful outputs or unsafe behaviour.">
+      <h3>Guardrails</h3>
+      <p>Rules, filters, prompts, policies, or product design choices meant to reduce harmful outputs or unsafe behaviour.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-H" data-glossary-section>
+  <h2>H</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-hallucination" data-glossary-term data-glossary-search-text="hallucination a confident ai output that is false, unsupported, or invented. hallucinations are one reason important ai outputs need review.">
+      <h3>Hallucination</h3>
+      <p>A confident AI output that is false, unsupported, or invented. Hallucinations are one reason important AI outputs need review.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-host-nation" data-glossary-term data-glossary-search-text="host nation an indigenous nation on whose territory an event, project, facility, or decision is taking place. confirm wording and protocol with the nation and local context.">
+      <h3>Host Nation</h3>
+      <p>An Indigenous Nation on whose territory an event, project, facility, or decision is taking place. Confirm wording and protocol with the Nation and local context.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-human-in-the-loop" data-glossary-term data-glossary-search-text="human-in-the-loop a workflow where a person reviews, approves, edits, or can override ai output before it affects people or systems.">
+      <h3>Human-in-the-loop</h3>
+      <p>A workflow where a person reviews, approves, edits, or can override AI output before it affects people or systems.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-I" data-glossary-section>
+  <h2>I</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-indigenomics" data-glossary-term data-glossary-search-text="indigenomics an indigenous economic lens and movement associated with building indigenous economic power, governance, and participation at scale. confirm final wording with current indigenomics.ai language before publication.">
+      <h3>Indigenomics</h3>
+      <p>An Indigenous economic lens and movement associated with building Indigenous economic power, governance, and participation at scale. Confirm final wording with current Indigenomics.ai language before publication.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-indigenous-ai" data-glossary-term data-glossary-search-text="indigenous ai ai work shaped by indigenous rights, governance, knowledge systems, community priorities, and self-determination rather than imposed from outside.">
+      <h3>Indigenous AI</h3>
+      <p>AI work shaped by Indigenous rights, governance, knowledge systems, community priorities, and self-determination rather than imposed from outside.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-indigenous-data-sovereignty" data-glossary-term data-glossary-search-text="indigenous data sovereignty the right of indigenous peoples and nations to govern data about their peoples, lands, resources, knowledge, and communities.">
+      <h3>Indigenous data sovereignty</h3>
+      <p>The right of Indigenous Peoples and Nations to govern data about their peoples, lands, resources, knowledge, and communities.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-indigenous-governance" data-glossary-term data-glossary-search-text="indigenous governance decision-making authority grounded in indigenous laws, institutions, rights, protocols, and relationships. do not reduce this to stakeholder feedback.">
+      <h3>Indigenous governance</h3>
+      <p>Decision-making authority grounded in Indigenous laws, institutions, rights, protocols, and relationships. Do not reduce this to stakeholder feedback.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-indigenous-rights-holder" data-glossary-term data-glossary-search-text="indigenous rights holder an indigenous nation or people with rights that must be respected. a rights holder is not the same as a stakeholder.">
+      <h3>Indigenous rights holder</h3>
+      <p>An Indigenous Nation or people with rights that must be respected. A rights holder is not the same as a stakeholder.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-inference" data-glossary-term data-glossary-search-text="inference running a trained model to produce an output, such as an answer, image, classification, or recommendation.">
+      <h3>Inference</h3>
+      <p>Running a trained model to produce an output, such as an answer, image, classification, or recommendation.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-L" data-glossary-section>
+  <h2>L</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-large-language-model-llm" data-glossary-term data-glossary-search-text="large language model (llm) an ai model trained to work with language. llms can draft, summarize, translate, classify, reason over text, and power chatbot products.">
+      <h3>Large language model (LLM)</h3>
+      <p>An AI model trained to work with language. LLMs can draft, summarize, translate, classify, reason over text, and power chatbot products.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-local-ai" data-glossary-term data-glossary-search-text="local ai ai that runs on a user&#x27;s own device, server, or private infrastructure instead of relying entirely on a cloud service.">
+      <h3>Local AI</h3>
+      <p>AI that runs on a user's own device, server, or private infrastructure instead of relying entirely on a cloud service.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-M" data-glossary-section>
+  <h2>M</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-machine-learning" data-glossary-term data-glossary-search-text="machine learning a branch of ai where systems learn patterns from data instead of being programmed with every rule by hand.">
+      <h3>Machine learning</h3>
+      <p>A branch of AI where systems learn patterns from data instead of being programmed with every rule by hand.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-model" data-glossary-term data-glossary-search-text="model the trained system that turns inputs into outputs. in ai writing tools, the model is the engine, while the app is the product wrapped around it.">
+      <h3>Model</h3>
+      <p>The trained system that turns inputs into outputs. In AI writing tools, the model is the engine, while the app is the product wrapped around it.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-model-weights" data-glossary-term data-glossary-search-text="model weights the learned parameters inside a model. weights are part of what allow a trained model to produce useful outputs.">
+      <h3>Model weights</h3>
+      <p>The learned parameters inside a model. Weights are part of what allow a trained model to produce useful outputs.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-multimodal-ai" data-glossary-term data-glossary-search-text="multimodal ai ai that can work across more than one kind of input or output, such as text, images, audio, video, and code.">
+      <h3>Multimodal AI</h3>
+      <p>AI that can work across more than one kind of input or output, such as text, images, audio, video, and code.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-O" data-glossary-section>
+  <h2>O</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-ocap" data-glossary-term data-glossary-search-text="ocap a first nations data governance framework standing for ownership, control, access, and possession. confirm final wording and attribution before publication.">
+      <h3>OCAP</h3>
+      <p>A First Nations data governance framework standing for ownership, control, access, and possession. Confirm final wording and attribution before publication.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-open-model" data-glossary-term data-glossary-search-text="open model a model released with enough access for others to inspect, use, adapt, or run it, depending on the license and release terms.">
+      <h3>Open model</h3>
+      <p>A model released with enough access for others to inspect, use, adapt, or run it, depending on the license and release terms.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-open-weights" data-glossary-term data-glossary-search-text="open weights model weights that are available for others to download or run. open weights do not automatically mean open data, open training methods, or unrestricted rights.">
+      <h3>Open weights</h3>
+      <p>Model weights that are available for others to download or run. Open weights do not automatically mean open data, open training methods, or unrestricted rights.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-P" data-glossary-section>
+  <h2>P</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-prompt" data-glossary-term data-glossary-search-text="prompt the instruction, question, context, file, or example given to an ai system.">
+      <h3>Prompt</h3>
+      <p>The instruction, question, context, file, or example given to an AI system.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-prompt-engineering" data-glossary-term data-glossary-search-text="prompt engineering the practice of designing prompts and workflows so ai systems produce more useful, reliable, or constrained outputs.">
+      <h3>Prompt engineering</h3>
+      <p>The practice of designing prompts and workflows so AI systems produce more useful, reliable, or constrained outputs.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-public-interest-compute" data-glossary-term data-glossary-search-text="public-interest compute compute capacity reserved or governed for civic, academic, public, indigenous, nonprofit, or community benefit rather than only private profit.">
+      <h3>Public-interest compute</h3>
+      <p>Compute capacity reserved or governed for civic, academic, public, Indigenous, nonprofit, or community benefit rather than only private profit.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-R" data-glossary-section>
+  <h2>R</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-reconciliation" data-glossary-term data-glossary-search-text="reconciliation the ongoing work of repairing relationships and systems shaped by colonialism. in technology work, this should include material commitments, governance, accountability, and respect for indigenous rights.">
+      <h3>Reconciliation</h3>
+      <p>The ongoing work of repairing relationships and systems shaped by colonialism. In technology work, this should include material commitments, governance, accountability, and respect for Indigenous rights.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-red-teaming" data-glossary-term data-glossary-search-text="red teaming testing a system by trying to make it fail, break rules, expose vulnerabilities, or produce harmful outputs.">
+      <h3>Red teaming</h3>
+      <p>Testing a system by trying to make it fail, break rules, expose vulnerabilities, or produce harmful outputs.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-retrieval-augmented-generation-rag" data-glossary-term data-glossary-search-text="retrieval-augmented generation (rag) a method where an ai system retrieves relevant documents or data before generating an answer, making it easier to cite sources and use current context.">
+      <h3>Retrieval-augmented generation (RAG)</h3>
+      <p>A method where an AI system retrieves relevant documents or data before generating an answer, making it easier to cite sources and use current context.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-rights-holder" data-glossary-term data-glossary-search-text="rights holder a person, people, or nation with legal, inherent, or recognized rights affected by a decision. rights holders require a different level of respect and authority than general stakeholders.">
+      <h3>Rights holder</h3>
+      <p>A person, people, or Nation with legal, inherent, or recognized rights affected by a decision. Rights holders require a different level of respect and authority than general stakeholders.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-S" data-glossary-section>
+  <h2>S</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-self-determination" data-glossary-term data-glossary-search-text="self-determination the right of a people or community to make decisions about its own future, governance, resources, culture, and development.">
+      <h3>Self-determination</h3>
+      <p>The right of a people or community to make decisions about its own future, governance, resources, culture, and development.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-sovereign-ai" data-glossary-term data-glossary-search-text="sovereign ai ai infrastructure, capability, or governance controlled by a country, nation, region, or community. the term should always raise the question: sovereign for whom?">
+      <h3>Sovereign AI</h3>
+      <p>AI infrastructure, capability, or governance controlled by a country, Nation, region, or community. The term should always raise the question: sovereign for whom?</p>
+    </article>
+    <article class="kk-glossary-term" id="term-stakeholder" data-glossary-term data-glossary-search-text="stakeholder a person or group with an interest in a decision. stakeholders matter, but the term should not be used to flatten rights holders, host nations, workers, creators, or affected communities into one generic category.">
+      <h3>Stakeholder</h3>
+      <p>A person or group with an interest in a decision. Stakeholders matter, but the term should not be used to flatten rights holders, host Nations, workers, creators, or affected communities into one generic category.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-synthetic-media" data-glossary-term data-glossary-search-text="synthetic media images, audio, video, or text created or heavily modified by ai.">
+      <h3>Synthetic media</h3>
+      <p>Images, audio, video, or text created or heavily modified by AI.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-T" data-glossary-section>
+  <h2>T</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-token" data-glossary-term data-glossary-search-text="token a chunk of text that an ai model processes. tokens can be words, parts of words, punctuation, or other units.">
+      <h3>Token</h3>
+      <p>A chunk of text that an AI model processes. Tokens can be words, parts of words, punctuation, or other units.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-traditional-knowledge" data-glossary-term data-glossary-search-text="traditional knowledge knowledge held by indigenous peoples and communities through lived practice, relationship, stewardship, language, and culture. it should not be treated as free training data.">
+      <h3>Traditional knowledge</h3>
+      <p>Knowledge held by Indigenous Peoples and communities through lived practice, relationship, stewardship, language, and culture. It should not be treated as free training data.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-training-data" data-glossary-term data-glossary-search-text="training data the material used to teach an ai model patterns. training data can include text, images, audio, video, code, or structured records.">
+      <h3>Training data</h3>
+      <p>The material used to teach an AI model patterns. Training data can include text, images, audio, video, code, or structured records.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-transformer" data-glossary-term data-glossary-search-text="transformer a model architecture that helped make modern language models possible by allowing systems to track relationships across large amounts of text.">
+      <h3>Transformer</h3>
+      <p>A model architecture that helped make modern language models possible by allowing systems to track relationships across large amounts of text.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-two-eyed-seeing" data-glossary-term data-glossary-search-text="two-eyed seeing a concept associated with mi&#x27;kmaw elder albert marshall about learning to see from both indigenous and western knowledge systems. confirm wording and attribution before publication.">
+      <h3>Two-Eyed Seeing</h3>
+      <p>A concept associated with Mi'kmaw Elder Albert Marshall about learning to see from both Indigenous and Western knowledge systems. Confirm wording and attribution before publication.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-U" data-glossary-section>
+  <h2>U</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-unceded-territory" data-glossary-term data-glossary-search-text="unceded territory land that was not surrendered through treaty. use local wording carefully and confirm with the relevant nation or trusted local sources.">
+      <h3>Unceded territory</h3>
+      <p>Land that was not surrendered through treaty. Use local wording carefully and confirm with the relevant Nation or trusted local sources.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-V" data-glossary-section>
+  <h2>V</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-vector-database" data-glossary-term data-glossary-search-text="vector database a database designed to store and search embeddings, often used for semantic search and rag systems.">
+      <h3>Vector database</h3>
+      <p>A database designed to store and search embeddings, often used for semantic search and RAG systems.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-vision-model" data-glossary-term data-glossary-search-text="vision model an ai model that can interpret images or video.">
+      <h3>Vision model</h3>
+      <p>An AI model that can interpret images or video.</p>
+    </article>
+  </div>
+</section>
+<section class="kk-glossary-section" id="glossary-W" data-glossary-section>
+  <h2>W</h2>
+  <div class="kk-glossary-term-grid">
+    <article class="kk-glossary-term" id="term-water-and-energy-footprint" data-glossary-term data-glossary-search-text="water and energy footprint the water, electricity, cooling, land, and infrastructure demands created by technology systems, including ai data centres.">
+      <h3>Water and energy footprint</h3>
+      <p>The water, electricity, cooling, land, and infrastructure demands created by technology systems, including AI data centres.</p>
+    </article>
+    <article class="kk-glossary-term" id="term-workflow-automation" data-glossary-term data-glossary-search-text="workflow automation software that connects steps in a process so repeated work can happen with less manual effort. good automation should still keep accountability clear.">
+      <h3>Workflow automation</h3>
+      <p>Software that connects steps in a process so repeated work can happen with less manual effort. Good automation should still keep accountability clear.</p>
+    </article>
+  </div>
+</section>
+</div>
+
+<script>
+(function () {
+  var root = document.querySelector('[data-kk-glossary]');
+  if (!root) return;
+  var input = root.querySelector('[data-glossary-search]');
+  var count = root.querySelector('[data-glossary-count]');
+  var noResults = root.querySelector('[data-glossary-no-results]');
+  var terms = Array.prototype.slice.call(root.querySelectorAll('[data-glossary-term]'));
+  var sections = Array.prototype.slice.call(root.querySelectorAll('[data-glossary-section]'));
+  function normalize(value) {
+    return String(value || '').toLowerCase().normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
+  }
+  function update() {
+    var query = normalize(input.value).trim();
+    var visible = 0;
+    terms.forEach(function (term) {
+      var haystack = normalize(term.getAttribute('data-glossary-search-text'));
+      var match = !query || haystack.indexOf(query) !== -1;
+      term.hidden = !match;
+      if (match) visible += 1;
+    });
+    sections.forEach(function (section) {
+      section.hidden = !section.querySelector('[data-glossary-term]:not([hidden])');
+    });
+    count.textContent = visible + (visible === 1 ? ' term visible.' : ' terms visible.');
+    noResults.hidden = visible !== 0;
+  }
+  input.addEventListener('input', update);
+  update();
+}());
+</script>
+<!-- /wp:html -->

--- a/content/drafts/ai-glossary-2026-05/publish-gate.md
+++ b/content/drafts/ai-glossary-2026-05/publish-gate.md
@@ -14,7 +14,7 @@ Draft source: `content/drafts/ai-glossary-2026-05/README.md`
 
 ## Gate Summary
 
-The glossary draft is review-ready but not publish-ready. It currently has 69 terms, alphabetical sections, SEO metadata, mobile/accessibility notes, a related-reading module, and a recommended accessible search/filter brief.
+The glossary draft is review-ready but not publish-ready. It currently has 69 terms, alphabetical sections, SEO metadata, mobile/accessibility notes, a related-reading module, and a Gutenberg-ready `post.html` body with an accessible in-page search/filter.
 
 Do not publish until the sensitive-term review is complete or the sensitive terms are removed from the first public version.
 
@@ -25,7 +25,7 @@ Do not publish until the sensitive-term review is complete or the sensitive term
 | `/glossary` page | Draft created | Private WordPress draft exists at slug `/glossary/`. Public publish waits for review. |
 | 50+ terms | Ready | Draft has 69 terms before editorial cuts. |
 | Alphabetical | Ready | Letter sections and terms are sorted in-page. |
-| Searchable | Needs build | Recommended MVP is an accessible in-page filter, not just browser find. |
+| Searchable | Ready for preview | `post.html` includes a visible search label, keyboard-usable input, term/definition filtering, result count, no-results state, and no-JS fallback. |
 | Internal links | Drafted | Related-reading module and post-publication link map are in the README. |
 | Mobile | Drafted | No tables; notes call out wrapping and mobile QA. |
 | SEO | Drafted | Title, meta description, excerpt, keyphrases, and schema caution are in the README. |
@@ -39,7 +39,7 @@ Do not publish until the sensitive-term review is complete or the sensitive term
 
 ## Search Gate
 
-Build or explicitly waive in-page search before closing issue #44.
+Built locally in `post.html`; verify in WordPress preview before closing issue #44.
 
 Minimum acceptable filter behavior:
 
@@ -80,4 +80,4 @@ Smoke searches:
 
 ## Closure Recommendation
 
-Issue #44 should stay open after this draft pass. Close it only after the WordPress page exists at `/glossary/`, the search behavior is implemented or explicitly waived, internal links are added, mobile/accessibility checks pass, and sensitive terms have KK/SME approval or are removed from the first public version.
+Issue #44 should stay open after this draft pass. Close it only after the WordPress page exists at `/glossary/`, the search behavior passes preview QA, internal links are added, mobile/accessibility checks pass, and sensitive terms have KK/SME approval or are removed from the first public version.

--- a/content/drafts/ai-glossary-2026-05/seo-meta.md
+++ b/content/drafts/ai-glossary-2026-05/seo-meta.md
@@ -29,7 +29,7 @@
 
 **Publication caution:** The draft includes terms touching Indigenous governance, rights, protocol, data governance, and legal concepts. Publish only after KK review and source or SME review for the sensitive-term queue in `README.md`.
 
-**Search gate:** Issue #44 should not close until in-page search/filter is built or explicitly waived. Minimum behavior: visible label, keyboard usable input, term and definition filtering, no-JS fallback with all terms visible, clear no-results state, and result count announced with `aria-live="polite"`.
+**Search gate:** Built locally in `post.html`. The draft includes a visible `Search glossary terms` label, keyboard-usable input, term and definition filtering, no-JS fallback with all terms visible, clear no-results state, and result count announced with `aria-live="polite"`. Still requires WordPress preview QA before publication.
 
 **Internal links after publication**
 - Link from posts and pages that use dense AI terminology.

--- a/docs/current-state/reports/morning-truth-20260618-023342Z.md
+++ b/docs/current-state/reports/morning-truth-20260618-023342Z.md
@@ -1,0 +1,466 @@
+# Morning Truth Report - 2026-06-18 02:33:42 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `0`
+- Open issues: `48`
+- WordPress version (smoke): `6.9.4`
+- Draft queue: future posts `8`, draft posts `64`, draft pages `5`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&#038;ssl=1`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `23`
+- `aurora-v2`: `6`
+- `track-b`: `5`
+- `swarm-ready`: `0`
+- `swarm-parked`: `8`
+- `needs-human-review`: `11`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 0 | no |
+| Open Issues | 63 | 48 | YES |
+| WordPress Version | 6.9.4 | 6.9.4 | no |
+| Scheduled Posts | 2 | 8 | YES |
+| Draft Posts | 72 | 64 | YES |
+| Draft Pages | 5 | 5 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` vs `origin/aurora/v2`: `50	38`
+- Local `aurora/v2` status: `## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip`
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## main...origin/main
+ M content/drafts/2026-05-23-you-cant-drink-data/internal-links.md
+ M content/drafts/2026-05-23-you-cant-drink-data/kb-clean.md
+ M content/drafts/2026-05-23-you-cant-drink-data/post.md
+ M content/drafts/2026-05-23-you-cant-drink-data/seo-meta.md
+ M content/source-packs/keynotes-2026/wp-payloads/about.html
+ M content/source-packs/keynotes-2026/wp-payloads/page-meta.json
+ M content/source-packs/keynotes-2026/wp-payloads/work.html
+ M fixes/issue-36-meta-descriptions.md
+?? fixes/issue-198-search-console-striking-distance-links-2026-06-18.md
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+f45efd1 Merge pull request #234 from WalksWithASwagger/codex/issue-workdown-deploy-20260618
+d2be4c2 tools: add public image audit
+e58fa59 theme: complete issue workdown metadata fixes
+0615d3e Merge pull request #232 from WalksWithASwagger/codex/swarm-active-197-36-aurora-20260617
+39b8d81 docs: record connector dry-run proof
+41f9d8b docs: record swarm blocker readbacks
+fa7abb2 refactor: split notion connector modules
+048adc3 Merge pull request #231 from WalksWithASwagger/codex/swarm-ready-docs-seo-20260617
+e5c53c8 tests: cover swarm-ready static checks
+162e240 fixes: align twitter card handle
+fa4317c theme: expose writing category feeds
+9f197c8 content: draft swarm-ready lanes
+d98cc2f Merge pull request #228 from WalksWithASwagger/codex/leftover-lanes-closeout-20260617
+7ae2761 seo: harden metadata backfill closeout
+01fc9aa docs: session closeout 2026-06-17 + storyhive draft consolidation
+1fa1999 content: surface Storyhive Victoria video and close transcript loop
+a027969 Merge pull request #227 from WalksWithASwagger/codex/favicon-161
+9b5395e Merge pull request #226 from WalksWithASwagger/codex/image-briefs-206
+6e66805 seo: add deploy-ready favicon/app-icon packet + gap inventory (Refs #161)
+8d6438f content: complete six-field Rafiki image briefs for 7 blocked drafts (Refs #206)
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+233	OPEN	[SEO] Tighten KrisKrug homepage metadata and internal-link striking-distance posts	priority:high, content, seo, needs-human-review	2026-06-18T01:54:22Z
+222	OPEN	[EPIC] Harden platform trust, forms, and publisher operations	priority:high, platform, needs-human-review, roadmap, tech-debt	2026-06-18T02:25:00Z
+219	OPEN	[EPIC] Restore KrisKrug.co content cadence safely	priority:high, content, needs-human-review, roadmap	2026-06-17T17:17:51Z
+174	OPEN	Verify monitored contact-form notification routing	documentation, priority:high, marketing, platform, needs-human-review, swarm-parked	2026-06-18T02:24:24Z
+128	OPEN	Triage Jetpack contact-form submissions + fix notification routing	priority:high, marketing, platform, needs-human-review, swarm-parked	2026-06-18T02:24:44Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, swarm-wave-2, blocked	2026-06-17T21:27:05Z
+125	OPEN	[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration	enhancement, priority:medium, performance, track-b, aurora-v2, swarm-wave-2, blocked	2026-06-17T21:27:11Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+95	OPEN	[CONTENT P0] Review media appearances draft before publish/backlinks	enhancement, priority:high, content, needs-human-review, swarm-parked	2026-06-17T17:15:34Z
+86	OPEN	[AURORA P2] Run performance and accessibility QA on real staging	bug, enhancement, priority:high, mobile, accessibility, performance, track-b, aurora-v2, swarm-wave-3, blocked	2026-06-17T21:27:05Z
+64	OPEN	[PORTAL] Unified Search Across All 6 Projects	enhancement, priority:high, platform, swarm-parked	2026-06-17T17:15:37Z
+63	OPEN	[PORTAL] Beautiful Constellation Navigation Design	enhancement, priority:medium, mobile, content, accessibility, ux	2026-06-17T21:09:51Z
+62	OPEN	[PORTAL] Unified Event Calendar - Luma API Integration	enhancement, priority:high, platform, mobile, seo, swarm-parked	2026-06-17T17:15:36Z
+61	OPEN	[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words	enhancement, priority:high, content, swarm-parked	2026-06-17T17:15:35Z
+60	OPEN	[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts	enhancement, priority:medium, content	2026-06-09T23:05:17Z
+59	OPEN	[ARCHIVE] Create Photography Archive - Decades of Work	enhancement, priority:high, mobile, content	2026-06-09T23:05:19Z
+58	OPEN	[MARKETING] User-Generated Content Collection System	enhancement, priority:low, marketing, community, content	2026-06-09T23:05:21Z
+57	OPEN	[MARKETING] Cross-Promotion Framework with BC+AI	enhancement, priority:medium, marketing	2026-06-09T23:05:22Z
+56	OPEN	[MARKETING] Social Media Amplification System	enhancement, priority:medium, marketing	2026-06-17T21:09:47Z
+55	OPEN	[MARKETING] Formalize Speaking Circuit Strategy	enhancement, priority:high, marketing, content	2026-06-09T23:05:25Z
+54	OPEN	[MARKETING] Create Community Advocate Program	enhancement, priority:medium, marketing, community	2026-06-17T21:09:44Z
+53	OPEN	[MARKETING] Build Community Referral Program	enhancement, priority:medium, marketing, community, content	2026-06-17T21:09:41Z
+52	OPEN	[MARKETING] Create Content Syndication Strategy	enhancement, priority:medium, marketing, content	2026-06-17T21:09:36Z
+51	OPEN	[MARKETING] Implement Email Onboarding Sequences	enhancement, priority:high, marketing, swarm-parked	2026-06-17T17:15:44Z
+50	OPEN	[MARKETING] Launch Podcast Guesting Tour Strategy	enhancement, priority:high, marketing	2026-06-09T23:05:32Z
+49	OPEN	[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides	enhancement, priority:high, marketing, content, swarm-parked	2026-06-17T17:15:41Z
+48	OPEN	[A11Y] Create Accessibility Statement	enhancement, priority:high, accessibility, needs-human-review, swarm-wave-1	2026-06-11T20:35:40Z
+47	OPEN	[A11Y] Keyboard Navigation Improvements	enhancement, priority:high, content, accessibility	2026-06-09T23:05:36Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-06-09T23:05:38Z
+44	OPEN	[CONTENT] Create Glossary Page for AI Terminology	enhancement, priority:low, mobile, content, accessibility, swarm-wave-3	2026-06-17T21:09:33Z
+42	OPEN	[PERFORMANCE] Implement Lazy Loading for Images	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:43Z
+41	OPEN	[PERFORMANCE] Reduce Plugin Bloat	enhancement, priority:medium, mobile, performance	2026-06-09T23:05:45Z
+40	OPEN	[SEO] Optimize Images for Performance and SEO	enhancement, priority:medium, mobile, seo, performance	2026-06-18T02:23:53Z
+30	OPEN	[DESIGN] Photography Showcase Component	enhancement, priority:medium, ux, track-b, aurora-v2	2026-05-24T21:12:52Z
+29	OPEN	[DESIGN] Footer Redesign	enhancement, priority:medium, mobile, ux, track-b, aurora-v2	2026-05-24T21:12:51Z
+23	OPEN	[CONTENT] Reorganize Blog Categories	enhancement, priority:medium, mobile, content, needs-human-review	2026-05-18T17:09:21Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+21	OPEN	[CONTENT] Create Photography Portfolio as Credential Section	enhancement, priority:medium, mobile, content	2026-06-09T23:05:56Z
+20	OPEN	[CONTENT] Update Voice/Tone to Professional but Warm	enhancement, priority:medium, content	2026-06-09T23:05:58Z
+19	OPEN	[CONTENT] Add Community Impact Metrics Throughout Site	enhancement, priority:medium, mobile, content, accessibility, performance	2026-06-09T23:06:38Z
+18	OPEN	[CONTENT] Create Vancouver AI Community Page	enhancement, priority:medium, mobile, content, swarm-wave-2	2026-06-17T21:09:30Z
+15	OPEN	[CONTENT] Create The Upgrade AI Co-Founder Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:48Z
+14	OPEN	[CONTENT] Create Indigenomics.ai CTO Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:45Z
+13	OPEN	[CONTENT] Create BC+AI Leadership Section	enhancement, priority:high, mobile, content, needs-human-review, swarm-wave-2	2026-06-11T20:32:43Z
+11	OPEN	[UX] Create Membership Benefits Comparison Matrix	enhancement, priority:medium, mobile, content, ux	2026-06-09T23:06:30Z
+7	OPEN	[CONTENT] Add Pricing Information to Services	enhancement, priority:medium, mobile, content	2026-06-09T23:06:25Z
+5	OPEN	[BUG] Fix Color Contrast for WCAG Compliance	bug, priority:high, accessibility	2026-06-09T23:06:23Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-06-18T02:23:44Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD f45efd1e4695745f0e7edb77d7d34dba60394ad9
+branch refs/heads/main
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80
+HEAD 81a62abfa2693ae41220cc5acfa21d4161100347
+branch refs/heads/aurora/v2
+locked claude agent agent-aec50fddbd7207f80 (pid 73140)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `0`
+
+```text
+18	303
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":233,"title":"[SEO] Tighten KrisKrug homepage metadata and internal-link striking-distance posts","updatedAt":"2026-06-18T01:54:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":222,"title":"[EPIC] Harden platform trust, forms, and publisher operations","updatedAt":"2026-06-18T02:25:00Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":219,"title":"[EPIC] Restore KrisKrug.co content cadence safely","updatedAt":"2026-06-17T17:17:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":174,"title":"Verify monitored contact-form notification routing","updatedAt":"2026-06-18T02:24:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":128,"title":"Triage Jetpack contact-form submissions + fix notification routing","updatedAt":"2026-06-18T02:24:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-06-17T21:27:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":125,"title":"[AURORA P2] Performance + Jetpack Boost Critical CSS regeneration","updatedAt":"2026-06-17T21:27:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":95,"title":"[CONTENT P0] Review media appearances draft before publish/backlinks","updatedAt":"2026-06-17T17:15:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":86,"title":"[AURORA P2] Run performance and accessibility QA on real staging","updatedAt":"2026-06-17T21:27:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":64,"title":"[PORTAL] Unified Search Across All 6 Projects","updatedAt":"2026-06-17T17:15:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"}],"number":63,"title":"[PORTAL] Beautiful Constellation Navigation Design","updatedAt":"2026-06-17T21:09:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":62,"title":"[PORTAL] Unified Event Calendar - Luma API Integration","updatedAt":"2026-06-17T17:15:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":61,"title":"[ARCHIVE] Integrate Indigenomics Knowledge Base - 1.13M Words","updatedAt":"2026-06-17T17:15:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":60,"title":"[ARCHIVE] Build Speaking Archive - Recordings, Slides, Transcripts","updatedAt":"2026-06-09T23:05:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":59,"title":"[ARCHIVE] Create Photography Archive - Decades of Work","updatedAt":"2026-06-09T23:05:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":58,"title":"[MARKETING] User-Generated Content Collection System","updatedAt":"2026-06-09T23:05:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":57,"title":"[MARKETING] Cross-Promotion Framework with BC+AI","updatedAt":"2026-06-09T23:05:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":56,"title":"[MARKETING] Social Media Amplification System","updatedAt":"2026-06-17T21:09:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":55,"title":"[MARKETING] Formalize Speaking Circuit Strategy","updatedAt":"2026-06-09T23:05:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"}],"number":54,"title":"[MARKETING] Create Community Advocate Program","updatedAt":"2026-06-17T21:09:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1ur9w","name":"community","description":"Community programs","color":"7BDCB5"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":53,"title":"[MARKETING] Build Community Referral Program","updatedAt":"2026-06-17T21:09:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":52,"title":"[MARKETING] Create Content Syndication Strategy","updatedAt":"2026-06-17T21:09:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":51,"title":"[MARKETING] Implement Email Onboarding Sequences","updatedAt":"2026-06-17T17:15:44Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"}],"number":50,"title":"[MARKETING] Launch Podcast Guesting Tour Strategy","updatedAt":"2026-06-09T23:05:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1ur8A","name":"marketing","description":"Marketing and lead generation","color":"FF69B4"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgA","name":"swarm-parked","description":"Deferred or too broad for current autonomous wave","color":"6E7781"}],"number":49,"title":"[MARKETING] Create Lead Magnet System - 5 Audience-Specific Guides","updatedAt":"2026-06-17T17:15:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":48,"title":"[A11Y] Create Accessibility Statement","updatedAt":"2026-06-11T20:35:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":47,"title":"[A11Y] Keyboard Navigation Improvements","updatedAt":"2026-06-09T23:05:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-06-09T23:05:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"}],"number":44,"title":"[CONTENT] Create Glossary Page for AI Terminology","updatedAt":"2026-06-17T21:09:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":42,"title":"[PERFORMANCE] Implement Lazy Loading for Images","updatedAt":"2026-06-09T23:05:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":41,"title":"[PERFORMANCE] Reduce Plugin Bloat","updatedAt":"2026-06-09T23:05:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":40,"title":"[SEO] Optimize Images for Performance and SEO","updatedAt":"2026-06-18T02:23:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":30,"title":"[DESIGN] Photography Showcase Component","updatedAt":"2026-05-24T21:12:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":29,"title":"[DESIGN] Footer Redesign","updatedAt":"2026-05-24T21:12:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":23,"title":"[CONTENT] Reorganize Blog Categories","updatedAt":"2026-05-18T17:09:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":21,"title":"[CONTENT] Create Photography Portfolio as Credential Section","updatedAt":"2026-06-09T23:05:56Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":20,"title":"[CONTENT] Update Voice/Tone to Professional but Warm","updatedAt":"2026-06-09T23:05:58Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"}],"number":19,"title":"[CONTENT] Add Community Impact Metrics Throughout Site","updatedAt":"2026-06-09T23:06:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":18,"title":"[CONTENT] Create Vancouver AI Community Page","updatedAt":"2026-06-17T21:09:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":15,"title":"[CONTENT] Create The Upgrade AI Co-Founder Section","updatedAt":"2026-06-11T20:32:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":14,"title":"[CONTENT] Create Indigenomics.ai CTO Section","updatedAt":"2026-06-11T20:32:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":13,"title":"[CONTENT] Create BC+AI Leadership Section","updatedAt":"2026-06-11T20:32:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"}],"number":11,"title":"[UX] Create Membership Benefits Comparison Matrix","updatedAt":"2026-06-09T23:06:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":7,"title":"[CONTENT] Add Pricing Information to Services","updatedAt":"2026-06-09T23:06:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":5,"title":"[BUG] Fix Color Contrast for WCAG Compliance","updatedAt":"2026-06-09T23:06:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-06-18T02:23:44Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=8, draft_posts=64, draft_pages=5
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 6.9.4 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.181.0",
+          "jetpack": "346d8384549cea9b9909",
+          "popup-maker": "1.22.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "6.9.4"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/recent-projects-include/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/blaze",
+          "jetpack/v4/blaze-app",
+          "jetpack/v4/explat",
+          "jetpack/v4/import",
+          "jetpack/v4/stats-app",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "wpcom/v2",
+          "wpcom/v3",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "6.9.4",
+  "started_at": "2026-06-18T02:33:52Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/WORK-PLAN-2026-05-23.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": false,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 0
+    },
+    {
+      "declared": 63,
+      "drift": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 48
+    },
+    {
+      "declared": "6.9.4",
+      "drift": false,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "6.9.4"
+    },
+    {
+      "declared": 2,
+      "drift": true,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 8
+    },
+    {
+      "declared": 72,
+      "drift": true,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 64
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 5
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/WORK-PLAN-2026-05-23.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301 
+date: Thu, 18 Jun 2026 02:34:14 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+location: https://kriskrug.co/recent-projects-include/
+server: Pagely-ARES/1.22.2
+x-gateway-request-id: 33f26b691ad4b3dc840ce220cdc525eb
+x-jetpack-boost-cache: miss
+vary: accept,content-type
+expires: Thu, 18 Jun 2026 03:30:30 GMT
+cache-control: max-age=3600
+x-redirect-by: KK Hotfix
+x-gateway-cache-key: 1781749251.43|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: HIT
+x-gateway-skip-cache: 0
+```
+
+### Aurora Local vs Origin Divergence
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 rev-list --left-right --count origin/aurora/v2...aurora/v2`
+- Exit code: `0`
+
+```text
+50	38
+```
+
+### Aurora Local Status
+
+- Command: `git -C /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80 status --short --branch`
+- Exit code: `0`
+
+```text
+## aurora/v2...origin/aurora/v2 [ahead 38, behind 50]
+ M theme/kk-aurora.zip
+```

--- a/scripts/tests/test_content_page_packages.py
+++ b/scripts/tests/test_content_page_packages.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VANCOUVER_AI_DIR = ROOT / "content/drafts/2026-06-11-vancouver-ai-community-page"
+
+
+class ContentPagePackageTests(unittest.TestCase):
+    def test_vancouver_ai_package_carries_public_proof_points(self):
+        html = (VANCOUVER_AI_DIR / "post.html").read_text(encoding="utf-8")
+        markdown = (VANCOUVER_AI_DIR / "post.md").read_text(encoding="utf-8")
+        combined = html + "\n" + markdown
+
+        for marker in ("250+", "3,000+", "94+", "Est. 2023", "T5ANAthZewE"):
+            self.assertIn(marker, combined)
+        for url in ("https://luma.com/vancouver-ai", "https://bc-ai.ca/membership/"):
+            self.assertIn(url, combined)
+        self.assertIn("<!-- wp:html -->", html)
+        self.assertNotIn("notion.so", combined.lower())
+        self.assertNotIn("notionusercontent", combined.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_glossary_draft.py
+++ b/scripts/tests/test_glossary_draft.py
@@ -1,0 +1,33 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GLOSSARY_DIR = ROOT / "content/drafts/ai-glossary-2026-05"
+
+
+class GlossaryDraftTests(unittest.TestCase):
+    def test_markdown_has_enough_alphabetized_terms(self):
+        markdown = (GLOSSARY_DIR / "post.md").read_text(encoding="utf-8")
+        terms = re.findall(r"^\*\*([^:*]+):\*\*", markdown, re.MULTILINE)
+
+        self.assertGreaterEqual(len(terms), 50)
+        self.assertEqual(terms, sorted(terms, key=str.lower))
+
+    def test_html_has_accessible_search_gate(self):
+        html = (GLOSSARY_DIR / "post.html").read_text(encoding="utf-8")
+
+        self.assertIn("data-kk-glossary", html)
+        self.assertIn("Search glossary terms", html)
+        self.assertIn('role="search"', html)
+        self.assertIn('aria-live="polite"', html)
+        self.assertIn("data-glossary-no-results", html)
+        self.assertIn("data-glossary-search-text", html)
+        self.assertIn("input.addEventListener('input', update)", html)
+        terms = re.findall(r"<article[^>]+data-glossary-term\b", html)
+        self.assertGreaterEqual(len(terms), 50)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Hardens the issue #44 AI glossary package with a Gutenberg-ready `post.html` body, accessible in-page search, result count, no-results state, and no-JS fallback.
- Reconciles the issue #18 Vancouver AI community package to the stronger source-pack payload with public BC+AI proof markers, Luma/BC+AI membership links, and the public YouTube talk embed.
- Adds focused repo tests for the glossary acceptance gates and Vancouver AI package markers, plus the startup morning-truth snapshot.

## Verification
- `make test`
- `make docs-truth-check`
- `git diff --check`

## Notes
- No live WordPress writes, deploys, private inbox reads, or production publishing were performed.
- This advances #18 and #44, but does not close them. #44 still needs WordPress preview QA, internal links, mobile/accessibility pass, and sensitive-term review before publish. #18 still needs the final URL/parent decision, current-stat recheck before WP draft/publish, preview QA, and any human-approved testimonials/partner names.

Refs #18
Refs #44
