### PR TITLE
The Marquee — self-improving marquee board hero (v1 prototype)

### DIFF
--- a/.github/workflows/marquee-weekly.yml
+++ b/.github/workflows/marquee-weekly.yml
@@ -1,0 +1,76 @@
+name: Marquee Weekly Scan
+
+# The Marquee loop — SCAN step. Every Monday (and on demand) it reads Kris's drafts,
+# proposes 2–8 board candidates, rebuilds the /marquee/ archive, and opens a DRAFT PR
+# with the proposals. Kris picks one in the PR; promote.py applies the pick.
+# Pick-flow: GitHub draft PR.
+
+on:
+  schedule:
+    - cron: "0 15 * * 1"   # Mondays 15:00 UTC
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Max candidates to propose"
+        required: false
+        default: "8"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install pyyaml
+
+      - name: Scan drafts → proposals
+        run: |
+          cd scripts/marquee
+          python3 scan.py --limit "${{ github.event.inputs.limit || '8' }}" --write
+
+      - name: Rebuild /marquee/ archive
+        run: |
+          cd scripts/marquee
+          python3 build.py
+
+      - name: Summarize proposals for PR body
+        id: summary
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, pathlib
+          p = json.loads(pathlib.Path("content/marquee/proposals.json").read_text())
+          lines = ["body<<EOF",
+                   "## 🪧 This week's marquee candidates",
+                   "",
+                   f"Scanned your drafts and pulled **{p['count']}** board-worthy lines. "
+                   "Pick one (or tweak it), then run `promote.py --candidate <id>`:",
+                   ""]
+          for c in p["candidates"]:
+              lines.append(f"- **{' / '.join(c['board'])}**  ·  _{c['source']['title']}_  ·  `{c['id']}`")
+          lines += ["",
+                    "Nothing is live until you promote. The previous board stays in the archive.",
+                    "EOF"]
+          print("\n".join(lines))
+          PY
+
+      - name: Open draft PR with proposals
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: marquee/weekly-proposals
+          base: main
+          draft: true
+          commit-message: "marquee: weekly scan — proposed board candidates"
+          title: "🪧 Marquee — weekly board candidates"
+          body: ${{ steps.summary.outputs.body }}
+          add-paths: |
+            content/marquee/proposals.json
+            content/marquee/dist/**

--- a/content/marquee/README.md
+++ b/content/marquee/README.md
@@ -45,38 +45,50 @@ Cadence: **weekly, or whenever there's interesting shit to say.** Not a fixed cr
 
 ---
 
-## Pick-flow (the one open decision)
+## Pick-flow — **GitHub draft PR** (chosen)
 
-How the 2–3 options reach Kris each round. Candidates, pick whichever feels right — all are buildable:
+Every Monday (`.github/workflows/marquee-weekly.yml`) the loop scans drafts, rebuilds the
+archive, and opens a **draft PR** listing the week's candidates. Kris picks one in the PR,
+runs `promote.py`, and merges. Nothing goes live until promoted.
 
-| Option | How it feels | Cost |
-|---|---|---|
-| **GitHub draft PR** | Loop opens a PR with rendered candidates + source notes; approve & merge. Fits this repo. | low |
-| **WordPress drafts** | Candidates land as draft `marquee` posts; pick/publish from WP admin. No git in the weekly loop. | med |
-| **Email / Beehiiv digest** | A short digest of the options hits the inbox; reply/click to choose. Lowest friction. | med |
+## Run it locally
 
-Default until told otherwise: **GitHub draft PR** (matches how everything else here ships).
+```bash
+cd scripts/marquee
+python3 scan.py --limit 8 --write          # mine drafts → proposals.json (proposes, never overwrites)
+python3 promote.py --list                  # see live board + curated candidates
+python3 promote.py --candidate cand-mcluhan-tools-shape-us --week 2026-W28
+python3 build.py                           # render /marquee/ archive (SEO pages + index wall)
+```
 
----
+The pipeline is **scan → curate → promote → build**: `scan.py` only *proposes*
+(`proposals.json`); a human moves the good ones into `marquee.json` `candidates`;
+`promote.py` applies the pick and archives the old board; `build.py` renders the wall.
 
 ## Files
 
 | File | Role |
 |---|---|
-| `marquee.json` | Data model — `meta`, live `boards[]`, pending `candidates[]`. Single source of truth. |
+| `marquee.json` | Data model — `meta`, live + archived `boards[]`, curated `candidates[]`. Source of truth. |
+| `proposals.json` | Raw output of the last scan (scores + provenance). Generated; curate from here. |
 | `preview.html` | **Open in a browser.** v1 board, 4 skins live-switchable, 3 McLuhan candidates. |
-| `archive/` | Past boards (one record each) → become `/marquee/<slug>/` pages. |
-| `../../theme/kk-aurora/patterns/marquee-hero.php` | Drop-in WordPress block pattern (self-contained). |
+| `dist/` | Built `/marquee/` archive — one SEO page per board + index wall. Generated. |
+| `../../scripts/marquee/` | `scan.py` · `promote.py` · `build.py` · `render.py` · `marquee_lib.py` |
+| `../../theme/kk-aurora/patterns/marquee-hero.php` | Drop-in WordPress hero pattern (self-contained, LED). |
 
 ## Skins
-`splitflap` (Solari departure board · default) · `led` (dot-matrix ticker) ·
-`letterpress` (Clash Display type-remix) · `teletype` (AI terminal). One board, four looks; switch in `marquee.json`.
+`led` (dot-matrix ticker · **default**) · `splitflap` (Solari departure board) ·
+`letterpress` (Clash Display type-remix) · `teletype` (AI terminal). One board, four looks;
+switch via `meta.default_skin` / a board's `skin`.
 
 ## Status — v1 prototype
 - [x] Data model + McLuhan seed board ("The Model Is the Message")
 - [x] Standalone visual preview with 4 skins + 3 candidates
-- [x] WordPress drop-in pattern (split-flap)
-- [ ] Pick-flow chosen + wired
-- [ ] SCAN step (reads drafts/posts/Beehiiv → candidates)
-- [ ] `marquee` post type + `/marquee/` archive route + SEO/OG
-- [ ] Promote into the live hero on the home page
+- [x] WordPress drop-in pattern (LED)
+- [x] Pick-flow chosen (**GitHub draft PR**) + weekly Action wired
+- [x] SCAN step — reads `content/drafts/` → ranked proposals (proven on 55 real drafts)
+- [x] `/marquee/` archive builder — SEO pages (OG, Twitter, JSON-LD) + index wall
+- [x] Promote step — applies the pick, archives the previous board
+- [ ] Extend SCAN to published posts + Beehiiv dispatch (MCP)
+- [ ] `marquee` WP post type / route so `/marquee/` is served by WordPress (currently static `dist/`)
+- [ ] Promote into the live home hero (swap the pattern into `front-page.html`)

--- a/content/marquee/README.md
+++ b/content/marquee/README.md
@@ -1,0 +1,82 @@
+# The Marquee 🪧
+
+A living hero element for kriskrug.co — a direct descendant of the **Kris Krug × Douglas Coupland
+marquee boards** (shared copyright), where Doug supplied ideas and Kris remixed the topography onto
+the board. Now the idea-feed is **Kris's own output**: the most interesting thing he's said this
+week, remixed into lights.
+
+Each board is, at once:
+
+- a **graphic** (the animated marquee in the hero),
+- a **micro blog post** (a sharp line + a paragraph of why it matters), and
+- an **SEO surface** (its own indexed `/marquee/<slug>/` page with title, description, tags, OG image).
+
+Over a year that's 50+ tiny, individually-rankable pages — a compounding "greatest hits of what Kris
+was thinking." Very McLuhan: the *archive* becomes a medium of its own.
+
+---
+
+## The self-improving loop
+
+```
+  SCAN ─────────▶ REMIX ─────────▶ PICK ─────────▶ PROMOTE ─────────▶ ARCHIVE
+  (your output)   (2–3 boards)     (you choose)    (takes hero)        (old → /marquee/)
+```
+
+1. **SCAN** — read what Kris is actually saying right now:
+   - `content/drafts/*` field notes (~55 live)
+   - published posts (WordPress MCP)
+   - the Beehiiv dispatch (Beehiiv MCP)
+   - optionally Slack / Notion / talks
+   Extract candidate *lines* — the sharpest tension, claim, or turn of phrase. Short enough for a board.
+
+2. **REMIX** — for the top theme, generate **2–3 board candidates** (`candidates[]` in `marquee.json`):
+   phrase (1–3 short lines) + dek + source note + tags + draft SEO. Honors the Coupland move: take
+   an idea, remix the *topography*, don't just quote it.
+
+3. **PICK** — human-in-the-loop. Kris chooses one. (Pick-flow is the one open decision — see below.)
+
+4. **PROMOTE** — chosen candidate becomes the `live` board (`meta.current`). Hero renders it.
+
+5. **ARCHIVE** — the previous live board moves to `archive/` with full meta and gets a permanent,
+   indexed `/marquee/<slug>/` page. Nothing is lost; the wall of past boards grows.
+
+Cadence: **weekly, or whenever there's interesting shit to say.** Not a fixed cron unless wanted.
+
+---
+
+## Pick-flow (the one open decision)
+
+How the 2–3 options reach Kris each round. Candidates, pick whichever feels right — all are buildable:
+
+| Option | How it feels | Cost |
+|---|---|---|
+| **GitHub draft PR** | Loop opens a PR with rendered candidates + source notes; approve & merge. Fits this repo. | low |
+| **WordPress drafts** | Candidates land as draft `marquee` posts; pick/publish from WP admin. No git in the weekly loop. | med |
+| **Email / Beehiiv digest** | A short digest of the options hits the inbox; reply/click to choose. Lowest friction. | med |
+
+Default until told otherwise: **GitHub draft PR** (matches how everything else here ships).
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `marquee.json` | Data model — `meta`, live `boards[]`, pending `candidates[]`. Single source of truth. |
+| `preview.html` | **Open in a browser.** v1 board, 4 skins live-switchable, 3 McLuhan candidates. |
+| `archive/` | Past boards (one record each) → become `/marquee/<slug>/` pages. |
+| `../../theme/kk-aurora/patterns/marquee-hero.php` | Drop-in WordPress block pattern (self-contained). |
+
+## Skins
+`splitflap` (Solari departure board · default) · `led` (dot-matrix ticker) ·
+`letterpress` (Clash Display type-remix) · `teletype` (AI terminal). One board, four looks; switch in `marquee.json`.
+
+## Status — v1 prototype
+- [x] Data model + McLuhan seed board ("The Model Is the Message")
+- [x] Standalone visual preview with 4 skins + 3 candidates
+- [x] WordPress drop-in pattern (split-flap)
+- [ ] Pick-flow chosen + wired
+- [ ] SCAN step (reads drafts/posts/Beehiiv → candidates)
+- [ ] `marquee` post type + `/marquee/` archive route + SEO/OG
+- [ ] Promote into the live hero on the home page

--- a/content/marquee/dist/index.html
+++ b/content/marquee/dist/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Marquee — archive of remixed boards | Kris Krüg</title>
+<meta name="description" content="A growing wall of marquee boards: the sharpest line from what Kris Krüg is making and saying, remixed into lights. One graphic, one micro-post, one indexed page at a time.">
+<link rel="canonical" href="https://kriskrug.co/marquee/">
+<meta property="og:type" content="article"><meta property="og:title" content="The Marquee — Kris Krüg">
+<meta property="og:description" content="A growing wall of marquee boards: the sharpest line from what Kris Krüg is making and saying, remixed into lights. One graphic, one micro-post, one indexed page at a time."><meta property="og:url" content="https://kriskrug.co/marquee/">
+<meta name="twitter:card" content="summary_large_image">
+<style>
+*{box-sizing:border-box}
+html,body{margin:0;background:#0a0a0f;color:#f6f5f2;
+  font-family:"Clash Display",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  background:radial-gradient(1200px 600px at 50% -10%,rgba(255,59,59,.06),transparent 60%),#0a0a0f}
+.wrap{max-width:1000px;margin:0 auto;padding:28px 18px 72px}
+a{color:#00e0c6;text-decoration:none}
+.top{display:flex;justify-content:space-between;align-items:center;font-family:"JetBrains Mono",monospace;
+  font-size:12px;color:#8a8aa0;text-transform:uppercase;letter-spacing:.16em;margin-bottom:8px}
+.dek{font-size:clamp(16px,2.2vw,20px);line-height:1.55;color:#d9d9e3;max-width:64ch;margin:26px auto 0}
+.dek b{color:#fff}
+.src{font-family:"JetBrains Mono",monospace;font-size:12px;color:#8a8aa0;margin-top:18px;line-height:1.7;
+  border-left:2px solid #1d1d2b;padding-left:14px;max-width:64ch}
+.src .k{color:#00e0c6}
+.tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:14px}
+.tag{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;border:1px solid #1d1d2b;
+  border-radius:999px;padding:3px 9px}
+.nav{display:flex;justify-content:space-between;margin-top:40px;font-family:"JetBrains Mono",monospace;font-size:12px}
+h1.idx{font-size:clamp(26px,5vw,46px);margin:6px 0 4px;letter-spacing:-.02em}
+.lede{color:#8a8aa0;max-width:60ch;margin:0 0 28px;line-height:1.6}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px}
+.card{background:#101019;border:1px solid #1d1d2b;border-radius:14px;padding:18px;display:block;transition:.15s}
+.card:hover{border-color:#ff3b3b}
+.card .ph{font-family:"JetBrains Mono",monospace;font-weight:700;color:#ff5a5a;font-size:15px;line-height:1.3}
+.card .wk{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;margin-top:10px;
+  text-transform:uppercase;letter-spacing:.1em}
+.live{color:#ffb000}
+
+.kkm{--kkm-amber:#ffb000;--kkm-line:#1d1d2b;--kkm-mono:"JetBrains Mono",ui-monospace,monospace;
+     display:flex;justify-content:center;padding:clamp(20px,4vw,44px) 16px}
+.kkm-frame{width:min(960px,100%);border-radius:18px;padding:clamp(24px,4vw,40px) clamp(18px,3vw,32px);
+     background:linear-gradient(180deg,#0e0e16,#08080d);border:1px solid var(--kkm-line);
+     box-shadow:0 40px 120px -50px rgba(0,0,0,.85),inset 0 1px 0 rgba(255,255,255,.04)}
+.kkm-kicker{font-family:var(--kkm-mono);text-transform:uppercase;letter-spacing:.22em;font-size:11px;
+     color:var(--kkm-amber);display:flex;gap:10px;align-items:center;margin:0 0 22px}
+.kkm-kicker::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--kkm-amber);
+     box-shadow:0 0 12px var(--kkm-amber);animation:kkm-pulse 2s infinite}
+@keyframes kkm-pulse{0%,100%{opacity:1}50%{opacity:.3}}
+.kkm-board{display:flex;flex-direction:column;gap:10px;user-select:none}
+.kkm-row{display:flex;flex-wrap:wrap;gap:6px}
+.kkm-cell{position:relative;display:inline-flex;align-items:center;justify-content:center;
+     width:clamp(26px,5.4vw,56px);height:clamp(40px,8vw,82px);font-family:var(--kkm-mono);font-weight:700;
+     font-size:clamp(20px,4.4vw,46px);line-height:1;background:#15151f;color:var(--kkm-amber);border-radius:6px;
+     box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -1px 0 rgba(0,0,0,.6),0 2px 4px rgba(0,0,0,.5)}
+.kkm-cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;background:#000;opacity:.7}
+.kkm-cell.kkm-space{background:transparent;box-shadow:none;width:clamp(10px,2.4vw,24px)}
+/* LED */
+.kkm[data-skin="led"] .kkm-cell{background:#0a0a0f;color:#ff3b3b;border-radius:4px;
+     text-shadow:0 0 10px #ff3b3b,0 0 22px #ff1010;
+     background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1.4px);background-size:6px 6px}
+.kkm[data-skin="led"] .kkm-cell::after{display:none}
+.kkm[data-skin="led"] .kkm-kicker{color:#ff5a5a}
+.kkm[data-skin="led"] .kkm-kicker::before{background:#ff3b3b;box-shadow:0 0 12px #ff3b3b}
+/* Letterpress */
+.kkm[data-skin="letterpress"] .kkm-frame{background:linear-gradient(180deg,#f6f3ec,#ece7da);border-color:#ddd6c4}
+.kkm[data-skin="letterpress"] .kkm-cell{background:transparent;box-shadow:none;color:#16140f;
+     font-family:var(--kkm-mono);font-weight:800;font-size:clamp(26px,6vw,72px);width:auto;height:auto;
+     padding:0 .02em;letter-spacing:-.02em}
+.kkm[data-skin="letterpress"] .kkm-cell::after{display:none}
+.kkm[data-skin="letterpress"] .kkm-kicker{color:#8a6a00}
+.kkm[data-skin="letterpress"] .kkm-kicker::before{background:#8a6a00;box-shadow:none}
+/* Teletype */
+.kkm[data-skin="teletype"] .kkm-frame{background:#04060a;border-color:#0c2a26}
+.kkm[data-skin="teletype"] .kkm-cell{background:transparent;box-shadow:none;color:#00e0c6;
+     font-family:var(--kkm-mono);font-weight:600;font-size:clamp(18px,4.2vw,42px);width:auto;height:auto;
+     text-shadow:0 0 8px rgba(0,224,198,.5)}
+.kkm[data-skin="teletype"] .kkm-cell::after{display:none}
+.kkm[data-skin="teletype"] .kkm-kicker{color:#00e0c6}
+</style></head><body><div class="wrap"><div class="top"><span>kriskrug.co</span><a href="/">← home</a></div>
+<h1 class="idx">The Marquee</h1>
+<p class="lede">A descendant of the Krug × Coupland marquee boards. Each week the sharpest line from what I'm making gets remixed into lights — then archived here as its own little indexed page.</p>
+<div class="grid"><a class="card" href="/marquee/the-model-is-the-message/"><div class="ph">THE MODEL IS THE MESSAGE</div><div class="wk live">2026-W26 · ● live</div></a></div></div></body></html>

--- a/content/marquee/dist/the-model-is-the-message/index.html
+++ b/content/marquee/dist/the-model-is-the-message/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>The Model Is the Message — McLuhan for the Age of Generative Everything</title>
+<meta name="description" content="Marshall McLuhan said the medium is the message. In the age of AI, the model is the medium: weights, training data, and defaults are the message now. A Kris Krug marquee board.">
+<link rel="canonical" href="https://kriskrug.co/marquee/the-model-is-the-message/">
+<meta property="og:type" content="article"><meta property="og:title" content="The Model Is the Message — McLuhan for the Age of Generative Everything">
+<meta property="og:description" content="Marshall McLuhan said the medium is the message. In the age of AI, the model is the medium: weights, training data, and defaults are the message now. A Kris Krug marquee board."><meta property="og:url" content="https://kriskrug.co/marquee/the-model-is-the-message/">
+<meta name="twitter:card" content="summary_large_image">
+<style>
+*{box-sizing:border-box}
+html,body{margin:0;background:#0a0a0f;color:#f6f5f2;
+  font-family:"Clash Display",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  background:radial-gradient(1200px 600px at 50% -10%,rgba(255,59,59,.06),transparent 60%),#0a0a0f}
+.wrap{max-width:1000px;margin:0 auto;padding:28px 18px 72px}
+a{color:#00e0c6;text-decoration:none}
+.top{display:flex;justify-content:space-between;align-items:center;font-family:"JetBrains Mono",monospace;
+  font-size:12px;color:#8a8aa0;text-transform:uppercase;letter-spacing:.16em;margin-bottom:8px}
+.dek{font-size:clamp(16px,2.2vw,20px);line-height:1.55;color:#d9d9e3;max-width:64ch;margin:26px auto 0}
+.dek b{color:#fff}
+.src{font-family:"JetBrains Mono",monospace;font-size:12px;color:#8a8aa0;margin-top:18px;line-height:1.7;
+  border-left:2px solid #1d1d2b;padding-left:14px;max-width:64ch}
+.src .k{color:#00e0c6}
+.tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:14px}
+.tag{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;border:1px solid #1d1d2b;
+  border-radius:999px;padding:3px 9px}
+.nav{display:flex;justify-content:space-between;margin-top:40px;font-family:"JetBrains Mono",monospace;font-size:12px}
+h1.idx{font-size:clamp(26px,5vw,46px);margin:6px 0 4px;letter-spacing:-.02em}
+.lede{color:#8a8aa0;max-width:60ch;margin:0 0 28px;line-height:1.6}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px}
+.card{background:#101019;border:1px solid #1d1d2b;border-radius:14px;padding:18px;display:block;transition:.15s}
+.card:hover{border-color:#ff3b3b}
+.card .ph{font-family:"JetBrains Mono",monospace;font-weight:700;color:#ff5a5a;font-size:15px;line-height:1.3}
+.card .wk{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;margin-top:10px;
+  text-transform:uppercase;letter-spacing:.1em}
+.live{color:#ffb000}
+
+.kkm{--kkm-amber:#ffb000;--kkm-line:#1d1d2b;--kkm-mono:"JetBrains Mono",ui-monospace,monospace;
+     display:flex;justify-content:center;padding:clamp(20px,4vw,44px) 16px}
+.kkm-frame{width:min(960px,100%);border-radius:18px;padding:clamp(24px,4vw,40px) clamp(18px,3vw,32px);
+     background:linear-gradient(180deg,#0e0e16,#08080d);border:1px solid var(--kkm-line);
+     box-shadow:0 40px 120px -50px rgba(0,0,0,.85),inset 0 1px 0 rgba(255,255,255,.04)}
+.kkm-kicker{font-family:var(--kkm-mono);text-transform:uppercase;letter-spacing:.22em;font-size:11px;
+     color:var(--kkm-amber);display:flex;gap:10px;align-items:center;margin:0 0 22px}
+.kkm-kicker::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--kkm-amber);
+     box-shadow:0 0 12px var(--kkm-amber);animation:kkm-pulse 2s infinite}
+@keyframes kkm-pulse{0%,100%{opacity:1}50%{opacity:.3}}
+.kkm-board{display:flex;flex-direction:column;gap:10px;user-select:none}
+.kkm-row{display:flex;flex-wrap:wrap;gap:6px}
+.kkm-cell{position:relative;display:inline-flex;align-items:center;justify-content:center;
+     width:clamp(26px,5.4vw,56px);height:clamp(40px,8vw,82px);font-family:var(--kkm-mono);font-weight:700;
+     font-size:clamp(20px,4.4vw,46px);line-height:1;background:#15151f;color:var(--kkm-amber);border-radius:6px;
+     box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -1px 0 rgba(0,0,0,.6),0 2px 4px rgba(0,0,0,.5)}
+.kkm-cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;background:#000;opacity:.7}
+.kkm-cell.kkm-space{background:transparent;box-shadow:none;width:clamp(10px,2.4vw,24px)}
+/* LED */
+.kkm[data-skin="led"] .kkm-cell{background:#0a0a0f;color:#ff3b3b;border-radius:4px;
+     text-shadow:0 0 10px #ff3b3b,0 0 22px #ff1010;
+     background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1.4px);background-size:6px 6px}
+.kkm[data-skin="led"] .kkm-cell::after{display:none}
+.kkm[data-skin="led"] .kkm-kicker{color:#ff5a5a}
+.kkm[data-skin="led"] .kkm-kicker::before{background:#ff3b3b;box-shadow:0 0 12px #ff3b3b}
+/* Letterpress */
+.kkm[data-skin="letterpress"] .kkm-frame{background:linear-gradient(180deg,#f6f3ec,#ece7da);border-color:#ddd6c4}
+.kkm[data-skin="letterpress"] .kkm-cell{background:transparent;box-shadow:none;color:#16140f;
+     font-family:var(--kkm-mono);font-weight:800;font-size:clamp(26px,6vw,72px);width:auto;height:auto;
+     padding:0 .02em;letter-spacing:-.02em}
+.kkm[data-skin="letterpress"] .kkm-cell::after{display:none}
+.kkm[data-skin="letterpress"] .kkm-kicker{color:#8a6a00}
+.kkm[data-skin="letterpress"] .kkm-kicker::before{background:#8a6a00;box-shadow:none}
+/* Teletype */
+.kkm[data-skin="teletype"] .kkm-frame{background:#04060a;border-color:#0c2a26}
+.kkm[data-skin="teletype"] .kkm-cell{background:transparent;box-shadow:none;color:#00e0c6;
+     font-family:var(--kkm-mono);font-weight:600;font-size:clamp(18px,4.2vw,42px);width:auto;height:auto;
+     text-shadow:0 0 8px rgba(0,224,198,.5)}
+.kkm[data-skin="teletype"] .kkm-cell::after{display:none}
+.kkm[data-skin="teletype"] .kkm-kicker{color:#00e0c6}
+</style></head><body><div class="wrap"><div class="top"><span>marquee · 2026-W26</span><a href="/marquee/">← all boards</a></div>
+<section class="kkm" data-skin="led" aria-label="THE MODEL IS THE MESSAGE">
+  <div class="kkm-frame">
+    <p class="kkm-kicker">now showing · marquee nº1</p>
+    <div class="kkm-board" data-board="[&quot;THE MODEL&quot;, &quot;IS THE&quot;, &quot;MESSAGE&quot;]" aria-label="THE MODEL IS THE MESSAGE"></div>
+  </div>
+</section>
+<p class="dek">McLuhan said the medium is the message — the channel reshapes us more than the content it carries. In the age of generative everything, the model is the medium. The weights, the training data, the defaults: that's the message now.</p>
+<p class="src"><span class="k">after</span> Marshall McLuhan<br><span class="k">source</span> Understanding Media: The Extensions of Man · Marshall McLuhan, 1964<br><span class="k">remix</span> Kris&#x27;s running thesis that AI models are environments, not tools — see field notes on &#x27;authored judgment in the age of generative everything.&#x27;</p>
+<div class="tags"><span class="tag">#mcluhan</span><span class="tag">#media-theory</span><span class="tag">#ai</span><span class="tag">#the-medium-is-the-message</span><span class="tag">#generative-ai</span><span class="tag">#punk-rock-ai</span></div>
+<div class="nav"><span></span><span></span></div>
+<script type="application/ld+json">{&quot;@context&quot;: &quot;https://schema.org&quot;, &quot;@type&quot;: &quot;CreativeWork&quot;, &quot;headline&quot;: &quot;THE MODEL IS THE MESSAGE&quot;, &quot;abstract&quot;: &quot;Marshall McLuhan said the medium is the message. In the age of AI, the model is the medium: weights, training data, and defaults are the message now. A Kris Krug marquee board.&quot;, &quot;url&quot;: &quot;https://kriskrug.co/marquee/the-model-is-the-message/&quot;, &quot;datePublished&quot;: &quot;2026-06-26&quot;, &quot;creator&quot;: {&quot;@type&quot;: &quot;Person&quot;, &quot;name&quot;: &quot;Kris Kr\u00fcg&quot;}, &quot;keywords&quot;: &quot;mcluhan, media-theory, ai, the-medium-is-the-message, generative-ai, punk-rock-ai&quot;, &quot;isBasedOn&quot;: &quot;Marshall McLuhan, 1964&quot;}</script><script>
+document.querySelectorAll('.kkm-board').forEach(function(board){
+  var lines = JSON.parse(board.getAttribute('data-board'));
+  var GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#@%&".split("");
+  var reduce = window.matchMedia('(prefers-reduced-motion:reduce)').matches;
+  lines.forEach(function(line){
+    var row = document.createElement('div'); row.className='kkm-row';
+    line.split('').forEach(function(ch){
+      var c=document.createElement('div');
+      c.className='kkm-cell'+(ch===' '?' kkm-space':'');
+      c.setAttribute('data-final', ch); c.textContent = ch===' '?'':ch;
+      row.appendChild(c);
+    });
+    board.appendChild(row);
+  });
+  if(reduce) return;
+  board.querySelectorAll('.kkm-cell:not(.kkm-space)').forEach(function(cell,idx){
+    var ticks = 6 + (idx % 7) + Math.floor(idx/3);
+    var iv = setInterval(function(){
+      if(ticks<=0){ cell.textContent = cell.getAttribute('data-final'); clearInterval(iv); return; }
+      cell.textContent = GLYPHS[(idx*3+ticks)%GLYPHS.length]; ticks--;
+    }, 45);
+  });
+});
+</script></div></body></html>

--- a/content/marquee/marquee.json
+++ b/content/marquee/marquee.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "./marquee.schema.json",
+  "meta": {
+    "name": "The Marquee",
+    "lineage": "Descendant of the Kris Krug x Douglas Coupland marquee boards — ideas remixed into topography. Now the idea-feed is Kris's own output.",
+    "current": "2026-w26-mcluhan-the-model-is-the-message",
+    "default_skin": "splitflap",
+    "cadence": "weekly-or-when-there-is-interesting-shit-to-say"
+  },
+  "boards": [
+    {
+      "id": "2026-w26-mcluhan-the-model-is-the-message",
+      "status": "live",
+      "week": "2026-W26",
+      "date": "2026-06-26",
+      "after": "Marshall McLuhan",
+      "skin": "splitflap",
+      "board": ["THE MODEL", "IS THE", "MESSAGE"],
+      "kicker": "now showing · marquee nº1",
+      "dek": "McLuhan said the medium is the message — the channel reshapes us more than the content it carries. In the age of generative everything, the model is the medium. The weights, the training data, the defaults: that's the message now.",
+      "source": {
+        "title": "Understanding Media: The Extensions of Man",
+        "author": "Marshall McLuhan, 1964",
+        "remixed_from": "Kris's running thesis that AI models are environments, not tools — see field notes on 'authored judgment in the age of generative everything.'"
+      },
+      "tags": ["mcluhan", "media-theory", "ai", "the-medium-is-the-message", "generative-ai", "punk-rock-ai"],
+      "seo": {
+        "title": "The Model Is the Message — McLuhan for the Age of Generative Everything",
+        "description": "Marshall McLuhan said the medium is the message. In the age of AI, the model is the medium: weights, training data, and defaults are the message now. A Kris Krug marquee board.",
+        "slug": "the-model-is-the-message",
+        "og_image": "auto"
+      }
+    }
+  ],
+  "candidates": [
+    {
+      "id": "cand-mcluhan-medium-message",
+      "after": "Marshall McLuhan",
+      "board": ["THE MEDIUM", "IS THE", "MESSAGE"],
+      "dek": "The original. The channel shapes us more than the content. Start at the source, then remix.",
+      "tags": ["mcluhan", "the-medium-is-the-message"]
+    },
+    {
+      "id": "cand-mcluhan-tools-shape-us",
+      "after": "Marshall McLuhan",
+      "board": ["WE SHAPE OUR TOOLS", "AND THEREAFTER", "OUR TOOLS SHAPE US"],
+      "dek": "The feedback loop in one line. Build the model; the model builds you back.",
+      "tags": ["mcluhan", "tools", "feedback-loop"]
+    },
+    {
+      "id": "cand-mcluhan-mass-age",
+      "after": "Marshall McLuhan",
+      "board": ["THE MEDIUM", "IS THE", "MASS-AGE"],
+      "dek": "McLuhan's own pun from The Medium Is the Massage. Mistype, mass, message, massage — all intended.",
+      "tags": ["mcluhan", "the-medium-is-the-massage", "wordplay"]
+    }
+  ]
+}

--- a/content/marquee/marquee.json
+++ b/content/marquee/marquee.json
@@ -4,7 +4,7 @@
     "name": "The Marquee",
     "lineage": "Descendant of the Kris Krug x Douglas Coupland marquee boards — ideas remixed into topography. Now the idea-feed is Kris's own output.",
     "current": "2026-w26-mcluhan-the-model-is-the-message",
-    "default_skin": "splitflap",
+    "default_skin": "led",
     "cadence": "weekly-or-when-there-is-interesting-shit-to-say"
   },
   "boards": [
@@ -14,7 +14,7 @@
       "week": "2026-W26",
       "date": "2026-06-26",
       "after": "Marshall McLuhan",
-      "skin": "splitflap",
+      "skin": "led",
       "board": ["THE MODEL", "IS THE", "MESSAGE"],
       "kicker": "now showing · marquee nº1",
       "dek": "McLuhan said the medium is the message — the channel reshapes us more than the content it carries. In the age of generative everything, the model is the medium. The weights, the training data, the defaults: that's the message now.",

--- a/content/marquee/preview.html
+++ b/content/marquee/preview.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en" data-skin="splitflap">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Marquee — v1 prototype (McLuhan)</title>
+<style>
+  :root{
+    --bg:#0a0a0f; --panel:#101019; --ink:#f6f5f2; --muted:#8a8aa0;
+    --amber:#ffb000; --amber-dim:#7a5400; --signal:#00e0c6; --line:#1d1d2b;
+    --cell-bg:#15151f; --cell-edge:#000; --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+    --display:"Clash Display",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--display)}
+  body{min-height:100vh;display:flex;flex-direction:column;align-items:center;padding:32px 20px 64px;gap:24px;
+       background:
+         radial-gradient(1200px 600px at 50% -10%, rgba(255,176,0,.06), transparent 60%),
+         radial-gradient(900px 500px at 80% 120%, rgba(0,224,198,.05), transparent 60%),
+         var(--bg);}
+
+  /* ---- controls ---- */
+  .bar{display:flex;flex-wrap:wrap;gap:8px;align-items:center;justify-content:center;max-width:980px}
+  .bar .grp{display:flex;gap:6px;align-items:center;background:var(--panel);border:1px solid var(--line);
+            border-radius:999px;padding:6px 8px}
+  .bar small{color:var(--muted);text-transform:uppercase;letter-spacing:.12em;font-size:10px;font-family:var(--mono);padding:0 4px}
+  button{font-family:var(--mono);font-size:12px;letter-spacing:.04em;color:var(--ink);background:transparent;
+         border:1px solid transparent;border-radius:999px;padding:6px 12px;cursor:pointer;transition:.15s}
+  button:hover{border-color:var(--line);color:#fff}
+  button[aria-pressed="true"]{background:var(--amber);color:#1a1300;border-color:var(--amber);font-weight:600}
+
+  /* ---- the board frame ---- */
+  .stage{width:min(980px,100%);}
+  .frame{position:relative;border-radius:18px;padding:38px 30px 26px;overflow:hidden;
+          background:linear-gradient(180deg,#0e0e16,#08080d);
+          border:1px solid var(--line);
+          box-shadow:0 40px 120px -40px rgba(0,0,0,.9), inset 0 1px 0 rgba(255,255,255,.04);}
+  .kicker{font-family:var(--mono);text-transform:uppercase;letter-spacing:.22em;font-size:11px;color:var(--amber);
+          display:flex;gap:10px;align-items:center;margin:0 0 22px}
+  .kicker::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--amber);
+                  box-shadow:0 0 12px var(--amber);animation:pulse 2s infinite}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.3}}
+
+  .board{display:flex;flex-direction:column;gap:10px;user-select:none}
+  .row{display:flex;flex-wrap:wrap;gap:6px}
+  .cell{position:relative;display:inline-flex;align-items:center;justify-content:center;
+        width:clamp(28px,6vw,62px);height:clamp(42px,9vw,90px);
+        font-family:var(--mono);font-weight:700;font-size:clamp(22px,5vw,52px);line-height:1;
+        background:var(--cell-bg);color:var(--amber);border-radius:6px;
+        box-shadow:inset 0 1px 0 rgba(255,255,255,.05), inset 0 -1px 0 rgba(0,0,0,.6), 0 2px 4px rgba(0,0,0,.5);}
+  .cell.space{background:transparent;box-shadow:none;width:clamp(12px,3vw,28px)}
+  /* split-flap seam */
+  [data-skin="splitflap"] .cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;
+        background:var(--cell-edge);opacity:.7}
+  .cell.flip{animation:flip .06s linear}
+  @keyframes flip{0%{transform:translateY(-2px) scaleY(.92);filter:brightness(1.4)}100%{transform:none;filter:none}}
+
+  /* ---- caption / meta ---- */
+  .meta{width:min(980px,100%);display:grid;grid-template-columns:1.4fr 1fr;gap:18px}
+  @media(max-width:720px){.meta{grid-template-columns:1fr}}
+  .dek{font-size:18px;line-height:1.5;color:#d9d9e3;margin:0}
+  .dek b{color:#fff}
+  .side{font-family:var(--mono);font-size:12px;line-height:1.7;color:var(--muted);
+        border-left:2px solid var(--line);padding-left:14px}
+  .side .k{color:var(--signal)}
+  .tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:6px}
+  .tag{font-family:var(--mono);font-size:10px;color:var(--muted);border:1px solid var(--line);
+       border-radius:999px;padding:3px 8px}
+
+  /* ---- archive strip ---- */
+  .archive{width:min(980px,100%);margin-top:6px}
+  .archive h3{font-family:var(--mono);text-transform:uppercase;letter-spacing:.18em;font-size:11px;color:var(--muted);margin:0 0 10px}
+  .strip{display:flex;gap:10px;overflow:auto;padding-bottom:6px}
+  .chip{flex:0 0 auto;min-width:150px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
+  .chip .ph{font-family:var(--mono);font-size:13px;color:var(--amber);font-weight:700}
+  .chip .wk{font-family:var(--mono);font-size:10px;color:var(--muted);margin-top:6px}
+
+  .note{max-width:760px;text-align:center;color:var(--muted);font-size:13px;line-height:1.6}
+  .note code{font-family:var(--mono);color:var(--signal)}
+
+  /* ================= SKINS ================= */
+  /* LED dot-matrix */
+  [data-skin="led"] .frame{background:radial-gradient(circle at 50% 0,#0c0c14,#050507)}
+  [data-skin="led"] .cell{background:#0a0a0f;color:#ff3b3b;border-radius:4px;
+      text-shadow:0 0 10px #ff3b3b,0 0 22px #ff1010;
+      background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1.4px);background-size:6px 6px}
+  [data-skin="led"] .cell::after{display:none}
+  [data-skin="led"] .kicker,[data-skin="led"] .side .k{color:#ff5a5a}
+  [data-skin="led"] .kicker::before{background:#ff3b3b;box-shadow:0 0 12px #ff3b3b}
+
+  /* Letterpress type-remix */
+  [data-skin="letterpress"] .frame{background:linear-gradient(180deg,#f6f3ec,#ece7da);border-color:#ddd6c4}
+  [data-skin="letterpress"] .board{gap:0}
+  [data-skin="letterpress"] .row{gap:0}
+  [data-skin="letterpress"] .cell{background:transparent;box-shadow:none;color:#16140f;
+      font-family:var(--display);font-weight:800;font-size:clamp(30px,8vw,86px);width:auto;height:auto;
+      padding:0 .02em;letter-spacing:-.02em;line-height:.92}
+  [data-skin="letterpress"] .cell.space{width:clamp(10px,2vw,22px)}
+  [data-skin="letterpress"] .cell::after{display:none}
+  [data-skin="letterpress"] .row:nth-child(2){margin-left:1.2em}
+  [data-skin="letterpress"] .kicker{color:#8a6a00}
+  [data-skin="letterpress"] .kicker::before{background:#8a6a00;box-shadow:none}
+
+  /* Teletype / terminal */
+  [data-skin="teletype"] .frame{background:#04060a;border-color:#0c2a26}
+  [data-skin="teletype"] .board{gap:2px}
+  [data-skin="teletype"] .cell{background:transparent;box-shadow:none;color:var(--signal);
+      font-family:var(--mono);font-weight:600;font-size:clamp(20px,4.6vw,46px);width:auto;height:auto;
+      text-shadow:0 0 8px rgba(0,224,198,.5)}
+  [data-skin="teletype"] .cell.space{width:.5em}
+  [data-skin="teletype"] .cell::after{display:none}
+  [data-skin="teletype"] .row::before{content:"> ";color:#2f6f66;font-family:var(--mono);
+      font-size:clamp(20px,4.6vw,46px);align-self:center}
+  [data-skin="teletype"] .kicker{color:var(--signal)}
+  [data-skin="teletype"] .kicker::before{background:var(--signal);box-shadow:0 0 12px var(--signal)}
+</style>
+</head>
+<body>
+
+  <div class="bar">
+    <div class="grp"><small>skin</small>
+      <button data-skin-btn="splitflap" aria-pressed="true">Split-flap</button>
+      <button data-skin-btn="led" aria-pressed="false">LED</button>
+      <button data-skin-btn="letterpress" aria-pressed="false">Letterpress</button>
+      <button data-skin-btn="teletype" aria-pressed="false">Teletype</button>
+    </div>
+    <div class="grp"><small>phrase</small>
+      <button data-board="0" aria-pressed="true">The Model</button>
+      <button data-board="1" aria-pressed="false">The Medium</button>
+      <button data-board="2" aria-pressed="false">Our Tools</button>
+      <button data-board="3" aria-pressed="false">Mass-age</button>
+    </div>
+    <div class="grp"><button id="reflip">↻ re-flip</button></div>
+  </div>
+
+  <div class="stage">
+    <div class="frame">
+      <p class="kicker" id="kicker">now showing · marquee nº1 · after marshall mcluhan</p>
+      <div class="board" id="board" aria-label="Marquee board"></div>
+    </div>
+  </div>
+
+  <div class="meta">
+    <p class="dek" id="dek"></p>
+    <div class="side">
+      <div><span class="k">after</span> &nbsp;<span id="after"></span></div>
+      <div><span class="k">source</span> &nbsp;<span id="source"></span></div>
+      <div class="tags" id="tags"></div>
+    </div>
+  </div>
+
+  <div class="archive">
+    <h3>archive · /marquee/</h3>
+    <div class="strip">
+      <div class="chip"><div class="ph">THE MODEL IS THE MESSAGE</div><div class="wk">2026 · W26 · live</div></div>
+      <div class="chip" style="opacity:.55"><div class="ph">— next board —</div><div class="wk">scanned from your field notes</div></div>
+      <div class="chip" style="opacity:.4"><div class="ph">— W28 —</div><div class="wk">auto-archived w/ SEO meta</div></div>
+      <div class="chip" style="opacity:.3"><div class="ph">— W29 —</div><div class="wk">indexed micro-post</div></div>
+    </div>
+  </div>
+
+  <p class="note">v1 prototype · 4 skins live-switchable · 3 McLuhan candidates · data is driven by
+  <code>marquee.json</code> · each board becomes a graphic + micro-post + SEO page in the
+  <code>/marquee/</code> archive. Pick a skin + phrase up top.</p>
+
+<script>
+const BOARDS = [
+  { board:["THE MODEL","IS THE","MESSAGE"], after:"Marshall McLuhan",
+    kicker:"now showing · marquee nº1 · after marshall mcluhan",
+    dek:"McLuhan said the medium is the message — the channel reshapes us more than the content it carries. In the age of generative everything, <b>the model is the medium</b>. The weights, the defaults, the training data: that's the message now.",
+    source:"Understanding Media (1964), remixed onto Kris's thesis that models are environments, not tools.",
+    tags:["mcluhan","media-theory","ai","generative-ai","punk-rock-ai"] },
+  { board:["THE MEDIUM","IS THE","MESSAGE"], after:"Marshall McLuhan",
+    kicker:"candidate · the original · after marshall mcluhan",
+    dek:"The original line. The channel shapes us more than the content. Start at the source — then remix.",
+    source:"Understanding Media: The Extensions of Man, Marshall McLuhan, 1964.",
+    tags:["mcluhan","the-medium-is-the-message"] },
+  { board:["WE SHAPE OUR TOOLS","AND THEREAFTER","OUR TOOLS SHAPE US"], after:"McLuhan (via John Culkin)",
+    kicker:"candidate · the feedback loop · after marshall mcluhan",
+    dek:"The feedback loop in one line. Build the model; the model builds you back. The most AI-native thing McLuhan never quite said.",
+    source:"Often attributed to McLuhan; phrased by John Culkin, 1967.",
+    tags:["mcluhan","tools","feedback-loop"] },
+  { board:["THE MEDIUM","IS THE","MASS-AGE"], after:"Marshall McLuhan",
+    kicker:"candidate · the pun · after marshall mcluhan",
+    dek:"McLuhan's own deliberate pun from <b>The Medium Is the Massage</b>. Message, massage, mass-age, mess-age — the typo was the point.",
+    source:"The Medium Is the Massage, McLuhan & Fiore, 1967.",
+    tags:["mcluhan","the-medium-is-the-massage","wordplay"] },
+];
+const GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ▓▒░#@%&".split("");
+let current = 0;
+
+function render(i){
+  const b = BOARDS[i]; current = i;
+  document.getElementById("kicker").textContent = b.kicker;
+  document.getElementById("dek").innerHTML = b.dek;
+  document.getElementById("after").textContent = b.after;
+  document.getElementById("source").textContent = b.source;
+  document.getElementById("tags").innerHTML = b.tags.map(t=>`<span class="tag">#${t}</span>`).join("");
+  const board = document.getElementById("board");
+  board.innerHTML = "";
+  b.board.forEach(line=>{
+    const row = document.createElement("div"); row.className="row";
+    line.split("").forEach(ch=>{
+      const cell = document.createElement("div");
+      cell.className = "cell" + (ch===" " ? " space":"");
+      cell.dataset.final = ch;
+      cell.textContent = ch===" " ? "" : ch;
+      row.appendChild(cell);
+    });
+    board.appendChild(row);
+  });
+  flip();
+}
+
+function flip(){
+  document.querySelectorAll(".cell:not(.space)").forEach((cell,idx)=>{
+    const final = cell.dataset.final;
+    let ticks = 6 + (idx % 7) + Math.floor(idx/3);
+    const iv = setInterval(()=>{
+      if(ticks<=0){ cell.textContent = final; clearInterval(iv); return; }
+      cell.textContent = GLYPHS[(Math.floor(performance.now()/13)+idx*3+ticks)%GLYPHS.length];
+      cell.classList.add("flip");
+      setTimeout(()=>cell.classList.remove("flip"),60);
+      ticks--;
+    }, 45);
+  });
+}
+
+document.querySelectorAll("[data-skin-btn]").forEach(btn=>{
+  btn.addEventListener("click",()=>{
+    document.documentElement.dataset.skin = btn.dataset.skinBtn;
+    document.querySelectorAll("[data-skin-btn]").forEach(b=>b.setAttribute("aria-pressed", b===btn));
+    flip();
+  });
+});
+document.querySelectorAll("[data-board]").forEach(btn=>{
+  btn.addEventListener("click",()=>{
+    document.querySelectorAll("[data-board]").forEach(b=>b.setAttribute("aria-pressed", b===btn));
+    render(+btn.dataset.board);
+  });
+});
+document.getElementById("reflip").addEventListener("click", flip);
+render(0);
+</script>
+</body>
+</html>

--- a/content/marquee/preview.html
+++ b/content/marquee/preview.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-skin="splitflap">
+<html lang="en" data-skin="led">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -119,8 +119,8 @@
 
   <div class="bar">
     <div class="grp"><small>skin</small>
-      <button data-skin-btn="splitflap" aria-pressed="true">Split-flap</button>
-      <button data-skin-btn="led" aria-pressed="false">LED</button>
+      <button data-skin-btn="led" aria-pressed="true">LED</button>
+      <button data-skin-btn="splitflap" aria-pressed="false">Split-flap</button>
       <button data-skin-btn="letterpress" aria-pressed="false">Letterpress</button>
       <button data-skin-btn="teletype" aria-pressed="false">Teletype</button>
     </div>

--- a/content/marquee/proposals.json
+++ b/content/marquee/proposals.json
@@ -1,0 +1,164 @@
+{
+  "generated_from": "content/drafts",
+  "count": 8,
+  "candidates": [
+    {
+      "id": "cand-ai-glossary-the-learned-parameters-i",
+      "board": [
+        "THE LEARNED",
+        "PARAMETERS",
+        "INSIDE A MODEL"
+      ],
+      "line": "The learned parameters inside a model",
+      "kind": "lead",
+      "score": 7.92,
+      "dek": "Plain-language definitions for the AI, local technology, data governance, Indigenous governance, and creative AI terms that show up across KrisKrug.co.",
+      "source": {
+        "title": "AI Glossary",
+        "slug": "glossary"
+      },
+      "tags": []
+    },
+    {
+      "id": "cand-ai-glossary-land-that-was-not-surren",
+      "board": [
+        "LAND THAT WAS",
+        "NOT SURRENDERED",
+        "THROUGH TREATY"
+      ],
+      "line": "Land that was not surrendered through treaty",
+      "kind": "lead",
+      "score": 7.64,
+      "dek": "Plain-language definitions for the AI, local technology, data governance, Indigenous governance, and creative AI terms that show up across KrisKrug.co.",
+      "source": {
+        "title": "AI Glossary",
+        "slug": "glossary"
+      },
+      "tags": []
+    },
+    {
+      "id": "cand-rewiring-education-hacking-the-system-for-an-ai-powered-futu-why-memorization-is-so-l",
+      "board": [
+        "WHY MEMORIZATION",
+        "IS SO LAST",
+        "CENTURY"
+      ],
+      "line": "Why Memorization Is So Last Century",
+      "kind": "lead",
+      "score": 7.37,
+      "dek": "A draft on rewiring education for an AI-powered future, with a focus on agency, experimentation, and rebuilding learning around real creative practice.",
+      "source": {
+        "title": "Rewiring Education: Hacking the System for an AI-Powered Future",
+        "slug": "rewiring-education-hacking-the-system-for-an-ai-powered-future"
+      },
+      "tags": []
+    },
+    {
+      "id": "cand-you-cant-drink-data-were-a-nonprofit",
+      "board": [
+        "WE'RE A",
+        "NONPROFIT"
+      ],
+      "line": "We're a nonprofit",
+      "kind": "lead",
+      "score": 7.31,
+      "dek": "Remixed from “You Can't Drink Data.”",
+      "source": {
+        "title": "You Can't Drink Data",
+        "slug": "2026-05-23-you-cant-drink-data"
+      },
+      "tags": [
+        "ai-protest",
+        "data-centres",
+        "vancouver",
+        "clean-energy-ai",
+        "indigenous-data-sovereignty"
+      ]
+    },
+    {
+      "id": "cand-ai-keynote-slides-need-taste-before-prompts-real-photos-are-part-of-",
+      "board": [
+        "REAL PHOTOS ARE",
+        "PART OF THE",
+        "CHAIN TOO"
+      ],
+      "line": "Real photos are part of the chain too",
+      "kind": "quote",
+      "score": 7.02,
+      "dek": "My creative operating system for turning raw talk notes into prompts, graphics, slides, websites, posts, guides, and other artifacts without letting AI flatten the work into generic slop.",
+      "source": {
+        "title": "AI Keynote Slides Need Taste Before Prompts",
+        "slug": "ai-keynote-slides-visual-workflow"
+      },
+      "tags": [
+        "ai-keynote-slides",
+        "keynote-visual-workflow",
+        "ai-image-prompts",
+        "canva",
+        "rafiki"
+      ]
+    },
+    {
+      "id": "cand-nobel-chemistry-foldit-foldit-wasnt-your-typica",
+      "board": [
+        "FOLDIT WASN’T",
+        "YOUR TYPICAL",
+        "DIGITAL ESCAPISM"
+      ],
+      "line": "Foldit wasn’t your typical digital escapism",
+      "kind": "lead",
+      "score": 6.98,
+      "dek": "A short draft connecting Foldit, protein folding, citizen science, and the strange joy of watching games spill into Nobel-worthy discovery.",
+      "source": {
+        "title": "Nobel Chemistry Foldit",
+        "slug": "nobel-chemistry-foldit"
+      },
+      "tags": []
+    },
+    {
+      "id": "cand-ai-wont-fix-your-broken-permit-process-llms-are-trained-on-what",
+      "board": [
+        "LLMS ARE TRAINED",
+        "ON WHAT EXISTS"
+      ],
+      "line": "LLMs are trained on what exists",
+      "kind": "lead",
+      "score": 6.83,
+      "dek": "AI will not repair broken civic systems by itself. Permit reform needs better process, public accountability, and human judgment before automation can help.",
+      "source": {
+        "title": "AI Won't Fix Your Broken Permit Process",
+        "slug": "ai-wont-fix-your-broken-permit-process"
+      },
+      "tags": [
+        "ai-governance",
+        "civic-tech",
+        "government-ai",
+        "public-sector",
+        "responsible-ai"
+      ]
+    },
+    {
+      "id": "cand-canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one-canada-distinctive-not-d",
+      "board": [
+        "CANADA",
+        "DISTINCTIVE, NOT",
+        "DERIVATIVE"
+      ],
+      "line": "Canada distinctive, not derivative",
+      "kind": "lead",
+      "score": 6.78,
+      "dek": "Canada does need AI infrastructure. But without consent, climate discipline, Indigenous governance, and community benefit, bigger just means faster extraction.",
+      "source": {
+        "title": "Canada Doesn't Need a Bigger AI Machine. It Needs a Better One.",
+        "slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one"
+      },
+      "tags": [
+        "ai-policy",
+        "sovereign-ai",
+        "ai-governance",
+        "bc-ai",
+        "responsible-ai"
+      ]
+    }
+  ]
+}

--- a/scripts/marquee/build.py
+++ b/scripts/marquee/build.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""BUILD — render the /marquee/ archive: one SEO page per board + an index wall.
+
+Each board becomes a graphic + micro-post + indexed page (title, meta description,
+canonical, OpenGraph, Twitter card, JSON-LD CreativeWork). Output is static HTML in
+content/marquee/dist/, ready to ship to WordPress or serve directly.
+
+Usage:  python3 scripts/marquee/build.py
+"""
+from __future__ import annotations
+import html
+import shutil
+
+from marquee_lib import load, DIST_DIR
+from render import BOARD_CSS, BOARD_JS, board_html
+
+SITE = "https://kriskrug.co"
+BASE = "/marquee"
+
+PAGE_CSS = """
+*{box-sizing:border-box}
+html,body{margin:0;background:#0a0a0f;color:#f6f5f2;
+  font-family:"Clash Display",-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+  background:radial-gradient(1200px 600px at 50% -10%,rgba(255,59,59,.06),transparent 60%),#0a0a0f}
+.wrap{max-width:1000px;margin:0 auto;padding:28px 18px 72px}
+a{color:#00e0c6;text-decoration:none}
+.top{display:flex;justify-content:space-between;align-items:center;font-family:"JetBrains Mono",monospace;
+  font-size:12px;color:#8a8aa0;text-transform:uppercase;letter-spacing:.16em;margin-bottom:8px}
+.dek{font-size:clamp(16px,2.2vw,20px);line-height:1.55;color:#d9d9e3;max-width:64ch;margin:26px auto 0}
+.dek b{color:#fff}
+.src{font-family:"JetBrains Mono",monospace;font-size:12px;color:#8a8aa0;margin-top:18px;line-height:1.7;
+  border-left:2px solid #1d1d2b;padding-left:14px;max-width:64ch}
+.src .k{color:#00e0c6}
+.tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:14px}
+.tag{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;border:1px solid #1d1d2b;
+  border-radius:999px;padding:3px 9px}
+.nav{display:flex;justify-content:space-between;margin-top:40px;font-family:"JetBrains Mono",monospace;font-size:12px}
+h1.idx{font-size:clamp(26px,5vw,46px);margin:6px 0 4px;letter-spacing:-.02em}
+.lede{color:#8a8aa0;max-width:60ch;margin:0 0 28px;line-height:1.6}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:16px}
+.card{background:#101019;border:1px solid #1d1d2b;border-radius:14px;padding:18px;display:block;transition:.15s}
+.card:hover{border-color:#ff3b3b}
+.card .ph{font-family:"JetBrains Mono",monospace;font-weight:700;color:#ff5a5a;font-size:15px;line-height:1.3}
+.card .wk{font-family:"JetBrains Mono",monospace;font-size:10px;color:#8a8aa0;margin-top:10px;
+  text-transform:uppercase;letter-spacing:.1em}
+.live{color:#ffb000}
+"""
+
+
+def page_head(title, desc, url, og_title):
+    e = html.escape
+    return f"""<!DOCTYPE html><html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{e(title)}</title>
+<meta name="description" content="{e(desc)}">
+<link rel="canonical" href="{e(url)}">
+<meta property="og:type" content="article"><meta property="og:title" content="{e(og_title)}">
+<meta property="og:description" content="{e(desc)}"><meta property="og:url" content="{e(url)}">
+<meta name="twitter:card" content="summary_large_image">
+<style>{PAGE_CSS}{BOARD_CSS}</style></head><body><div class="wrap">"""
+
+
+def board_page(b, prev_b, next_b):
+    e = html.escape
+    seo = b.get("seo", {})
+    slug = seo.get("slug") or b["id"]
+    url = f"{SITE}{BASE}/{slug}/"
+    title = seo.get("title") or " ".join(b["board"])
+    desc = seo.get("description") or b.get("dek", "")
+    src = b.get("source", {})
+    src_line = " · ".join(x for x in [src.get("title"), src.get("author")] if x)
+    jsonld = {
+        "@context": "https://schema.org", "@type": "CreativeWork",
+        "headline": " ".join(b["board"]), "abstract": desc, "url": url,
+        "datePublished": b.get("date"), "creator": {"@type": "Person", "name": "Kris Krüg"},
+        "keywords": ", ".join(b.get("tags", [])),
+        "isBasedOn": src.get("author") or src.get("title"),
+    }
+    out = page_head(title, desc, url, title)
+    out += f'<div class="top"><span>marquee · {e(b.get("week",""))}</span><a href="{BASE}/">← all boards</a></div>\n'
+    out += board_html(b["board"], b.get("kicker", "marquee"), b.get("skin", "led")) + "\n"
+    out += f'<p class="dek">{b.get("dek","")}</p>\n'
+    if src_line or src.get("remixed_from"):
+        out += '<p class="src">'
+        if b.get("after"):
+            out += f'<span class="k">after</span> {e(b["after"])}<br>'
+        if src_line:
+            out += f'<span class="k">source</span> {e(src_line)}<br>'
+        if src.get("remixed_from"):
+            out += f'<span class="k">remix</span> {e(src["remixed_from"])}'
+        out += "</p>\n"
+    if b.get("tags"):
+        out += '<div class="tags">' + "".join(f'<span class="tag">#{e(t)}</span>' for t in b["tags"]) + "</div>\n"
+    out += '<div class="nav">'
+    out += (f'<a href="{BASE}/{prev_b}/">← previous board</a>' if prev_b else "<span></span>")
+    out += (f'<a href="{BASE}/{next_b}/">next board →</a>' if next_b else "<span></span>")
+    out += "</div>\n"
+    out += f'<script type="application/ld+json">{html.escape(__import__("json").dumps(jsonld))}</script>'
+    out += f"<script>{BOARD_JS}</script></div></body></html>"
+    return slug, out
+
+
+def index_page(boards):
+    e = html.escape
+    url = f"{SITE}{BASE}/"
+    out = page_head("The Marquee — archive of remixed boards | Kris Krüg",
+                    "A growing wall of marquee boards: the sharpest line from what Kris Krüg is making and saying, remixed into lights. One graphic, one micro-post, one indexed page at a time.",
+                    url, "The Marquee — Kris Krüg")
+    out += '<div class="top"><span>kriskrug.co</span><a href="/">← home</a></div>\n'
+    out += '<h1 class="idx">The Marquee</h1>\n'
+    out += '<p class="lede">A descendant of the Krug × Coupland marquee boards. Each week the sharpest line from what I\'m making gets remixed into lights — then archived here as its own little indexed page.</p>\n'
+    out += '<div class="grid">'
+    for b in boards:
+        slug = b.get("seo", {}).get("slug") or b["id"]
+        live = b.get("status") == "live"
+        out += (f'<a class="card" href="{BASE}/{slug}/"><div class="ph">{e(" ".join(b["board"]))}</div>'
+                f'<div class="wk {"live" if live else ""}">{e(b.get("week",""))} · {"● live" if live else "archived"}</div></a>')
+    out += "</div></div></body></html>"
+    return out
+
+
+def main():
+    data = load()
+    boards = data.get("boards", [])
+    if DIST_DIR.exists():
+        shutil.rmtree(DIST_DIR)
+    DIST_DIR.mkdir(parents=True)
+    order = boards  # live first as authored
+    for i, b in enumerate(order):
+        prev_b = (order[i - 1].get("seo", {}).get("slug") or order[i - 1]["id"]) if i > 0 else None
+        next_b = (order[i + 1].get("seo", {}).get("slug") or order[i + 1]["id"]) if i < len(order) - 1 else None
+        slug, page = board_page(b, prev_b, next_b)
+        d = DIST_DIR / slug
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "index.html").write_text(page, encoding="utf-8")
+        print(f"  board → {BASE}/{slug}/")
+    (DIST_DIR / "index.html").write_text(index_page(order), encoding="utf-8")
+    print(f"  index → {BASE}/  ({len(order)} board{'s' if len(order)!=1 else ''})")
+    print(f"\nBuilt archive into {DIST_DIR.relative_to(DIST_DIR.parents[2])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/marquee/marquee_lib.py
+++ b/scripts/marquee/marquee_lib.py
@@ -1,0 +1,50 @@
+"""Shared helpers for the Marquee loop: data IO, slugs, board text wrapping."""
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MARQUEE_JSON = ROOT / "content" / "marquee" / "marquee.json"
+DRAFTS_DIR = ROOT / "content" / "drafts"
+DIST_DIR = ROOT / "content" / "marquee" / "dist"
+
+# Board geometry: the LED board reads best at ~16 chars/line, up to 3 lines.
+MAX_LINE_CHARS = 16
+MAX_LINES = 3
+MAX_BOARD_CHARS = MAX_LINE_CHARS * MAX_LINES
+
+
+def load() -> dict:
+    return json.loads(MARQUEE_JSON.read_text(encoding="utf-8"))
+
+
+def save(data: dict) -> None:
+    MARQUEE_JSON.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def slugify(text: str) -> str:
+    text = re.sub(r"[^\w\s-]", "", text.lower())
+    return re.sub(r"[\s_]+", "-", text).strip("-")[:60]
+
+
+def wrap_board(line: str):
+    """Greedy-wrap a phrase into <=MAX_LINES uppercase rows of <=MAX_LINE_CHARS.
+
+    Returns a list of rows, or None if it can't fit cleanly (too long for the board).
+    """
+    words = line.upper().split()
+    rows, cur = [], ""
+    for w in words:
+        if len(w) > MAX_LINE_CHARS:
+            return None  # single word won't fit a row
+        if cur and len(cur) + 1 + len(w) > MAX_LINE_CHARS:
+            rows.append(cur)
+            cur = w
+        else:
+            cur = f"{cur} {w}".strip()
+    if cur:
+        rows.append(cur)
+    if not rows or len(rows) > MAX_LINES:
+        return None
+    return rows

--- a/scripts/marquee/promote.py
+++ b/scripts/marquee/promote.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""PROMOTE — apply Kris's pick: a candidate becomes the live board.
+
+The previously-live board is flipped to `archived` (it stays in boards[] forever, so
+the archive only grows). The chosen candidate is removed from candidates[] and promoted
+to a full board record with week/date and SEO scaffold.
+
+Usage:
+  python3 scripts/marquee/promote.py --candidate <candidate-id> --week 2026-W28
+  python3 scripts/marquee/promote.py --list        # show current live + candidates
+"""
+from __future__ import annotations
+import argparse
+import datetime as dt
+
+from marquee_lib import load, save, slugify
+
+
+def find_live(data):
+    for b in data["boards"]:
+        if b.get("status") == "live":
+            return b
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--candidate")
+    ap.add_argument("--week")
+    ap.add_argument("--date")
+    ap.add_argument("--list", action="store_true")
+    args = ap.parse_args()
+
+    data = load()
+
+    if args.list or not args.candidate:
+        live = find_live(data)
+        print("LIVE:", " / ".join(live["board"]) if live else "(none)")
+        print("\nCANDIDATES:")
+        for c in data.get("candidates", []):
+            print(f"  {c['id']}\n     {' / '.join(c['board'])}")
+        if not args.candidate:
+            return
+
+    cand = next((c for c in data.get("candidates", []) if c["id"] == args.candidate), None)
+    if not cand:
+        raise SystemExit(f"No candidate '{args.candidate}'. Run --list to see options.")
+
+    date = args.date or dt.date.today().isoformat()
+    iso = dt.date.fromisoformat(date).isocalendar()
+    week = args.week or f"{iso[0]}-W{iso[1]:02d}"
+
+    # demote current live
+    live = find_live(data)
+    if live:
+        live["status"] = "archived"
+
+    phrase = " ".join(cand["board"])
+    slug = slugify(phrase)
+    board = {
+        "id": f"{week.lower()}-{slug}",
+        "status": "live",
+        "week": week,
+        "date": date,
+        "after": cand.get("after"),
+        "skin": data["meta"].get("default_skin", "led"),
+        "board": cand["board"],
+        "kicker": f"now showing · {week.lower()}",
+        "dek": cand.get("dek", ""),
+        "source": cand.get("source", {}),
+        "tags": cand.get("tags", []),
+        "seo": {
+            "title": f"{phrase.title()} — a Kris Krüg marquee board",
+            "description": (cand.get("dek", "")[:155]).strip(),
+            "slug": slug,
+            "og_image": "auto",
+        },
+    }
+    data["boards"].insert(0, board)
+    data["meta"]["current"] = board["id"]
+    data["candidates"] = [c for c in data["candidates"] if c["id"] != args.candidate]
+    save(data)
+    print(f"\nPromoted → {phrase}\n  live id: {board['id']}\n  previous live archived.")
+    print("Next: python3 scripts/marquee/build.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/marquee/render.py
+++ b/scripts/marquee/render.py
@@ -1,0 +1,97 @@
+"""Shared marquee board renderer.
+
+Renders a board (list of text lines) to self-contained HTML/CSS/JS in any of the
+four skins. Used by build.py for the static /marquee/ archive pages. The live hero
+is rendered by the WordPress pattern (theme/kk-aurora/patterns/marquee-hero.php),
+which mirrors this markup.
+"""
+from __future__ import annotations
+import html
+import json
+
+SKINS = ("led", "splitflap", "letterpress", "teletype")
+
+# Scoped CSS for the static archive board. Mirrors the WP pattern's .kkm styles.
+BOARD_CSS = """
+.kkm{--kkm-amber:#ffb000;--kkm-line:#1d1d2b;--kkm-mono:"JetBrains Mono",ui-monospace,monospace;
+     display:flex;justify-content:center;padding:clamp(20px,4vw,44px) 16px}
+.kkm-frame{width:min(960px,100%);border-radius:18px;padding:clamp(24px,4vw,40px) clamp(18px,3vw,32px);
+     background:linear-gradient(180deg,#0e0e16,#08080d);border:1px solid var(--kkm-line);
+     box-shadow:0 40px 120px -50px rgba(0,0,0,.85),inset 0 1px 0 rgba(255,255,255,.04)}
+.kkm-kicker{font-family:var(--kkm-mono);text-transform:uppercase;letter-spacing:.22em;font-size:11px;
+     color:var(--kkm-amber);display:flex;gap:10px;align-items:center;margin:0 0 22px}
+.kkm-kicker::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--kkm-amber);
+     box-shadow:0 0 12px var(--kkm-amber);animation:kkm-pulse 2s infinite}
+@keyframes kkm-pulse{0%,100%{opacity:1}50%{opacity:.3}}
+.kkm-board{display:flex;flex-direction:column;gap:10px;user-select:none}
+.kkm-row{display:flex;flex-wrap:wrap;gap:6px}
+.kkm-cell{position:relative;display:inline-flex;align-items:center;justify-content:center;
+     width:clamp(26px,5.4vw,56px);height:clamp(40px,8vw,82px);font-family:var(--kkm-mono);font-weight:700;
+     font-size:clamp(20px,4.4vw,46px);line-height:1;background:#15151f;color:var(--kkm-amber);border-radius:6px;
+     box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -1px 0 rgba(0,0,0,.6),0 2px 4px rgba(0,0,0,.5)}
+.kkm-cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;background:#000;opacity:.7}
+.kkm-cell.kkm-space{background:transparent;box-shadow:none;width:clamp(10px,2.4vw,24px)}
+/* LED */
+.kkm[data-skin="led"] .kkm-cell{background:#0a0a0f;color:#ff3b3b;border-radius:4px;
+     text-shadow:0 0 10px #ff3b3b,0 0 22px #ff1010;
+     background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1.4px);background-size:6px 6px}
+.kkm[data-skin="led"] .kkm-cell::after{display:none}
+.kkm[data-skin="led"] .kkm-kicker{color:#ff5a5a}
+.kkm[data-skin="led"] .kkm-kicker::before{background:#ff3b3b;box-shadow:0 0 12px #ff3b3b}
+/* Letterpress */
+.kkm[data-skin="letterpress"] .kkm-frame{background:linear-gradient(180deg,#f6f3ec,#ece7da);border-color:#ddd6c4}
+.kkm[data-skin="letterpress"] .kkm-cell{background:transparent;box-shadow:none;color:#16140f;
+     font-family:var(--kkm-mono);font-weight:800;font-size:clamp(26px,6vw,72px);width:auto;height:auto;
+     padding:0 .02em;letter-spacing:-.02em}
+.kkm[data-skin="letterpress"] .kkm-cell::after{display:none}
+.kkm[data-skin="letterpress"] .kkm-kicker{color:#8a6a00}
+.kkm[data-skin="letterpress"] .kkm-kicker::before{background:#8a6a00;box-shadow:none}
+/* Teletype */
+.kkm[data-skin="teletype"] .kkm-frame{background:#04060a;border-color:#0c2a26}
+.kkm[data-skin="teletype"] .kkm-cell{background:transparent;box-shadow:none;color:#00e0c6;
+     font-family:var(--kkm-mono);font-weight:600;font-size:clamp(18px,4.2vw,42px);width:auto;height:auto;
+     text-shadow:0 0 8px rgba(0,224,198,.5)}
+.kkm[data-skin="teletype"] .kkm-cell::after{display:none}
+.kkm[data-skin="teletype"] .kkm-kicker{color:#00e0c6}
+"""
+
+BOARD_JS = """
+document.querySelectorAll('.kkm-board').forEach(function(board){
+  var lines = JSON.parse(board.getAttribute('data-board'));
+  var GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#@%&".split("");
+  var reduce = window.matchMedia('(prefers-reduced-motion:reduce)').matches;
+  lines.forEach(function(line){
+    var row = document.createElement('div'); row.className='kkm-row';
+    line.split('').forEach(function(ch){
+      var c=document.createElement('div');
+      c.className='kkm-cell'+(ch===' '?' kkm-space':'');
+      c.setAttribute('data-final', ch); c.textContent = ch===' '?'':ch;
+      row.appendChild(c);
+    });
+    board.appendChild(row);
+  });
+  if(reduce) return;
+  board.querySelectorAll('.kkm-cell:not(.kkm-space)').forEach(function(cell,idx){
+    var ticks = 6 + (idx % 7) + Math.floor(idx/3);
+    var iv = setInterval(function(){
+      if(ticks<=0){ cell.textContent = cell.getAttribute('data-final'); clearInterval(iv); return; }
+      cell.textContent = GLYPHS[(idx*3+ticks)%GLYPHS.length]; ticks--;
+    }, 45);
+  });
+});
+"""
+
+
+def board_html(board_lines, kicker, skin="led"):
+    """Return the .kkm <section> markup for a board (animation hydrated by BOARD_JS)."""
+    data = html.escape(json.dumps(board_lines), quote=True)
+    return (
+        f'<section class="kkm" data-skin="{html.escape(skin)}" '
+        f'aria-label="{html.escape(" ".join(board_lines))}">\n'
+        f'  <div class="kkm-frame">\n'
+        f'    <p class="kkm-kicker">{html.escape(kicker)}</p>\n'
+        f'    <div class="kkm-board" data-board="{data}" '
+        f'aria-label="{html.escape(" ".join(board_lines))}"></div>\n'
+        f'  </div>\n'
+        f'</section>'
+    )

--- a/scripts/marquee/scan.py
+++ b/scripts/marquee/scan.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""SCAN — mine Kris's drafts for board-worthy lines and propose marquee candidates.
+
+Reads content/drafts/*/post.md (YAML frontmatter + markdown body), extracts the
+sharpest short lines, scores them for "board-ability," and writes the top proposals
+into marquee.json -> candidates[] (and a richer proposals.json with provenance).
+
+The REMIX/PICK step (human-in-the-loop via GitHub PR) refines a candidate into the
+final board. This scanner is deliberately conservative: it surfaces real lines Kris
+actually wrote, it does not invent copy.
+
+Usage:  python3 scripts/marquee/scan.py [--limit N] [--write]
+Without --write it prints the ranked proposals (dry run).
+"""
+from __future__ import annotations
+import argparse
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from marquee_lib import DRAFTS_DIR, slugify, wrap_board, MAX_BOARD_CHARS
+
+STRONG = re.compile(
+    r"\b(is|are|isn't|aren't|won't|can't|don't|never|always|not|only|the|your|our|we|you)\b",
+    re.I,
+)
+URL = re.compile(r"https?://|www\.|\]\(")
+MD_NOISE = re.compile(r"[*_`#>\[\]]")
+# Editorial scaffolding that lives in drafts but isn't an idea — never put it on the board.
+STOPWORDS = re.compile(
+    r"\b(outline|prompt|stub|hook|setup|angle|section|draft|tk|todo|caption|diagram|"
+    r"image|images|alt|content|notes?|placeholder|wip|intro|conclusion|takeaway|cta|"
+    r"the bc angle|in action|possible)\b",
+    re.I,
+)
+
+
+def is_label(s: str) -> bool:
+    """A header/label, not a claim: ends with a colon, or is all-caps scaffolding."""
+    if s.endswith(":"):
+        return True
+    letters = [c for c in s if c.isalpha()]
+    return bool(letters) and all(c.isupper() for c in letters)  # no lowercase => a LABEL
+
+
+def parse_post(path: Path):
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    fm, body = {}, text
+    if text.startswith("---"):
+        end = text.find("\n---", 3)
+        if end != -1:
+            try:
+                fm = yaml.safe_load(text[3:end]) or {}
+            except Exception:
+                fm = {}
+            body = text[end + 4:]
+    return fm, body
+
+
+def candidate_lines(body: str):
+    """Yield (line, kind) for board-worthy raw lines: pull-quotes, bold leads, short declaratives."""
+    for raw in body.splitlines():
+        s = raw.strip()
+        if not s or URL.search(s):
+            continue
+        kind = "line"
+        m = re.fullmatch(r"[*_](.+?)[*_]", s)              # *pull quote* (highest value)
+        if m:
+            s, kind = m.group(1), "quote"
+        else:
+            m = re.match(r"\*\*(.+?)\*\*[:.]?\s*(.*)", s)  # **bold lead** + trailing sentence
+            if m:
+                # prefer the sentence AFTER the bold label if there is one, else the bold text
+                s, kind = (m.group(2) or m.group(1)), "lead"
+        s = MD_NOISE.sub("", s).strip(' "“”')
+        s = re.split(r"(?<=[.!?])\s", s)[0].strip(" .")    # first sentence only
+        if is_label(s) or STOPWORDS.search(s):
+            continue                                       # drop headers + scaffolding
+        words = s.split()
+        has_lower = any(c.islower() for c in s)
+        if 12 <= len(s) <= 60 and 3 <= len(words) <= 9 and has_lower and STRONG.search(s):
+            yield s, kind
+
+
+def score(line: str, kind: str, recency: float) -> float:
+    sc = 0.0
+    sc += {"lead": 3.0, "quote": 2.0, "line": 0.0}[kind]
+    sc += 2.5 if len(line) <= MAX_BOARD_CHARS else 0.0      # fits the board outright
+    sc += 1.5 if wrap_board(line) else -2.0                  # can it wrap cleanly?
+    sc += min(len(STRONG.findall(line)), 3) * 0.4           # declarative punch
+    sc -= 0.04 * len(line)                                   # prefer short
+    sc += 2.0 * recency                                     # newer drafts weigh more
+    return round(sc, 2)
+
+
+def scan(limit: int):
+    posts = sorted(DRAFTS_DIR.glob("*/post.md"))
+    proposals = []
+    for i, p in enumerate(posts):
+        recency = i / max(len(posts) - 1, 1)               # 0..1, later folders newer (date-sorted names)
+        fm, body = parse_post(p)
+        title = (fm.get("title") or p.parent.name).strip()
+        excerpt = (fm.get("excerpt") or "").strip()
+        tags = [slugify(t) for t in (fm.get("tags") or [])][:5]
+        seen = set()
+        for line, kind in candidate_lines(body):
+            key = line.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            rows = wrap_board(line)
+            if not rows:
+                continue
+            proposals.append({
+                "id": f"cand-{slugify(title)}-{slugify(line)[:24]}",
+                "board": rows,
+                "line": line,
+                "kind": kind,
+                "score": score(line, kind, recency),
+                "dek": excerpt or f"Remixed from “{title}.”",
+                "source": {"title": title, "slug": fm.get("slug") or p.parent.name},
+                "tags": tags,
+            })
+    proposals.sort(key=lambda x: x["score"], reverse=True)
+    # de-dupe near-identical boards, keep variety of sources
+    out, used_src = [], {}
+    for c in proposals:
+        s = c["source"]["slug"]
+        if used_src.get(s, 0) >= 2:
+            continue
+        used_src[s] = used_src.get(s, 0) + 1
+        out.append(c)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=8)
+    ap.add_argument("--write", action="store_true", help="write the scan to content/marquee/proposals.json")
+    args = ap.parse_args()
+
+    props = scan(args.limit)
+    print(f"Scanned {len(list(DRAFTS_DIR.glob('*/post.md')))} drafts -> {len(props)} candidates\n")
+    for c in props:
+        print(f"  [{c['score']:>5}] {c['kind']:<5} {' / '.join(c['board'])}")
+        print(f"          from: {c['source']['title']}")
+
+    if args.write:
+        # scan() proposes; a human curates which proposals become marquee.json candidates,
+        # then promote.py picks the live board. We never auto-overwrite curated candidates.
+        out = {"generated_from": "content/drafts", "count": len(props), "candidates": props}
+        (DRAFTS_DIR.parent / "marquee" / "proposals.json").write_text(
+            json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"\nWrote {len(props)} proposals -> content/marquee/proposals.json")
+        print("Curate into marquee.json 'candidates', then: python3 promote.py --candidate <id>")
+
+
+if __name__ == "__main__":
+    main()

--- a/theme/kk-aurora/patterns/marquee-hero.php
+++ b/theme/kk-aurora/patterns/marquee-hero.php
@@ -13,7 +13,7 @@
  */
 ?>
 <!-- wp:html -->
-<section class="kkm" aria-label="Marquee board: The Model Is the Message" data-skin="splitflap">
+<section class="kkm" aria-label="Marquee board: The Model Is the Message" data-skin="led">
   <div class="kkm-frame">
     <p class="kkm-kicker">now showing · marquee n&ordm;1 · after marshall mcluhan</p>
     <div class="kkm-board"
@@ -46,6 +46,13 @@
          box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -1px 0 rgba(0,0,0,.6),0 2px 4px rgba(0,0,0,.5)}
     .kkm-cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;background:#000;opacity:.7}
     .kkm-cell.kkm-space{background:transparent;box-shadow:none;width:clamp(10px,2.4vw,24px)}
+    /* LED dot-matrix skin (default) */
+    .kkm[data-skin="led"] .kkm-cell{background:#0a0a0f;color:#ff3b3b;border-radius:4px;
+         text-shadow:0 0 10px #ff3b3b,0 0 22px #ff1010;
+         background-image:radial-gradient(rgba(255,255,255,.05) 1px,transparent 1.4px);background-size:6px 6px}
+    .kkm[data-skin="led"] .kkm-cell::after{display:none}
+    .kkm[data-skin="led"] .kkm-kicker{color:#ff5a5a}
+    .kkm[data-skin="led"] .kkm-kicker::before{background:#ff3b3b;box-shadow:0 0 12px #ff3b3b}
     .kkm-dek{font-size:clamp(15px,2vw,18px);line-height:1.5;color:#d9d9e3;margin:22px 0 0;max-width:62ch}
     .kkm-dek b{color:#fff}
     .kkm-foot{display:flex;flex-wrap:wrap;gap:8px 18px;justify-content:space-between;margin:18px 0 0;

--- a/theme/kk-aurora/patterns/marquee-hero.php
+++ b/theme/kk-aurora/patterns/marquee-hero.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Title: Marquee Board Hero
+ * Slug: kk-aurora/marquee-hero
+ * Categories: kk-aurora-hero
+ * Keywords: marquee, hero, split-flap, board, coupland, mcluhan
+ * Viewport Width: 1400
+ * Description: Self-improving "marquee board" hero — a split-flap board that flips into the current remixed line, with source + archive link. Descendant of the Krug x Coupland marquee boards.
+ *
+ * Self-contained: scoped CSS + JS are inline so the pattern can be dropped into the hero
+ * without enqueueing global assets. Board copy is driven by data-* and can be swapped from
+ * content/marquee/marquee.json by the loop.
+ */
+?>
+<!-- wp:html -->
+<section class="kkm" aria-label="Marquee board: The Model Is the Message" data-skin="splitflap">
+  <div class="kkm-frame">
+    <p class="kkm-kicker">now showing · marquee n&ordm;1 · after marshall mcluhan</p>
+    <div class="kkm-board"
+         data-board='[["THE MODEL","IS THE","MESSAGE"]]'
+         aria-label="The Model Is the Message"></div>
+    <p class="kkm-dek">McLuhan said the medium is the message. In the age of generative everything,
+      <b>the model is the medium</b> — the weights, the defaults, the training data are the message now.</p>
+    <p class="kkm-foot">
+      <span>after Marshall McLuhan &middot; Understanding Media, 1964</span>
+      <a href="/marquee/">See the archive &rarr;</a>
+    </p>
+  </div>
+
+  <style>
+    .kkm{--kkm-amber:#ffb000;--kkm-line:#1d1d2b;--kkm-mono:"JetBrains Mono",ui-monospace,monospace;
+         width:100%;display:flex;justify-content:center;padding:clamp(20px,4vw,48px) 16px}
+    .kkm-frame{width:min(960px,100%);border-radius:18px;padding:clamp(24px,4vw,40px) clamp(18px,3vw,32px);
+         background:linear-gradient(180deg,#0e0e16,#08080d);border:1px solid var(--kkm-line);
+         box-shadow:0 40px 120px -50px rgba(0,0,0,.85),inset 0 1px 0 rgba(255,255,255,.04)}
+    .kkm-kicker{font-family:var(--kkm-mono);text-transform:uppercase;letter-spacing:.22em;font-size:11px;
+         color:var(--kkm-amber);display:flex;gap:10px;align-items:center;margin:0 0 22px}
+    .kkm-kicker::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--kkm-amber);
+         box-shadow:0 0 12px var(--kkm-amber);animation:kkm-pulse 2s infinite}
+    @keyframes kkm-pulse{0%,100%{opacity:1}50%{opacity:.3}}
+    .kkm-board{display:flex;flex-direction:column;gap:10px;user-select:none}
+    .kkm-row{display:flex;flex-wrap:wrap;gap:6px}
+    .kkm-cell{position:relative;display:inline-flex;align-items:center;justify-content:center;
+         width:clamp(26px,5.4vw,56px);height:clamp(40px,8vw,82px);font-family:var(--kkm-mono);font-weight:700;
+         font-size:clamp(20px,4.4vw,46px);line-height:1;background:#15151f;color:var(--kkm-amber);border-radius:6px;
+         box-shadow:inset 0 1px 0 rgba(255,255,255,.05),inset 0 -1px 0 rgba(0,0,0,.6),0 2px 4px rgba(0,0,0,.5)}
+    .kkm-cell::after{content:"";position:absolute;left:0;right:0;top:50%;height:1px;background:#000;opacity:.7}
+    .kkm-cell.kkm-space{background:transparent;box-shadow:none;width:clamp(10px,2.4vw,24px)}
+    .kkm-dek{font-size:clamp(15px,2vw,18px);line-height:1.5;color:#d9d9e3;margin:22px 0 0;max-width:62ch}
+    .kkm-dek b{color:#fff}
+    .kkm-foot{display:flex;flex-wrap:wrap;gap:8px 18px;justify-content:space-between;margin:18px 0 0;
+         font-family:var(--kkm-mono);font-size:12px;color:#8a8aa0}
+    .kkm-foot a{color:#00e0c6;text-decoration:none}
+    @media(prefers-reduced-motion:reduce){.kkm-cell{transition:none}}
+  </style>
+
+  <script>
+  (function(){
+    var root = document.currentScript.closest('.kkm');
+    var board = root.querySelector('.kkm-board');
+    var lines = JSON.parse(board.getAttribute('data-board'))[0];
+    var GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ#@%&".split("");
+    var reduce = window.matchMedia('(prefers-reduced-motion:reduce)').matches;
+    lines.forEach(function(line){
+      var row = document.createElement('div'); row.className='kkm-row';
+      line.split('').forEach(function(ch){
+        var c=document.createElement('div');
+        c.className='kkm-cell'+(ch===' '?' kkm-space':'');
+        c.setAttribute('data-final', ch); c.textContent = ch===' '?'':ch;
+        row.appendChild(c);
+      });
+      board.appendChild(row);
+    });
+    if(reduce) return;
+    var cells = root.querySelectorAll('.kkm-cell:not(.kkm-space)');
+    cells.forEach(function(cell,idx){
+      var ticks = 6 + (idx % 7) + Math.floor(idx/3);
+      var iv = setInterval(function(){
+        if(ticks<=0){ cell.textContent = cell.getAttribute('data-final'); clearInterval(iv); return; }
+        cell.textContent = GLYPHS[(idx*3+ticks)%GLYPHS.length]; ticks--;
+      }, 45);
+    });
+  })();
+  </script>
+</section>
+<!-- /wp:html -->

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -3,6 +3,8 @@
 <!-- wp:group {"tagName":"main","className":"aurora-home-2026 aurora-keynote-first","layout":{"type":"default"}} -->
 <main id="aurora-main" class="wp-block-group aurora-home-2026 aurora-keynote-first">
 
+  <!-- wp:pattern {"slug":"kk-aurora/marquee-hero"} /-->
+
   <!-- wp:html -->
   <section class="aurora-hero-2026" aria-labelledby="aurora-home-title">
     <figure class="aurora-hero-media" aria-label="Kris Krug speaking on stage at CreativeMornings Vancouver">


### PR DESCRIPTION
## The Marquee 🪧

A living hero — a descendant of the **Krug × Coupland marquee boards**, except the idea-feed is now **Kris's own output**. It scans what he's making, remixes the sharpest line into an LED board, lets him pick from a weekly batch, and archives every past board as an indexed micro-post with SEO. Each board = **graphic + micro-post + ranking page** (`/marquee/<slug>/`). Over a year → 50+ individually-rankable pages.

Inaugural board: **"The Model Is the Message"** (after Marshall McLuhan).

**Decisions locked:** LED skin · GitHub draft-PR pick-flow.

### Working engine (`scripts/marquee/`)
`scan → curate → promote → build`, proven on 55 real drafts:
- **`scan.py`** — mines `content/drafts/` → ranked board proposals (drops editorial scaffolding; surfaces real claims like *"LLMs are trained on what exists"*). Writes `proposals.json`; never auto-overwrites curated candidates.
- **`promote.py`** — applies the pick, archives the previous board (the wall only grows).
- **`build.py`** — renders the `/marquee/` archive: one SEO page per board (OG, Twitter, JSON-LD `CreativeWork`) + index wall.
- **`render.py`** — shared 4-skin board renderer.
- **`.github/workflows/marquee-weekly.yml`** — Monday scan → opens a **draft PR** of candidates.

### Live placement
- `theme/kk-aurora/patterns/marquee-hero.php` — self-contained LED hero pattern (reduced-motion safe).
- `front-page.html` now **leads with the marquee board**, above the existing hero. Single-source via `wp:pattern`; revert = remove one line.

### Look at it
- `content/marquee/preview.html` — board flipping into the line, 4 skins switchable, 3 McLuhan candidates.
- `content/marquee/dist/` — built archive (open `index.html`).

### Remaining (post-merge)
- [ ] Extend SCAN to published posts + Beehiiv dispatch (MCP)
- [ ] `marquee` WP post type/route so `/marquee/` is served by WordPress (currently static `dist/`)
- [ ] Decide full hero takeover vs. lead-band (currently leads above the existing hero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W4uBDX2SC16x4SrCCJw3k