### PR TITLE
Docs: Add issue 233 SEO review handoff

### DIFF
--- a/fixes/issue-233-homepage-metadata-internal-links-2026-06-18.md
+++ b/fixes/issue-233-homepage-metadata-internal-links-2026-06-18.md
@@ -39,6 +39,27 @@ not the visible WordPress page title.
 | `david zabowski nerdwallet mobile engineering` | No repo-local KrisKrug.co target found in the existing handoff. | Do not create or link anything until the target is confirmed as an existing page, quote, testimonial, media mention, or irrelevant people-search artifact. |
 | `lord of the rings drinking game` | Park as legacy/low-strategy traffic. | Ignore unless KK confirms an entertainment/archive business reason to refresh, redirect, or noindex it. |
 
+## Live SEO Deploy Gate
+
+Before any WordPress metadata edit, complete all of these gates:
+
+- Capture a current public HTML snapshot of the homepage.
+- Confirm Jetpack is still the single owner for homepage SEO title and meta
+  description output.
+- Record a rollback note with the exact previous homepage metadata values.
+- Get KK approval for the live metadata edit.
+- Omit `title` from any REST payload unless KK explicitly approves a visible
+  WordPress page-title change.
+
+After deployment, read back the public homepage and confirm:
+
+- Rendered SEO title matches `Kris Krüg | AI Keynote Speaker & Creative Technologist`.
+- Rendered meta description matches the approved copy above.
+- Canonical and robots meta are present and indexable.
+- No duplicate SEO generator has been introduced.
+- No unrelated page content, post content, contact forms, accessibility scope,
+  or Aurora theme files were changed.
+
 ## Suggested Anchors
 
 - `you can't drink data`
@@ -57,3 +78,4 @@ exact-match anchor across unrelated pages.
 - [ ] No live WordPress writes are made from this repo-only handoff.
 - [ ] Any future deployment uses Jetpack SEO fields only and includes public
       HTML readback for title, description, canonical, and robots meta.
+- [ ] The live deploy gate above is completed before any metadata write.

--- a/fixes/issue-233-homepage-metadata-internal-links-2026-06-18.md
+++ b/fixes/issue-233-homepage-metadata-internal-links-2026-06-18.md
@@ -1,0 +1,59 @@
+# Issue #233: Homepage Metadata and Striking-Distance Links
+
+**Track:** A - Content + SEO
+**Status:** repo-side review handoff; no live WordPress writes
+**Control surface:** GitHub issue #233
+
+## Scope
+
+This file turns the June 17 Search Console/GA4 signals into a review-ready repo
+handoff. It does not deploy metadata, publish posts, edit WordPress, or create
+REST payloads.
+
+## Existing Repo Evidence
+
+| Surface | Source | Finding |
+|---|---|---|
+| Homepage metadata | `content/source-packs/keynotes-2026/wp-payloads/page-meta.json` | Canonical repo payload already contains the tightened homepage title and description for review. |
+| Meta description context | `fixes/issue-36-meta-descriptions.md` | Jetpack is the existing metadata owner; do not introduce Yoast, Rank Math, SEOPress, Code Snippets, or a second generator for this pass. |
+| Search Console handoff | `fixes/issue-198-search-console-striking-distance-links-2026-06-18.md` | June 17 query clusters were `you cant drink data`, `david zabowski nerdwallet mobile engineering`, and `lord of the rings drinking game`. |
+| Article target | `content/drafts/2026-05-23-you-cant-drink-data/` | Local draft package has SEO metadata and post-publish internal-link notes. |
+
+## Review-Ready Homepage Metadata
+
+Use the existing Jetpack SEO owner only. Both values are already present in
+`page-meta.json`; no repo JSON change is needed.
+
+- `jetpack_seo_html_title`: `Kris Krüg | AI Keynote Speaker & Creative Technologist`
+- `advanced_seo_description`: `Kris Krüg is an AI keynote speaker and creative technologist building community-first tools, talks, training, and media across BC+AI and Both Hands Full.`
+
+Do not include a `title` field in any future REST update payload unless KK
+explicitly confirms a page-title change. This handoff is about SEO metadata,
+not the visible WordPress page title.
+
+## Query Disposition
+
+| Query cluster | Disposition | Next safe action |
+|---|---|---|
+| `you cant drink data` | Use `content/drafts/2026-05-23-you-cant-drink-data/` as the target. | After the article and companion protest posts are live, add contextual backlinks from the two companion posts and one relevant homepage/About/hub surface if the surrounding copy fits. |
+| `david zabowski nerdwallet mobile engineering` | No repo-local KrisKrug.co target found in the existing handoff. | Do not create or link anything until the target is confirmed as an existing page, quote, testimonial, media mention, or irrelevant people-search artifact. |
+| `lord of the rings drinking game` | Park as legacy/low-strategy traffic. | Ignore unless KK confirms an entertainment/archive business reason to refresh, redirect, or noindex it. |
+
+## Suggested Anchors
+
+- `you can't drink data`
+- `Vancouver AI protest`
+- `data centre protest`
+- `cleaner AI infrastructure`
+
+Use one strong contextual link from a relevant surface instead of repeating an
+exact-match anchor across unrelated pages.
+
+## Review Checklist
+
+- [ ] Homepage metadata values above still match `page-meta.json`.
+- [ ] The `You Can't Drink Data` draft package remains the correct target for
+      the Search Console query.
+- [ ] No live WordPress writes are made from this repo-only handoff.
+- [ ] Any future deployment uses Jetpack SEO fields only and includes public
+      HTML readback for title, description, canonical, and robots meta.


### PR DESCRIPTION
## Summary

Related: #233

This is a repo-only SEO review handoff for the June 17 Search Console/GA4 findings. It does not make live WordPress changes, publish content, update GitHub issues, or change Aurora/theme scope.

## What changed

- Added a review handoff for the homepage SEO metadata already present in `page-meta.json`.
- Documented `You Can't Drink Data` as the existing draft target for the striking-distance query.
- Recorded that the David Zabowski/NerdWallet query has no confirmed repo-local target and should not be edited until the target is confirmed.
- Parked `lord of the rings drinking game` as legacy/low-strategy traffic unless KK confirms a business reason.
- Added a live SEO deploy gate for a future human-approved WordPress metadata edit.

## Safety notes

- Repo-only: no WordPress admin/API writes were made.
- Jetpack remains the intended single SEO metadata owner.
- Any future REST payload must omit `title` unless KK explicitly approves a visible WordPress page-title change.
- The untracked morning-truth report is intentionally not part of this PR.

## Validation

- `git diff --check origin/main...HEAD`
- `make docs-truth-check`
- `python3 -m json.tool content/source-packs/keynotes-2026/wp-payloads/page-meta.json >/dev/null`
- Confirmed PR diff is only `fixes/issue-233-homepage-metadata-internal-links-2026-06-18.md`.