### PR TITLE
theme: fix primary CTA contrast

### DIFF
--- a/scripts/tests/test_aurora_contrast_tokens.py
+++ b/scripts/tests/test_aurora_contrast_tokens.py
@@ -54,6 +54,14 @@ class AuroraContrastTokenTests(unittest.TestCase):
         self.assertIsNotNone(match)
         self.assertEqual(match.group(1).upper(), self.colors["signal"].upper())
 
+    def test_primary_cta_control_colors_meet_wcag_aa(self):
+        css = (THEME_DIR / "style.css").read_text(encoding="utf-8")
+        control_colors = re.findall(r"--aurora-signal-control(?:-hover)?:\s*(#[0-9a-fA-F]{6});", css)
+
+        self.assertEqual(len(control_colors), 2)
+        for color in control_colors:
+            self.assertGreaterEqual(contrast_ratio("#FFFAF6", color), 4.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.21');
+define('KK_AURORA_VERSION', '1.3.22');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.22 =
+* Darkened Aurora primary CTA colors to meet WCAG AA contrast with off-white button text.
+
 = 1.3.21 =
 * Added late Twitter Card fallbacks so missing title, description, image, and site fields mirror available Open Graph metadata.
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.21
+Version: 1.3.22
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -493,6 +493,8 @@ a {
   --aurora-paper: #f7f5f1;
   --aurora-signal: #f15b43;
   --aurora-signal-dark: #a52918;
+  --aurora-signal-control: #c8371f;
+  --aurora-signal-control-hover: #b82f1c;
   --aurora-wildcard: #c8ff3d;
   --aurora-black: #030405;
   --aurora-panel: rgba(10, 13, 15, 0.78);
@@ -542,8 +544,8 @@ a {
 
 .aurora-button-primary,
 .wp-block-button.is-style-aurora-primary .wp-block-button__link {
-  background: var(--aurora-signal);
-  border: 1px solid var(--aurora-signal);
+  background: var(--aurora-signal-control);
+  border: 1px solid var(--aurora-signal-control);
   color: #fffaf6;
   box-shadow: 0 0 28px rgba(229, 70, 46, 0.22);
 }
@@ -557,8 +559,8 @@ a {
 
 .aurora-button-primary:hover,
 .wp-block-button.is-style-aurora-primary .wp-block-button__link:hover {
-  background: #f2644d;
-  border-color: #f2644d;
+  background: var(--aurora-signal-control-hover);
+  border-color: var(--aurora-signal-control-hover);
   box-shadow: 0 0 38px rgba(229, 70, 46, 0.34);
 }
 


### PR DESCRIPTION
## Summary
- add button-only Aurora control colors for primary CTA normal and hover states
- keep the global `signal` token unchanged so signal text remains WCAG AA on dark surfaces
- bump Aurora to `1.3.22`
- add a regression test for primary CTA control color contrast

## Live audit finding
A read-only Playwright audit of production found primary CTA buttons using off-white text over the signal red at roughly `3.86:1`, below WCAG AA for normal-size button text.

New local ratios:
- normal: `#FFFAF6` on `#C8371F` = `5.04:1`
- hover: `#FFFAF6` on `#B82F1C` = `5.85:1`
- existing signal text on deep remains `5.83:1`

## Verification
- `make test`
- `make docs-truth-check`
- `php -l theme/kk-aurora/functions.php`
- `git diff --check`
