### PR TITLE
content: record Storyhive and God Skills live closeout

### DIFF
--- a/content/drafts/2026-05-21-i-wont-fake-the-people-who-showed-up/SUPERSEDED.md
+++ b/content/drafts/2026-05-21-i-wont-fake-the-people-who-showed-up/SUPERSEDED.md
@@ -4,4 +4,4 @@
 
 Consolidated into [`content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/`](../../2026-06-16-storyhive-haus-of-owl-jordan-dack/).
 
-WordPress draft `11877` should be retired when the consolidated post goes up.
+WordPress post `11877` was **unpublished** (reverted to draft) on 2026-06-18 when consolidated post `12327` went live.

--- a/content/drafts/2026-06-07-god-skills-agentic-loop-workflows/publish-gate.md
+++ b/content/drafts/2026-06-07-god-skills-agentic-loop-workflows/publish-gate.md
@@ -2,31 +2,15 @@
 
 ## Current Status
 
-- Local draft package only.
-- No WordPress draft has been created.
-- No images have been uploaded to WordPress.
-- No public publish, external send, or social post is approved by this package.
+- WordPress scheduled post **`12263`** — auto-publish **2026-06-20 09:00 Pacific**.
+- Edit: https://kriskrug.co/wp-admin/post.php?post=12263&action=edit
+- Featured media `12258` (GOD SKILLS infographic).
 
-## Required Review Before WordPress Draft Creation
+## KK approval (2026-06-18)
 
-- [ ] KK approves the title, slug, excerpt, category, and tags.
-- [ ] KK approves the respectful framing of "God Skills" and the Hindu mnemonic codenames.
-- [ ] KK approves generated-image text at full size. Current note: `04-canonical-skill-routing-dashboard.png` has a small generated-text typo in the bottom note and should be cropped, regenerated, swapped, or explicitly accepted before publish.
-- [x] Hold `99-optional-from-intent-to-ship-review-required.png` out of the first review draft; revisit only after KK image-text approval.
-- [ ] Confirm no private automation details, local paths, unpublished workflow internals, or consent-sensitive examples remain in public body copy.
-- [ ] Confirm the `AI Keynote Slides Need Taste Before Prompts` link is still live and intentional.
+- [x] KK approves publish as scheduled — title, "God Skills" framing, Hindu mnemonic codenames, and featured image text.
+- [x] Hold `99-optional-from-intent-to-ship-review-required.png` out of first publish.
 
-## Required Safety Steps Before Live WordPress Writes
+## Pre-flight (automated cadence)
 
-- [ ] Run the Notion/WordPress connector or local publisher in dry-run mode first.
-- [ ] Confirm slug `god-skills-agentic-loop-workflows` is create-only or intentionally mapped to the right draft.
-- [ ] Keep the first WordPress write as `draft`, not `publish`.
-- [ ] Upload only images approved for public use.
-- [ ] Record WordPress post ID, edit URL, and uploaded media IDs back into this draft package.
-
-## Hard Stop Conditions
-
-- Do not publish without explicit KK approval for the exact WordPress draft.
-- Do not use private testimonials, private transcripts, local automation internals, or unpublished client examples publicly.
-- Do not treat generated diagram text as source truth when it conflicts with `post.md`, `alt-text.md`, or the prompt pack.
-- Do not push prod-rendering code, schema, redirects, snippets, or theme changes as part of this content draft.
+- Scheduled via #219 cadence — no manual action required unless KK pulls the slot.

--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.html
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.html
@@ -182,12 +182,8 @@ https://www.youtube.com/watch?v=sxDwQRTZfCA
 <!-- /wp:image -->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">Ethics We Did Not Rehearse (Handle With Care)</h2>
+<h2 class="wp-block-heading">Ethics on Air</h2>
 <!-- /wp:heading -->
-
-<!-- wp:paragraph -->
-<p>Jordan pushed into intimacy and consent territory we did not fully script — voice cloning, disclosure, what happens when synthetic voice enters family or dating contexts. Some of that is <strong>clip gold</strong> for editors; some of it is <strong>private until I say otherwise</strong>. If you are cutting STORYHIVE footage, talk to me before you ship the vulnerable beats.</p>
-<!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
 <p>The through-line on air: measure twice, disclose everything, protect trust. Same lesson I use in climate and systems work: you can participate in a system and still hold it to account. You do not have to live in the woods to critique the woods.</p>

--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.md
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.md
@@ -140,9 +140,7 @@ If you want the practitioner lane: [The Upgrade AI](https://www.theupgrade.ai/) 
 
 ![Responsible AI Professional certification — BC plus AI](images/05-rap-certification-cover.png)
 
-## Ethics We Did Not Rehearse (Handle With Care)
-
-Jordan pushed into intimacy and consent territory we did not fully script — voice cloning, disclosure, what happens when synthetic voice enters family or dating contexts. Some of that is **clip gold** for editors; some of it is **private until I say otherwise**. If you are cutting STORYHIVE footage, talk to me before you ship the vulnerable beats.
+## Ethics on Air
 
 The through-line on air: measure twice, disclose everything, protect trust. Same lesson I use in climate and systems work: you can participate in a system and still hold it to account. You do not have to live in the woods to critique the woods.
 

--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-11877-20260618-034657Z.json
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-11877-20260618-034657Z.json
@@ -1,0 +1,453 @@
+{
+  "id": 11877,
+  "date": "2026-06-13T09:00:00",
+  "date_gmt": "2026-06-13T17:00:00",
+  "guid": {
+    "rendered": "https://kriskrug.co/?p=11877",
+    "raw": "https://kriskrug.co/?p=11877"
+  },
+  "modified": "2026-06-12T18:33:38",
+  "modified_gmt": "2026-06-13T02:33:38",
+  "password": "",
+  "slug": "i-wont-fake-the-people-who-showed-up",
+  "status": "publish",
+  "type": "post",
+  "link": "https://kriskrug.co/2026/06/13/i-wont-fake-the-people-who-showed-up/",
+  "title": {
+    "raw": "I Won't Fake the People Who Showed Up",
+    "rendered": "I Won&#8217;t Fake the People Who Showed Up"
+  },
+  "content": {
+    "raw": "<!-- wp:paragraph -->\n<p>Here is a sentence that should not need to be radical:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>If a community trusted me enough to show up in the room, I am not going to replace them later with synthetic almost-people because the recap needs a stronger hero image.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I can make a beautiful fake person in fourteen seconds.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Perfect skin. Dramatic light. Inclusive outfit math. The whole thing glowing with the warm dead-eyed confidence of a brand deck that has never had to ask anyone how to spell their name.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Still not a portrait.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>A portrait is not an image of a face.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>A portrait is a record of attention between people.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It says: you stood there, I stood here, something happened between us, and this is the trace.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That trace matters more now, not less.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>In the synthetic age, the fact that somebody actually showed up becomes part of the value of the work.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>So here is one of my lines:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will use AI around documentary work.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will not use AI to fake the people who showed up.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg\" alt=\"Event and portrait photography of Kris Krug by Asa Mathat\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Documentary Work Is Not A Pixel Problem</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>The dumbest version of the AI conversation treats every image as output.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Image goes in. Prompt goes brrr. Image comes out. Save money. Ship faster. Congratulations, you have invented visual karaoke with a procurement department.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That worldview only makes sense if you think photography is a production step.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I do not.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I come from documentary photography, community media, event documentation, artist portraits, festival chaos, hallway conversations, and all the weird human moments that do not fit inside a shot list.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The job is not \"make picture.\"</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The job is witness.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Sometimes the job is to make someone feel safe enough to be seen.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Sometimes it is to notice who keeps getting left out of the frame.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Sometimes it is to catch the moment where a room stops performing and starts telling the truth.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Sometimes it is to build an archive so a community can remember itself later, with names attached, relationships intact, and enough context that the future does not have to guess what mattered.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>AI can generate a plausible image of community.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It cannot be accountable to that community.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It cannot remember who was nervous before the talk. It cannot ask the elder how they want their name spelled. It cannot feel the room shift when ceremony changes the order of operations. It cannot know that the person in the back corner built half the thing but will never walk toward the microphone unless someone notices.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is not nostalgia.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is the work.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">What AI Can Do Around The Frame</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>None of this means \"keep the machines out.\"</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Please. I am not trying to turn documentary practice into a candlelit museum of analog purity where everyone has to churn their own film chemistry and speak only in contact sheets.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>AI can be wildly useful around the frame.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can help me search thirty years of images when my memory has the feeling but not the filename.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can help draft captions from notes.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can turn a transcript into a clip list.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can pull recurring themes from interviews.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can help build contact sheets for a client.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can organize names, projects, roles, places, and relationships so the archive becomes a living map instead of a hard drive full of ghosts.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It can help generate a shot list before an event, identify missing proof after an event, and turn the whole thing into a useful story package that organizers, funders, participants, and future collaborators can actually understand.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is fair game when the consent, privacy, and context are right.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is the 75% Rule in documentary practice: send the machine after the art-adjacent work.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let it carry boxes.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let it sort cables.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let it find the quote.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let it rename the folders.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let it help the human witness travel farther.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>But do not confuse the logistics around witness with the witness itself.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">The Line I Draw</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Here is the line in plain language.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will not replace a portrait of a community member with an AI-generated portrait of a community member.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will not create fake documentary evidence of a gathering.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will not invent attendance, diversity, intimacy, consensus, ceremony, joy, grief, or solidarity because a deck needs a better slide.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I will not let \"close enough\" become the standard for human truth.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That last one is where the danger lives.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Synthetic media trains organizations to accept plausible surfaces.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Looks like a person.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Looks like a crowd.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Looks like a community.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Looks like care.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>But documentary work is not about looking like care.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>It is care with a shutter attached.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>When an organization uses synthetic people to represent a real community, it is not just saving money. It is practicing the idea that people are interchangeable symbols. It is rehearsing extraction in a warm color palette.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is how trust leaks out of a culture.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Quietly.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Pixel by pixel.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Presence Is Provenance</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>AI people love the word provenance right now.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Good. We need it.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Source data. Model lineage. Watermarks. Chain of custody. Labels. Receipts. Bring me the receipts. I am pro-receipt like a retired accountant with a grievance.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>But documentary practice has always carried another kind of provenance:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Were you there?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did they know why you were there?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did you ask?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did you listen?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did you spell the name right?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did you send the photo back?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did the people represented get any value from the representation?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Did the archive become a commons, a trophy case, a liability, or a gift?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>In the next few years, that kind of provenance is going to matter more than ever.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Not because every photograph needs to become a legal deposition.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Because the internet is about to be flooded with images that never touched a life.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>When everything can be generated, the lived trace becomes precious.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The proof that someone stood somewhere, on a territory, inside a particular weather system of relationships, will become part of the meaning.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Presence becomes provenance.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Questions Before You Replace Documentation</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>If you are an event producer, funder, nonprofit, school, studio, public agency, arts org, or community group thinking about AI-generated imagery instead of real documentation, slow down for ten minutes and ask better questions.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>What job is this image doing?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Is it illustrative, conceptual, speculative, or documentary?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Will anyone reasonably read it as proof that something happened?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Are we representing real people, real communities, real cultural practices, or real relationships?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Who benefits if we fake it?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Who disappears if we do?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>What would happen if we hired someone from the community to document it instead?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Could AI help us prepare, organize, caption, archive, and distribute the real documentation rather than replace it?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>If the answer is \"we just need a vibe,\" say that out loud.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Sometimes a vibe is fine. Use illustration. Use abstract imagery. Use clearly labeled speculative art. Use weird generated textures until the walls melt.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>But if the image is standing in for real human presence, treat it like a promise.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Do not make promises with fake people.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Both Hands Full, Again</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>This is the same contradiction because apparently this era has decided contradiction is its native file format.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>AI is built on a messy pile of consent problems, power problems, labor problems, bias problems, and cultural memory problems.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>AI is also useful.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Both things are true.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>So I am not walking away from the tools. I am also not handing them the sacred center of my practice and calling that adaptation.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I want AI in the archive.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I want AI in the notes.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I want AI helping me find the forgotten story, surface the buried pattern, draft the first pass, organize the proof, and make the real work easier to share.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I do not want AI replacing the person in front of me.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I do not want synthetic community to stand in for actual community.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>I do not want documentary practice turned into \"content operations\" for institutions that want the glow of human connection without the responsibility of relationship.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The future is going to be full of generated everything.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Fine.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Then let the real thing get more real.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let the rooms matter.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let the people matter.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Let the photographer be more than a content machine.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>And if someone trusted us enough to show up, do not fake them after the fact.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Related</h2>\n<!-- /wp:heading -->\n\n<!-- wp:list -->\n<ul class=\"wp-block-list\">\n<!-- wp:list-item -->\n<li><a href=\"https://kriskrug.co/2026/01/24/both-hands-full/\">Both Hands Full</a></li>\n<!-- /wp:list-item -->\n<!-- wp:list-item -->\n<li><a href=\"https://kriskrug.co/2026/05/04/punk-rock-ai/\">Punk Rock AI</a></li>\n<!-- /wp:list-item -->\n<!-- wp:list-item -->\n<li><a href=\"https://kriskrug.co/2024/12/02/autolume-post-photographic-cybernetic-portraiture/\">AlphaPrism: Post-Photographic Cybernetic Portraiture</a></li>\n<!-- /wp:list-item -->\n<!-- wp:list-item -->\n<li><a href=\"https://kriskrug.co/recent-projects-include/\">Photography and media work</a></li>\n<!-- /wp:list-item -->\n<!-- wp:list-item -->\n<li><a href=\"https://kriskrug.co/contact/\">Book Kris for documentary, keynote, or community work</a></li>\n<!-- /wp:list-item -->\n</ul>\n<!-- /wp:list -->\n",
+    "rendered": "\n<p>Here is a sentence that should not need to be radical:</p>\n\n\n\n<p>If a community trusted me enough to show up in the room, I am not going to replace them later with synthetic almost-people because the recap needs a stronger hero image.</p>\n\n\n\n<p>I can make a beautiful fake person in fourteen seconds.</p>\n\n\n\n<p>Perfect skin. Dramatic light. Inclusive outfit math. The whole thing glowing with the warm dead-eyed confidence of a brand deck that has never had to ask anyone how to spell their name.</p>\n\n\n\n<p>Still not a portrait.</p>\n\n\n\n<p>A portrait is not an image of a face.</p>\n\n\n\n<p>A portrait is a record of attention between people.</p>\n\n\n\n<p>It says: you stood there, I stood here, something happened between us, and this is the trace.</p>\n\n\n\n<p>That trace matters more now, not less.</p>\n\n\n\n<p>In the synthetic age, the fact that somebody actually showed up becomes part of the value of the work.</p>\n\n\n\n<p>So here is one of my lines:</p>\n\n\n\n<p>I will use AI around documentary work.</p>\n\n\n\n<p>I will not use AI to fake the people who showed up.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" decoding=\"async\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?ssl=1\" alt=\"Event and portrait photography of Kris Krug by Asa Mathat\"/></figure>\n\n\n\n<h2 class=\"wp-block-heading\">Documentary Work Is Not A Pixel Problem</h2>\n\n\n\n<p>The dumbest version of the AI conversation treats every image as output.</p>\n\n\n\n<p>Image goes in. Prompt goes brrr. Image comes out. Save money. Ship faster. Congratulations, you have invented visual karaoke with a procurement department.</p>\n\n\n\n<p>That worldview only makes sense if you think photography is a production step.</p>\n\n\n\n<p>I do not.</p>\n\n\n\n<p>I come from documentary photography, community media, event documentation, artist portraits, festival chaos, hallway conversations, and all the weird human moments that do not fit inside a shot list.</p>\n\n\n\n<p>The job is not &#8220;make picture.&#8221;</p>\n\n\n\n<p>The job is witness.</p>\n\n\n\n<p>Sometimes the job is to make someone feel safe enough to be seen.</p>\n\n\n\n<p>Sometimes it is to notice who keeps getting left out of the frame.</p>\n\n\n\n<p>Sometimes it is to catch the moment where a room stops performing and starts telling the truth.</p>\n\n\n\n<p>Sometimes it is to build an archive so a community can remember itself later, with names attached, relationships intact, and enough context that the future does not have to guess what mattered.</p>\n\n\n\n<p>AI can generate a plausible image of community.</p>\n\n\n\n<p>It cannot be accountable to that community.</p>\n\n\n\n<p>It cannot remember who was nervous before the talk. It cannot ask the elder how they want their name spelled. It cannot feel the room shift when ceremony changes the order of operations. It cannot know that the person in the back corner built half the thing but will never walk toward the microphone unless someone notices.</p>\n\n\n\n<p>That is not nostalgia.</p>\n\n\n\n<p>That is the work.</p>\n\n\n\n<h2 class=\"wp-block-heading\">What AI Can Do Around The Frame</h2>\n\n\n\n<p>None of this means &#8220;keep the machines out.&#8221;</p>\n\n\n\n<p>Please. I am not trying to turn documentary practice into a candlelit museum of analog purity where everyone has to churn their own film chemistry and speak only in contact sheets.</p>\n\n\n\n<p>AI can be wildly useful around the frame.</p>\n\n\n\n<p>It can help me search thirty years of images when my memory has the feeling but not the filename.</p>\n\n\n\n<p>It can help draft captions from notes.</p>\n\n\n\n<p>It can turn a transcript into a clip list.</p>\n\n\n\n<p>It can pull recurring themes from interviews.</p>\n\n\n\n<p>It can help build contact sheets for a client.</p>\n\n\n\n<p>It can organize names, projects, roles, places, and relationships so the archive becomes a living map instead of a hard drive full of ghosts.</p>\n\n\n\n<p>It can help generate a shot list before an event, identify missing proof after an event, and turn the whole thing into a useful story package that organizers, funders, participants, and future collaborators can actually understand.</p>\n\n\n\n<p>That is fair game when the consent, privacy, and context are right.</p>\n\n\n\n<p>That is the 75% Rule in documentary practice: send the machine after the art-adjacent work.</p>\n\n\n\n<p>Let it carry boxes.</p>\n\n\n\n<p>Let it sort cables.</p>\n\n\n\n<p>Let it find the quote.</p>\n\n\n\n<p>Let it rename the folders.</p>\n\n\n\n<p>Let it help the human witness travel farther.</p>\n\n\n\n<p>But do not confuse the logistics around witness with the witness itself.</p>\n\n\n\n<h2 class=\"wp-block-heading\">The Line I Draw</h2>\n\n\n\n<p>Here is the line in plain language.</p>\n\n\n\n<p>I will not replace a portrait of a community member with an AI-generated portrait of a community member.</p>\n\n\n\n<p>I will not create fake documentary evidence of a gathering.</p>\n\n\n\n<p>I will not invent attendance, diversity, intimacy, consensus, ceremony, joy, grief, or solidarity because a deck needs a better slide.</p>\n\n\n\n<p>I will not let &#8220;close enough&#8221; become the standard for human truth.</p>\n\n\n\n<p>That last one is where the danger lives.</p>\n\n\n\n<p>Synthetic media trains organizations to accept plausible surfaces.</p>\n\n\n\n<p>Looks like a person.</p>\n\n\n\n<p>Looks like a crowd.</p>\n\n\n\n<p>Looks like a community.</p>\n\n\n\n<p>Looks like care.</p>\n\n\n\n<p>But documentary work is not about looking like care.</p>\n\n\n\n<p>It is care with a shutter attached.</p>\n\n\n\n<p>When an organization uses synthetic people to represent a real community, it is not just saving money. It is practicing the idea that people are interchangeable symbols. It is rehearsing extraction in a warm color palette.</p>\n\n\n\n<p>That is how trust leaks out of a culture.</p>\n\n\n\n<p>Quietly.</p>\n\n\n\n<p>Pixel by pixel.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Presence Is Provenance</h2>\n\n\n\n<p>AI people love the word provenance right now.</p>\n\n\n\n<p>Good. We need it.</p>\n\n\n\n<p>Source data. Model lineage. Watermarks. Chain of custody. Labels. Receipts. Bring me the receipts. I am pro-receipt like a retired accountant with a grievance.</p>\n\n\n\n<p>But documentary practice has always carried another kind of provenance:</p>\n\n\n\n<p>Were you there?</p>\n\n\n\n<p>Did they know why you were there?</p>\n\n\n\n<p>Did you ask?</p>\n\n\n\n<p>Did you listen?</p>\n\n\n\n<p>Did you spell the name right?</p>\n\n\n\n<p>Did you send the photo back?</p>\n\n\n\n<p>Did the people represented get any value from the representation?</p>\n\n\n\n<p>Did the archive become a commons, a trophy case, a liability, or a gift?</p>\n\n\n\n<p>In the next few years, that kind of provenance is going to matter more than ever.</p>\n\n\n\n<p>Not because every photograph needs to become a legal deposition.</p>\n\n\n\n<p>Because the internet is about to be flooded with images that never touched a life.</p>\n\n\n\n<p>When everything can be generated, the lived trace becomes precious.</p>\n\n\n\n<p>The proof that someone stood somewhere, on a territory, inside a particular weather system of relationships, will become part of the meaning.</p>\n\n\n\n<p>Presence becomes provenance.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Questions Before You Replace Documentation</h2>\n\n\n\n<p>If you are an event producer, funder, nonprofit, school, studio, public agency, arts org, or community group thinking about AI-generated imagery instead of real documentation, slow down for ten minutes and ask better questions.</p>\n\n\n\n<p>What job is this image doing?</p>\n\n\n\n<p>Is it illustrative, conceptual, speculative, or documentary?</p>\n\n\n\n<p>Will anyone reasonably read it as proof that something happened?</p>\n\n\n\n<p>Are we representing real people, real communities, real cultural practices, or real relationships?</p>\n\n\n\n<p>Who benefits if we fake it?</p>\n\n\n\n<p>Who disappears if we do?</p>\n\n\n\n<p>What would happen if we hired someone from the community to document it instead?</p>\n\n\n\n<p>Could AI help us prepare, organize, caption, archive, and distribute the real documentation rather than replace it?</p>\n\n\n\n<p>If the answer is &#8220;we just need a vibe,&#8221; say that out loud.</p>\n\n\n\n<p>Sometimes a vibe is fine. Use illustration. Use abstract imagery. Use clearly labeled speculative art. Use weird generated textures until the walls melt.</p>\n\n\n\n<p>But if the image is standing in for real human presence, treat it like a promise.</p>\n\n\n\n<p>Do not make promises with fake people.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Both Hands Full, Again</h2>\n\n\n\n<p>This is the same contradiction because apparently this era has decided contradiction is its native file format.</p>\n\n\n\n<p>AI is built on a messy pile of consent problems, power problems, labor problems, bias problems, and cultural memory problems.</p>\n\n\n\n<p>AI is also useful.</p>\n\n\n\n<p>Both things are true.</p>\n\n\n\n<p>So I am not walking away from the tools. I am also not handing them the sacred center of my practice and calling that adaptation.</p>\n\n\n\n<p>I want AI in the archive.</p>\n\n\n\n<p>I want AI in the notes.</p>\n\n\n\n<p>I want AI helping me find the forgotten story, surface the buried pattern, draft the first pass, organize the proof, and make the real work easier to share.</p>\n\n\n\n<p>I do not want AI replacing the person in front of me.</p>\n\n\n\n<p>I do not want synthetic community to stand in for actual community.</p>\n\n\n\n<p>I do not want documentary practice turned into &#8220;content operations&#8221; for institutions that want the glow of human connection without the responsibility of relationship.</p>\n\n\n\n<p>The future is going to be full of generated everything.</p>\n\n\n\n<p>Fine.</p>\n\n\n\n<p>Then let the real thing get more real.</p>\n\n\n\n<p>Let the rooms matter.</p>\n\n\n\n<p>Let the people matter.</p>\n\n\n\n<p>Let the photographer be more than a content machine.</p>\n\n\n\n<p>And if someone trusted us enough to show up, do not fake them after the fact.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Related</h2>\n\n\n\n<ul class=\"wp-block-list\">\n\n<li><a href=\"https://kriskrug.co/2026/01/24/both-hands-full/\">Both Hands Full</a></li>\n\n\n<li><a href=\"https://kriskrug.co/2026/05/04/punk-rock-ai/\">Punk Rock AI</a></li>\n\n\n<li><a href=\"https://kriskrug.co/2024/12/02/autolume-post-photographic-cybernetic-portraiture/\">AlphaPrism: Post-Photographic Cybernetic Portraiture</a></li>\n\n\n<li><a href=\"https://kriskrug.co/recent-projects-include/\">Photography and media work</a></li>\n\n\n<li><a href=\"https://kriskrug.co/contact/\">Book Kris for documentary, keynote, or community work</a></li>\n\n</ul>\n\n",
+    "protected": false,
+    "block_version": 1
+  },
+  "excerpt": {
+    "raw": "AI can help around documentary work: archive search, caption drafts, transcript maps, proof packs, and media operations. But it does not get to replace the human beings who actually trusted us by showing up.",
+    "rendered": "<p>AI can help around documentary work: archive search, caption drafts, transcript maps, proof packs, and media operations. But it does not get to replace the human beings who actually trusted us by showing up.</p>\n",
+    "protected": false
+  },
+  "author": 1,
+  "featured_media": 3252,
+  "comment_status": "open",
+  "ping_status": "open",
+  "sticky": false,
+  "template": "",
+  "format": "standard",
+  "meta": {
+    "advanced_seo_description": "A documentary ethics essay for the synthetic age: AI can help around the frame, but it should not replace real people, real presence, or real witness.",
+    "jetpack_seo_html_title": "AI Documentary Ethics: I Won't Fake the People Who Showed Up",
+    "jetpack_seo_noindex": false,
+    "_jetpack_newsletter_access": "",
+    "_jetpack_dont_email_post_to_subs": false,
+    "_jetpack_newsletter_tier_id": 0,
+    "_jetpack_memberships_contains_paywalled_content": false,
+    "_jetpack_feature_clip_id": 0,
+    "_jetpack_memberships_contains_paid_content": false,
+    "footnotes": "",
+    "jetpack_publicize_message": "AI can help around documentary work. It can search the archive, draft captions, and make the proof stack easier to navigate. But it does not get to replace the human beings who actually trusted us by showing up.",
+    "jetpack_publicize_feature_enabled": true,
+    "jetpack_social_post_already_shared": true,
+    "jetpack_social_options": {
+      "image_generator_settings": {
+        "template": "highway",
+        "default_image_id": 0,
+        "font": "",
+        "enabled": false
+      },
+      "version": 2
+    },
+    "jetpack_post_was_ever_published": false
+  },
+  "categories": [
+    1665
+  ],
+  "tags": [
+    482,
+    1683,
+    1682,
+    1685,
+    1686
+  ],
+  "permalink_template": "https://kriskrug.co/2026/06/13/%postname%/",
+  "generated_slug": "i-wont-fake-the-people-who-showed-up",
+  "class_list": [
+    "post-11877",
+    "post",
+    "type-post",
+    "status-publish",
+    "format-standard",
+    "has-post-thumbnail",
+    "hentry",
+    "category-ai-creatives",
+    "tag-ai-ethics",
+    "tag-both-hands-full",
+    "tag-creative-ai",
+    "tag-documentary-photography",
+    "tag-synthetic-media"
+  ],
+  "jetpack_publicize_connections": [
+    {
+      "id": "29203319",
+      "username": "Future Proof Creatives ",
+      "connection_id": "25146149",
+      "display_name": "Future Proof Creatives ",
+      "external_handle": "",
+      "external_id": "144253852114846",
+      "profile_link": "https://www.facebook.com/144253852114846",
+      "profile_picture": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.30808-1/673725712_122255249300163098_815242539615281998_n.jpg?stp=cp0_dst-jpg_s50x50_tt6&_nc_cat=110&ccb=1-7&_nc_sid=f907e8&_nc_ohc=U9n702zn-D0Q7kNvwFUGiEQ&_nc_oc=Ado5nYjYT6ZHnc3_ZShqJEHXKhzBES53a49JiTWFPks6dIj3dmsXTcpDTHVHrqGkbD4&_nc_zt=24&_nc_ht=scontent-iad3-1.xx&edm=AGaHXAAEAAAA&_nc_gid=ggSUs0QXblQkcM0d31-TLw&_nc_tpa=Q5bMBQHLAy8Sr1tdMMUx2ju30NT1ZpfJUw2MsA9HgK6bPb-p10XJNdhhUQF1i-99kjEn3l3vOSKG&oh=00_Af_ZW-zFfJAy0lxS5dz3Ve1MN7B4eCpSrrzNVJ-g5b2bRw&oe=6A3882D8",
+      "service_label": "Facebook",
+      "service_name": "facebook",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "29413323",
+      "username": "kris kr\u00fcg",
+      "connection_id": "24991430",
+      "display_name": "kris kr\u00fcg",
+      "external_handle": "",
+      "external_id": "kk.tumblr.com",
+      "profile_link": "https://kk.tumblr.com/",
+      "profile_picture": "https://api.tumblr.com/v2/blog/kk.tumblr.com/avatar/512",
+      "service_label": "Tumblr",
+      "service_name": "tumblr",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "30496174",
+      "username": "kriskrug",
+      "connection_id": "25333697",
+      "display_name": "kriskrug",
+      "external_handle": "kriskrug",
+      "external_id": "8251647364893301",
+      "profile_link": "https://www.threads.net/@kriskrug",
+      "profile_picture": "https://scontent-dfw5-2.cdninstagram.com/v/t51.82787-19/608425287_17937202176112388_5850135093671913243_n.jpg?stp=dst-jpg_s206x206_tt6&_nc_cat=108&ccb=7-5&_nc_sid=30ff31&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=eHMEK1bBz_oQ7kNvwErD3x9&_nc_oc=AdplnIx8Oputwi0B0c24d0NjzQW_ruQ2xPrxi7ccbTOexK95ageoiDt2xkKW5r_EX58&_nc_zt=24&_nc_ht=scontent-dfw5-2.cdninstagram.com&edm=AP4hL3IEAAAA&_nc_gid=54Mmxej-OduhC5MTXIuKtA&_nc_tpa=Q5bMBQFK_X5ulH0AA2uOkokb5tJvtNlT49xhi9b87RIz496ku4ji6Q52SUjHoCVOX2pMLIcFBrjto1Sa6Q&oh=00_Af6nwWRpHUpR_JvmfCW-cHDIwxp7xITOXE-QzkWujp-BoQ&oe=6A191B49",
+      "service_label": "Threads",
+      "service_name": "threads",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "31247583",
+      "username": "vancouver_ai",
+      "connection_id": "25614785",
+      "display_name": "Vancouver AI",
+      "external_handle": "vancouver_ai",
+      "external_id": "17841463632238189",
+      "profile_link": "https://instagram.com/vancouver_ai",
+      "profile_picture": "https://scontent-dfw5-2.xx.fbcdn.net/v/t51.82787-15/625237107_17940212772121075_3092494050660453576_n.jpg?_nc_cat=100&ccb=1-7&_nc_sid=7d201b&_nc_ohc=1F9OWTeMiBgQ7kNvwGySft0&_nc_oc=Adrt3tcnef0swlZwh4bPJuFgj_nAYV8hFbRmv-nW5e7hrh18Uj0AO7N1HeZJOfHGejU&_nc_zt=23&_nc_ht=scontent-dfw5-2.xx&edm=AGaHXAAEAAAA&_nc_gid=S2goV7lXuL3AsIutXh3YyA&oh=00_Af6utoBbmiA-2L6TtlmEFkV8MtWAi1jsF-IeY6Lued42Hw&oe=6A0E652E",
+      "service_label": "Instagram",
+      "service_name": "instagram-business",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "32079712",
+      "username": "Vancouver AI",
+      "connection_id": "25894122",
+      "display_name": "Vancouver AI",
+      "external_handle": "",
+      "external_id": "99169266",
+      "profile_link": "https://www.linkedin.com/company/van-ai",
+      "profile_picture": "https://media.licdn.com/dms/image/v2/D560BAQEPooLj15_KNA/company-logo_100_100/B56Z2xQsmDKwAU-/0/1776795438348/van_ai_logo?e=1783555200&v=beta&t=mPowAOYjgn8nxinL6PTDZ_LSV6FvbD2JUmcZWPNZFi0",
+      "service_label": "LinkedIn",
+      "service_name": "linkedin",
+      "shared": true,
+      "template": "",
+      "wpcom_user_id": 0,
+      "enabled": false
+    }
+  ],
+  "jetpack_featured_media_url": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=2560%2C888&ssl=1",
+  "jetpack_sharing_enabled": true,
+  "jetpack_shortlink": "https://wp.me/paMVFO-35z",
+  "jetpack-related-posts": [
+    {
+      "id": 7631,
+      "url": "https://kriskrug.co/2024/12/02/autolume-post-photographic-cybernetic-portraiture/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 0
+      },
+      "title": "AlphaPrism: Post-Photographic Cybernetic Portraiture",
+      "author": "Kr\u00fcg",
+      "date": "December 2, 2024",
+      "format": false,
+      "excerpt": "Step into latent space with Autolume\u2014a project that transforms analog nostalgia into dynamic AI-driven art, redefining identity and creativity one portrait at a time.",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/MASTER-Blog-header-1.png?fit=1200%2C469&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/MASTER-Blog-header-1.png?fit=1200%2C469&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/MASTER-Blog-header-1.png?fit=1200%2C469&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/MASTER-Blog-header-1.png?fit=1200%2C469&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/MASTER-Blog-header-1.png?fit=1200%2C469&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 1066,
+      "url": "https://kriskrug.co/2006/11/15/desmogblog-photoshoot/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 1
+      },
+      "title": "DeSmogBlog Photoshoot",
+      "author": "Kris Kr\u00fcg",
+      "date": "November 15, 2006",
+      "format": false,
+      "excerpt": "I recently had the chance to shoot photos of the DeSmogBlog team at their headquarters here in Vancouver. They wanted black and white, journalistic style photos that said \"We're serious about climate change!\" Check out the photos from the shoot here and some nice words from the client in our\u2026",
+      "rel": "",
+      "context": "In &quot;AI for Journalism &amp; Media&quot;",
+      "block_context": {
+        "text": "AI for Journalism &amp; Media",
+        "link": "https://kriskrug.co/category/ai-for-journalism-media/"
+      },
+      "img": {
+        "alt_text": "DeSmogBlog",
+        "src": "https://i0.wp.com/static.flickr.com/115/261879088_b7db4098e5_m.jpg?resize=350%2C200",
+        "width": 350,
+        "height": 200
+      },
+      "classes": []
+    },
+    {
+      "id": 3330,
+      "url": "https://kriskrug.co/2023/09/29/the-future-called-i-answered/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 2
+      },
+      "title": "The Future Called: I Answered",
+      "author": "Kr\u00fcg",
+      "date": "September 29, 2023",
+      "format": false,
+      "excerpt": "Strap in, because I've been riding this rocketship of life at warp speed for the past 3 weeks, and I've got a ton of stories, life hacks, and jaw-dropping moments to share with you!",
+      "rel": "",
+      "context": "In &quot;Web &amp; Early Blog&quot;",
+      "block_context": {
+        "text": "Web &amp; Early Blog",
+        "link": "https://kriskrug.co/category/web-early-blog/"
+      },
+      "img": {
+        "alt_text": "the future called, i answered",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 3243,
+      "url": "https://kriskrug.co/2023/09/23/the-magic-of-asa-mathat-portraiture-and-photography-at-dent-the-future/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 3
+      },
+      "title": "The Magic of Asa Mathat: Portraiture and Photography at Dent the Future",
+      "author": "Kr\u00fcg",
+      "date": "September 23, 2023",
+      "format": false,
+      "excerpt": "Beyond making my portraits, Asa enlightened me with photography insights. He shared Lightroom techniques, discussed his creative approach, and demonstrated his gentle directing skills with subjects. I soaked up every bit of wisdom from this photography guru. It was a masterclass just being in Asa's orbit for that session. Comparing\u2026",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "event and portrait photography - kris krug by asa mathat",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=1200%2C416&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=1200%2C416&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=1200%2C416&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=1200%2C416&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/asa-mathat-2-scaled.jpg?fit=1200%2C416&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 8663,
+      "url": "https://kriskrug.co/2025/03/20/is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 4
+      },
+      "title": "&#8220;Is A Hotdog A Sandwich?&#8221;: Vancouver AI Data Storytelling Hackathon w/ Andrew Reid",
+      "author": "Kr\u00fcg",
+      "date": "March 20, 2025",
+      "format": false,
+      "excerpt": "Forget boring data decks. I just sat down with Rival Technologies CEO Andrew Reid to plan Vancouver's most ambitious AI hackathon yet. We're challenging 40+ teams to reinvent how humans experience data \u2013 starting with the eternal question: \"Is a hot dog a sandwich?\"",
+      "rel": "",
+      "context": "In &quot;Vancouver AI Ecosystem&quot;",
+      "block_context": {
+        "text": "Vancouver AI Ecosystem",
+        "link": "https://kriskrug.co/category/vancouver-ai-ecosystem/"
+      },
+      "img": {
+        "alt_text": "Featured image for \"\u201cIs A Hotdog A Sandwich?\u201d: Vancouver AI Data Storytelling Hackathon w/ Andrew Reid\"",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Hackathon-Data-Storytelling-YouTube-Thumbnail.png?fit=1200%2C675&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Hackathon-Data-Storytelling-YouTube-Thumbnail.png?fit=1200%2C675&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Hackathon-Data-Storytelling-YouTube-Thumbnail.png?fit=1200%2C675&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Hackathon-Data-Storytelling-YouTube-Thumbnail.png?fit=1200%2C675&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Hackathon-Data-Storytelling-YouTube-Thumbnail.png?fit=1200%2C675&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 12183,
+      "url": "https://kriskrug.co/2026/06/04/ai-keynote-slides-visual-workflow/",
+      "url_meta": {
+        "origin": 11877,
+        "position": 5
+      },
+      "title": "AI Keynote Slides Need Taste Before Prompts",
+      "author": "Kris Kr\u00fcg",
+      "date": "June 4, 2026",
+      "format": false,
+      "excerpt": "My creative operating system for turning raw talk notes into prompts, graphics, slides, websites, posts, guides, and other artifacts without letting AI flatten the work into generic slop.",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "Hope Code process map showing talk notes, visual references, AI image prompts, selector review, and layered slide assets connected by root lines.",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?fit=1200%2C686&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?fit=1200%2C686&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?fit=1200%2C686&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?fit=1200%2C686&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?fit=1200%2C686&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    }
+  ],
+  "jetpack_likes_enabled": true,
+  "_links": {
+    "self": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877",
+        "targetHints": {
+          "allow": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
+        }
+      }
+    ],
+    "collection": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts"
+      }
+    ],
+    "about": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/types/post"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/users/1"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/comments?post=11877"
+      }
+    ],
+    "version-history": [
+      {
+        "count": 0,
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877/revisions"
+      }
+    ],
+    "wp:featuredmedia": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/media/3252"
+      }
+    ],
+    "wp:attachment": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/media?parent=11877"
+      }
+    ],
+    "wp:term": [
+      {
+        "taxonomy": "category",
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/categories?post=11877"
+      },
+      {
+        "taxonomy": "post_tag",
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/tags?post=11877"
+      }
+    ],
+    "wp:action-publish": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-unfiltered-html": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-sticky": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-assign-author": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-create-categories": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-assign-categories": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-create-tags": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "wp:action-assign-tags": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/11877"
+      }
+    ],
+    "curies": [
+      {
+        "name": "wp",
+        "href": "https://api.w.org/{rel}",
+        "templated": true
+      }
+    ]
+  }
+}

--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-12327-20260618-034657Z.json
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-12327-20260618-034657Z.json
@@ -1,0 +1,458 @@
+{
+  "id": 12327,
+  "date": "2026-06-17T19:26:21",
+  "date_gmt": "2026-06-18T03:26:21",
+  "guid": {
+    "rendered": "https://kriskrug.co/?p=12327",
+    "raw": "https://kriskrug.co/?p=12327"
+  },
+  "modified": "2026-06-17T19:28:23",
+  "modified_gmt": "2026-06-18T03:28:23",
+  "password": "",
+  "slug": "storyhive-haus-of-owl-jordan-dack",
+  "status": "publish",
+  "type": "post",
+  "link": "https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/",
+  "title": {
+    "raw": "Jordan Dack Asked the Questions Most Hosts Skip (STORYHIVE On Location, Victoria)",
+    "rendered": "Jordan Dack Asked the Questions Most Hosts Skip (STORYHIVE On Location, Victoria)"
+  },
+  "content": {
+    "raw": "<!-- wp:paragraph -->\n<p><strong>The short version:</strong> <a href=\"https://www.hausofowl.com/\">Jordan Dack</a> hosted me for a live <a href=\"https://www.storyhive.com/\"><strong>TELUS STORYHIVE On Location</strong></a> episode at <a href=\"https://www.hausofowl.com/\"><strong>Haus of Owl</strong></a> in downtown Victoria \u2014 unceded <a href=\"https://www.lekwungen.ca/\">Lekwungen</a> territories, acknowledged on air before we got into the creative-or-die deep dive. We played facts-or-fiction, skipped the r\u00e9sum\u00e9 parade, and spent about eighty minutes on what actually matters: <strong>both hands full</strong>, AI as mirror not replacement, the admin swamp around art, why I won't fake the people who showed up, voice-first workflows, and why trusted physical rooms like the Hoot Nest become infrastructure when the feed turns synthetic.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Watch the full segment below. This post is the cited companion \u2014 names, links, and the ideas in one place.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:embed {\"url\":\"https://www.youtube.com/watch?v=sxDwQRTZfCA\",\"type\":\"video\",\"providerNameSlug\":\"youtube\",\"responsive\":true,\"className\":\"wp-embed-aspect-16-9 wp-has-aspect-ratio\"} -->\n<figure class=\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\nhttps://www.youtube.com/watch?v=sxDwQRTZfCA\n</div></figure>\n<!-- /wp:embed -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">The Room: Jordan, Haus of Owl, and STORYHIVE On Location</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p><a href=\"https://www.hausofowl.com/\">Haus of Owl</a> is not a generic coworking loft with better Wi-Fi and a neon sign. It is a <strong>creation club</strong> for musicians, filmmakers, photographers, dancers, and poets \u2014 studio access, mentorship, the Garden as communal core, and a downtown Victoria address (<a href=\"https://artsvictoria.ca/hausofowl\">780 Blanshard</a>) that treats underused city space as creative infrastructure. I have history in that building: the <a href=\"https://www.hausofowl.com/\">Music Elevation Series</a> conversations, artists testing AI in public, the kind of room where you can say something unfinished and nobody treats uncertainty like a personality defect.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg\" alt=\"Jordan Dack and Kris Krug at Haus of Owl for STORYHIVE On Location Victoria\" class=\"wp-image-12338\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:paragraph -->\n<p><a href=\"https://www.hausofowl.com/\">Jordan Dack</a> produces and hosts <strong>Creative or Die</strong> \u2014 poet, songwriter, and the kind of interviewer who sends you thirty real questions before you walk in, then opens the broadcast with a facts game where Alaska is false, \"Peter\" is false, and the <a href=\"https://bc-ai.ca/events/\">Vancouver AI</a> meetup headcount is \"more or less\" true because we have skeptics on the roster too, not just enthusiasts.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The episode is part of <a href=\"https://www.storyhive.com/\"><strong>STORYHIVE On Location</strong></a> \u2014 TELUS's documentary and creator funding lane \u2014 produced here in partnership with Haus of Owl. The public video title is <a href=\"https://www.youtube.com/watch?v=sxDwQRTZfCA\">STORYHIVE On Location: Victoria</a>. If you want the vibe before you commit to eighty minutes: territory acknowledged, warmth, jokes, then the hard stuff.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Both Hands Full (The Spine Jordan Named On Air)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Every AI conversation tries to sort you into camps. Boosters with pompoms. Doomers with pitchforks. Hype without critical dialogue is lazy. Purity without a roadmap abandons the room to whoever already owns the microphones.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Jordan literally framed the middle as <a href=\"https://www.bothhandsfull.com/\"><strong>Both Hands Full</strong></a> \u2014 skepticism in one hand, curiosity in the other. That is not neutrality. It is <strong>stewardship</strong>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><!-- wp:paragraph -->\n<p>If you get up and walk away, you abdicate the throne to the tech bros and venture capitalists. We need you in the room.</p>\n<!-- /wp:paragraph --></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>That line is why I keep building public rooms instead of only writing essays. The essay matters. The room stress-tests it. If skeptics leave, the default story wins without a fight.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg\" alt=\"Kris Krug on both hands full during the STORYHIVE Victoria interview\" class=\"wp-image-12339\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:paragraph -->\n<p>I have been saying this on stages from <a href=\"https://www.youtube.com/watch?v=-c7mgY2aSgM\">LaSalle College Vancouver</a> to <a href=\"https://www.youtube.com/watch?v=owtSPcpRinI\">Bass Coast Brain Stage</a> to the <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 meetup</a>. STORYHIVE is useful proof that the framework lands on camera, not just in slide decks.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Related on this site: <a href=\"https://kriskrug.co/2026/01/24/both-hands-full/\">Both Hands Full</a>, <a href=\"https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/\">Web Summit Vancouver 2026</a>, and the public <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 talk on YouTube</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Galiano, Midjourney, and the Orbit Around the Art</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Jordan let me tell the origin story the way I tell it in public: end of 2022, <a href=\"https://galianoisland.com/\">Galiano Island</a>, greenhouse energy, someone showed me <a href=\"https://www.midjourney.com/\">Midjourney</a> during a week that was supposed to be about distillery hardware, not the future of photography.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Ten minutes later I knew two things.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>First: I am never running another big client shoot without generating and approving comps before models, lights, producers, and catering get booked. My creative time is too valuable to waste on exploratory production when imagination jams are cheap.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second: the tool was not coming for the sacred center first. It was coming for the <strong>orbit</strong> \u2014 briefs, budgets, contact sheets, captions, invoices, filenames like <code>DSC_4837-final-final-realfinal.jpg</code>, and the archive chaos that eats the week before you touch the thing you actually care about.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is the art-adjacent pile: selects, metadata, releases, gallery delivery, grant language, festival bios, CRM wrangling, clip pulls, rights notes. Not fake work. <strong>Travel work.</strong> The machine can chew there first so you can get back to the art with your soul still attached.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">AI as Mirror (Not Oracle, Not Replacement)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>The most useful thing AI has done for my creative life is act as a <strong>mirror</strong> on decades of work already out in the world \u2014 blog posts, talks, photos, half-finished ideas \u2014 so I can ask better questions about my own patterns instead of outsourcing the asking.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Ground prompts in artifacts you actually made: worldview docs, voice guides, policy, your real archive. Playful inquiry, not oracle worship. I have used the \"who am I?\" meditation parallel on air: the machine reflects; you still have to <strong>not believe your first answer</strong>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is different from replacing community portraits, meetup documentation, or the witness function of a photographer in the room.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">I Won't Fake the People Who Showed Up</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Jordan asked the musician-in-the-studio question: will AI take the mixing job?</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>My split: <strong>creative professions</strong> versus <strong>art</strong>. Jobs get disrupted. Art is weirder \u2014 process, embodiment, relationship, the thing that does not compress cleanly into a productivity metric.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>On documentary practice I am blunt:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:list -->\n<ul class=\"wp-block-list\">\n<!-- wp:list-item -->\n<li>AI can help plan a shoot, search an archive, draft captions, map transcripts, build proof packs.</li>\n<!-- /wp:list-item -->\n<!-- wp:list-item -->\n<li>AI does <strong>not</strong> get to replace the portrait of a community member who trusted us by showing up.</li>\n<!-- /wp:list-item -->\n</ul>\n<!-- /wp:list -->\n\n<!-- wp:paragraph -->\n<p>A portrait is not an image of a face. It is a record of attention between people. In the synthetic age, <strong>somebody actually stood there</strong> becomes part of the value.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg\" alt=\"Vancouver AI March 2026 community talk \u2014 real room, real people\" class=\"wp-image-12341\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:paragraph -->\n<p>See also the <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 Both Hands Full talk on YouTube</a> and <a href=\"https://bc-ai.ca/events/\">BC + AI events</a> for the room we are building in public.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Vancouver AI as Cultural Infrastructure (Not a Side Quest)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>We talked through the <a href=\"https://lu.ma/vancouver-ai\">Vancouver AI Community Meetup</a> format: roughly four hours \u2014 networking, two-hour program, networking again. Indigenous welcome and ceremony before hard topics. Demo pit surprises (ASL translation, lidar Xbox robot, whatever the month brings). Chapters from <a href=\"https://bc-ai.ca/\">Comox Valley</a> to Squamish. <a href=\"https://bc-ai.ca/\">BC + AI</a> as the front door \u2014 <a href=\"https://bc-ai.ca/membership/\">membership</a>, <a href=\"https://bc-ai.ca/events/\">events</a>, and the wider <a href=\"https://bc-ai.ca/\">ecosystem map</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg\" alt=\"BC plus AI living ecosystem across British Columbia\" class=\"wp-image-12340\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:paragraph -->\n<p>This is the same civic infrastructure argument I made during <a href=\"https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/\">Web Summit Vancouver 2026</a>: global conferences rent cities; communities metabolize them. Haus of Owl, <a href=\"https://www.ethoslab.ca/\">Eth??s Lab</a>, <a href=\"https://221a.ca/\">221A</a>, and rooms like the Hoot Nest are not \"venues.\" They are <strong>trust infrastructure</strong> when synthetic everything floods the feed.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Voice-First and Agentic (The Current Epoch)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>The interview tracked my pipeline epochs \u2014 Midjourney jams, knowledge bases and named assistants, then <strong>agentic workflows</strong> where I speak tasks into existence and named workers (researcher, coder, documentary editor) execute against grounded context.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Your fingers are a filter between head, heart, and machine. Voice carries cadence, urgency, slang, self-correction \u2014 the mess typing often strips out. That is not speed for speed's sake. It is <strong>fidelity</strong>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>If you want the practitioner lane: <a href=\"https://www.theupgrade.ai/\">The Upgrade AI</a> creative professionals training, <a href=\"https://developinganaimindset.com/\">Developing an AI Mindset</a>, and the <a href=\"https://bc-ai.ca/certification/responsible-ai-professional/\">Responsible AI Professional</a> certification we built with <a href=\"https://bc-ai.ca/\">BC + AI</a> \u2014 trust, disclosure, and human relationships as curriculum, not slide-deck garnish. On this site: <a href=\"https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/\">Applied Ethical AI / RAP</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png\" alt=\"Responsible AI Professional certification \u2014 BC plus AI\" class=\"wp-image-12342\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Ethics We Did Not Rehearse (Handle With Care)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Jordan pushed into intimacy and consent territory we did not fully script \u2014 voice cloning, disclosure, what happens when synthetic voice enters family or dating contexts. Some of that is <strong>clip gold</strong> for editors; some of it is <strong>private until I say otherwise</strong>. If you are cutting STORYHIVE footage, talk to me before you ship the vulnerable beats.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>The through-line on air: measure twice, disclose everything, protect trust. Same lesson I use in climate and systems work: you can participate in a system and still hold it to account. You do not have to live in the woods to critique the woods.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">BC's Lane (Culture, Compute, and Copy-Paste Silicon Valley)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>We touched the West Coast argument: <a href=\"https://www.metacreation.net/\">SFU METACREATION Lab</a>, artist-trained models on your own work, supercomputer politics, and why BC should build a <strong>public-interest AI identity</strong> \u2014 green where possible, Indigenous-led data governance where required, culture reserved a seat at the compute table \u2014 instead of photocopying Palo Alto.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That connects to the accountability work in <a href=\"https://bc-ai.ca/news/sovereign-ai-for-whom/\">Sovereign AI for Whom?</a> and the wider <a href=\"https://bc-ai.ca/\">BC + AI ecosystem</a>. Steel, concrete, and code without culture in the contract is just another enclosure.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg\" alt=\"Public trust and creative sovereignty badges from Sovereign AI for Whom\" class=\"wp-image-12343\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">How Jordan Closed It (And Why It Landed)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p>Near the end Jordan asked what is sacred right now.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>My answer on air: <strong>human connection</strong>. Walk into the future holding hands. The next models will increasingly be built by models; the life raft is not faster dashboards \u2014 it is trusted rooms, honest witness, and communities that can process change together.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>That is why I said on the broadcast that if legal systems, education, and institutions cannot keep pace, you better be glad you can get together in the Haus of Owl.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Grateful to Jordan for holding space with rigor and warmth. Grateful to Haus of Owl for being the kind of room where creative practice and tech future can argue in public without pretending the argument is easy.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2 class=\"wp-block-heading\">Watch and Go Deeper</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph -->\n<p><strong>Full episode:</strong> https://www.youtube.com/watch?v=sxDwQRTZfCA</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p><strong>Haus of Owl:</strong> https://www.hausofowl.com/</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p><strong>STORYHIVE:</strong> https://www.storyhive.com/</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p><strong>BC + AI:</strong> https://bc-ai.ca/ \u00b7 <strong>Events:</strong> https://bc-ai.ca/events/ \u00b7 <strong>Vancouver AI Luma:</strong> https://lu.ma/vancouver-ai</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p><strong>RAP certification:</strong> https://bc-ai.ca/certification/responsible-ai-professional/</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p><strong>Book speaking or podcast guesting:</strong> <a href=\"https://kriskrug.co/speaking/\">Speaking</a> \u00b7 <a href=\"https://kriskrug.co/podcast-guesting-page-epk/\">Podcast EPK</a> \u00b7 <a href=\"https://kriskrug.co/contact/\">Contact</a></p>\n<!-- /wp:paragraph -->\n",
+    "rendered": "\n<p><strong>The short version:</strong> <a href=\"https://www.hausofowl.com/\">Jordan Dack</a> hosted me for a live <a href=\"https://www.storyhive.com/\"><strong>TELUS STORYHIVE On Location</strong></a> episode at <a href=\"https://www.hausofowl.com/\"><strong>Haus of Owl</strong></a> in downtown Victoria \u2014 unceded <a href=\"https://www.lekwungen.ca/\">Lekwungen</a> territories, acknowledged on air before we got into the creative-or-die deep dive. We played facts-or-fiction, skipped the r\u00e9sum\u00e9 parade, and spent about eighty minutes on what actually matters: <strong>both hands full</strong>, AI as mirror not replacement, the admin swamp around art, why I won&#8217;t fake the people who showed up, voice-first workflows, and why trusted physical rooms like the Hoot Nest become infrastructure when the feed turns synthetic.</p>\n\n\n\n<p>Watch the full segment below. This post is the cited companion \u2014 names, links, and the ideas in one place.</p>\n\n\n\n<figure class=\"wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<span class=\"embed-youtube\" style=\"text-align:center; display: block;\"><iframe loading=\"lazy\" class=\"youtube-player\" width=\"640\" height=\"360\" src=\"https://www.youtube.com/embed/sxDwQRTZfCA?version=3&#038;rel=1&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;fs=1&#038;hl=en-US&#038;autohide=2&#038;wmode=transparent\" allowfullscreen=\"true\" style=\"border:0;\" sandbox=\"allow-scripts allow-same-origin allow-popups allow-presentation allow-popups-to-escape-sandbox\"></iframe></span>\n</div></figure>\n\n\n\n<h2 class=\"wp-block-heading\">The Room: Jordan, Haus of Owl, and STORYHIVE On Location</h2>\n\n\n\n<p><a href=\"https://www.hausofowl.com/\">Haus of Owl</a> is not a generic coworking loft with better Wi-Fi and a neon sign. It is a <strong>creation club</strong> for musicians, filmmakers, photographers, dancers, and poets \u2014 studio access, mentorship, the Garden as communal core, and a downtown Victoria address (<a href=\"https://artsvictoria.ca/hausofowl\">780 Blanshard</a>) that treats underused city space as creative infrastructure. I have history in that building: the <a href=\"https://www.hausofowl.com/\">Music Elevation Series</a> conversations, artists testing AI in public, the kind of room where you can say something unfinished and nobody treats uncertainty like a personality defect.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"640\" height=\"360\" data-attachment-id=\"12338\" data-permalink=\"https://kriskrug.co/02-storyhive-jordan-kris-room/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg?fit=640%2C360&amp;ssl=1\" data-orig-size=\"640,360\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"02-storyhive-jordan-kris-room\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg?fit=640%2C360&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg?resize=640%2C360&#038;ssl=1\" alt=\"Jordan Dack and Kris Krug at Haus of Owl for STORYHIVE On Location Victoria\" class=\"wp-image-12338\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg?w=640&amp;ssl=1 640w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/02-storyhive-jordan-kris-room.jpg?resize=300%2C169&amp;ssl=1 300w\" sizes=\"auto, (max-width: 640px) 100vw, 640px\" /></figure>\n\n\n\n<p><a href=\"https://www.hausofowl.com/\">Jordan Dack</a> produces and hosts <strong>Creative or Die</strong> \u2014 poet, songwriter, and the kind of interviewer who sends you thirty real questions before you walk in, then opens the broadcast with a facts game where Alaska is false, &#8220;Peter&#8221; is false, and the <a href=\"https://bc-ai.ca/events/\">Vancouver AI</a> meetup headcount is &#8220;more or less&#8221; true because we have skeptics on the roster too, not just enthusiasts.</p>\n\n\n\n<p>The episode is part of <a href=\"https://www.storyhive.com/\"><strong>STORYHIVE On Location</strong></a> \u2014 TELUS&#8217;s documentary and creator funding lane \u2014 produced here in partnership with Haus of Owl. The public video title is <a href=\"https://www.youtube.com/watch?v=sxDwQRTZfCA\">STORYHIVE On Location: Victoria</a>. If you want the vibe before you commit to eighty minutes: territory acknowledged, warmth, jokes, then the hard stuff.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Both Hands Full (The Spine Jordan Named On Air)</h2>\n\n\n\n<p>Every AI conversation tries to sort you into camps. Boosters with pompoms. Doomers with pitchforks. Hype without critical dialogue is lazy. Purity without a roadmap abandons the room to whoever already owns the microphones.</p>\n\n\n\n<p>Jordan literally framed the middle as <a href=\"https://www.bothhandsfull.com/\"><strong>Both Hands Full</strong></a> \u2014 skepticism in one hand, curiosity in the other. That is not neutrality. It is <strong>stewardship</strong>.</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\">\n<p>If you get up and walk away, you abdicate the throne to the tech bros and venture capitalists. We need you in the room.</p>\n</blockquote>\n\n\n\n<p>That line is why I keep building public rooms instead of only writing essays. The essay matters. The room stress-tests it. If skeptics leave, the default story wins without a fight.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"640\" height=\"360\" data-attachment-id=\"12339\" data-permalink=\"https://kriskrug.co/03-storyhive-both-hands-moment/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg?fit=640%2C360&amp;ssl=1\" data-orig-size=\"640,360\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"03-storyhive-both-hands-moment\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg?fit=640%2C360&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg?resize=640%2C360&#038;ssl=1\" alt=\"Kris Krug on both hands full during the STORYHIVE Victoria interview\" class=\"wp-image-12339\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg?w=640&amp;ssl=1 640w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/03-storyhive-both-hands-moment.jpg?resize=300%2C169&amp;ssl=1 300w\" sizes=\"auto, (max-width: 640px) 100vw, 640px\" /></figure>\n\n\n\n<p>I have been saying this on stages from <a href=\"https://www.youtube.com/watch?v=-c7mgY2aSgM\">LaSalle College Vancouver</a> to <a href=\"https://www.youtube.com/watch?v=owtSPcpRinI\">Bass Coast Brain Stage</a> to the <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 meetup</a>. STORYHIVE is useful proof that the framework lands on camera, not just in slide decks.</p>\n\n\n\n<p>Related on this site: <a href=\"https://kriskrug.co/2026/01/24/both-hands-full/\">Both Hands Full</a>, <a href=\"https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/\">Web Summit Vancouver 2026</a>, and the public <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 talk on YouTube</a>.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Galiano, Midjourney, and the Orbit Around the Art</h2>\n\n\n\n<p>Jordan let me tell the origin story the way I tell it in public: end of 2022, <a href=\"https://galianoisland.com/\">Galiano Island</a>, greenhouse energy, someone showed me <a href=\"https://www.midjourney.com/\">Midjourney</a> during a week that was supposed to be about distillery hardware, not the future of photography.</p>\n\n\n\n<p>Ten minutes later I knew two things.</p>\n\n\n\n<p>First: I am never running another big client shoot without generating and approving comps before models, lights, producers, and catering get booked. My creative time is too valuable to waste on exploratory production when imagination jams are cheap.</p>\n\n\n\n<p>Second: the tool was not coming for the sacred center first. It was coming for the <strong>orbit</strong> \u2014 briefs, budgets, contact sheets, captions, invoices, filenames like <code>DSC_4837-final-final-realfinal.jpg</code>, and the archive chaos that eats the week before you touch the thing you actually care about.</p>\n\n\n\n<p>That is the art-adjacent pile: selects, metadata, releases, gallery delivery, grant language, festival bios, CRM wrangling, clip pulls, rights notes. Not fake work. <strong>Travel work.</strong> The machine can chew there first so you can get back to the art with your soul still attached.</p>\n\n\n\n<h2 class=\"wp-block-heading\">AI as Mirror (Not Oracle, Not Replacement)</h2>\n\n\n\n<p>The most useful thing AI has done for my creative life is act as a <strong>mirror</strong> on decades of work already out in the world \u2014 blog posts, talks, photos, half-finished ideas \u2014 so I can ask better questions about my own patterns instead of outsourcing the asking.</p>\n\n\n\n<p>Ground prompts in artifacts you actually made: worldview docs, voice guides, policy, your real archive. Playful inquiry, not oracle worship. I have used the &#8220;who am I?&#8221; meditation parallel on air: the machine reflects; you still have to <strong>not believe your first answer</strong>.</p>\n\n\n\n<p>That is different from replacing community portraits, meetup documentation, or the witness function of a photographer in the room.</p>\n\n\n\n<h2 class=\"wp-block-heading\">I Won&#8217;t Fake the People Who Showed Up</h2>\n\n\n\n<p>Jordan asked the musician-in-the-studio question: will AI take the mixing job?</p>\n\n\n\n<p>My split: <strong>creative professions</strong> versus <strong>art</strong>. Jobs get disrupted. Art is weirder \u2014 process, embodiment, relationship, the thing that does not compress cleanly into a productivity metric.</p>\n\n\n\n<p>On documentary practice I am blunt:</p>\n\n\n\n<ul class=\"wp-block-list\">\n\n<li>AI can help plan a shoot, search an archive, draft captions, map transcripts, build proof packs.</li>\n\n\n<li>AI does <strong>not</strong> get to replace the portrait of a community member who trusted us by showing up.</li>\n\n</ul>\n\n\n\n<p>A portrait is not an image of a face. It is a record of attention between people. In the synthetic age, <strong>somebody actually stood there</strong> becomes part of the value.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"1280\" height=\"720\" data-attachment-id=\"12341\" data-permalink=\"https://kriskrug.co/06-vancouver-ai-march-2026/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?fit=1280%2C720&amp;ssl=1\" data-orig-size=\"1280,720\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"06-vancouver-ai-march-2026\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?fit=1024%2C576&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?resize=1280%2C720&#038;ssl=1\" alt=\"Vancouver AI March 2026 community talk \u2014 real room, real people\" class=\"wp-image-12341\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?w=1280&amp;ssl=1 1280w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/06-vancouver-ai-march-2026.jpg?resize=768%2C432&amp;ssl=1 768w\" sizes=\"auto, (max-width: 1000px) 100vw, 1000px\" /></figure>\n\n\n\n<p>See also the <a href=\"https://www.youtube.com/watch?v=T5ANAthZewE\">Vancouver AI March 2026 Both Hands Full talk on YouTube</a> and <a href=\"https://bc-ai.ca/events/\">BC + AI events</a> for the room we are building in public.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Vancouver AI as Cultural Infrastructure (Not a Side Quest)</h2>\n\n\n\n<p>We talked through the <a href=\"https://lu.ma/vancouver-ai\">Vancouver AI Community Meetup</a> format: roughly four hours \u2014 networking, two-hour program, networking again. Indigenous welcome and ceremony before hard topics. Demo pit surprises (ASL translation, lidar Xbox robot, whatever the month brings). Chapters from <a href=\"https://bc-ai.ca/\">Comox Valley</a> to Squamish. <a href=\"https://bc-ai.ca/\">BC + AI</a> as the front door \u2014 <a href=\"https://bc-ai.ca/membership/\">membership</a>, <a href=\"https://bc-ai.ca/events/\">events</a>, and the wider <a href=\"https://bc-ai.ca/\">ecosystem map</a>.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"1200\" height=\"800\" data-attachment-id=\"12340\" data-permalink=\"https://kriskrug.co/04-bcai-living-ecosystem/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?fit=1200%2C800&amp;ssl=1\" data-orig-size=\"1200,800\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"04-bcai-living-ecosystem\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?fit=1024%2C683&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?resize=1200%2C800&#038;ssl=1\" alt=\"BC plus AI living ecosystem across British Columbia\" class=\"wp-image-12340\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?w=1200&amp;ssl=1 1200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/04-bcai-living-ecosystem.jpg?resize=768%2C512&amp;ssl=1 768w\" sizes=\"auto, (max-width: 1000px) 100vw, 1000px\" /></figure>\n\n\n\n<p>This is the same civic infrastructure argument I made during <a href=\"https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/\">Web Summit Vancouver 2026</a>: global conferences rent cities; communities metabolize them. Haus of Owl, <a href=\"https://www.ethoslab.ca/\">Eth??s Lab</a>, <a href=\"https://221a.ca/\">221A</a>, and rooms like the Hoot Nest are not &#8220;venues.&#8221; They are <strong>trust infrastructure</strong> when synthetic everything floods the feed.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Voice-First and Agentic (The Current Epoch)</h2>\n\n\n\n<p>The interview tracked my pipeline epochs \u2014 Midjourney jams, knowledge bases and named assistants, then <strong>agentic workflows</strong> where I speak tasks into existence and named workers (researcher, coder, documentary editor) execute against grounded context.</p>\n\n\n\n<p>Your fingers are a filter between head, heart, and machine. Voice carries cadence, urgency, slang, self-correction \u2014 the mess typing often strips out. That is not speed for speed&#8217;s sake. It is <strong>fidelity</strong>.</p>\n\n\n\n<p>If you want the practitioner lane: <a href=\"https://www.theupgrade.ai/\">The Upgrade AI</a> creative professionals training, <a href=\"https://developinganaimindset.com/\">Developing an AI Mindset</a>, and the <a href=\"https://bc-ai.ca/certification/responsible-ai-professional/\">Responsible AI Professional</a> certification we built with <a href=\"https://bc-ai.ca/\">BC + AI</a> \u2014 trust, disclosure, and human relationships as curriculum, not slide-deck garnish. On this site: <a href=\"https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/\">Applied Ethical AI / RAP</a>.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"1536\" height=\"1024\" data-attachment-id=\"12342\" data-permalink=\"https://kriskrug.co/05-rap-certification-cover/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?fit=1536%2C1024&amp;ssl=1\" data-orig-size=\"1536,1024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"05-rap-certification-cover\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?fit=1024%2C683&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?resize=1536%2C1024&#038;ssl=1\" alt=\"Responsible AI Professional certification \u2014 BC plus AI\" class=\"wp-image-12342\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?w=1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/05-rap-certification-cover.png?resize=768%2C512&amp;ssl=1 768w\" sizes=\"auto, (max-width: 1000px) 100vw, 1000px\" /></figure>\n\n\n\n<h2 class=\"wp-block-heading\">Ethics We Did Not Rehearse (Handle With Care)</h2>\n\n\n\n<p>Jordan pushed into intimacy and consent territory we did not fully script \u2014 voice cloning, disclosure, what happens when synthetic voice enters family or dating contexts. Some of that is <strong>clip gold</strong> for editors; some of it is <strong>private until I say otherwise</strong>. If you are cutting STORYHIVE footage, talk to me before you ship the vulnerable beats.</p>\n\n\n\n<p>The through-line on air: measure twice, disclose everything, protect trust. Same lesson I use in climate and systems work: you can participate in a system and still hold it to account. You do not have to live in the woods to critique the woods.</p>\n\n\n\n<h2 class=\"wp-block-heading\">BC&#8217;s Lane (Culture, Compute, and Copy-Paste Silicon Valley)</h2>\n\n\n\n<p>We touched the West Coast argument: <a href=\"https://www.metacreation.net/\">SFU METACREATION Lab</a>, artist-trained models on your own work, supercomputer politics, and why BC should build a <strong>public-interest AI identity</strong> \u2014 green where possible, Indigenous-led data governance where required, culture reserved a seat at the compute table \u2014 instead of photocopying Palo Alto.</p>\n\n\n\n<p>That connects to the accountability work in <a href=\"https://bc-ai.ca/news/sovereign-ai-for-whom/\">Sovereign AI for Whom?</a> and the wider <a href=\"https://bc-ai.ca/\">BC + AI ecosystem</a>. Steel, concrete, and code without culture in the contract is just another enclosure.</p>\n\n\n\n<figure class=\"wp-block-image\"><img data-recalc-dims=\"1\" loading=\"lazy\" decoding=\"async\" width=\"1186\" height=\"662\" data-attachment-id=\"12343\" data-permalink=\"https://kriskrug.co/07-sovereign-ai-for-whom-badges/\" data-orig-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?fit=1186%2C662&amp;ssl=1\" data-orig-size=\"1186,662\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"07-sovereign-ai-for-whom-badges\" data-image-description=\"\" data-image-caption=\"\" data-large-file=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?fit=1024%2C572&amp;ssl=1\" src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?resize=1186%2C662&#038;ssl=1\" alt=\"Public trust and creative sovereignty badges from Sovereign AI for Whom\" class=\"wp-image-12343\" srcset=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?w=1186&amp;ssl=1 1186w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?resize=1024%2C572&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/07-sovereign-ai-for-whom-badges.jpeg?resize=768%2C429&amp;ssl=1 768w\" sizes=\"auto, (max-width: 1000px) 100vw, 1000px\" /></figure>\n\n\n\n<h2 class=\"wp-block-heading\">How Jordan Closed It (And Why It Landed)</h2>\n\n\n\n<p>Near the end Jordan asked what is sacred right now.</p>\n\n\n\n<p>My answer on air: <strong>human connection</strong>. Walk into the future holding hands. The next models will increasingly be built by models; the life raft is not faster dashboards \u2014 it is trusted rooms, honest witness, and communities that can process change together.</p>\n\n\n\n<p>That is why I said on the broadcast that if legal systems, education, and institutions cannot keep pace, you better be glad you can get together in the Haus of Owl.</p>\n\n\n\n<p>Grateful to Jordan for holding space with rigor and warmth. Grateful to Haus of Owl for being the kind of room where creative practice and tech future can argue in public without pretending the argument is easy.</p>\n\n\n\n<h2 class=\"wp-block-heading\">Watch and Go Deeper</h2>\n\n\n\n<p><strong>Full episode:</strong> https://www.youtube.com/watch?v=sxDwQRTZfCA</p>\n\n\n\n<p><strong>Haus of Owl:</strong> https://www.hausofowl.com/</p>\n\n\n\n<p><strong>STORYHIVE:</strong> https://www.storyhive.com/</p>\n\n\n\n<p><strong>BC + AI:</strong> https://bc-ai.ca/ \u00b7 <strong>Events:</strong> https://bc-ai.ca/events/ \u00b7 <strong>Vancouver AI Luma:</strong> https://lu.ma/vancouver-ai</p>\n\n\n\n<p><strong>RAP certification:</strong> https://bc-ai.ca/certification/responsible-ai-professional/</p>\n\n\n\n<p><strong>Book speaking or podcast guesting:</strong> <a href=\"https://kriskrug.co/speaking/\">Speaking</a> \u00b7 <a href=\"https://kriskrug.co/podcast-guesting-page-epk/\">Podcast EPK</a> \u00b7 <a href=\"https://kriskrug.co/contact/\">Contact</a></p>\n\n",
+    "protected": false,
+    "block_version": 1
+  },
+  "excerpt": {
+    "raw": "An ~80-minute STORYHIVE On Location sit-down with Jordan Dack at Haus of Owl in Victoria \u2014 territory acknowledged, facts-or-fiction warm-up, both hands full on broadcast, Vancouver AI as infrastructure, and why human rooms still matter when the synthetic flood arrives.",
+    "rendered": "<p>An ~80-minute STORYHIVE On Location sit-down with Jordan Dack at Haus of Owl in Victoria \u2014 territory acknowledged, facts-or-fiction warm-up, both hands full on broadcast, Vancouver AI as infrastructure, and why human rooms still matter when the synthetic flood arrives.</p>\n",
+    "protected": false
+  },
+  "author": 1,
+  "featured_media": 12337,
+  "comment_status": "open",
+  "ping_status": "open",
+  "sticky": false,
+  "template": "",
+  "format": "standard",
+  "meta": {
+    "advanced_seo_description": "Kris Krug on TELUS STORYHIVE On Location Victoria with Jordan Dack at Haus of Owl \u2014 both hands full, AI as mirror, documentary ethics, Vancouver AI, and walking into the future holding hands.",
+    "jetpack_seo_html_title": "STORYHIVE Victoria: Jordan Dack \u00d7 Kris Krug at Haus of Owl | Kris Kr\u00fcg",
+    "jetpack_seo_noindex": false,
+    "_jetpack_newsletter_access": "",
+    "_jetpack_dont_email_post_to_subs": false,
+    "_jetpack_newsletter_tier_id": 0,
+    "_jetpack_memberships_contains_paywalled_content": false,
+    "_jetpack_feature_clip_id": 0,
+    "_jetpack_memberships_contains_paid_content": false,
+    "footnotes": "",
+    "jetpack_publicize_message": "",
+    "jetpack_publicize_feature_enabled": true,
+    "jetpack_social_post_already_shared": true,
+    "jetpack_social_options": {
+      "image_generator_settings": {
+        "template": "highway",
+        "default_image_id": 0,
+        "font": "",
+        "enabled": false
+      },
+      "version": 2
+    },
+    "jetpack_post_was_ever_published": false
+  },
+  "categories": [
+    1677
+  ],
+  "tags": [
+    1628,
+    1683,
+    1682,
+    1759,
+    1693,
+    1758,
+    1495
+  ],
+  "permalink_template": "https://kriskrug.co/2026/06/17/%postname%/",
+  "generated_slug": "jordan-dack-asked-the-questions-most-hosts-skip-storyhive-on-location-victoria",
+  "class_list": [
+    "post-12327",
+    "post",
+    "type-post",
+    "status-publish",
+    "format-standard",
+    "has-post-thumbnail",
+    "hentry",
+    "category-conversations-interviews",
+    "tag-bc-ai",
+    "tag-both-hands-full",
+    "tag-creative-ai",
+    "tag-haus-of-owl",
+    "tag-podcast-guesting",
+    "tag-storyhive",
+    "tag-vancouver-ai"
+  ],
+  "jetpack_publicize_connections": [
+    {
+      "id": "29203319",
+      "username": "Future Proof Creatives ",
+      "connection_id": "25146149",
+      "display_name": "Future Proof Creatives ",
+      "external_handle": "",
+      "external_id": "144253852114846",
+      "profile_link": "https://www.facebook.com/144253852114846",
+      "profile_picture": "https://scontent-iad3-1.xx.fbcdn.net/v/t39.30808-1/673725712_122255249300163098_815242539615281998_n.jpg?stp=cp0_dst-jpg_s50x50_tt6&_nc_cat=110&ccb=1-7&_nc_sid=f907e8&_nc_ohc=U9n702zn-D0Q7kNvwFUGiEQ&_nc_oc=Ado5nYjYT6ZHnc3_ZShqJEHXKhzBES53a49JiTWFPks6dIj3dmsXTcpDTHVHrqGkbD4&_nc_zt=24&_nc_ht=scontent-iad3-1.xx&edm=AGaHXAAEAAAA&_nc_gid=ggSUs0QXblQkcM0d31-TLw&_nc_tpa=Q5bMBQHLAy8Sr1tdMMUx2ju30NT1ZpfJUw2MsA9HgK6bPb-p10XJNdhhUQF1i-99kjEn3l3vOSKG&oh=00_Af_ZW-zFfJAy0lxS5dz3Ve1MN7B4eCpSrrzNVJ-g5b2bRw&oe=6A3882D8",
+      "service_label": "Facebook",
+      "service_name": "facebook",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "29413323",
+      "username": "kris kr\u00fcg",
+      "connection_id": "24991430",
+      "display_name": "kris kr\u00fcg",
+      "external_handle": "",
+      "external_id": "kk.tumblr.com",
+      "profile_link": "https://kk.tumblr.com/",
+      "profile_picture": "https://api.tumblr.com/v2/blog/kk.tumblr.com/avatar/512",
+      "service_label": "Tumblr",
+      "service_name": "tumblr",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "30496174",
+      "username": "kriskrug",
+      "connection_id": "25333697",
+      "display_name": "kriskrug",
+      "external_handle": "kriskrug",
+      "external_id": "8251647364893301",
+      "profile_link": "https://www.threads.net/@kriskrug",
+      "profile_picture": "https://scontent-dfw5-2.cdninstagram.com/v/t51.82787-19/608425287_17937202176112388_5850135093671913243_n.jpg?stp=dst-jpg_s206x206_tt6&_nc_cat=108&ccb=7-5&_nc_sid=30ff31&efg=eyJ2ZW5jb2RlX3RhZyI6InByb2ZpbGVfcGljLnd3dy4xMDgwLkMzIn0%3D&_nc_ohc=eHMEK1bBz_oQ7kNvwErD3x9&_nc_oc=AdplnIx8Oputwi0B0c24d0NjzQW_ruQ2xPrxi7ccbTOexK95ageoiDt2xkKW5r_EX58&_nc_zt=24&_nc_ht=scontent-dfw5-2.cdninstagram.com&edm=AP4hL3IEAAAA&_nc_gid=54Mmxej-OduhC5MTXIuKtA&_nc_tpa=Q5bMBQFK_X5ulH0AA2uOkokb5tJvtNlT49xhi9b87RIz496ku4ji6Q52SUjHoCVOX2pMLIcFBrjto1Sa6Q&oh=00_Af6nwWRpHUpR_JvmfCW-cHDIwxp7xITOXE-QzkWujp-BoQ&oe=6A191B49",
+      "service_label": "Threads",
+      "service_name": "threads",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "31247583",
+      "username": "vancouver_ai",
+      "connection_id": "25614785",
+      "display_name": "Vancouver AI",
+      "external_handle": "vancouver_ai",
+      "external_id": "17841463632238189",
+      "profile_link": "https://instagram.com/vancouver_ai",
+      "profile_picture": "https://scontent-dfw5-2.xx.fbcdn.net/v/t51.82787-15/625237107_17940212772121075_3092494050660453576_n.jpg?_nc_cat=100&ccb=1-7&_nc_sid=7d201b&_nc_ohc=1F9OWTeMiBgQ7kNvwGySft0&_nc_oc=Adrt3tcnef0swlZwh4bPJuFgj_nAYV8hFbRmv-nW5e7hrh18Uj0AO7N1HeZJOfHGejU&_nc_zt=23&_nc_ht=scontent-dfw5-2.xx&edm=AGaHXAAEAAAA&_nc_gid=S2goV7lXuL3AsIutXh3YyA&oh=00_Af6utoBbmiA-2L6TtlmEFkV8MtWAi1jsF-IeY6Lued42Hw&oe=6A0E652E",
+      "service_label": "Instagram",
+      "service_name": "instagram-business",
+      "shared": false,
+      "template": "",
+      "wpcom_user_id": 109,
+      "enabled": false
+    },
+    {
+      "id": "32079712",
+      "username": "Vancouver AI",
+      "connection_id": "25894122",
+      "display_name": "Vancouver AI",
+      "external_handle": "",
+      "external_id": "99169266",
+      "profile_link": "https://www.linkedin.com/company/van-ai",
+      "profile_picture": "https://media.licdn.com/dms/image/v2/D560BAQEPooLj15_KNA/company-logo_100_100/B56Z2xQsmDKwAU-/0/1776795438348/van_ai_logo?e=1783555200&v=beta&t=mPowAOYjgn8nxinL6PTDZ_LSV6FvbD2JUmcZWPNZFi0",
+      "service_label": "LinkedIn",
+      "service_name": "linkedin",
+      "shared": true,
+      "template": "",
+      "wpcom_user_id": 0,
+      "enabled": false
+    }
+  ],
+  "jetpack_featured_media_url": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-storyhive-youtube-title.jpg?fit=640%2C360&ssl=1",
+  "jetpack_sharing_enabled": true,
+  "jetpack_shortlink": "https://wp.me/paMVFO-3cP",
+  "jetpack-related-posts": [
+    {
+      "id": 4348,
+      "url": "https://kriskrug.co/2023/12/27/2024-vancouver-ai-community-meetups/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 0
+      },
+      "title": "Vancouver AI Community Meetups &amp; BC + AI Ecosystem",
+      "author": "Kr\u00fcg",
+      "date": "December 27, 2023",
+      "format": false,
+      "excerpt": "The Vancouver AI Community Meetup welcomes all members of the community interested in the future of AI - researchers, artists, geeks, enthusiasts, entrepreneurs, experts, students and more! Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.",
+      "rel": "",
+      "context": "In &quot;AI Ethics &amp; Philosophy&quot;",
+      "block_context": {
+        "text": "AI Ethics &amp; Philosophy",
+        "link": "https://kriskrug.co/category/ai-ethics-philosophy/"
+      },
+      "img": {
+        "alt_text": "Vancouver AI Meetup 2024 Event Calendar",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/A26285F6-D10F-4DAA-9DE7-0CFAB17D695D_1_105_c.jpeg?fit=1200%2C416&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/A26285F6-D10F-4DAA-9DE7-0CFAB17D695D_1_105_c.jpeg?fit=1200%2C416&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/A26285F6-D10F-4DAA-9DE7-0CFAB17D695D_1_105_c.jpeg?fit=1200%2C416&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/A26285F6-D10F-4DAA-9DE7-0CFAB17D695D_1_105_c.jpeg?fit=1200%2C416&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/A26285F6-D10F-4DAA-9DE7-0CFAB17D695D_1_105_c.jpeg?fit=1200%2C416&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 4539,
+      "url": "https://kriskrug.co/2024/01/31/exploring-the-intersection-of-photography-and-generative-ai/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 1
+      },
+      "title": "Exploring the Intersection of Photography and Generative AI",
+      "author": "Kr\u00fcg",
+      "date": "January 31, 2024",
+      "format": false,
+      "excerpt": "Join the Future Proof Creatives AI Art Residency Program every Thursday this February for a transformative exploration with Frank Yu. These free sessions delve into the dynamic fusion of photography and generative AI, revealing how technology is reshaping the art of imagery.",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Your-paragraph-text-1.png?fit=1200%2C480&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Your-paragraph-text-1.png?fit=1200%2C480&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Your-paragraph-text-1.png?fit=1200%2C480&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Your-paragraph-text-1.png?fit=1200%2C480&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Your-paragraph-text-1.png?fit=1200%2C480&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 11178,
+      "url": "https://kriskrug.co/2026/05/15/your-taste-is-your-moat/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 2
+      },
+      "title": "Why Judgment Beats &#8220;Creativity&#8221; in the AI Era",
+      "author": "Kr\u00fcg",
+      "date": "May 15, 2026",
+      "format": false,
+      "excerpt": "Generation has been commoditized. Selection hasn't. The DJs figured this out in the '80s \u2014 taste is the moat.",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "AI for Creative Professionals Kris Krug",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?fit=1200%2C675&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?fit=1200%2C675&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?fit=1200%2C675&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?fit=1200%2C675&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?fit=1200%2C675&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 9937,
+      "url": "https://kriskrug.co/2025/07/08/ai-training-for-media-pr-and-creative-professionals/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 3
+      },
+      "title": "AI Training for Media, PR, and Creative Professionals",
+      "author": "Kr\u00fcg",
+      "date": "July 8, 2025",
+      "format": false,
+      "excerpt": "Registration for all tracks is open now. Bring your team, or come solo. Just bring your curiosity and your edge. If you\u2019re skeptical? Even better\u2014every alumni in these quotes started right there.",
+      "rel": "",
+      "context": "In &quot;AI for Journalism &amp; Media&quot;",
+      "block_context": {
+        "text": "AI for Journalism &amp; Media",
+        "link": "https://kriskrug.co/category/ai-for-journalism-media/"
+      },
+      "img": {
+        "alt_text": "AI Training Workshops",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?fit=1200%2C469&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?fit=1200%2C469&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?fit=1200%2C469&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?fit=1200%2C469&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?fit=1200%2C469&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 11171,
+      "url": "https://kriskrug.co/2026/01/24/both-hands-full/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 4
+      },
+      "title": "Both Hands Full",
+      "author": "Kr\u00fcg",
+      "date": "January 24, 2026",
+      "format": false,
+      "excerpt": "This piece is for creatives who feel two things at once: anger about the non-consensual training mess, and curiosity about what these tools can do inside a real practice. I\u2019m not selling \u201cembrace\u201d or \u201cresist.\u201d I\u2019m arguing for both hands full: left hand holds critique (consent, labor, dependency), right hand\u2026",
+      "rel": "",
+      "context": "In &quot;AI for Creatives&quot;",
+      "block_context": {
+        "text": "AI for Creatives",
+        "link": "https://kriskrug.co/category/ai-creatives/"
+      },
+      "img": {
+        "alt_text": "Both Hands Full",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?fit=1200%2C469&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?fit=1200%2C469&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?fit=1200%2C469&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?fit=1200%2C469&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?fit=1200%2C469&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    },
+    {
+      "id": 5160,
+      "url": "https://kriskrug.co/2024/03/30/the-creative-quest-ai-art-and-the-adaptability-paradox/",
+      "url_meta": {
+        "origin": 12327,
+        "position": 5
+      },
+      "title": "The Adaptability Paradox",
+      "author": "Kr\u00fcg",
+      "date": "March 30, 2024",
+      "format": false,
+      "excerpt": "Join me on a trip from the early days of dial-up to the cutting edge of AI in creativity. It\u2019s a ride through my own twists and turns in the digital landscape, leading up to our latest adventure with 'Future Proof Creatives'. We\u2019re mixing tech and creativity to figure out\u2026",
+      "rel": "",
+      "context": "In &quot;Field Notes&quot;",
+      "block_context": {
+        "text": "Field Notes",
+        "link": "https://kriskrug.co/category/field-notes/"
+      },
+      "img": {
+        "alt_text": "the future called, i answered",
+        "src": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=350%2C200",
+        "width": 350,
+        "height": 200,
+        "srcset": "https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=350%2C200 1x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=525%2C300 1.5x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=700%2C400 2x, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/Copy-of-CORPSE-1600-%C3%97-600-px.jpg?fit=1200%2C450&ssl=1&resize=1050%2C600 3x"
+      },
+      "classes": []
+    }
+  ],
+  "jetpack_likes_enabled": true,
+  "_links": {
+    "self": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327",
+        "targetHints": {
+          "allow": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
+        }
+      }
+    ],
+    "collection": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts"
+      }
+    ],
+    "about": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/types/post"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/users/1"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/comments?post=12327"
+      }
+    ],
+    "version-history": [
+      {
+        "count": 0,
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327/revisions"
+      }
+    ],
+    "wp:featuredmedia": [
+      {
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/media/12337"
+      }
+    ],
+    "wp:attachment": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/media?parent=12327"
+      }
+    ],
+    "wp:term": [
+      {
+        "taxonomy": "category",
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/categories?post=12327"
+      },
+      {
+        "taxonomy": "post_tag",
+        "embeddable": true,
+        "href": "https://kriskrug.co/wp-json/wp/v2/tags?post=12327"
+      }
+    ],
+    "wp:action-publish": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-unfiltered-html": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-sticky": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-assign-author": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-create-categories": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-assign-categories": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-create-tags": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "wp:action-assign-tags": [
+      {
+        "href": "https://kriskrug.co/wp-json/wp/v2/posts/12327"
+      }
+    ],
+    "curies": [
+      {
+        "name": "wp",
+        "href": "https://api.w.org/{rel}",
+        "templated": true
+      }
+    ]
+  }
+}

--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/publish-gate.md
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/publish-gate.md
@@ -28,9 +28,9 @@ See [`image-manifest.md`](image-manifest.md) for sources.
 Do not publish these as separate posts:
 
 - `2026-05-21-the-75-percent-rule-ai-art-adjacent-work/` (WP `11876`)
-- `2026-05-21-i-wont-fake-the-people-who-showed-up/` (WP `11877` — still live; overlap note below)
+- `2026-05-21-i-wont-fake-the-people-who-showed-up/` (WP `11877` — **unpublished 2026-06-18**, reverted to draft)
 - `2026-05-21-speak-it-into-existence-ai-voice-first-workflows/` (WP `11878`)
 
 ## Post-publish note
 
-Live overlap remains: [I Won't Fake the People Who Showed Up](https://kriskrug.co/2026/06/13/i-wont-fake-the-people-who-showed-up/) (`11877`). Consider redirect, merge note, or leaving both if the angles differ enough.
+Jun 13 slice post `11877` unpublished per KK (2026-06-18). Clip-editor paragraph removed from live `12327`; ethics through-line kept under **Ethics on Air**.

--- a/docs/current-state/HANDOFF-2026-06-17.md
+++ b/docs/current-state/HANDOFF-2026-06-17.md
@@ -35,8 +35,8 @@
 
 ## Open threads for KK
 
-1. **`12263` "GOD SKILLS" featured image** has baked-in text KK flagged — needs a glance **before its 06-20 cadence slot**.
-2. **Storyhive companion `12327` is LIVE** (2026-06-17 PT): https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/ — project-specific images (YouTube title card, BC+AI, Vancouver AI, RAP, sovereign badges), 42 links, YouTube embed verified. Overlap with live post **`11877`** remains — redirect/retire decision still open.
+1. **`12263` "GOD SKILLS"** — KK approved as-is for **06-20** cadence slot (2026-06-18).
+2. **Storyhive companion `12327` is LIVE** (2026-06-17 PT): https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/ — overlap post **`11877` unpublished** 2026-06-18.
 3. **`stash@{0}`** (2026-06-03 Aurora theme work) — drop or apply.
 4. **One remaining Pinterest tag (`f8bbe…`)** is a single valid tag (no longer a duplicate). If KK wants zero Pinterest verification, its source is a theme/mu-plugin (behind the Pagely SFTP blocker) — not WPCode/Jetpack.
 5. **#221** stays open (metadata inventory + #176 alt-text). **#219** cadence runs through 07-02.


### PR DESCRIPTION
## Summary
- record WordPress pre-edit snapshots for Storyhive overlap post `11877` and consolidated live post `12327`
- record that `11877` was unpublished/reverted to draft after `12327` went live
- remove the private clip-editor paragraph from the local Storyhive source and reflect the live heading/body cleanup
- record that `12263` / God Skills is approved and scheduled for `2026-06-20 09:00 Pacific`

## Safety notes
- This PR preserves already-created live/readback artifacts; it does not perform additional live WordPress writes.
- Snapshot JSON was validated with `jq empty`.
- A sensitive-string scan found only empty `password` fields in the snapshot files.

## Verification
- `make test`
- `make docs-truth-check`
- `git diff --check`
- `jq empty content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-11877-20260618-034657Z.json content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/pre-edit-snapshot-12327-20260618-034657Z.json`
