### PR TITLE
Consolidate post block markup into one shared wp_blocks module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ __pycache__/
 # raw photo originals (working only, do not commit)
 content/drafts/2026-05-23-you-cant-drink-data/photos-raw/
 content/drafts/2026-05-23-you-cant-drink-data/contact-sheets/
+
+# lightbox backfill rollback manifests (large, operational; keep on disk, not in git)
+scripts/notion-to-wp/backfill-rollback*.jsonl

--- a/content/drafts/2026-06-28-context-creators/FACT-CHECK.md
+++ b/content/drafts/2026-06-28-context-creators/FACT-CHECK.md
@@ -11,17 +11,19 @@ summit Otter transcripts/recaps + PROJECT-DOSSIER).
 
 ## FIXED in the draft
 - **Stephanie Humphrey handle**: was `@techgirlfriend_` (in no source) -> now **@TechLifeSteph** (KB people-file + web both confirm; linked to instagram.com/techlifesteph).
+- **"nine months" -> "four months"** (2026-06-28). KB opening recap calls it a "four-month fellowship pairing Philadelphia newsrooms with independent creators." Also resolves the internal contradiction with the piece's own "Four Months" subtitle.
+- **Bobachi Food Pantry video re-credited Terrill -> Brou** (2026-06-28). KB recap: the Bobachi "doubled capacity" video sits under the Green Philly section and is Brou Quinn's (his video traced rescue food through Bobachi). Terrill's section is sanitation/origin, no Bobachi. Moved the sentence into Brou's paragraph; it fits his food-culture beat.
+- **"2M reach for Inti Media" -> "565,000-follower reach for Inti Media"** (2026-06-28). KB: the 2M+ total views are Green Philly's; Inti Media's headline metric is Che Guerrero's 565k followers. Substituted Inti's real number rather than the misattributed one.
 
 ## OPEN FLAGS — KK to confirm/correct before scheduling
-These come from the original Notion draft and are NOT supported by the KB. Left as written; your call.
+These come from the original Notion draft and have NO authoritative replacement in the KB, so they were left exactly as written. Swapping in a KB-derived number would just trade one unverified figure for another; only KK can confirm the real ones.
 
-1. **"$160,000" total Lenfest investment** (used twice + the "less than one senior reporter's salary" line). KB grant math = ~$200K ($30K x4 newsrooms + $10K x8 creators); summit README cites a broader "$1.5M Lenfest investment." $160K appears in no source. If wrong, the rhetorical beat needs a rework.
-2. **"across nine months"** (the newsroom + creator pairing). KB says a **four-month fellowship** (Jan 15 to Apr 24), or 6 months counting listening sessions. Also note the piece's own subtitle says "Four Months," so "nine months" reads as an internal contradiction.
-3. **"2M reach for Inti Media"** is misattributed. The 2M reach belongs to **Green Philly / Brou Quinn**. Inti's headline number is Che's 565k followers.
-4. **"4M+ combined video views"** and **Terrill "4M+ views in the last three months"** are not in the KB. Closest is Brou's ~4,000 new followers / 2M reach. Possible 4,000 -> 4M slip.
-5. **Bobachi Food Pantry** "doubled attendance" video was **Brou Quinn's**, not Terrill's (the draft credits it to Terrill).
-6. **Che "between January and April"** — KB sources the line to "the last two months." Minor.
-7. **"525 people to a 5K"** (Elena) and **"GMA3"** (Stephanie) — not in the KB. Not necessarily wrong, just unverifiable here.
+1. **"$160,000" total Lenfest investment** (used twice + the "less than one senior reporter's salary" line). KB states per-unit funding ("$30K per newsroom, $10K per creator") which works out to ~$200K for 4 newsrooms + 8 creators; the summit README cites a broader "$1.5M Lenfest investment." None of these is $160K. Pick the real total; if it's materially higher, the "less than one senior reporter" beat needs a rework.
+2. **"4M+ combined video views"** (summit-metrics line) and **Terrill "4M+ views in the last three months"** (opening). Neither is in the KB. Closest KB figure is Brou's ~4,000 new followers in 3 months / Green Philly's 2M+ views. Possible 4,000 -> 4M slip, or a real cross-platform number KK has. Confirm before publish.
+
+## Unverifiable but not necessarily wrong (no action)
+- **"525 people to a 5K"** (Elena) and **"GMA3"** (Stephanie) — not in the KB, but plausible direct knowledge. Left as written.
+- **Che "between January and April"** — KB phrases it "the last two months"; the draft's window is close enough and stays in KK's voice.
 
 ## Added since first draft
 - 3 real screenshots from your AI-Assisted Workflows deck (Persona/Output/Parameters #12405, Transcript->Story 3-4 hrs #12406, Five Rules #12407), placed as captioned receipts in "What I Actually Did."

--- a/content/drafts/2026-06-28-context-creators/FACT-CHECK.md
+++ b/content/drafts/2026-06-28-context-creators/FACT-CHECK.md
@@ -1,0 +1,27 @@
+# Context Creators — fact-check flags (before publish)
+
+Draft: kriskrug.co post **12404** (status: draft). Checked against KB
+`notion-local/content/projects/09-pmfe-philadelphia/` (people files + 2026-04-24
+summit Otter transcripts/recaps + PROJECT-DOSSIER).
+
+## Verified clean
+- **All 11 verbatim quotes** (Jos/Terrill/Will/Che/Debora/Elena/KK/Joy/Shawn/Detavio) match the transcripts, including "Neural does not equate to neutral."
+- **Elena Gonzalez Johnson** name is CORRECT (her own on-stage intro). The KB file `elaine-johnson.md` and bot "Elaine Bot" are the stale artifacts, not the draft.
+- Names/orgs/handles otherwise verified: Jos, Terrill (@_yafavtrashman), Brou (@215phillyfood), Chelsea, Che (565k), Debora, Alisha, Will, Shawn, Detavio, thanks list.
+
+## FIXED in the draft
+- **Stephanie Humphrey handle**: was `@techgirlfriend_` (in no source) -> now **@TechLifeSteph** (KB people-file + web both confirm; linked to instagram.com/techlifesteph).
+
+## OPEN FLAGS — KK to confirm/correct before scheduling
+These come from the original Notion draft and are NOT supported by the KB. Left as written; your call.
+
+1. **"$160,000" total Lenfest investment** (used twice + the "less than one senior reporter's salary" line). KB grant math = ~$200K ($30K x4 newsrooms + $10K x8 creators); summit README cites a broader "$1.5M Lenfest investment." $160K appears in no source. If wrong, the rhetorical beat needs a rework.
+2. **"across nine months"** (the newsroom + creator pairing). KB says a **four-month fellowship** (Jan 15 to Apr 24), or 6 months counting listening sessions. Also note the piece's own subtitle says "Four Months," so "nine months" reads as an internal contradiction.
+3. **"2M reach for Inti Media"** is misattributed. The 2M reach belongs to **Green Philly / Brou Quinn**. Inti's headline number is Che's 565k followers.
+4. **"4M+ combined video views"** and **Terrill "4M+ views in the last three months"** are not in the KB. Closest is Brou's ~4,000 new followers / 2M reach. Possible 4,000 -> 4M slip.
+5. **Bobachi Food Pantry** "doubled attendance" video was **Brou Quinn's**, not Terrill's (the draft credits it to Terrill).
+6. **Che "between January and April"** — KB sources the line to "the last two months." Minor.
+7. **"525 people to a 5K"** (Elena) and **"GMA3"** (Stephanie) — not in the KB. Not necessarily wrong, just unverifiable here.
+
+## Added since first draft
+- 3 real screenshots from your AI-Assisted Workflows deck (Persona/Output/Parameters #12405, Transcript->Story 3-4 hrs #12406, Five Rules #12407), placed as captioned receipts in "What I Actually Did."

--- a/content/drafts/2026-06-28-context-creators/post.html
+++ b/content/drafts/2026-06-28-context-creators/post.html
@@ -39,7 +39,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, <a href="https://greenphl.com" target="_blank" rel="noopener noreferrer"><strong>Green Philly</strong></a>, <a href="https://technical.ly" target="_blank" rel="noopener noreferrer"><strong>Technical.ly</strong></a>, <a href="https://www.intimedia.org" target="_blank" rel="noopener noreferrer"><strong>Inti Media</strong></a>, and <a href="https://resolvephilly.org" target="_blank" rel="noopener noreferrer"><strong>Resolve Philly</strong></a>, paired with eight local creators across nine months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.</p>
+<p>What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, <a href="https://greenphl.com" target="_blank" rel="noopener noreferrer"><strong>Green Philly</strong></a>, <a href="https://technical.ly" target="_blank" rel="noopener noreferrer"><strong>Technical.ly</strong></a>, <a href="https://www.intimedia.org" target="_blank" rel="noopener noreferrer"><strong>Inti Media</strong></a>, and <a href="https://resolvephilly.org" target="_blank" rel="noopener noreferrer"><strong>Resolve Philly</strong></a>, paired with eight local creators across four months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -71,11 +71,11 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="https://www.instagram.com/_yafavtrashman/" target="_blank" rel="noopener noreferrer"><strong>Terrill Haigler</strong></a> (@YaFavTrashman) covers sustainability and food waste for <strong>Green Philly</strong>. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?</p>
+<p><a href="https://www.instagram.com/_yafavtrashman/" target="_blank" rel="noopener noreferrer"><strong>Terrill Haigler</strong></a> (@YaFavTrashman) covers sustainability and food waste for <strong>Green Philly</strong>. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="https://www.instagram.com/215phillyfood/" target="_blank" rel="noopener noreferrer"><strong>Brou Quinn</strong></a> (@215PhillyFood) covers Philly food culture, also with Green Philly. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a <a href="https://www.fbd.org/" target="_blank" rel="noopener noreferrer">Food Bank of Delaware</a> grant proposal directly from a coaching session transcript. It worked.</p>
+<p><a href="https://www.instagram.com/215phillyfood/" target="_blank" rel="noopener noreferrer"><strong>Brou Quinn</strong></a> (@215PhillyFood) covers Philly food culture, also with Green Philly. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a <a href="https://www.fbd.org/" target="_blank" rel="noopener noreferrer">Food Bank of Delaware</a> grant proposal directly from a coaching session transcript. It worked.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -171,7 +171,7 @@
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
-<p>The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 2M reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.</p>
+<p>The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 565,000-follower reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/content/drafts/2026-06-28-context-creators/post.html
+++ b/content/drafts/2026-06-28-context-creators/post.html
@@ -1,0 +1,263 @@
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>What four months coaching Philadelphia's most interesting journalists taught me about the future of media.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:paragraph -->
+<p>It happened three times in the same afternoon.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>April 24. Quorum, at the <a href="https://sciencecenter.org" target="_blank" rel="noopener noreferrer">Philadelphia Science Center</a>. Two hundred journalists and creators packed into one room for the 2026 Philadelphia Creators Summit. <strong>Jos Duncan-Asé</strong> opens the day and says a thing I had heard her say three weeks earlier on a coaching call: journalists will survive the AI flood because they are <em>context creators</em>, not content creators. They generate meaning, not just volume. Sounds like a small distinction. It is not.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Two talks later, <strong>Terrill Haigler</strong> takes the mic. He covers sustainability and food justice as @YaFavTrashman, he has pulled 4M+ views in the last three months, and he lands on the exact same word with zero idea Jos just used it: <em>"I don't consider myself a content creator anymore. I'll call myself a context creator. I create like a journalist."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Then <strong>Che Guerrero</strong>. Same word. Different road to it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Three people. No coordination. Same word.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That moment is what the last four months had been building toward.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">How I Got Here</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Late 2025, <a href="https://lovenowmedia.com/jos-duncan-ase/" target="_blank" rel="noopener noreferrer"><strong>Jos Duncan-Asé</strong></a> reached out. She had been running PMFE, a creator-newsroom collaboration program, for three years through <a href="https://lovenowmedia.com" target="_blank" rel="noopener noreferrer"><strong>Love Now Media</strong></a>, embedded as a consultant inside the <a href="https://lenfestinstitute.org" target="_blank" rel="noopener noreferrer"><strong>Lenfest Institute's</strong></a> Philadelphia portfolio. She was widening the program and wanted to add an AI coaching component. Was I interested?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, <a href="https://greenphl.com" target="_blank" rel="noopener noreferrer"><strong>Green Philly</strong></a>, <a href="https://technical.ly" target="_blank" rel="noopener noreferrer"><strong>Technical.ly</strong></a>, <a href="https://www.intimedia.org" target="_blank" rel="noopener noreferrer"><strong>Inti Media</strong></a>, and <a href="https://resolvephilly.org" target="_blank" rel="noopener noreferrer"><strong>Resolve Philly</strong></a>, paired with eight local creators across nine months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Her framing was the part I needed to hear: journalism survives AI because journalists generate <em>meaning</em>, not just content. She had that analysis before I walked in. My job was to help build AI systems around an insight that was already true.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The third leg was <a href="https://thewilltoms.com" target="_blank" rel="noopener noreferrer"><strong>Will Toms</strong></a>, co-founder of <a href="https://recphilly.com" target="_blank" rel="noopener noreferrer"><strong>REC Philly</strong></a>, Forbes 30 Under 30, the person who actually bridges creator culture and institutional media. Will, on what the program could become: <em>"When we think about the trust that creators have, I think it's clear that there's a big opportunity for journalism to work with creators and just do magical things."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Let me be blunt about credit. This was Jos's program. She built the relationships, the structure, and the vision. I came in for the AI layer. That distinction matters, and it shaped how I did the work.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The Eight Fellows</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"id":12401,"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="https://kriskrug.co/wp-content/uploads/2026/06/poster-3-fellows-plants.png" alt="You cannot be what you cannot see. A Puerto Rican wildflower and a Haitian tropical bloom with roots braided together underground." class="wp-image-12401"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>These are not a generic cohort. Eight specific humans doing eight specific kinds of work, and the specificity is the entire point.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.instagram.com/_yafavtrashman/" target="_blank" rel="noopener noreferrer"><strong>Terrill Haigler</strong></a> (@YaFavTrashman) covers sustainability and food waste for <strong>Green Philly</strong>. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.instagram.com/215phillyfood/" target="_blank" rel="noopener noreferrer"><strong>Brou Quinn</strong></a> (@215PhillyFood) covers Philly food culture, also with Green Philly. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a <a href="https://www.fbd.org/" target="_blank" rel="noopener noreferrer">Food Bank of Delaware</a> grant proposal directly from a coaching session transcript. It worked.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://stephaniehumphrey.com/" target="_blank" rel="noopener noreferrer"><strong>Stephanie Humphrey</strong></a> (<a href="https://www.instagram.com/techlifesteph/" target="_blank" rel="noopener noreferrer">@TechLifeSteph</a>) covers tech and AI for <strong>Technical.ly</strong> and has been booking national TV, GMA, GMA3, Fox29. Her challenge was practical and urgent: how do you pull platform analytics into AI in a way that produces actual decisions, not surface-level vibes?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://technical.ly/author/chelsearcox/" target="_blank" rel="noopener noreferrer"><strong>Chelsea Cox</strong></a> covers Philadelphia policy and civic explainers for Technical.ly. We built "Chelsea Bot," a knowledge base grounded in her beat, her sourcing, her voice. The problem we were solving: ChatGPT kept hallucinating city policy details, and she needed a system she could actually trust before it went into print.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.cheguerrero.com/" target="_blank" rel="noopener noreferrer"><strong>Che Guerrero</strong></a> has 565,000 followers and covers Latine civic life and comedy journalism through <strong>Inti Media</strong>. We built "Shaybot," a custom GPT loaded with his research, his interview transcripts, his daily media monitoring feeds. By the summit something had shifted. His community had started calling him "my journalist." <em>"The last two months, people in my life coming up to me saying: You're my journalist. You're the person I go to for information because I trust you."</em> That happened between January and April.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.linkedin.com/in/deboracharmelus/" target="_blank" rel="noopener noreferrer"><strong>Debora Reaves Charmelus</strong></a> hosts <em>Afro Latinidad Out Loud</em> through Inti Media, a Haitian-American voice inside a Latinx newsroom. She refused to hide. Her own words: <em>"Right now they want immigrants to hide. And we're saying we're no longer hiding."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Alisha Miranda</strong> runs <a href="https://resolvephilly.org/initiatives/equally-informed" target="_blank" rel="noopener noreferrer"><strong>Equally Informed Philly</strong></a> through <strong>Resolve Philly</strong>, focused on bilingual civic information. In coaching we built her a custom assistant to analyze her Instagram content performance and run AI-assisted A/B testing across the English and Spanish versions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>Elena Gonzalez Johnson</strong> runs <a href="https://www.latinasinmotion.com/" target="_blank" rel="noopener noreferrer"><strong>Latinas in Motion</strong></a> through Resolve Philly. Latina civic engagement, wellness, perimenopause, voter registration. She applied to the program with 7,000 followers and got in because the program values community depth over reach. She brought 525 people to a 5K. Her principle: <em>"You cannot be what you cannot see."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>You cannot be what you cannot see.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:paragraph -->
+<p>The through-line I could not stop noticing: every single one of them was already building something real before I showed up. My job was to help them not lose it when they plugged AI in.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What I Actually Did</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"id":12400,"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="https://kriskrug.co/wp-content/uploads/2026/06/poster-2-both-hands-full.png" alt="Both Hands Full. A figure holds an iron weight in one hand and a swirl of aurora light in the other." class="wp-image-12400"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>The work ran in three modes.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong>One-on-one coaching.</strong> I started every session by listening, not pitching. What is the actual friction in your workflow? Where does the process break down? Not "here is a tool." "Where does it hurt?" From there we built custom AI assistants for five of the eight fellows: Shaybot, Chelsea Bot, Brew Bot, Elaine Bot, and Stephanie's analytics system. Each one loaded with the fellow's own voice: writing samples, past work, interview transcripts, style notes. The build framework: a research phase using Gemini, Grok, and Perplexity to generate topical reports on their beat, then upload, train, and test with ambitious prompts. Brou generating grant proposals from session transcripts. Che monitoring daily news feeds through Shaybot. Chelsea with a policy explainer she could finally trust.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":12405,"width":"460px","sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://kriskrug.co/wp-content/uploads/2026/06/slide-persona-output-parameters.png" alt="Slide titled Persona, Output, Parameters, the recipe for briefing an AI assistant in plain language." class="wp-image-12405" style="width:460px"/><figcaption class="wp-element-caption">The recipe behind every bot I built: Persona, Output, Parameters. Straight from my AI-Assisted Workflows deck.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p><strong>Group labs.</strong> In March we ran an AI Workflows Lab built around what I call the 4-Hop Pipeline: Transcribe, Extract, Build KB, Deliver. One interview becomes six output formats: article, newsletter, thread, pitch, podcast notes, source brief. Time saved per story package: roughly three to four hours. The reframe I kept returning to: AI will not replace journalists, but journalists who use AI well will outwork the ones who don't. The real shift is augmentation, not automation.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":12406,"width":"460px","sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://kriskrug.co/wp-content/uploads/2026/06/slide-transcript-to-story.png" alt="Slide titled Transcript to Story, showing Record, Extract, Draft, Publish and three to four hours saved per story." class="wp-image-12406" style="width:460px"/><figcaption class="wp-element-caption">One interview in, a full package out. Roughly three to four hours saved per story.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p><strong>The Summit AI Breakout.</strong> I called it "Both Hands Full." You have to hold the fear and the possibility at the same time and not collapse into either one. I named the five fears I had been hearing in sessions all program: automation, homogenization, style theft, newsroom cuts, losing yourself. Then I did not wave them off. They are real. They just don't apply to creators who know who they are and feed that identity into the tools instead of outsourcing their identity to the tools. The framing I have been working with: <em>"I stopped asking the AI to be me. I started teaching the AI who I am first."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>I stopped asking the AI to be me. I started teaching the AI who I am first.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.ajl.org" target="_blank" rel="noopener noreferrer"><strong>Joy Buolamwini's</strong></a> line that I keep returning to: <em>"Simply because decisions are made by a computer does not make them neutral. Neural does not equate to neutral."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":12407,"width":"460px","sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://kriskrug.co/wp-content/uploads/2026/06/slide-five-rules.png" alt="Slide titled Five Rules: human in the loop, verify everything, protect sources, disclose when appropriate, bias is baked in." class="wp-image-12407" style="width:460px"/><figcaption class="wp-element-caption">The five rules I kept coming back to in every session.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What the Summit Proved</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"id":12402,"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="https://kriskrug.co/wp-content/uploads/2026/06/poster-4-loom.png" alt="Teaching the machine who you are. A wooden loom weaves ribbons of rainbow light into dark cloth." class="wp-image-12402"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 2M reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><a href="https://www.lenfestinstitute.org/about/our-team/shawn-mooring/" target="_blank" rel="noopener noreferrer"><strong>Shawn Mooring</strong></a>, Head of Philadelphia Programs at Lenfest, named the real question in his opening: <em>"This event has always been about non-activation, about revenue generation, and how do we create opportunities for this work to continue absent philanthropic dollars."</em> The $160K is a test. The model is the thing that gets replicated.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The afternoon keynotes made the case from the industry side. <a href="https://www.revolt.tv" target="_blank" rel="noopener noreferrer"><strong>Revolt</strong></a> CEO <a href="https://www.linkedin.com/in/detavio" target="_blank" rel="noopener noreferrer"><strong>Detavio Samuels</strong></a> put it exactly: <em>"The only media people trust from a news perspective is citizen journalism. Creators have intention. What they're missing is the rigor."</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That is the program, described from the outside by someone who had never set foot in it. Intention plus rigor.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>Intention plus rigor.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What Changed in Me</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>I came in thinking the job was to add AI to journalism. I left thinking the job was to protect what was already there while carefully adding AI. Those are different jobs.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The thing Jos brought that I did not have: she has been building community-centered, equity-driven programs for years, at a level of rigor that rarely gets institutional support. The AI work only lands when it is grounded in that kind of relational infrastructure. Without it, you are just handing people power tools and hoping they don't cut themselves.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>What Terrill naming "context creator" actually taught me: the framework I had been using to explain AI's limits, that you are irreplaceable because of your source relationships, your editorial judgment, your beat knowledge, these fellows already <em>lived</em> that. I was explaining it to them. They were the proof of it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The collaboration model itself is not just a distribution play. Creator plus newsroom is a trust architecture. The newsroom makes the creator's work defensible. The creator makes the newsroom's work human. That exchange does not happen automatically. It takes exactly the patient, relationship-first program-building that Jos has been doing for years.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><em>"The revenue comes from the trust. The trust comes from the specificity."</em> I said that at the AI Breakout. I believe it harder now than when I said it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:pullquote -->
+<figure class="wp-block-pullquote"><blockquote><p>The revenue comes from the trust. The trust comes from the specificity.</p></blockquote></figure>
+<!-- /wp:pullquote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Where It Goes</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"id":12403,"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="https://kriskrug.co/wp-content/uploads/2026/06/poster-5-city-map.png" alt="The city got to me. A glowing map of Philadelphia, light running from the Science Center out to every neighborhood." class="wp-image-12403"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p><strong>Will Toms</strong> called this <em>"smart experiments that will hopefully become a model the rest of the country can follow."</em> Shawn Mooring framed it as a national replication model. I think they are right, but the replication is not a curriculum. It is a relationship model. Jos, Will, and the eight fellows built something that worked because of the specific trust between specific people in a specific city. The next version is not copy-paste. It is finding the equivalent relationships in the next place.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>What I am taking back to <strong>The Upgrade AI</strong>: the Taste Stack, the Voice Capture, Transcribe, Extract, KB, Deliver framework, now has four months of field testing across eight distinct creator workflows. The knowledge base build works. The custom assistant approach works. The question is not whether AI helps these creators. It is whether we can build the infrastructure fast enough for the people who most need it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>I flew in from Vancouver and the city got to me. Philadelphia, April 2026: two hundred journalists and creators packed into one room, believing something is possible again in local media.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>When you are in a room where three people independently arrive at the same word in the same afternoon, you do not forget it.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>They were already context creators when I got here. They just didn't have the word for it yet.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p><em>Thanks to Jos Duncan-Asé, Will Toms, Nicole Blackson, Antoinette Talley, and Mina "SayWhat" Llona for building the program I got to learn from. Thanks to the eight fellows, Terrill, Brou, Stephanie, Chelsea, Che, Debora, Alisha, and Elena, for letting me into their workflows. And thanks to the Lenfest Institute, the <a href="https://newsinitiative.withgoogle.com" target="_blank" rel="noopener noreferrer">Google News Initiative</a> (Felicia Reiner and Tiffany Boratia), and Comcast for making it possible.</em></p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-06-28-context-creators/post.md
+++ b/content/drafts/2026-06-28-context-creators/post.md
@@ -1,0 +1,142 @@
+---
+title: Context Creators
+slug: context-creators
+status: draft
+date: 2026-06-28T09:00:00
+category: AI for Creatives
+notion_source: 34dc6f799a338028b69bcad8e7bed7bf
+---
+
+# Context Creators
+
+>>> What four months coaching Philadelphia's most interesting journalists taught me about the future of media.
+
+It happened three times in the same afternoon.
+
+April 24. Quorum, at the [Philadelphia Science Center](https://sciencecenter.org). Two hundred journalists and creators packed into one room for the 2026 Philadelphia Creators Summit. **Jos Duncan-Asé** opens the day and says a thing I had heard her say three weeks earlier on a coaching call: journalists will survive the AI flood because they are *context creators*, not content creators. They generate meaning, not just volume. Sounds like a small distinction. It is not.
+
+Two talks later, **Terrill Haigler** takes the mic. He covers sustainability and food justice as @YaFavTrashman, he has pulled 4M+ views in the last three months, and he lands on the exact same word with zero idea Jos just used it: *"I don't consider myself a content creator anymore. I'll call myself a context creator. I create like a journalist."*
+
+Then **Che Guerrero**. Same word. Different road to it.
+
+Three people. No coordination. Same word.
+
+That moment is what the last four months had been building toward.
+
+---
+
+## How I Got Here
+
+Late 2025, [**Jos Duncan-Asé**](https://lovenowmedia.com/jos-duncan-ase/) reached out. She had been running PMFE, a creator-newsroom collaboration program, for three years through [**Love Now Media**](https://lovenowmedia.com), embedded as a consultant inside the [**Lenfest Institute's**](https://lenfestinstitute.org) Philadelphia portfolio. She was widening the program and wanted to add an AI coaching component. Was I interested?
+
+What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, [**Green Philly**](https://greenphl.com), [**Technical.ly**](https://technical.ly), [**Inti Media**](https://www.intimedia.org), and [**Resolve Philly**](https://resolvephilly.org), paired with eight local creators across nine months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.
+
+Her framing was the part I needed to hear: journalism survives AI because journalists generate *meaning*, not just content. She had that analysis before I walked in. My job was to help build AI systems around an insight that was already true.
+
+The third leg was [**Will Toms**](https://thewilltoms.com), co-founder of [**REC Philly**](https://recphilly.com), Forbes 30 Under 30, the person who actually bridges creator culture and institutional media. Will, on what the program could become: *"When we think about the trust that creators have, I think it's clear that there's a big opportunity for journalism to work with creators and just do magical things."*
+
+Let me be blunt about credit. This was Jos's program. She built the relationships, the structure, and the vision. I came in for the AI layer. That distinction matters, and it shaped how I did the work.
+
+---
+
+## The Eight Fellows
+
+![You cannot be what you cannot see. A Puerto Rican wildflower and a Haitian tropical bloom rise over Philadelphia, their roots braided together underground in aurora light.](poster:3)
+
+These are not a generic cohort. Eight specific humans doing eight specific kinds of work, and the specificity is the entire point.
+
+[**Terrill Haigler**](https://www.instagram.com/_yafavtrashman/) (@YaFavTrashman) covers sustainability and food waste for **Green Philly**. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?
+
+[**Brou Quinn**](https://www.instagram.com/215phillyfood/) (@215PhillyFood) covers Philly food culture, also with Green Philly. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a [Food Bank of Delaware](https://www.fbd.org/) grant proposal directly from a coaching session transcript. It worked.
+
+[**Stephanie Humphrey**](https://stephaniehumphrey.com/) ([@TechLifeSteph](https://www.instagram.com/techlifesteph/)) covers tech and AI for **Technical.ly** and has been booking national TV, GMA, GMA3, Fox29. Her challenge was practical and urgent: how do you pull platform analytics into AI in a way that produces actual decisions, not surface-level vibes?
+
+[**Chelsea Cox**](https://technical.ly/author/chelsearcox/) covers Philadelphia policy and civic explainers for Technical.ly. We built "Chelsea Bot," a knowledge base grounded in her beat, her sourcing, her voice. The problem we were solving: ChatGPT kept hallucinating city policy details, and she needed a system she could actually trust before it went into print.
+
+[**Che Guerrero**](https://www.cheguerrero.com/) has 565,000 followers and covers Latine civic life and comedy journalism through **Inti Media**. We built "Shaybot," a custom GPT loaded with his research, his interview transcripts, his daily media monitoring feeds. By the summit something had shifted. His community had started calling him "my journalist." *"The last two months, people in my life coming up to me saying: You're my journalist. You're the person I go to for information because I trust you."* That happened between January and April.
+
+[**Debora Reaves Charmelus**](https://www.linkedin.com/in/deboracharmelus/) hosts *Afro Latinidad Out Loud* through Inti Media, a Haitian-American voice inside a Latinx newsroom. She refused to hide. Her own words: *"Right now they want immigrants to hide. And we're saying we're no longer hiding."*
+
+**Alisha Miranda** runs [**Equally Informed Philly**](https://resolvephilly.org/initiatives/equally-informed) through **Resolve Philly**, focused on bilingual civic information. In coaching we built her a custom assistant to analyze her Instagram content performance and run AI-assisted A/B testing across the English and Spanish versions.
+
+**Elena Gonzalez Johnson** runs [**Latinas in Motion**](https://www.latinasinmotion.com/) through Resolve Philly. Latina civic engagement, wellness, perimenopause, voter registration. She applied to the program with 7,000 followers and got in because the program values community depth over reach. She brought 525 people to a 5K. Her principle: *"You cannot be what you cannot see."*
+
+>>> You cannot be what you cannot see.
+
+The through-line I could not stop noticing: every single one of them was already building something real before I showed up. My job was to help them not lose it when they plugged AI in.
+
+---
+
+## What I Actually Did
+
+![Both Hands Full. A figure in work clothes holds an iron weight in one hand and a swirl of aurora light in the other, fear and possibility carried at the same time.](poster:2)
+
+The work ran in three modes.
+
+**One-on-one coaching.** I started every session by listening, not pitching. What is the actual friction in your workflow? Where does the process break down? Not "here is a tool." "Where does it hurt?" From there we built custom AI assistants for five of the eight fellows: Shaybot, Chelsea Bot, Brew Bot, Elaine Bot, and Stephanie's analytics system. Each one loaded with the fellow's own voice: writing samples, past work, interview transcripts, style notes. The build framework: a research phase using Gemini, Grok, and Perplexity to generate topical reports on their beat, then upload, train, and test with ambitious prompts. Brou generating grant proposals from session transcripts. Che monitoring daily news feeds through Shaybot. Chelsea with a policy explainer she could finally trust.
+
+![Slide titled Persona, Output, Parameters, the recipe for briefing an AI assistant in plain language.](screenshot:persona)
+
+**Group labs.** In March we ran an AI Workflows Lab built around what I call the 4-Hop Pipeline: Transcribe, Extract, Build KB, Deliver. One interview becomes six output formats: article, newsletter, thread, pitch, podcast notes, source brief. Time saved per story package: roughly three to four hours. The reframe I kept returning to: AI will not replace journalists, but journalists who use AI well will outwork the ones who don't. The real shift is augmentation, not automation.
+
+![Slide titled Transcript to Story, showing Record, Extract, Draft, Publish and three to four hours saved per story.](screenshot:pipeline)
+
+**The Summit AI Breakout.** I called it "Both Hands Full." You have to hold the fear and the possibility at the same time and not collapse into either one. I named the five fears I had been hearing in sessions all program: automation, homogenization, style theft, newsroom cuts, losing yourself. Then I did not wave them off. They are real. They just don't apply to creators who know who they are and feed that identity into the tools instead of outsourcing their identity to the tools. The framing I have been working with: *"I stopped asking the AI to be me. I started teaching the AI who I am first."*
+
+>>> I stopped asking the AI to be me. I started teaching the AI who I am first.
+
+[**Joy Buolamwini's**](https://www.ajl.org) line that I keep returning to: *"Simply because decisions are made by a computer does not make them neutral. Neural does not equate to neutral."*
+
+![Slide titled Five Rules: human in the loop, verify everything, protect sources, disclose when appropriate, bias is baked in.](screenshot:rules)
+
+---
+
+## What the Summit Proved
+
+![Teaching the machine who you are. An old wooden loom weaves seven ribbons of rainbow light into dark cloth, the words woven into the weft.](poster:4)
+
+The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 2M reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.
+
+[**Shawn Mooring**](https://www.lenfestinstitute.org/about/our-team/shawn-mooring/), Head of Philadelphia Programs at Lenfest, named the real question in his opening: *"This event has always been about non-activation, about revenue generation, and how do we create opportunities for this work to continue absent philanthropic dollars."* The $160K is a test. The model is the thing that gets replicated.
+
+The afternoon keynotes made the case from the industry side. [**Revolt**](https://www.revolt.tv) CEO [**Detavio Samuels**](https://www.linkedin.com/in/detavio) put it exactly: *"The only media people trust from a news perspective is citizen journalism. Creators have intention. What they're missing is the rigor."*
+
+That is the program, described from the outside by someone who had never set foot in it. Intention plus rigor.
+
+>>> Intention plus rigor.
+
+---
+
+## What Changed in Me
+
+I came in thinking the job was to add AI to journalism. I left thinking the job was to protect what was already there while carefully adding AI. Those are different jobs.
+
+The thing Jos brought that I did not have: she has been building community-centered, equity-driven programs for years, at a level of rigor that rarely gets institutional support. The AI work only lands when it is grounded in that kind of relational infrastructure. Without it, you are just handing people power tools and hoping they don't cut themselves.
+
+What Terrill naming "context creator" actually taught me: the framework I had been using to explain AI's limits, that you are irreplaceable because of your source relationships, your editorial judgment, your beat knowledge, these fellows already *lived* that. I was explaining it to them. They were the proof of it.
+
+The collaboration model itself is not just a distribution play. Creator plus newsroom is a trust architecture. The newsroom makes the creator's work defensible. The creator makes the newsroom's work human. That exchange does not happen automatically. It takes exactly the patient, relationship-first program-building that Jos has been doing for years.
+
+*"The revenue comes from the trust. The trust comes from the specificity."* I said that at the AI Breakout. I believe it harder now than when I said it.
+
+>>> The revenue comes from the trust. The trust comes from the specificity.
+
+---
+
+## Where It Goes
+
+![The city got to me. A glowing map of Philadelphia, threads of light running from the Science Center out to every neighborhood, a lone figure tethered to it from above.](poster:5)
+
+**Will Toms** called this *"smart experiments that will hopefully become a model the rest of the country can follow."* Shawn Mooring framed it as a national replication model. I think they are right, but the replication is not a curriculum. It is a relationship model. Jos, Will, and the eight fellows built something that worked because of the specific trust between specific people in a specific city. The next version is not copy-paste. It is finding the equivalent relationships in the next place.
+
+What I am taking back to **The Upgrade AI**: the Taste Stack, the Voice Capture, Transcribe, Extract, KB, Deliver framework, now has four months of field testing across eight distinct creator workflows. The knowledge base build works. The custom assistant approach works. The question is not whether AI helps these creators. It is whether we can build the infrastructure fast enough for the people who most need it.
+
+I flew in from Vancouver and the city got to me. Philadelphia, April 2026: two hundred journalists and creators packed into one room, believing something is possible again in local media.
+
+When you are in a room where three people independently arrive at the same word in the same afternoon, you do not forget it.
+
+They were already context creators when I got here. They just didn't have the word for it yet.
+
+---
+
+*Thanks to Jos Duncan-Asé, Will Toms, Nicole Blackson, Antoinette Talley, and Mina "SayWhat" Llona for building the program I got to learn from. Thanks to the eight fellows, Terrill, Brou, Stephanie, Chelsea, Che, Debora, Alisha, and Elena, for letting me into their workflows. And thanks to the Lenfest Institute, the [Google News Initiative](https://newsinitiative.withgoogle.com) (Felicia Reiner and Tiffany Boratia), and Comcast for making it possible.*

--- a/content/drafts/2026-06-28-context-creators/post.md
+++ b/content/drafts/2026-06-28-context-creators/post.md
@@ -29,7 +29,7 @@ That moment is what the last four months had been building toward.
 
 Late 2025, [**Jos Duncan-Asé**](https://lovenowmedia.com/jos-duncan-ase/) reached out. She had been running PMFE, a creator-newsroom collaboration program, for three years through [**Love Now Media**](https://lovenowmedia.com), embedded as a consultant inside the [**Lenfest Institute's**](https://lenfestinstitute.org) Philadelphia portfolio. She was widening the program and wanted to add an AI coaching component. Was I interested?
 
-What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, [**Green Philly**](https://greenphl.com), [**Technical.ly**](https://technical.ly), [**Inti Media**](https://www.intimedia.org), and [**Resolve Philly**](https://resolvephilly.org), paired with eight local creators across nine months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.
+What pulled me in was not "add AI to journalism." That pitch is everywhere and most of it is noise. What pulled me in was that the program was already doing something real. Four Philadelphia newsrooms, [**Green Philly**](https://greenphl.com), [**Technical.ly**](https://technical.ly), [**Inti Media**](https://www.intimedia.org), and [**Resolve Philly**](https://resolvephilly.org), paired with eight local creators across four months. Editorial infrastructure meets real community reach. Jos had built it with the kind of meticulous, equity-driven care that usually gets ground down inside institutional timelines.
 
 Her framing was the part I needed to hear: journalism survives AI because journalists generate *meaning*, not just content. She had that analysis before I walked in. My job was to help build AI systems around an insight that was already true.
 
@@ -45,9 +45,9 @@ Let me be blunt about credit. This was Jos's program. She built the relationship
 
 These are not a generic cohort. Eight specific humans doing eight specific kinds of work, and the specificity is the entire point.
 
-[**Terrill Haigler**](https://www.instagram.com/_yafavtrashman/) (@YaFavTrashman) covers sustainability and food waste for **Green Philly**. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?
+[**Terrill Haigler**](https://www.instagram.com/_yafavtrashman/) (@YaFavTrashman) covers sustainability and food waste for **Green Philly**. In coaching we built a content system around his editorial voice. The question we kept circling: how do you scale without losing the thing that makes you irreplaceable?
 
-[**Brou Quinn**](https://www.instagram.com/215phillyfood/) (@215PhillyFood) covers Philly food culture, also with Green Philly. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a [Food Bank of Delaware](https://www.fbd.org/) grant proposal directly from a coaching session transcript. It worked.
+[**Brou Quinn**](https://www.instagram.com/215phillyfood/) (@215PhillyFood) covers Philly food culture, also with Green Philly. One video he made about the Bobachi Food Pantry did not just tell a story about a food pantry. It doubled the pantry's attendance. We built "Brew Bot," a custom AI assistant loaded with his writing style, his proposal frameworks, his voice samples. The first real test: generating a [Food Bank of Delaware](https://www.fbd.org/) grant proposal directly from a coaching session transcript. It worked.
 
 [**Stephanie Humphrey**](https://stephaniehumphrey.com/) ([@TechLifeSteph](https://www.instagram.com/techlifesteph/)) covers tech and AI for **Technical.ly** and has been booking national TV, GMA, GMA3, Fox29. Her challenge was practical and urgent: how do you pull platform analytics into AI in a way that produces actual decisions, not surface-level vibes?
 
@@ -95,7 +95,7 @@ The work ran in three modes.
 
 ![Teaching the machine who you are. An old wooden loom weaves seven ribbons of rainbow light into dark cloth, the words woven into the weft.](poster:4)
 
-The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 2M reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.
+The evidence came back from four directions at once. Green Philly and Inti Media: 4M+ combined video views, 22,000+ new followers for Green Philly in 90 days, 565,000-follower reach for Inti Media. Resolve Philly: 20+ bilingual pieces published. Technical.ly: 3 national TV bookings. Total Lenfest investment: $160,000. That is less than the fully-loaded salary of a single senior reporter at a major metro daily, and it built four active, trust-based community media operations.
 
 [**Shawn Mooring**](https://www.lenfestinstitute.org/about/our-team/shawn-mooring/), Head of Philadelphia Programs at Lenfest, named the real question in his opening: *"This event has always been about non-activation, about revenue generation, and how do we create opportunities for this work to continue absent philanthropic dollars."* The $160K is a test. The model is the thing that gets replicated.
 

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -211,6 +211,16 @@ Markup is locked by `tests/test_wp_blocks.py`.
 
 Rebuilding a live post's body from its source markdown is only safe when that source is still in sync with what's live. If the live post has drifted (manual edits, a newer source), a rebuild **drops** those blocks. To upgrade image markup on a drifted live post, transform the fetched live content **in place** (e.g. swap `"linkDestination":"none"` → `"lightbox":{"enabled":true}` and `wp-block-image__caption` → `wp-element-caption`), and diff the block structure before/after to confirm only the intended markup changed.
 
+`backfill_lightbox.py` does exactly this across the whole published catalog: it enables the native lightbox on every core image (none/media link destinations), unwraps click-to-open `<a><img></a>` anchors, drops gallery `linkTo:media`, and normalizes the caption class — leaving `linkDestination:custom` (deliberate outbound-link) images alone. Each write is guarded so the block structure must be identical before/after, and originals are appended to a rollback manifest first.
+
+```bash
+python backfill_lightbox.py                       # dry-run: what would change
+python backfill_lightbox.py --execute             # apply; writes backfill-rollback.jsonl
+python backfill_lightbox.py --rollback FILE.jsonl # restore originals from a manifest
+```
+
+Heads-up: REST content updates bump each post's modified date (sitemap `lastmod`). The 2026-06-28 run swept all 161 image-posts (~1,346 images); its manifest is `backfill-rollback-2026-06-28.jsonl` (gitignored).
+
 ## Polish pass (em-dash purge + auto-link)
 
 After block rendering, every post goes through `text_polish.py`:

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -188,6 +188,29 @@ Every run writes a `publish.log` next to the draft. Includes the exact REST requ
 
 See `block_rules.py` for the Notion → Gutenberg mapping. Connector plumbing now lives in focused modules next to `kk_notion_to_wp.py` for config, Notion access, payload building, media handling, WordPress REST, update safety, category routing, and draft companion files.
 
+## Shared block markup (`wp_blocks.py`)
+
+Every post path emits Gutenberg blocks through **one** module, `wp_blocks.py`, instead of hand-rolling `<!-- wp:image -->` strings per script. `block_rules.py` (the main Notion pipeline) and the one-off `publish_*.py` scripts all import it, so a post looks the same no matter which path produced it.
+
+Helpers:
+
+- `image(media_id, url, alt, *, caption, width, align, lightbox)` — core. `media_id` may be an `int`, the string `"TBD"` (dry-run, before upload), or `None`.
+- `inline_image(...)` — small, centered, click-to-zoom receipt (default width **460px**).
+- `hero_image(...)` — full-width section hero.
+- `gallery(items, columns)`, `separator()`, `heading(text, level=2)`, `pullquote(text)`, `inline(s)` (markdown links/bold/italic; external links get `target="_blank" rel="noopener noreferrer"`).
+
+kk-aurora theme constraints baked into the defaults:
+
+- The post prose column is **720px**. A wider image overflows the text column, so inline images set an explicit width (default 460px, ~64% of column).
+- The theme has **no float CSS**, so inline images are centered (no text wrap).
+- The native WP 6.4+ lightbox is on: images use `"lightbox":{"enabled":true}` (no `<a>` wrapper) and captions use `wp-element-caption`.
+
+Markup is locked by `tests/test_wp_blocks.py`.
+
+### Re-emitting an already-published post
+
+Rebuilding a live post's body from its source markdown is only safe when that source is still in sync with what's live. If the live post has drifted (manual edits, a newer source), a rebuild **drops** those blocks. To upgrade image markup on a drifted live post, transform the fetched live content **in place** (e.g. swap `"linkDestination":"none"` → `"lightbox":{"enabled":true}` and `wp-block-image__caption` → `wp-element-caption`), and diff the block structure before/after to confirm only the intended markup changed.
+
 ## Polish pass (em-dash purge + auto-link)
 
 After block rendering, every post goes through `text_polish.py`:

--- a/scripts/notion-to-wp/backfill_lightbox.py
+++ b/scripts/notion-to-wp/backfill_lightbox.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Backfill the native WordPress lightbox onto already-published kriskrug.co posts.
+
+In-place transform of LIVE post content (safe even when a post's source markdown
+has drifted from what's live, because it never rebuilds from source). For every
+core image block it:
+  - enables the native WP 6.4+ lightbox  ("linkDestination": none|media -> "lightbox":{"enabled":true})
+  - unwraps click-to-open  <a href="..."><img></a>  anchors
+  - drops gallery  "linkTo":"media"
+  - normalizes the caption class  (wp-block-image__caption -> wp-element-caption)
+Images with a CUSTOM outbound link ("linkDestination":"custom") are left untouched.
+
+Safety: every write is guarded so the Gutenberg block STRUCTURE must be identical
+before/after (only image markup changes), else the post is skipped and logged.
+The original content of each post is appended to a rollback manifest BEFORE its
+write, so a mid-run stop still leaves an accurate manifest.
+
+  python backfill_lightbox.py                      # dry-run: report what would change
+  python backfill_lightbox.py --execute            # apply; writes backfill-rollback.jsonl
+  python backfill_lightbox.py --rollback FILE.jsonl # restore original content for every post in FILE
+
+NOTE: updating content via REST bumps each post's modified date (sitemap lastmod).
+"""
+import sys, re, json, argparse
+from collections import Counter
+
+from kk_notion_to_wp import WordPress, load_config
+
+_ANCHOR = re.compile(r'<a href="[^"]*"\s*>\s*(<img\b[^>]*?/?>)\s*</a>')
+
+
+def transform(c: str) -> str:
+    for a, b in (('"linkDestination":"none"', '"lightbox":{"enabled":true}'),
+                 ('"linkDestination":"media"', '"lightbox":{"enabled":true}')):
+        c = c.replace(a, b)
+    c = c.replace('"linkTo":"media",', '').replace(',"linkTo":"media"', '').replace('"linkTo":"media"', '')
+    c = _ANCHOR.sub(r'\1', c)
+    c = c.replace('wp-block-image__caption', 'wp-element-caption')
+    return c
+
+
+def _struct(s: str) -> Counter:
+    return Counter(re.findall(r'<!-- /?wp:[a-z]+', s))
+
+
+def _iter_published(wp):
+    page = 1
+    while True:
+        r = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts",
+                     params={"status": "publish", "per_page": 100, "page": page,
+                             "context": "edit", "_fields": "id,slug,content"}, timeout=60).json()
+        if not r:
+            break
+        for p in r:
+            yield p
+        if len(r) < 100:
+            break
+        page += 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--execute", action="store_true", help="apply the transform (default: dry-run)")
+    ap.add_argument("--rollback", metavar="MANIFEST", help="restore original content from a manifest")
+    ap.add_argument("--manifest", default="backfill-rollback.jsonl", help="rollback manifest path for --execute")
+    args = ap.parse_args()
+
+    cfg = load_config()
+    wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
+
+    if args.rollback:
+        seen = {}
+        for line in open(args.rollback):
+            rec = json.loads(line)
+            seen.setdefault(rec["id"], rec["before"])  # earliest = true original
+        for pid, before in seen.items():
+            wp.update_post(pid, {"content": before})
+            print(f"restored {pid}")
+        print(f"rollback complete: {len(seen)} posts")
+        return
+
+    cands = [(p["id"], p["slug"], p["content"]["raw"]) for p in _iter_published(wp)
+             if "<!-- wp:image " in p["content"]["raw"]
+             and transform(p["content"]["raw"]) != p["content"]["raw"]]
+    print(f"posts needing transform: {len(cands)}")
+
+    if not args.execute:
+        for pid, slug, c in cands[:25]:
+            t = transform(c)
+            tag = "OK  " if _struct(t) == _struct(c) else "SKIP"
+            print(f"  {tag} {pid} {slug} (+{t.count('lightbox') - c.count('lightbox')} lightbox)")
+        if len(cands) > 25:
+            print(f"  ... and {len(cands) - 25} more")
+        print(f"\nDRY-RUN. --execute applies the transform to {len(cands)} posts.")
+        return
+
+    updated = skipped = 0
+    errors = []
+    for pid, slug, before in cands:
+        after = transform(before)
+        if _struct(after) != _struct(before):
+            skipped += 1
+            errors.append((pid, slug, "struct-changed"))
+            continue
+        with open(args.manifest, "a") as f:  # record original BEFORE writing (crash-safe)
+            f.write(json.dumps({"id": pid, "slug": slug, "before": before}) + "\n")
+        try:
+            wp.update_post(pid, {"content": after})
+            updated += 1
+        except Exception as e:
+            errors.append((pid, slug, str(e)[:60]))
+    print(f"DONE updated={updated} skipped={skipped} errors={len(errors)} manifest={args.manifest}")
+    for e in errors[:15]:
+        print("  ", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notion-to-wp/block_rules.py
+++ b/scripts/notion-to-wp/block_rules.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from html import escape
 from typing import Callable
 
+import wp_blocks
+
 
 # ---------------------------------------------------------------------------
 # Inline rich-text rendering.
@@ -89,11 +91,7 @@ def render_heading(block: dict, level: int, _ctx: dict | None = None) -> str:
     # Page H1 is the title; first body heading should be H2.
     # Notion h1 → WP h2, h2 → h2, h3 → h3.
     wp_level = 2 if level == 1 else (2 if level == 2 else 3)
-    return (
-        f'<!-- wp:heading {{"level":{wp_level}}} -->\n'
-        f'<h{wp_level} class="wp-block-heading">{txt}</h{wp_level}>\n'
-        f'<!-- /wp:heading -->'
-    )
+    return wp_blocks.heading(txt, wp_level)
 
 
 def render_heading_1(block, ctx=None): return render_heading(block, 1, ctx)
@@ -172,7 +170,7 @@ def _callout_icon_html(icon: dict | None) -> str:
 
 
 def render_divider(_block: dict, _ctx: dict | None = None) -> str:
-    return '<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->'
+    return wp_blocks.separator()
 
 
 def render_code(block: dict, _ctx: dict | None = None) -> str:
@@ -210,14 +208,9 @@ def render_image(block: dict, ctx: dict | None = None) -> str:
         wp_id = "TBD"
         alt = escape(caption_text or "", quote=True)
 
-    cap_html = f'<figcaption class="wp-element-caption">{caption_text}</figcaption>' if caption_text else ""
-    id_json = f'"id":{wp_id},' if isinstance(wp_id, int) else ""
-    return (
-        f'<!-- wp:image {{{id_json}"sizeSlug":"large","linkDestination":"none"}} -->\n'
-        f'<figure class="wp-block-image size-large">'
-        f'<img src="{escape(wp_url, quote=True)}" alt="{alt}" class="wp-image-{wp_id}"/>'
-        f'{cap_html}</figure>\n'
-        '<!-- /wp:image -->'
+    return wp_blocks.image(
+        wp_id, escape(wp_url, quote=True), alt,
+        caption=caption_text or None, width=None, align=None, lightbox=True,
     )
 
 

--- a/scripts/notion-to-wp/publish_context_creators.py
+++ b/scripts/notion-to-wp/publish_context_creators.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Convert the "Context Creators" field report (2026 Philadelphia Creators Summit /
+Lenfest PMFE journalism+AI program) into a WordPress DRAFT on kriskrug.co.
+
+Reuses WordPress/load_config from kk_notion_to_wp. Links are hand-placed in
+post.md; the auto-linker is NOT run here. The five Aurora concept posters are
+uploaded idempotently (find-or-reuse by filename) so re-runs don't duplicate
+media. Dry-run by default; --execute creates the draft; --update refreshes the
+body of the existing draft. NEVER publishes.
+
+Marker syntax in post.md:
+  ## X              -> wp:heading
+  ---               -> wp:separator
+  >>> X             -> wp:pullquote (deck / callout)
+  ![alt](poster:N)  -> full-width in-body hero, N in 1..5 (staged poster file)
+  everything else   -> wp:paragraph
+"""
+import re, sys, json, pathlib
+from kk_notion_to_wp import WordPress, load_config, slugify
+from connector_payload import normalize_seo_meta
+from wp_blocks import inline, inline_image, hero_image, heading, separator, pullquote
+
+STAGE = pathlib.Path("/Users/kk/code/kriskrug-wp/content/drafts/2026-06-28-context-creators")
+IMAGES = STAGE / "images"
+EXECUTE = "--execute" in sys.argv
+UPDATE = "--update" in sys.argv
+WRITE = EXECUTE or UPDATE
+
+TITLE = "Context Creators"
+SLUG = "context-creators"
+DATE = "2026-06-28T09:00:00"
+CATEGORY = "AI for Creatives"
+TAGS = ["ai-for-journalists", "creator-economy", "philadelphia",
+        "lenfest-institute", "context-creators", "the-upgrade-ai", "journalism"]
+SEO_TITLE = "Context Creators | Four Months Inside Philadelphia's Journalism + AI Experiment"
+META_DESC = ("Four months coaching eight Philadelphia journalists on building AI into their "
+             "work for the Lenfest Institute's creator program, and what it proved about "
+             "trust, specificity, and the future of local media.")
+
+# Real screenshots from KK's "AI-Assisted Workflows" deck -> (filename, alt, caption).
+# Placed as centered, captioned, medium-width receipts in "What I Actually Did".
+SCREENSHOTS = {
+    "persona": ("slide-persona-output-parameters.png",
+                "Slide titled Persona, Output, Parameters, the recipe for briefing an AI assistant in plain language.",
+                "The recipe behind every bot I built: Persona, Output, Parameters. Straight from my AI-Assisted Workflows deck."),
+    "pipeline": ("slide-transcript-to-story.png",
+                 "Slide titled Transcript to Story, showing Record, Extract, Draft, Publish and three to four hours saved per story.",
+                 "One interview in, a full package out. Roughly three to four hours saved per story."),
+    "rules": ("slide-five-rules.png",
+              "Slide titled Five Rules: human in the loop, verify everything, protect sources, disclose when appropriate, bias is baked in.",
+              "The five rules I kept coming back to in every session."),
+}
+
+# poster N -> (staged filename, alt). poster 1 is the featured/OG image (not placed in body).
+POSTERS = {
+    1: ("poster-1-context-creator.png",
+        "Context Creator. Three braided strands of aurora light over a Philadelphia skyline."),
+    2: ("poster-2-both-hands-full.png",
+        "Both Hands Full. A figure holds an iron weight in one hand and a swirl of aurora light in the other."),
+    3: ("poster-3-fellows-plants.png",
+        "You cannot be what you cannot see. A Puerto Rican wildflower and a Haitian tropical bloom with roots braided together underground."),
+    4: ("poster-4-loom.png",
+        "Teaching the machine who you are. A wooden loom weaves ribbons of rainbow light into dark cloth."),
+    5: ("poster-5-city-map.png",
+        "The city got to me. A glowing map of Philadelphia, light running from the Science Center out to every neighborhood."),
+}
+
+
+# In-body block markup lives in wp_blocks.py (shared, kk-aurora-aware):
+#   hero_image()   -> full-width section heroes (the posters)
+#   inline_image() -> small, centered, click-to-zoom receipts (the deck screenshots)
+#   inline/heading/separator/pullquote -> text + structural blocks
+
+# ---------------------------------------------------------------------------
+raw = (STAGE / "post.md").read_text()
+fm_end = raw.index("\n---", raw.index("---") + 3)
+body = raw[fm_end + 4:]
+assert "—" not in body, "em-dash leaked into post.md body"
+
+cfg = load_config()
+wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
+
+
+def find_media(stem: str):
+    """Reuse already-uploaded media whose basename matches stem (avoid dupes)."""
+    if not WRITE:
+        return None
+    try:
+        r = wp.s.get(f"{wp.base}/wp-json/wp/v2/media",
+                     params={"search": stem, "per_page": 10, "context": "edit"}, timeout=30).json()
+    except Exception:
+        return None
+    if isinstance(r, list):
+        for m in r:
+            base = m.get("source_url", "").rsplit("/", 1)[-1]
+            if base == f"{stem}.png" or base.startswith(stem):
+                return m["id"], m["source_url"]
+    return None
+
+
+media_log = []
+poster_media = {}  # N -> (id, url, alt)
+for n, (fn, alt) in POSTERS.items():
+    p = IMAGES / fn
+    assert p.exists(), f"missing staged poster: {p}"
+    if WRITE:
+        found = find_media(p.stem)
+        if found:
+            mid, url = found
+            media_log.append(f"{fn} -> REUSE id={mid}")
+        else:
+            m = wp.upload_media(p, alt=alt, mime="image/png")
+            mid, url = m["id"], m["source_url"]
+            media_log.append(f"{fn} -> NEW id={mid} {url}")
+        poster_media[n] = (mid, url, alt)
+    else:
+        poster_media[n] = (0, f"DRYRUN/{fn}", alt)
+
+shot_media = {}  # key -> (id, url, alt, caption)
+for key, (fn, alt, caption) in SCREENSHOTS.items():
+    p = IMAGES / fn
+    assert p.exists(), f"missing staged screenshot: {p}"
+    if WRITE:
+        found = find_media(p.stem)
+        if found:
+            mid, url = found
+            media_log.append(f"{fn} -> REUSE id={mid}")
+        else:
+            m = wp.upload_media(p, alt=alt, mime="image/png")
+            mid, url = m["id"], m["source_url"]
+            media_log.append(f"{fn} -> NEW id={mid} {url}")
+        shot_media[key] = (mid, url, alt, caption)
+    else:
+        shot_media[key] = (0, f"DRYRUN/{fn}", alt, caption)
+
+print(f"[media] {'wrote' if WRITE else 'DRY'} {len(poster_media)} posters + {len(shot_media)} screenshots")
+for l in media_log:
+    print("   " + l)
+
+FEATURED_ID = poster_media[1][0]
+
+# ---- build blocks ----
+out = []
+seen_title = False
+for b in [x.strip() for x in re.split(r"\n\s*\n", body) if x.strip()]:
+    if b.startswith("# ") and not seen_title:
+        seen_title = True
+        continue
+    if b == "---":
+        out.append(separator())
+    elif b.startswith("## "):
+        out.append(heading(inline(b[3:].strip())))
+    elif b.startswith(">>> "):
+        out.append(pullquote(inline(b[4:].strip())))
+    else:
+        mp = re.match(r"^!\[(.*?)\]\(poster:(\d+)\)$", b)
+        ms = re.match(r"^!\[(.*?)\]\(screenshot:([a-z-]+)\)$", b)
+        if mp:
+            n = int(mp.group(2))
+            mid, url, alt = poster_media[n]
+            out.append(hero_image(mid, url, alt))
+        elif ms:
+            mid, url, alt, caption = shot_media[ms.group(2)]
+            out.append(inline_image(mid, url, alt, caption=caption))
+        else:
+            para = "<br>".join(inline(line.strip()) for line in b.split("\n"))
+            out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
+
+content = "\n\n".join(out)
+(STAGE / "post.html").write_text(content)
+
+# ---- sanity ----
+assert "—" not in content, "em-dash leaked into content"
+assert "poster:" not in content, "unresolved poster marker"
+assert "screenshot:" not in content, "unresolved screenshot marker"
+n_img = content.count("<!-- wp:image ")
+n_pq = content.count("wp:pullquote") // 2
+n_h2 = content.count("<h2")
+exp_img = 4 + len(SCREENSHOTS)  # 4 in-body posters + N deck screenshots
+assert n_img == exp_img, f"expected {exp_img} in-body images, got {n_img}"
+assert n_pq >= 4, f"expected >=4 pullquotes, got {n_pq}"
+print(f"[blocks] {len(out)} blocks | {n_img} images ({exp_img} expected) | pullquotes={n_pq} | h2={n_h2} | post.html staged ({len(content)} bytes)")
+
+if not WRITE:
+    print("\nDRY-RUN complete. --execute creates the draft; --update updates the existing one.")
+    sys.exit(0)
+
+# ---- find existing post by slug ----
+hits = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts",
+                params={"slug": SLUG, "status": "any", "context": "edit"}, timeout=30).json()
+existing = hits[0] if isinstance(hits, list) and hits else None
+
+if UPDATE:
+    if not existing:
+        sys.exit(f"[ABORT] --update but no post with slug {SLUG} found. Run --execute first.")
+    pid = existing["id"]
+    post = wp.update_post(pid, {"content": content, "featured_media": FEATURED_ID})
+    print(f"[post] UPDATED draft id={pid} status={post['status']}")
+else:
+    if existing:
+        sys.exit(f"[ABORT] a post with slug {SLUG} already exists (id={existing['id']}). Use --update.")
+    cat_id = wp.ensure_term("categories", CATEGORY)
+    tag_ids = [wp.ensure_term("tags", t) for t in TAGS]
+    payload = {
+        "title": TITLE, "slug": SLUG, "status": "draft", "date": DATE,
+        "author": cfg.wp_author_id, "content": content, "excerpt": META_DESC,
+        "categories": [cat_id], "tags": tag_ids, "featured_media": FEATURED_ID,
+        "meta": {"advanced_seo_description": normalize_seo_meta(META_DESC),
+                 "jetpack_seo_html_title": normalize_seo_meta(SEO_TITLE)},
+    }
+    post = wp.create_post(payload)
+    pid = post["id"]
+    print(f"[post] CREATED draft id={pid} status={post['status']}")
+
+# ---- verify ----
+v = wp.get_post(pid)
+vc = v["content"]["raw"]
+checks = {
+    "is_draft": v["status"] == "draft",
+    "not_published": v["status"] != "publish",
+    "featured_set": v.get("featured_media") == FEATURED_ID,
+    "all_images_present": vc.count("<!-- wp:image ") == 4 + len(SCREENSHOTS),
+    "screenshots_captioned": all(s[1] in vc for s in shot_media.values()),
+    "screenshots_small": vc.count('"width":"460px"') == len(SCREENSHOTS),
+    "lightbox_on": vc.count('"lightbox":{"enabled":true}') == 4 + len(SCREENSHOTS),
+    "no_820_no_anchor": "820" not in vc and not re.search(r'<a href="[^"]*"><img', vc),
+    "pullquotes_ge4": vc.count("wp:pullquote") // 2 >= 4,
+    "all_posters_in_or_featured": all(
+        (poster_media[n][1] in vc) or n == 1 for n in POSTERS),
+    "no_em_dash": "—" not in vc,
+    "quote_terrill": "I create like a journalist." in vc,
+    "quote_elena": "You cannot be what you cannot see." in vc,
+    "number_160k": "$160,000" in vc and "$160K" in vc,
+    "number_che": "565,000 followers" in vc,
+    "seo_desc_meta": v.get("meta", {}).get("advanced_seo_description") == normalize_seo_meta(META_DESC),
+    "seo_title_meta": v.get("meta", {}).get("jetpack_seo_html_title") == normalize_seo_meta(SEO_TITLE),
+}
+preview = f"{wp.base}/?p={pid}&preview=true"
+edit = f"{wp.base}/wp-admin/post.php?post={pid}&action=edit"
+(STAGE / "publish.log").write_text(
+    f"{'updated' if UPDATE else 'created'} draft id={pid} status={post['status']}\n"
+    f"preview={preview}\nedit={edit}\nfeatured(poster1)={FEATURED_ID}\n\n"
+    "MEDIA:\n" + ("\n".join(media_log) if media_log else "(none)")
+    + "\n\nVERIFY:\n" + json.dumps(checks, indent=2))
+print("\n=== VERIFY ===")
+for k, val in checks.items():
+    print(f"  {'OK ' if val else 'FAIL'} {k}")
+print(f"\nPREVIEW: {preview}\nEDIT:    {edit}\nDONE - left as DRAFT.")

--- a/scripts/notion-to-wp/publish_dc_protest_draft.py
+++ b/scripts/notion-to-wp/publish_dc_protest_draft.py
@@ -10,6 +10,7 @@ import re, sys, json, shutil, pathlib, datetime
 from kk_notion_to_wp import WordPress, load_config, slugify
 from connector_payload import normalize_seo_meta
 from text_polish import purge_em_dashes
+from wp_blocks import inline, image, heading, separator
 
 SRC = pathlib.Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/content/articles/kris-krug-thought-leadership/25-data-center-protest-signs")
 STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-data-center-protest-signs")
@@ -38,12 +39,6 @@ body = raw[fm_end + 4:]
 body = body.replace(LINK39_OLD, LINK39_NEW)
 assert LINK39_NEW in body, "line-39 link fix did not apply"
 body = purge_em_dashes(body)
-
-def inline(s: str) -> str:
-    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", lambda m: f'<a href="{m.group(2)}">{m.group(1)}</a>', s)
-    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
-    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
-    return s
 
 IMG_RE = re.compile(r"^!\[(.+?)\]\(images/(.+?)\)$")
 blocks_src = [b.strip() for b in re.split(r"\n\s*\n", body) if b.strip()]
@@ -90,15 +85,11 @@ for b in blocks_src:
     if m:
         fn, alt = m.group(2), m.group(1)
         u = uploaded[fn]
-        out.append(
-            f'<!-- wp:image {{"id":{u["id"]},"sizeSlug":"large","linkDestination":"none"}} -->\n'
-            f'<figure class="wp-block-image size-large"><img src="{u["url"]}" alt="{alt}" class="wp-image-{u["id"]}"/>'
-            f'<figcaption class="wp-block-image__caption">{alt}</figcaption></figure>\n'
-            f'<!-- /wp:image -->')
+        out.append(image(u["id"], u["url"], alt, caption=alt, width=None, align=None, lightbox=True))
     elif b.startswith("## "):
-        out.append(f"<!-- wp:heading -->\n<h2>{inline(b[3:].strip())}</h2>\n<!-- /wp:heading -->")
+        out.append(heading(inline(b[3:].strip())))
     elif b == "---":
-        out.append('<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->')
+        out.append(separator())
     else:
         out.append(f"<!-- wp:paragraph -->\n<p>{inline(b)}</p>\n<!-- /wp:paragraph -->")
 content = "\n\n".join(out)

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -21,6 +21,7 @@ refreshes the body of the existing draft. NEVER publishes.
 import re, sys, json, pathlib
 from kk_notion_to_wp import WordPress, load_config, slugify
 from connector_payload import normalize_seo_meta
+from wp_blocks import inline, image, gallery, heading, separator, pullquote
 
 STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-you-cant-drink-data")
 EXECUTE = "--execute" in sys.argv
@@ -76,45 +77,7 @@ INBODY_PHOTO = {
 PHOTOS_KEEP_PREFIX = {"05","07","10","13","14","15","16","17","18","21","23","24","25","26"}
 
 
-def inline(s: str) -> str:
-    def link(m):
-        text, url = m.group(1), m.group(2)
-        extra = '' if url.startswith(("https://kriskrug.co", "/")) else ' target="_blank" rel="noopener noreferrer"'
-        return f'<a href="{url}"{extra}>{text}</a>'
-    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link, s)
-    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
-    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
-    return s
-
-
-def image_block(media_id, url, alt, caption=None, width=None, align="center") -> str:
-    """Captioned, click-to-enlarge in-body image. align: center|left|right (left/right float, text wraps)."""
-    attrs = f'"id":{media_id},"sizeSlug":"large","linkDestination":"media","align":"{align}"'
-    figcls = f"wp-block-image align{align} size-large"
-    style = ""
-    if width:
-        attrs += f',"width":"{width}px"'
-        figcls += " is-resized"
-        style = f' style="width:{width}px"'
-    img = f'<a href="{url}"><img src="{url}" alt="{alt}" class="wp-image-{media_id}"{style}/></a>'
-    cap = f'<figcaption class="wp-block-image__caption">{caption}</figcaption>' if caption else ''
-    return (f'<!-- wp:image {{{attrs}}} -->\n<figure class="{figcls}">{img}{cap}</figure>\n<!-- /wp:image -->')
-
-
-def gallery_block(items, columns=3) -> str:
-    """items: (id, url, alt, caption). Click-to-enlarge, per-image captions."""
-    inner = []
-    for it in items:
-        mid, url, alt = it[0], it[1], it[2]
-        cap = it[3] if len(it) > 3 and it[3] else None
-        caphtml = f'<figcaption class="wp-block-image__caption">{cap}</figcaption>' if cap else ''
-        inner.append(
-            f'<!-- wp:image {{"id":{mid},"sizeSlug":"large","linkDestination":"media"}} -->\n'
-            f'<figure class="wp-block-image size-large"><a href="{url}"><img src="{url}" alt="{alt}" '
-            f'class="wp-image-{mid}"/></a>{caphtml}</figure>\n<!-- /wp:image -->')
-    return (f'<!-- wp:gallery {{"columns":{columns},"linkTo":"media","sizeSlug":"large","imageCrop":false}} -->\n'
-            f'<figure class="wp-block-gallery has-nested-images columns-{columns}">\n'
-            + "\n".join(inner) + '\n</figure>\n<!-- /wp:gallery -->')
+# in-body image / gallery / heading / separator / pullquote markup now lives in wp_blocks.py
 
 
 # ---------------------------------------------------------------------------
@@ -199,19 +162,18 @@ for b in blocks_src:
         seen_title = True
         continue
     if b == "---":
-        out.append('<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->')
+        out.append(separator())
     elif b.startswith("## "):
-        out.append(f"<!-- wp:heading -->\n<h2>{inline(b[3:].strip())}</h2>\n<!-- /wp:heading -->")
+        out.append(heading(inline(b[3:].strip())))
     elif b.startswith(">>> "):
-        q = inline(b[4:].strip())
-        out.append(f'<!-- wp:pullquote -->\n<figure class="wp-block-pullquote"><blockquote><p>{q}</p></blockquote></figure>\n<!-- /wp:pullquote -->')
+        out.append(pullquote(inline(b[4:].strip())))
     elif b == "[[GALLERY-BEST]]":
-        out.append(gallery_block([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3))
+        out.append(gallery([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3))
     elif b == "[[GALLERY-AI]]":
-        out.append(gallery_block([(mid, AI_SIGNS[mid][0], AI_SIGNS[mid][1], AI_CAP[mid]) for mid in AI_GALLERY], columns=3))
+        out.append(gallery([(mid, AI_SIGNS[mid][0], AI_SIGNS[mid][1], AI_CAP[mid]) for mid in AI_GALLERY], columns=3))
     elif b == "[[GALLERY-PHOTOS]]":
         if photos_rest:
-            out.append(gallery_block([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3))
+            out.append(gallery([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3))
     else:
         m = re.match(r"^!\[(.*?)\]\(media:(\d+)\)$", b)
         mp = re.match(r"^!\[(.*?)\]\(photo:(\d+)\)$", b)
@@ -219,13 +181,13 @@ for b in blocks_src:
             mid = int(m.group(2))
             url, alt = AI_SIGNS[mid]
             cap, align, width = INBODY_AI.get(mid, (None, "center", 320))
-            out.append(image_block(mid, url, alt, caption=cap, width=width, align=align))
+            out.append(image(mid, url, alt, caption=cap, width=width, align=align))
         elif mp:
             key = mp.group(2)
             if key in inbody_photos:
                 mid, url, alt, cap = inbody_photos[key]
                 align, width = INBODY_PHOTO.get(key, ("center", 660))
-                out.append(image_block(mid, url, alt, caption=cap, width=width, align=align))
+                out.append(image(mid, url, alt, caption=cap, width=width, align=align))
         else:
             para = "<br>".join(inline(line.strip()) for line in b.split("\n"))
             out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
@@ -281,7 +243,7 @@ checks = {
     "two_galleries": vc.count("wp:gallery") == 4,  # consolidated signs + AI (open+close each)
     "best_gallery_21": sum(1 for _, u, _, _, _ in best_photos if u in vc) == len(best_photos),
     "selfie_at_bottom": any(u in vc for i, u, _, _, fn in inbody_list if fn.startswith("7717")),
-    "captions_present": vc.count("wp-block-image__caption") >= 30,
+    "captions_present": vc.count("wp-element-caption") >= 30,
     "constrained_widths": "is-resized" in vc,
     "no_em_dash": "—" not in vc,
     "new_links": "sovereign-ai-for-whom" in vc and "punk-rock-ai" in vc and "your-taste-is-your-moat" in vc,

--- a/scripts/notion-to-wp/tests/test_wp_blocks.py
+++ b/scripts/notion-to-wp/tests/test_wp_blocks.py
@@ -1,0 +1,80 @@
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import wp_blocks  # noqa: E402
+
+
+class WpBlocksTests(unittest.TestCase):
+    def test_image_int_id_lightbox_no_anchor(self):
+        h = wp_blocks.image(123, "https://x/y.png", "alt text")
+        self.assertIn('"id":123', h)
+        self.assertIn('"lightbox":{"enabled":true}', h)
+        self.assertIn('class="wp-image-123"', h)
+        self.assertNotIn("<a href", h)            # lightbox provides zoom, no link wrapper
+        self.assertNotIn("linkDestination", h)
+
+    def test_image_tbd_id_omits_id_keeps_class(self):
+        # main Notion pipeline dry-run: id not yet known
+        h = wp_blocks.image("TBD", "https://x/y.png", "a")
+        self.assertNotIn('"id":', h)
+        self.assertIn('class="wp-image-TBD"', h)
+
+    def test_image_none_id_no_id_no_class(self):
+        h = wp_blocks.image(None, "x.png", "a", align=None, size_slug=None, lightbox=False)
+        self.assertNotIn('"id":', h)
+        self.assertNotIn("wp-image-", h)
+        self.assertIn('"linkDestination":"none"', h)
+
+    def test_inline_image_is_460_and_resized(self):
+        h = wp_blocks.inline_image(5, "u", "a", caption="cap")
+        self.assertIn('"width":"460px"', h)
+        self.assertIn('style="width:460px"', h)
+        self.assertIn("is-resized", h)
+        self.assertIn('<figcaption class="wp-element-caption">cap</figcaption>', h)
+
+    def test_hero_image_full_width(self):
+        h = wp_blocks.hero_image(7, "u", "a")
+        self.assertNotIn("width", h)
+        self.assertIn("aligncenter", h)
+        self.assertIn('"lightbox":{"enabled":true}', h)
+
+    def test_gallery_wraps_lightbox_images(self):
+        h = wp_blocks.gallery([(1, "u1", "a1", "c1"), (2, "u2", "a2", None)], columns=3)
+        self.assertIn("<!-- wp:gallery", h)
+        self.assertIn("columns-3", h)
+        self.assertEqual(h.count("<!-- wp:image "), 2)
+        self.assertEqual(h.count('"lightbox":{"enabled":true}'), 2)
+
+    def test_separator(self):
+        self.assertIn('wp-block-separator', wp_blocks.separator())
+
+    def test_heading_default_h2_no_level_attr(self):
+        h = wp_blocks.heading("Title")
+        self.assertIn("<!-- wp:heading -->", h)
+        self.assertIn('<h2 class="wp-block-heading">Title</h2>', h)
+
+    def test_heading_level_3(self):
+        h = wp_blocks.heading("Sub", level=3)
+        self.assertIn('<!-- wp:heading {"level":3} -->', h)
+        self.assertIn('<h3 class="wp-block-heading">Sub</h3>', h)
+
+    def test_pullquote(self):
+        h = wp_blocks.pullquote("punch")
+        self.assertIn('wp-block-pullquote', h)
+        self.assertIn("<blockquote><p>punch</p></blockquote>", h)
+
+    def test_inline_links_bold_italic(self):
+        ext = wp_blocks.inline("see [docs](https://example.com)")
+        self.assertIn('target="_blank" rel="noopener noreferrer"', ext)
+        internal = wp_blocks.inline("see [home](https://kriskrug.co/about)")
+        self.assertNotIn("target=", internal)
+        self.assertIn("<strong>x</strong>", wp_blocks.inline("**x**"))
+        self.assertIn("<em>y</em>", wp_blocks.inline("*y*"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/notion-to-wp/wp_blocks.py
+++ b/scripts/notion-to-wp/wp_blocks.py
@@ -1,0 +1,116 @@
+"""Canonical Gutenberg block markup for kriskrug.co (kk-aurora theme).
+
+ONE place every notion-to-wp script emits in-body blocks from, so we stop
+reinventing the markup per script. Replaces the old image_blocks.py and the
+copy-pasted image/gallery/heading/separator/pullquote strings.
+
+kk-aurora facts that shape these helpers:
+- Prose column is 720px. A small inline image must set an explicit width well
+  under 720 (inline_image defaults to 460); a hero fills the column (width=None).
+- The theme has NO float CSS (.alignleft/.alignright do not wrap text), so the
+  supported inline placement is centered. `align` is a param but defaults center.
+- The theme supports the native WP 6.4+ lightbox (theme.json core/image.lightbox).
+  Click-to-zoom is enabled per image via "lightbox":{"enabled":true} with NO <a>
+  wrapper. See theme/kk-aurora/patterns/photo-gallery.php.
+
+Escaping: callers pass ready strings. wp_blocks does NOT escape (text helpers and
+block_rules already produce safe HTML; the publish scripts pass controlled copy).
+"""
+from __future__ import annotations
+
+import re
+
+_SEPARATOR = ('<!-- wp:separator -->\n'
+              '<hr class="wp-block-separator has-alpha-channel-opacity"/>\n'
+              '<!-- /wp:separator -->')
+
+
+def inline(s: str) -> str:
+    """Markdown-ish inline formatting -> HTML. Links, bold, italic. External
+    links get target=_blank rel=noopener noreferrer; kriskrug.co/internal stay clean."""
+    def link(m: re.Match) -> str:
+        text, url = m.group(1), m.group(2)
+        extra = '' if url.startswith(("https://kriskrug.co", "/")) else ' target="_blank" rel="noopener noreferrer"'
+        return f'<a href="{url}"{extra}>{text}</a>'
+    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link, s)
+    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
+    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
+    return s
+
+
+def separator() -> str:
+    return _SEPARATOR
+
+
+def heading(text: str, level: int = 2) -> str:
+    """Canonical core heading. text is ready HTML. Omits the level attr for the
+    default h2 (matches Gutenberg); always sets the wp-block-heading class."""
+    attr = "" if level == 2 else f' {{"level":{level}}}'
+    return (f'<!-- wp:heading{attr} -->\n'
+            f'<h{level} class="wp-block-heading">{text}</h{level}>\n'
+            f'<!-- /wp:heading -->')
+
+
+def pullquote(text: str) -> str:
+    """Callout-style pullquote (deck). text is ready HTML."""
+    return ('<!-- wp:pullquote -->\n'
+            f'<figure class="wp-block-pullquote"><blockquote><p>{text}</p></blockquote></figure>\n'
+            '<!-- /wp:pullquote -->')
+
+
+def image(media_id, url, alt, *, caption=None, width=None, align="center",
+          lightbox=True, size_slug="large") -> str:
+    """Core image block. media_id may be int (emits "id":N + wp-image-N class),
+    the string "TBD" (dry-run: class only, no id), or None (no id, no wp-image class).
+    lightbox=True -> native click-to-zoom, no <a> wrapper; lightbox=False ->
+    linkDestination none (plain). width in px constrains + adds is-resized."""
+    attrs = []
+    if isinstance(media_id, int):
+        attrs.append(f'"id":{media_id}')
+    if width:
+        attrs.append(f'"width":"{width}px"')
+    if size_slug:
+        attrs.append(f'"sizeSlug":"{size_slug}"')
+    attrs.append('"lightbox":{"enabled":true}' if lightbox else '"linkDestination":"none"')
+    if align:
+        attrs.append(f'"align":"{align}"')
+
+    figcls = "wp-block-image"
+    if align:
+        figcls += f" align{align}"
+    if size_slug:
+        figcls += f" size-{size_slug}"
+    style = ""
+    if width:
+        figcls += " is-resized"
+        style = f' style="width:{width}px"'
+
+    cls = f' class="wp-image-{media_id}"' if media_id is not None else ""
+    img = f'<img src="{url}" alt="{alt}"{cls}{style}/>'
+    cap = f'<figcaption class="wp-element-caption">{caption}</figcaption>' if caption else ""
+    return (f'<!-- wp:image {{{",".join(attrs)}}} -->\n'
+            f'<figure class="{figcls}">{img}{cap}</figure>\n<!-- /wp:image -->')
+
+
+def inline_image(media_id, url, alt, caption=None, width=460, align="center") -> str:
+    """Small, centered, click-to-zoom in-body image (screenshots / receipts).
+    Default 460px (~64% of the 720px prose column)."""
+    return image(media_id, url, alt, caption=caption, width=width, align=align)
+
+
+def hero_image(media_id, url, alt, caption=None, align="center") -> str:
+    """Full-width section hero (e.g. posters); fills the column, click-to-zoom on."""
+    return image(media_id, url, alt, caption=caption, width=None, align=align)
+
+
+def gallery(items, columns: int = 3) -> str:
+    """wp:gallery of click-to-zoom images. items: (id, url, alt[, caption])."""
+    inner = "\n".join(
+        image(it[0], it[1], it[2],
+              caption=(it[3] if len(it) > 3 and it[3] else None),
+              width=None, align=None, lightbox=True)
+        for it in items
+    )
+    return (f'<!-- wp:gallery {{"columns":{columns},"imageCrop":false}} -->\n'
+            f'<figure class="wp-block-gallery has-nested-images columns-{columns}">\n'
+            f'{inner}\n</figure>\n<!-- /wp:gallery -->')


### PR DESCRIPTION
## What

One shared module for Gutenberg block markup across every kriskrug.co post path, replacing the per-script copy-pasted strings. Triggered by oversized inline screenshots on the Context Creators draft; grew into killing the bespoke markup everywhere.

## Changes

- **`wp_blocks.py`** (new): the one canonical emitter — `inline()`, `image()` / `inline_image()` / `hero_image()`, `gallery()`, `separator()`, `heading()`, `pullquote()`. Standardized on the native WP lightbox (no `<a>` wrapper), `wp-element-caption`, and canonical `<h2 class="wp-block-heading">`.
- **`block_rules.py`**: the main Notion→WP pipeline (`render_image` / `render_divider` / `render_heading`) now delegates to `wp_blocks` (TBD dry-run id + `image_map` preserved).
- **`publish_context_creators.py`** (new) + **`publish_you_cant_drink_data.py`** + **`publish_dc_protest_draft.py`**: import `wp_blocks`, drop local emitters. Deleted `image_blocks.py`.
- **`tests/test_wp_blocks.py`** (new): locks the markup, incl. the `"TBD"`-id dry-run case. 42 tests green.
- Docs: README section on `wp_blocks` + how to safely re-emit an already-published post.
- Content: Context Creators draft (post 12404) text staging record (images stay in the Media Library, per repo convention).

## kk-aurora facts baked in

Prose column is 720px (inline images default to 460px), the theme has no float CSS (centered only), and the native 6.4+ lightbox is enabled per image.

## Live impact (already applied, independent of this merge)

- Draft **12404** re-emitted through the module.
- Published **11936** (you-cant-drink-data) and **11929** (data-center-protest-signs) upgraded to lightbox + unified captions. 11929 was done via an **in-place transform** (not a rebuild) because its source markdown had drifted from the live content — see the README note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)