### PR TITLE
theme: raise Aurora contrast tokens

### DIFF
--- a/scripts/tests/test_aurora_contrast_tokens.py
+++ b/scripts/tests/test_aurora_contrast_tokens.py
@@ -1,0 +1,59 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME_DIR = ROOT / "theme/kk-aurora"
+
+
+def contrast_ratio(foreground, background):
+    def relative_luminance(hex_color):
+        color = hex_color.lstrip("#")
+        channels = [int(color[index : index + 2], 16) / 255 for index in (0, 2, 4)]
+
+        def linearize(channel):
+            if channel <= 0.03928:
+                return channel / 12.92
+            return ((channel + 0.055) / 1.055) ** 2.4
+
+        red, green, blue = [linearize(channel) for channel in channels]
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+    lighter, darker = sorted(
+        [relative_luminance(foreground), relative_luminance(background)],
+        reverse=True,
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+class AuroraContrastTokenTests(unittest.TestCase):
+    def setUp(self):
+        theme = json.loads((THEME_DIR / "theme.json").read_text(encoding="utf-8"))
+        palette = theme["settings"]["color"]["palette"]
+        self.colors = {entry["slug"]: entry["color"] for entry in palette}
+
+    def test_text_tokens_meet_wcag_aa_on_dark_surfaces(self):
+        foregrounds = ("text-primary", "text-secondary", "text-muted", "signal")
+        backgrounds = ("deep", "surface", "elevated", "muted")
+
+        failures = []
+        for foreground in foregrounds:
+            for background in backgrounds:
+                ratio = contrast_ratio(self.colors[foreground], self.colors[background])
+                if ratio < 4.5:
+                    failures.append(f"{foreground} on {background}: {ratio:.2f}:1")
+
+        self.assertEqual(failures, [])
+
+    def test_css_signal_token_matches_theme_palette(self):
+        css = (THEME_DIR / "style.css").read_text(encoding="utf-8")
+        match = re.search(r"--aurora-signal:\s*(#[0-9a-fA-F]{6});", css)
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group(1).upper(), self.colors["signal"].upper())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/assets/css/editor.css
+++ b/theme/kk-aurora/assets/css/editor.css
@@ -119,7 +119,7 @@
 }
 
 .editor-styles-wrapper .is-style-callout-red {
-  --aurora-editor-callout-accent: #e5462e;
+  --aurora-editor-callout-accent: #f15b43;
   --aurora-editor-callout-rgb: 229, 70, 46;
 }
 
@@ -160,7 +160,7 @@
 }
 
 .editor-styles-wrapper .is-style-aurora-article-aside {
-  border-left-color: #e5462e;
+  border-left-color: #f15b43;
 }
 
 .editor-styles-wrapper .is-style-bookmark a,

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -491,7 +491,7 @@ a {
   --aurora-ink-soft: #c8cac8;
   --aurora-ink-muted: #8f9697;
   --aurora-paper: #f7f5f1;
-  --aurora-signal: #e5462e;
+  --aurora-signal: #f15b43;
   --aurora-signal-dark: #a52918;
   --aurora-wildcard: #c8ff3d;
   --aurora-black: #030405;
@@ -557,8 +557,8 @@ a {
 
 .aurora-button-primary:hover,
 .wp-block-button.is-style-aurora-primary .wp-block-button__link:hover {
-  background: #f15b43;
-  border-color: #f15b43;
+  background: #f2644d;
+  border-color: #f2644d;
   box-shadow: 0 0 38px rgba(229, 70, 46, 0.34);
 }
 
@@ -616,7 +616,7 @@ a {
 }
 
 .aurora-kicker {
-  color: var(--wp--preset--color--signal, #e5462e);
+  color: var(--wp--preset--color--signal, #f15b43);
   font-family: var(--wp--preset--font-family--mono);
   font-size: clamp(0.72rem, 0.68rem + 0.16vw, 0.82rem);
   font-weight: 500;
@@ -3104,13 +3104,13 @@ a {
 .aurora-article-category a:focus,
 .aurora-post-tags a:focus,
 .aurora-prose a:not(.wp-block-button__link):focus {
-  outline: 2px solid var(--wp--preset--color--signal, #e5462e) !important;
+  outline: 2px solid var(--wp--preset--color--signal, #f15b43) !important;
   outline-offset: 3px !important;
 }
 
 .aurora-single-2026 a:focus,
 .aurora-writing-archive a:focus {
-  outline: 2px solid var(--wp--preset--color--signal, #e5462e) !important;
+  outline: 2px solid var(--wp--preset--color--signal, #f15b43) !important;
   outline-offset: 3px !important;
 }
 
@@ -3517,7 +3517,7 @@ a {
 }
 
 .aurora-prose .is-style-callout-red {
-  --aurora-callout-accent: #e5462e;
+  --aurora-callout-accent: #f15b43;
   --aurora-callout-rgb: 229, 70, 46;
 }
 

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -54,7 +54,7 @@
         {
           "slug": "text-muted",
           "name": "Text Muted",
-          "color": "#7C7C98"
+          "color": "#8E8EA8"
         },
         {
           "slug": "paper",
@@ -64,7 +64,7 @@
         {
           "slug": "signal",
           "name": "Aurora Signal",
-          "color": "#E5462E"
+          "color": "#F15B43"
         },
         {
           "slug": "wildcard",
@@ -116,7 +116,7 @@
         {
           "slug": "aurora-primary",
           "name": "Aurora Primary",
-          "gradient": "linear-gradient(135deg, #E5462E 0%, #C8FF3D 100%)"
+          "gradient": "linear-gradient(135deg, #F15B43 0%, #C8FF3D 100%)"
         },
         {
           "slug": "aurora-secondary",


### PR DESCRIPTION
## Summary
- Raises Aurora `text-muted` from `#7C7C98` to `#8E8EA8`, clearing WCAG AA on the core dark/elevated surfaces.
- Raises the Aurora signal red from `#E5462E` to `#F15B43`, aligns front-end/editor fallbacks, and keeps a distinct hover state.
- Adds a regression test that parses `theme.json` and checks `text-primary`, `text-secondary`, `text-muted`, and `signal` against `deep`, `surface`, `elevated`, and `muted` at 4.5:1 or higher.

## Verification
- `make test`
- `make docs-truth-check`
- `git diff --check`

## Notes
- No deploy or live WordPress write performed.
- This advances #5 but does not fully close it until a deployed/live browser accessibility pass confirms there is no visual regression across representative pages.

Refs #5
