### PR TITLE
theme: restore skip-link targets

### DIFF
--- a/scripts/tests/test_aurora_skip_links.py
+++ b/scripts/tests/test_aurora_skip_links.py
@@ -1,0 +1,28 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME_DIR = ROOT / "theme/kk-aurora"
+
+
+class AuroraSkipLinkTests(unittest.TestCase):
+    def test_header_skip_link_has_template_targets(self):
+        header = (THEME_DIR / "parts/header.html").read_text(encoding="utf-8")
+
+        self.assertIn('class="skip-link"', header)
+        self.assertIn('href="#aurora-main"', header)
+
+        missing = []
+        for template_path in sorted((THEME_DIR / "templates").glob("*.html")):
+            template = template_path.read_text(encoding="utf-8")
+            if '"slug":"header"' not in template:
+                continue
+            if 'id="aurora-main"' not in template:
+                missing.append(template_path.name)
+
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/templates/404.html
+++ b/theme/kk-aurora/templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|200","bottom":"var:preset|spacing|200"}}},"layout":{"type":"constrained","contentSize":"600px"}} -->
-<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--200);padding-bottom:var(--wp--preset--spacing--200)">
+<main id="aurora-main" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--200);padding-bottom:var(--wp--preset--spacing--200)">
   
   <!-- wp:heading {"textAlign":"center","level":1,"className":"has-gradient-text","style":{"typography":{"fontSize":"clamp(6rem, 15vw, 12rem)","fontStyle":"normal","fontWeight":"900","lineHeight":"1"}}} -->
   <h1 class="wp-block-heading has-text-align-center has-gradient-text" style="font-size:clamp(6rem, 15vw, 12rem);font-style:normal;font-weight:900;line-height:1">404</h1>

--- a/theme/kk-aurora/templates/index.html
+++ b/theme/kk-aurora/templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"var:preset|spacing|120","bottom":"var:preset|spacing|120"}}},"layout":{"type":"constrained","contentSize":"800px"}} -->
-<main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--120);padding-bottom:var(--wp--preset--spacing--120)">
+<main id="aurora-main" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--120);padding-bottom:var(--wp--preset--spacing--120)">
   
   <!-- wp:query-title {"type":"archive","textAlign":"center","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} /-->
   


### PR DESCRIPTION
## Summary
- Adds the missing `id="aurora-main"` target to the 404 and fallback index templates.
- Keeps the existing header skip link functional across every template that loads the Aurora header.
- Adds a static regression test that fails if any header-using template lacks the skip-link target.

## Verification
- `make test`
- `make docs-truth-check`
- `git diff --check`
- Static template check: all templates now report `has-id` for `id="aurora-main"`.

## Notes
- No deploy or live WordPress write performed.
- This advances #47. It should remain open until a broader keyboard/manual pass covers tab order, forms, traps, and screen-reader behavior on live representative pages.

Refs #47
