### PR TITLE
content: "Keep the Machine Strange" — Postman x AI draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ __pycache__/
 # raw photo originals (working only, do not commit)
 content/drafts/2026-05-23-you-cant-drink-data/photos-raw/
 content/drafts/2026-05-23-you-cant-drink-data/contact-sheets/
+
+# downloaded image working copies (re-fetched by the publish script; live in WP media after publish)
+content/drafts/2026-06-28-keep-the-machine-strange/img/

--- a/content/drafts/2026-06-28-keep-the-machine-strange/post.md
+++ b/content/drafts/2026-06-28-keep-the-machine-strange/post.md
@@ -1,0 +1,203 @@
+---
+title: 'Keep the Machine Strange: Technological Resistance in the Age of AI'
+slug: keep-the-machine-strange
+post_date: '2026-06-28'
+status: draft
+post_type: post
+author_wp_id: 18
+categories:
+- AI Ethics & Philosophy
+- Responsible AI & Policy
+tags:
+- Neil Postman
+- Marshall McLuhan
+- Technopoly
+- Media Ecology
+- Responsible AI
+- AI Governance
+- AI for All
+- Both Hands Full
+- Technological Resistance
+featured: true
+featured_media_id: 0   # hero uploaded + set by publish_keep_the_machine_strange.py
+excerpt: 'Neil Postman did not predict AI. He left us something more useful: a discipline for refusing to treat any technology as the weather. Here is what technological resistance looks like in 2026.'
+seo:
+  meta_title: 'Keep the Machine Strange: Neil Postman, AI, and Technological Resistance | Kris Krüg'
+  meta_description: 'Neil Postman gave us a discipline for refusing technological inevitability. In the age of AI, technological resistance is not rejection. It is civic attention.'
+sources:
+  postman_five_things: https://student.cs.uwaterloo.ca/~cs492/papers/neil-postman--five-things.html
+  ai_index_2026: https://hai.stanford.edu/ai-index/2026-ai-index-report
+  ai_for_all: https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all
+  nist_rmf: https://www.nist.gov/itl/ai-risk-management-framework
+  oecd_principles: https://oecd.ai/en/ai-principles
+---
+
+I studied [Neil Postman](https://en.wikipedia.org/wiki/Neil_Postman) in college. Same stretch of years I fell hard for [Marshall McLuhan](https://en.wikipedia.org/wiki/Marshall_McLuhan), back when media theory still felt like something you argued about in a seminar instead of something that could reach into your pocket and rearrange your whole day.
+
+Postman read like cultural criticism then. Smart, a little cranky, great at a party if the party was mostly grad students.
+
+In 2026 he reads like a field manual.
+
+A phrase has been going around lately, dressed up in his clothes: "technological resistance, a discerning, lucid, vigilant engagement with the systems that are increasingly shaping our world." It is a good line. It is also, as far as I can tell, not actually his. I went looking for the source and came back with nothing. It is a modern paraphrase wearing a Postman coat.
+
+So let me hand you the real thing instead, because the real thing has teeth.
+
+>>> The opposite of AI hype is not AI panic. It is civic attention.
+
+## Postman was not anti-technology. He was anti-surrender
+
+In [Technopoly](https://en.wikipedia.org/wiki/Technopoly), his 1992 book, Postman describes a character he calls the loving resistance fighter. Not a luddite. Not a guy jamming his boot into the gears. Someone who simply refuses to treat technology as weather, as fate, as a thing that just happens to us with no author and no off switch.
+
+QUOTE: a technological resistance fighter maintains an epistemological and psychic distance from any technology, so that it always appears somewhat strange, never inevitable, never natural. || Neil Postman, Technopoly (1992)
+
+Read it twice. Keep it strange. Never inevitable. Never natural.
+
+That is the entire discipline, and it is the opposite of how we are being sold AI right now.
+
+The conversation keeps collapsing into two dumb costumes. Priest of the miracle on one side, telling you the future is already decided and resistance is just nostalgia in a cardigan. Prophet of doom on the other, telling you it is all theft and collapse and you are a sucker for even opening the app.
+
+Postman hands you a third move. Use the thing. Stay awake while you use it.
+
+>>> AI does not need more priests or more doom. It needs citizens with receipts.
+
+If you have never heard Postman make this case in his own voice, it holds up. In 1992, the year Technopoly came out, he was on television saying it to anyone who would book him, sounding less like a scold than like a man who could already see the shape of the thing coming.
+
+## This is moving faster than our judgment
+
+A receipt, since I believe in those. The 2026 [Stanford AI Index](https://hai.stanford.edu/ai-index/2026-ai-index-report) clocked generative AI at roughly 53 percent adoption worldwide within three years of showing up. The personal computer took about fifteen years to travel that far. The internet took about seven. (Canada and the US actually sit below that global number, which is its own awkward conversation for another day.)
+
+Now look at school, where it matters most. More than 80 percent of American high school and college students already use AI for their work. Only about half of schools have any AI policy at all. And a grand total of 6 percent of teachers say their school's policy is clear.
+
+Sit with that gap. The tool is everywhere. The judgment about the tool is nowhere.
+
+That is the exact condition Postman spent his life warning about. A technology going mythic. Becoming weather. Becoming common sense before the culture ever sat down and decided what it was actually for.
+
+>>> The tool is everywhere. The judgment about the tool is nowhere.
+
+## A tool is never just a tool. It ships with a worldview
+
+This is the part people skip. They treat AI like a faster calculator, a neutral pipe you pour your intentions through. Postman's whole career was an argument against exactly that fantasy.
+
+QUOTE: embedded in every tool is an ideological bias, a predisposition to construct the world as one thing rather than another, to value one thing over another, to amplify one sense or skill or attitude more loudly than another. || Neil Postman, Technopoly (1992)
+
+He got a lot of this from McLuhan, who taught a generation that the medium is the message. The shape of a tool changes you more than whatever content happens to run through it.
+
+![Marshall McLuhan leaning against a television set that displays his own face, 1967](img:mcluhan)
+
+A chatbot teaches you things before you read a single word of its output. It teaches you that language can be produced without anyone having lived anything. That confidence and accuracy are the same costume. That a fast, fluent, plausible answer has earned the same trust as a true one.
+
+Every AI system quietly answers a question before you ask it one. The question is: what does this thing think a human being is?
+
+YT: HeDnPP6ntic || McLuhan describing the "global village" on CBC in 1960. He is talking about electric media. Swap in the word AI and he barely misses.
+
+## The real danger is not bad output. It is outsourced judgment
+
+Bad answers we can catch. The deeper risk is what we hand over without even noticing we let go.
+
+Postman borrowed a phrase from the psychologist [Stanley Milgram](https://en.wikipedia.org/wiki/Stanley_Milgram): the agentic shift. Milgram used it for the moment a person stops acting as a moral agent and starts acting as the instrument of some authority. The "I was only following orders" reflex. In Technopoly, Postman saw the same move happening between people and machines. We let the system hold the responsibility so we do not have to.
+
+You hear it everywhere now. The model said. The algorithm flagged it. The agent decided. The dashboard recommends. The score came back low, sorry, nothing I can do.
+
+Every one of those sentences is a human being stepping behind a machine so they do not have to stand in front of a decision.
+
+I wrote a whole piece about the small, sneaky, personal version of this, the habit of asking [what Chat would do](https://kriskrug.co/2026/06/28/what-would-chat-do-and-why-thats-the-wrong-question/) instead of what you think. Same disease. Smaller dose.
+
+>>> The machine must not become the excuse.
+
+So responsible AI is not only bias testing and red teaming, important as those are. It is responsibility tracking. Who chose to use this. Who benefits. Who gets harmed. Who can appeal. Who is allowed to look inside. Who is accountable when the answer arrives wearing the lab coat of objectivity.
+
+Postman put the cleanest version of this to an interviewer back in 1995, and it still cuts. Am I using this technology, or is it using me?
+
+## Technological resistance is a practice, not a vibe
+
+Here is what the discipline actually looks like on a Tuesday. Not a manifesto. A set of habits. I call it CASK. It is the working version of something I keep circling back to, the idea that you show up to this with [both hands full](https://kriskrug.co/2026/01/24/both-hands-full/). Curiosity in one hand. Boundaries in the other.
+
+**Curiosity.** Actually use the tools. Learn what they are genuinely good at and where they fall on their face. You cannot resist what you refuse to understand, and criticism from total ignorance is just vibes with a grudge.
+
+**Awareness.** Know the supply chain behind the magic trick. The data. The labour, including the people paid badly to label the worst of the internet so you never have to see it. The water and the power feeding the data centres. The capital. Who actually owns the model you are about to build your life on top of.
+
+**Skepticism.** Demand receipts. What benchmark. Whose dataset. Compared to what. "It's AI" is not evidence. It is marketing with better lighting.
+
+**Caution.** Slow all the way down where the stakes are high and the people are vulnerable. Kids. Health. Courts. Hiring. Benefits. Surveillance. Anywhere a wrong answer lands on someone who has no way to push back.
+
+None of that is anti-AI. It is anti-stupid-AI. There is a real difference, and most of the grown-up conversation lives inside it.
+
+The sober institutions are circling the same idea, slower and in worse prose. [NIST's AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) exists to incorporate trustworthiness into how AI gets designed, used, and evaluated, and to manage risk to individuals, organizations, and society. The [OECD's AI Principles](https://oecd.ai/en/ai-principles), updated in 2024, ask for transparency, accountability, and what they call human agency and oversight. That is Postman in a policy suit.
+
+---
+
+## Canada just bet $200 billion. It needs a public layer, not just a target
+
+This stopped being abstract for me a few weeks ago, because my country went all in.
+
+On June 4, 2026, the federal government launched [AI for All](https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all), a national strategy with real numbers bolted on. An extra 200 billion dollars in economic growth. 250,000 new AI jobs over five years. Business adoption pushed from just over 12 percent today to 60 percent by 2034. The new AI minister, Evan Solomon, framed it with a line Postman would have nodded at: AI that serves Canadians, not the other way around.
+
+Good slogan. Now hold it over the fire.
+
+Because the governance underneath is thin. Canada's first serious attempt at AI law, AIDA, died on the order paper in January 2025 when Parliament was prorogued, and it has not come back. So as of this summer we have a very ambitious spending plan and no binding federal AI law for it to sit under. Adoption targets are easy. Accountability is the hard part, and the hard part is the part we keep quietly deferring.
+
+Pointing AI at a broken system does not fix the system. It just automates the brokenness at scale, which is a [whole post of its own](https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/). Adoption without literacy is just compliance theatre with a bigger budget.
+
+I have made this argument twice already this month, that [Canada does not need a bigger AI machine, it needs a better one](https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/), and that sovereignty is meaningless until you answer [sovereign AI for whom](https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/). A country can buy every GPU on earth and still hand its judgment away.
+
+What Canada actually needs, more than one more adoption statistic, is more technological resistance fighters. People inside the rooms whose entire job is to keep the machine strange.
+
+And not by building a smaller Silicon Valley. Out here in BC the better bet is a community-rooted version, where artists, educators, founders, Indigenous leaders, workers, and the usefully skeptical get to shape adoption before adoption shapes them. That is the whole point of [BC + AI](https://bc-ai.ca/) and most of the work I spend my time on. Communities lead. Technology serves. People keep asking who gains power and who quietly loses it.
+
+## What will AI undo?
+
+Postman's single most useful question is not even in Technopoly. It is in a talk he gave in Denver in 1998 called [Five Things We Need to Know About Technological Change](https://student.cs.uwaterloo.ca/~cs492/papers/neil-postman--five-things.html). His first rule:
+
+QUOTE: Technology giveth and technology taketh away. This means that for every advantage a new technology offers, there is always a corresponding disadvantage. || Neil Postman, "Five Things We Need to Know About Technological Change," 1998
+
+So he made you ask both halves, every time. What will a new technology do, and what will a new technology undo.
+
+AI will undo plenty that has it coming. Soul-crushing paperwork. Language barriers. The tyranny of the blank page. Expensive prototyping. Expertise locked behind a paywall or a PhD. The administrative sludge that eats a working artist's whole week, which is [most of what I actually use it for](https://kriskrug.co/2026/05/21/the-75-percent-rule-ai-art-adjacent-work/).
+
+AI may also undo things we will only miss once they are gone. Authorship. Apprenticeship. The patience to sit inside a hard thought instead of autocompleting straight past it. Consent. Local knowledge. Fair pay for creative work. The plain civic assumption that a human being stands behind a decision that lands on your life.
+
+Both lists are true at the same time. Holding both at once is the only adult sentence available in this whole argument.
+
+![A working replica of an early Gutenberg-style printing press at the Gutenberg Museum in Mainz](img:gutenberg)
+
+Postman loved the printing press as his example, because it is the cleanest case of giveth and taketh there is. It shattered the church's monopoly on knowledge and lit the fuse on science and democracy. It also helped burn a lot of so-called witches and dropped Europe into a century of religious war. Same machine. Both ledgers. The people living through it did not get to opt out. They only got to decide how awake they would be while it happened.
+
+This is where Postman gets quietly terrifying. In [Amusing Ourselves to Death](https://en.wikipedia.org/wiki/Amusing_Ourselves_to_Death) he warned that our future might not arrive as Orwell's boot. It might arrive as Huxley's pleasure.
+
+QUOTE: people will come to love their oppression, to adore the technologies that undo their capacities to think. || Neil Postman, Amusing Ourselves to Death (1985)
+
+Tell me that does not describe an endless, personalized, always-agreeable answer machine that never once asks you to struggle.
+
+---
+
+## Keep it strange
+
+So what does technological resistance actually ask of us, past having a good attitude about it? A few concrete things, and not one of them is "log off."
+
+- Public AI literacy that teaches judgment, not just prompting. Knowing when not to reach for it is the senior skill.
+- Procurement rules, especially in government, that require transparency, a real path to appeal, and a named human who is accountable.
+- Honest environmental accounting for the compute and the data centres, instead of filing the power and water under someone else's problem.
+- Indigenous data sovereignty and genuine consent built in as infrastructure, not bolted on later as a consultation photo op.
+- Audits that include lived experience, not only the metrics that happen to be easy to measure.
+- Rooms where the builders and the critics are not sorted into enemy camps, because the most useful person in the room is almost always fluent in both.
+
+Postman's resistance fighter was never trying to stop the future. He was trying to keep human beings awake inside it.
+
+That is the assignment. Not to flee the machine. Not to worship it. To keep it strange enough that we can still choose what kind of humans we intend to become.
+
+>>> AI is not the weather. It is made by people, funded by people, deployed by people, and it can be resisted and redirected by people.
+
+His last rule from that 1998 talk still holds, with one small typo fixed. Proceed with our eyes wide open, so that we use technology rather than be used by it.
+
+Keep it strange.
+
+---
+
+## Related
+
+- [Canada Doesn't Need a Bigger AI Machine. It Needs a Better One.](https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/)
+- [Sovereign AI for Whom?](https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/)
+- [What Would Chat Do? And Why That's the Wrong Question](https://kriskrug.co/2026/06/28/what-would-chat-do-and-why-thats-the-wrong-question/)
+- [AI Won't Fix Your Broken Permit Process](https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/)
+- [The 75% Rule: Send AI After the Art-Adjacent Work](https://kriskrug.co/2026/05/21/the-75-percent-rule-ai-art-adjacent-work/)
+- [Both Hands Full](https://kriskrug.co/2026/01/24/both-hands-full/)

--- a/content/drafts/2026-06-28-keep-the-machine-strange/publish-gate.md
+++ b/content/drafts/2026-06-28-keep-the-machine-strange/publish-gate.md
@@ -1,0 +1,20 @@
+# Publish gate — Keep the Machine Strange (2026-06-28)
+
+DRAFT staged. Create on kriskrug.co:
+  python3 scripts/notion-to-wp/publish_keep_the_machine_strange.py            # dry-run
+  python3 scripts/notion-to-wp/publish_keep_the_machine_strange.py --execute  # draft-only, slug-idempotent
+
+Routing: post; categories AI Ethics & Philosophy (1678) + Responsible AI & Policy (1754); status=draft.
+
+Citation hygiene:
+- "technological resistance: a discerning, lucid, vigilant engagement…" = contemporary paraphrase, NOT Postman. Said so in the piece.
+- Verified: Technopoly Ch.11 ("strange, never inevitable, never natural"; "embedded in every tool…"); "Five Things" 1998 ("technology giveth…"; "what will a new technology undo?"); Amusing Ourselves to Death (Huxley). Agentic shift = Milgram, used by Postman (Technopoly Ch.7).
+
+Receipts (verified + corrected):
+- Stanford AI Index 2026: 53% gen-AI adoption = GLOBAL (US 28.3%).
+- Canada "AI for All" (2026-06-04): $200B, 250k jobs, 12%->60% by 2034; "serves Canadians" = Min. Evan Solomon.
+- AIDA died on order paper Jan 2025; no binding federal AI law. NIST AI RMF; OECD 2024 update for "human agency and oversight".
+
+Media: McLuhan global-village embed (CBC 1960, HeDnPP6ntic, verified). Featured: McLuhan 1967 (public domain, LoC). Section art: Gutenberg press (CC BY 2.0, dronepicr); attribution in captions. No free Postman portrait; two Postman interview clips were not embeddable, so rendered as prose. img/ working copies are re-fetched by the script + uploaded to WP media; not committed.
+
+Dry-run: 80 blocks | 9 headings, 5 pullquotes, 4 quotes, 1 embed, 2 images, 2 lists.

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Publish "Keep the Machine Strange" as a WordPress DRAFT on kriskrug.co.
+
+Stdlib-only on top of scripts/common.py's verified WPClient (Basic auth + retry).
+Reads content/drafts/2026-06-28-keep-the-machine-strange/post.md, converts the
+marker syntax to Gutenberg blocks, uploads licensing-clean images (idempotent by
+filename), and creates the draft. Dry-run by default; --execute creates; --update
+refreshes the body of the existing draft. NEVER publishes (status stays draft).
+
+Marker syntax in post.md (each marker is its own blank-line-delimited block):
+  ## X / ### X            -> wp:heading (h2/h3)
+  ---                     -> wp:separator
+  >>> X [|| cite]         -> wp:pullquote (KK's punchy lines)
+  QUOTE: X || cite        -> wp:quote with <cite> (verbatim, attributed source)
+  YT: VIDEO_ID || caption -> wp:embed (YouTube, 16:9 responsive)
+  ![alt](img:KEY)         -> wp:image resolved from IMAGES (downloaded + uploaded)
+  - item / - item         -> wp:list (consecutive "- " lines)
+  everything else         -> wp:paragraph
+Inline: [text](url) (external gets target=_blank), **bold**, *italic*.
+
+Images are downloaded from their source (Wikimedia) with attribution baked into
+the figcaption, then uploaded once and reused on re-runs. The hero/featured image
+is content/drafts/.../img/hero.png if present, else it falls back to the McLuhan
+public-domain image so the OG/social card is never empty.
+"""
+import json
+import pathlib
+import re
+import sys
+import unicodedata
+import urllib.request
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from common import WPClient, load_env, wp_credentials  # noqa: E402
+
+ENV_PATH = "/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+STAGE = REPO_ROOT / "content/drafts/2026-06-28-keep-the-machine-strange"
+EXECUTE = "--execute" in sys.argv
+UPDATE = "--update" in sys.argv
+WRITE = EXECUTE or UPDATE
+
+TITLE = "Keep the Machine Strange: Technological Resistance in the Age of AI"
+SLUG = "keep-the-machine-strange"
+DATE = "2026-06-28T09:00:00"
+CATEGORY_IDS = [1678, 1754]  # AI Ethics & Philosophy; Responsible AI & Policy
+TAGS = ["Neil Postman", "Marshall McLuhan", "Technopoly", "Media Ecology",
+        "Responsible AI", "AI Governance", "AI for All", "Both Hands Full",
+        "Technological Resistance"]
+SEO_TITLE = "Keep the Machine Strange: Neil Postman, AI, and Technological Resistance | Kris Krüg"
+META_DESC = ("Neil Postman gave us a discipline for refusing technological inevitability. "
+             "In the age of AI, technological resistance is not rejection. It is civic attention.")
+EXCERPT = ("Neil Postman did not predict AI. He left us something more useful: a discipline for "
+           "refusing to treat any technology as the weather. Here is what technological "
+           "resistance looks like in 2026.")
+
+# Licensing-clean images, downloaded from source then uploaded once. Attribution
+# lives in the figcaption so CC BY terms are satisfied on the page itself.
+IMAGES = {
+    "mcluhan": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/3/38/Marshall_McLuhan_with_and_on_television_%28cropped%29.jpg",
+        "file": "mcluhan-1967.jpg",
+        "mime": "image/jpeg",
+        "alt": "Marshall McLuhan leaning against a television set that displays his own face, 1967",
+        "caption": "Marshall McLuhan, 1967. Photo by Bernard Gotfryd, Library of Congress (public domain).",
+        "align": "center", "width": 620,
+    },
+    "gutenberg": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/6/62/Gutenberg%27s_vintage_printing_press_in_the_Gutenberg_Museum_in_Mainz%2C_Germany_%2848988497077%29.jpg",
+        "file": "gutenberg-press.jpg",
+        "mime": "image/jpeg",
+        "alt": "A working replica of an early Gutenberg-style printing press at the Gutenberg Museum in Mainz",
+        "caption": ('Gutenberg press replica, Gutenberg Museum, Mainz. Photo by dronepicr, '
+                    '<a href="https://creativecommons.org/licenses/by/2.0/" target="_blank" '
+                    'rel="noopener noreferrer">CC BY 2.0</a>.'),
+        "align": "center", "width": 720,
+    },
+}
+HERO_FILE = STAGE / "img" / "hero.png"  # optional Rafiki hero; falls back to mcluhan
+
+
+def normalize_seo_meta(text: str) -> str:
+    """NFC then drop combining marks (Jetpack SEO REST 500s on combining diacritics)."""
+    nfc = unicodedata.normalize("NFC", text)
+    return "".join(ch for ch in nfc if not unicodedata.combining(ch))
+
+
+def slugify(s: str) -> str:
+    s = s.lower().strip()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"\s+", "-", s)
+    return re.sub(r"-+", "-", s).strip("-")
+
+
+def inline(s: str) -> str:
+    def link(m):
+        text, url = m.group(1), m.group(2)
+        extra = "" if url.startswith(("https://kriskrug.co", "/", "#")) else ' target="_blank" rel="noopener noreferrer"'
+        return f'<a href="{url}"{extra}>{text}</a>'
+    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link, s)
+    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
+    return s
+
+
+def http_get(url: str, timeout: int = 120) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (kriskrug.co editorial bot)"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def yt_ok(vid: str) -> bool:
+    try:
+        http_get(f"https://www.youtube.com/oembed?url=https://youtu.be/{vid}&format=json", timeout=20)
+        return True
+    except Exception:
+        return False
+
+
+# ---- blocks -----------------------------------------------------------------
+def b_heading(text, level):
+    attr = "" if level == 2 else ' {"level":3}'
+    return f"<!-- wp:heading{attr} -->\n<h{level}>{inline(text)}</h{level}>\n<!-- /wp:heading -->"
+
+
+def b_separator():
+    return '<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->'
+
+
+def b_list(items):
+    lis = "".join(f"<!-- wp:list-item -->\n<li>{it}</li>\n<!-- /wp:list-item -->\n" for it in items)
+    return f'<!-- wp:list -->\n<ul class="wp-block-list">\n{lis}</ul>\n<!-- /wp:list -->'
+
+
+def b_pullquote(text, cite=None):
+    body = f"<p>{inline(text)}</p>" + (f"<cite>{inline(cite)}</cite>" if cite else "")
+    return f'<!-- wp:pullquote -->\n<figure class="wp-block-pullquote"><blockquote>{body}</blockquote></figure>\n<!-- /wp:pullquote -->'
+
+
+def b_quote(text, cite=None):
+    body = f"<p>{inline(text)}</p>" + (f"<cite>{inline(cite)}</cite>" if cite else "")
+    return f'<!-- wp:quote -->\n<blockquote class="wp-block-quote">{body}</blockquote>\n<!-- /wp:quote -->'
+
+
+def b_youtube(vid, caption=None):
+    url = f"https://www.youtube.com/watch?v={vid}"
+    cap = f'<figcaption class="wp-element-caption">{inline(caption)}</figcaption>' if caption else ""
+    return (
+        '<!-- wp:embed {"url":"%s","type":"video","providerNameSlug":"youtube","responsive":true,'
+        '"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->\n'
+        '<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube '
+        'wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">\n%s\n'
+        "</div>%s</figure>\n<!-- /wp:embed -->" % (url, url, cap)
+    )
+
+
+def b_image(media_id, url, alt, caption=None, width=None, align="center"):
+    attrs = f'"id":{media_id},"sizeSlug":"large","linkDestination":"media","align":"{align}"'
+    figcls = f"wp-block-image align{align} size-large"
+    style = ""
+    if width:
+        attrs += f',"width":"{width}px"'
+        figcls += " is-resized"
+        style = f' style="width:{width}px"'
+    img = f'<a href="{url}"><img src="{url}" alt="{alt}" class="wp-image-{media_id}"{style}/></a>'
+    cap = f'<figcaption class="wp-block-image__caption">{caption}</figcaption>' if caption else ""
+    return f'<!-- wp:image {{{attrs}}} -->\n<figure class="{figcls}">{img}{cap}</figure>\n<!-- /wp:image -->'
+
+
+# ---- media upload (idempotent) ----------------------------------------------
+def find_media(c, stem):
+    try:
+        r = c.get("media", params={"search": stem, "per_page": 10, "context": "edit"})
+    except Exception:
+        return None
+    for m in r or []:
+        base = m.get("source_url", "").rsplit("/", 1)[-1]
+        if base.startswith(stem):
+            return m["id"], m["source_url"]
+    return None
+
+
+def upload_media(c, path, alt, mime):
+    found = find_media(c, path.stem)
+    if found:
+        print(f"   [media] REUSE {path.name} -> id={found[0]}")
+        if alt:
+            c.post(f"media/{found[0]}", {"alt_text": alt})
+        return found
+    data = path.read_bytes()
+    req = urllib.request.Request(
+        f"{c.base}/wp-json/wp/v2/media", data=data, method="POST",
+        headers={"Authorization": c._auth,
+                 "Content-Disposition": f'attachment; filename="{path.name}"',
+                 "Content-Type": mime},
+    )
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        media = json.loads(resp.read().decode())
+    if alt:
+        c.post(f"media/{media['id']}", {"alt_text": alt})
+    print(f"   [media] NEW   {path.name} -> id={media['id']} {media['source_url']}")
+    return media["id"], media["source_url"]
+
+
+def ensure_term(c, taxonomy, name):
+    hits = c.get(taxonomy, params={"search": name, "per_page": 50, "context": "edit"})
+    for t in hits or []:
+        if t.get("name", "").lower() == name.lower() or t.get("slug", "") == slugify(name):
+            return t["id"]
+    return c.post(taxonomy, {"name": name, "slug": slugify(name)})["id"]
+
+
+# ---- load + verify post.md --------------------------------------------------
+raw = (STAGE / "post.md").read_text(encoding="utf-8")
+fm_end = raw.index("\n---", raw.index("---") + 3)
+body = raw[fm_end + 4:]
+assert "—" not in body, "em-dash leaked into post.md body"
+
+base, user, pw = wp_credentials(load_env(ENV_PATH))
+c = WPClient(base, user, pw)
+
+# ---- verify YouTube embeds resolve ------------------------------------------
+yt_ids = re.findall(r"^YT:\s*([A-Za-z0-9_-]{6,})", body, re.M)
+print(f"[youtube] checking {len(yt_ids)} embeds")
+for vid in yt_ids:
+    print(f"   {'OK ' if yt_ok(vid) else 'FAIL'} {vid}")
+
+# ---- download + (optionally) upload images ----------------------------------
+(STAGE / "img").mkdir(parents=True, exist_ok=True)
+resolved = {}
+for key, meta in IMAGES.items():
+    dest = STAGE / "img" / meta["file"]
+    if not (dest.exists() and dest.stat().st_size > 0):
+        dest.write_bytes(http_get(meta["url"]))
+        print(f"[img] downloaded {key} -> {dest.name} ({dest.stat().st_size}b)")
+    else:
+        print(f"[img] cached     {key} -> {dest.name} ({dest.stat().st_size}b)")
+    if WRITE:
+        resolved[key] = upload_media(c, dest, meta["alt"], meta["mime"])
+    else:
+        resolved[key] = (0, f"DRYRUN/{meta['file']}")
+
+# hero / featured
+if HERO_FILE.exists() and HERO_FILE.stat().st_size > 0:
+    FEATURED_ID = upload_media(c, HERO_FILE, "Keep the machine strange: technological resistance in the age of AI", "image/png")[0] if WRITE else 0
+    print(f"[hero] using Rafiki hero {HERO_FILE.name} -> featured id={FEATURED_ID}")
+else:
+    FEATURED_ID = resolved["mcluhan"][0]
+    print(f"[hero] no hero.png; falling back to McLuhan image as featured (id={FEATURED_ID})")
+
+# ---- build blocks -----------------------------------------------------------
+out = []
+for blk in [b.strip() for b in re.split(r"\n\s*\n", body) if b.strip()]:
+    if blk == "---":
+        out.append(b_separator())
+    elif blk.startswith("### "):
+        out.append(b_heading(blk[4:].strip(), 3))
+    elif blk.startswith("## "):
+        out.append(b_heading(blk[3:].strip(), 2))
+    elif blk.startswith(">>> "):
+        text, _, cite = blk[4:].partition(" || ")
+        out.append(b_pullquote(text.strip(), cite.strip() or None))
+    elif blk.startswith("QUOTE: "):
+        text, _, cite = blk[7:].partition(" || ")
+        out.append(b_quote(text.strip(), cite.strip() or None))
+    elif blk.startswith("YT: "):
+        vid, _, cap = blk[4:].partition(" || ")
+        out.append(b_youtube(vid.strip(), cap.strip() or None))
+    else:
+        m = re.match(r"^!\[(.*?)\]\(img:([a-z0-9_-]+)\)$", blk)
+        blk_lines = [ln.strip() for ln in blk.split("\n") if ln.strip()]
+        if m:
+            alt, key = m.group(1), m.group(2)
+            mid, url = resolved[key]
+            meta = IMAGES[key]
+            out.append(b_image(mid, url, alt or meta["alt"], caption=meta.get("caption"),
+                               width=meta.get("width"), align=meta.get("align", "center")))
+        elif blk_lines and all(ln.startswith("- ") for ln in blk_lines):
+            out.append(b_list([inline(ln[2:].strip()) for ln in blk_lines]))
+        else:
+            para = "<br>".join(inline(line.strip()) for line in blk.split("\n"))
+            out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
+
+content = "\n\n".join(out)
+(STAGE / "post.html").write_text(content, encoding="utf-8")
+
+# ---- sanity -----------------------------------------------------------------
+assert "—" not in content, "em-dash leaked into content"
+assert "](img:" not in content, "unresolved image marker"
+assert "QUOTE:" not in content, "unresolved QUOTE marker"
+n_h = content.count("<!-- wp:heading")
+n_pq = content.count("<!-- wp:pullquote")
+n_q = content.count("<!-- wp:quote")
+n_em = content.count("<!-- wp:embed")
+n_img = content.count("<!-- wp:image")
+n_li = content.count("<!-- wp:list ")
+print(f"[blocks] {len(out)} blocks | headings={n_h} pullquotes={n_pq} quotes={n_q} embeds={n_em} images={n_img} lists={n_li} | {len(content)}b staged")
+
+if not WRITE:
+    print("\nDRY-RUN complete. --execute creates the draft; --update refreshes the body.")
+    sys.exit(0)
+
+# ---- create / update draft (idempotent by slug, never publishes) -------------
+hits = c.get("posts", params={"slug": SLUG, "status": "any", "context": "edit", "per_page": 5})
+existing = hits[0] if isinstance(hits, list) and hits else None
+author_id = int(load_env(ENV_PATH).get("WP_DEFAULT_AUTHOR_ID") or 18)
+
+if UPDATE:
+    if not existing:
+        sys.exit(f"[ABORT] --update but no post with slug {SLUG}. Run --execute first.")
+    pid = existing["id"]
+    c.post(f"posts/{pid}", {"content": content, "featured_media": FEATURED_ID})
+    print(f"[post] UPDATED draft id={pid}")
+else:
+    if existing:
+        sys.exit(f"[ABORT] slug {SLUG} already exists (id={existing['id']}). Use --update.")
+    tag_ids = [ensure_term(c, "tags", t) for t in TAGS]
+    payload = {
+        "title": TITLE, "slug": SLUG, "status": "draft", "date": DATE,
+        "author": author_id, "content": content, "excerpt": EXCERPT,
+        "categories": CATEGORY_IDS, "tags": tag_ids, "featured_media": FEATURED_ID,
+        "meta": {"advanced_seo_description": normalize_seo_meta(META_DESC),
+                 "jetpack_seo_html_title": normalize_seo_meta(SEO_TITLE)},
+    }
+    post = c.post("posts", payload)
+    pid = post["id"]
+    print(f"[post] CREATED draft id={pid} status={post['status']}")
+
+# ---- readback ---------------------------------------------------------------
+v = c.get(f"posts/{pid}", params={"context": "edit"})
+vc = v["content"]["raw"]
+checks = {
+    "status_is_draft": v["status"] == "draft",
+    "not_published": v["status"] != "publish",
+    "featured_set": bool(v.get("featured_media")) and v.get("featured_media") == FEATURED_ID,
+    "embeds_1": vc.count("wp:embed") == 2,            # one McLuhan embed; open+close
+    "quotes_4": vc.count("<!-- wp:quote") == 4,
+    "pullquotes_5plus": vc.count("<!-- wp:pullquote") >= 5,
+    "images_2": vc.count("<!-- wp:image") == 2,
+    "no_em_dash": "—" not in vc,
+    "seo_title_meta": v.get("meta", {}).get("jetpack_seo_html_title") == normalize_seo_meta(SEO_TITLE),
+    "seo_desc_meta": v.get("meta", {}).get("advanced_seo_description") == normalize_seo_meta(META_DESC),
+    "links_canada": "canada-doesnt-need-a-bigger-ai-machine" in vc,
+    "links_sovereign": "sovereign-ai-for-whom" in vc,
+    "links_chat": "what-would-chat-do" in vc,
+    "links_bothhands": "/2026/01/24/both-hands-full/" in vc,
+    "cites_five_things": "neil-postman--five-things" in vc,
+}
+preview = f"{c.base}/?p={pid}&preview=true"
+edit = f"{c.base}/wp-admin/post.php?post={pid}&action=edit"
+(STAGE / "publish.log").write_text(
+    f"{'updated' if UPDATE else 'created'} draft id={pid} status={v['status']}\n"
+    f"preview={preview}\nedit={edit}\nfeatured={FEATURED_ID}\n\n" + json.dumps(checks, indent=2),
+    encoding="utf-8")
+print("\n=== VERIFY ===")
+for k, val in checks.items():
+    print(f"  {'OK  ' if val else 'FAIL'} {k}")
+print(f"\nPREVIEW: {preview}\nEDIT:    {edit}\nDONE — left as DRAFT.")


### PR DESCRIPTION
## What
New kriskrug.co thought-leadership draft, *Keep the Machine Strange: Technological Resistance in the Age of AI*, plus the publish script and a verification doc. Created as a **draft**, not published.

## Citation hygiene
- Flags the viral "technological resistance: a discerning, lucid, vigilant engagement…" line as a contemporary paraphrase, **not** Postman (no traceable source).
- Verified quotes from Technopoly (Ch.11 + Ch.1), the 1998 "Five Things" talk, and Amusing Ourselves to Death; agentic shift attributed to Milgram.
- Corrected receipts: AI Index 2026 (53% is **global**), Canada "AI for All" (2026-06-04; "serves Canadians" = Min. Solomon), AIDA dead Jan 2025, NIST, OECD 2024.

## Media / links
- Embeddable McLuhan clip (CBC 1960); two non-embeddable Postman clips rendered as prose, not broken embeds.
- McLuhan 1967 (public domain) featured; Gutenberg press (CC BY 2.0); attribution in captions.
- Cross-linked: Canada AI Machine, Sovereign AI for Whom, What Would Chat Do, Broken Permit Process, 75% Rule, Both Hands Full.

## Publish
`python3 scripts/notion-to-wp/publish_keep_the_machine_strange.py --execute` (draft-only). Dry-run: 80 blocks, 9 headings, 5 pullquotes, 4 quotes, 1 embed, 2 images, 2 lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
