### PR TITLE
Refresh homepage/footer project roster (drop Upgrade/Indigenomics, add Vancouver AI + Futureproof)

### DIFF
--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -31,8 +31,8 @@
       <div>
         <h3>Projects</h3>
         <a href="https://bc-ai.ca/">BC + AI</a>
-        <a href="https://www.theupgrade.ai/">The Upgrade AI</a>
-        <a href="https://indigenomics.ai/">Indigenomics.ai</a>
+        <a href="https://vancouver.ai/">Vancouver AI</a>
+        <a href="https://futureproof.website/">Futureproof Festival</a>
         <a href="https://www.punkrockai.com/">Punk Rock AI</a>
         <a href="https://www.bothhandsfull.com/">Both Hands Full</a>
         <a href="https://ethosblockparty.com/the-day">Ethọ́s Block Party</a>

--- a/theme/kk-aurora/patterns/hero-gradient.php
+++ b/theme/kk-aurora/patterns/hero-gradient.php
@@ -20,7 +20,7 @@
       <!-- /wp:heading -->
       
       <!-- wp:paragraph {"align":"center","className":"aurora-hero-description","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"textColor":"text-secondary","fontSize":"lg"} -->
-      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC+AI · Co-founder The Upgrade AI · Techartist &amp; Culture Hacker</p>
+      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC+AI · Lead Curator, Futureproof Festival · Techartist &amp; Culture Hacker</p>
       <!-- /wp:paragraph -->
       
       <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
@@ -36,7 +36,7 @@
         <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
         <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
           <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"signal"} -->
-          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">Indigenomics</p>
+          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">Vancouver AI</p>
           <!-- /wp:paragraph -->
         </div>
         <!-- /wp:group -->
@@ -44,7 +44,7 @@
         <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
         <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
           <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"signal"} -->
-          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">The Upgrade AI</p>
+          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">Futureproof Festival</p>
           <!-- /wp:paragraph -->
         </div>
         <!-- /wp:group -->

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -18,11 +18,11 @@
     <div class="aurora-hero-copy" data-reveal>
       <p class="aurora-kicker">AI keynote speaker. Community builder. Technology-for-justice operator.</p>
       <h1 id="aurora-home-title">Authored judgment in the age of generative everything.</h1>
-      <p class="aurora-hero-dek">Bridging art, AI, Indigenous wisdom, and justice through BC+AI's 2,000+ member ecosystem, Indigenomics.ai's $200B Indigenous economy work, and The Upgrade AI's practical training for enterprise and creative teams.</p>
+      <p class="aurora-hero-dek">Bridging art, AI, Indigenous wisdom, and justice through BC+AI's province-wide ecosystem, the monthly Vancouver AI community, and Futureproof Festival, the most honest AI conversation happening anywhere this year.</p>
       <div class="aurora-proof-row" aria-label="Current proof">
         <a href="https://bc-ai.ca/">Executive Director, BC+AI</a>
-        <a href="https://indigenomics.ai/">CTO, Indigenomics.ai</a>
-        <a href="https://www.theupgrade.ai/">Co-founder, The Upgrade AI</a>
+        <a href="https://vancouver.ai/">Host &amp; Founder, Vancouver AI</a>
+        <a href="https://futureproof.website/">Lead Curator, Futureproof Festival</a>
         <a href="/work/">Culture, code, community</a>
       </div>
       <div class="aurora-action-row">
@@ -73,23 +73,23 @@
       </article>
 
       <article class="aurora-media-card">
-        <a href="https://indigenomics.ai/" aria-label="Explore Indigenomics.ai">
-          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/image-19.png?w=1200&amp;ssl=1" alt="Indigenomics AI visual from Kris Krug's public writing" loading="lazy" decoding="async">
-          <span class="aurora-card-label">Sovereignty tech</span>
+        <a href="https://vancouver.ai/" aria-label="Explore Vancouver AI">
+          <img src="https://bc-ai.ca/wp-content/uploads/2026/06/june-meetup-30-full-lineup-hero-1024x1024.png" alt="Vancouver AI monthly community meetup lineup" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Community</span>
           <div>
-            <h3>Indigenomics.ai</h3>
-            <p>CTO work supporting Indigenous economic sovereignty, evidence systems, and the $200B Indigenous economy frame.</p>
+            <h3>Vancouver AI</h3>
+            <p>The monthly room where Vancouver's artists, engineers, and builders actually meet. Indigenous-led, ceremony-opened, hundreds a month.</p>
           </div>
         </a>
       </article>
 
       <article class="aurora-media-card">
-        <a href="https://www.theupgrade.ai/" aria-label="Explore TheUpgrade.ai">
-          <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/07/ai-courses-workshops-trainings.png?w=1200&amp;ssl=1" alt="The Upgrade AI courses workshops and trainings graphic" loading="lazy" decoding="async">
-          <span class="aurora-card-label">Training</span>
+        <a href="https://futureproof.website/" aria-label="Explore Futureproof Festival">
+          <img src="https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260527.jpg" alt="Futureproof Festival 2026 key art" loading="lazy" decoding="async">
+          <span class="aurora-card-label">Festival</span>
           <div>
-            <h3>The Upgrade AI</h3>
-            <p>Co-founded with Peter Bittner to bring useful AI training to Fortune 500 teams, creative pros, and community builders.</p>
+            <h3>Futureproof Festival</h3>
+            <p>Three days of the most honest AI conversation anywhere. Talks, film, performance, and a hackathon at the Space Centre, Oct 28-30.</p>
           </div>
         </a>
       </article>

--- a/theme/kk-aurora/templates/single.html
+++ b/theme/kk-aurora/templates/single.html
@@ -52,7 +52,7 @@
         <h2 class="wp-block-heading aurora-author-title">About Kris</h2>
         <!-- /wp:heading -->
         <!-- wp:paragraph -->
-        <p>Kris Krug is an AI keynote speaker, creative technologist, photographer, and community builder working across BC + AI, The Upgrade AI, Indigenomics.ai, and a living network of AI-era projects.</p>
+        <p>Kris Krug is an AI keynote speaker, creative technologist, photographer, and community builder working across BC + AI, Vancouver AI, and Futureproof Festival, and a living network of AI-era projects.</p>
         <!-- /wp:paragraph -->
         <!-- wp:buttons {"layout":{"type":"flex","flexWrap":"wrap"}} -->
         <div class="wp-block-buttons">


### PR DESCRIPTION
Swaps stale current-work signaling for what KK actually runs now, after researching his live sites + KB.

**Out (no longer current):** The Upgrade AI (folded into BC+AI), Indigenomics.ai (past; CTO role wrapped end 2025).
**In:** Vancouver AI (vancouver.ai, Host & Founder) and Futureproof Festival (futureproof.website, Lead Curator; Oct 28–30 2026 @ the Space Centre).

Theme files changed (one kk-aurora deploy):
- `parts/footer.html` — Projects column swap
- `templates/front-page.html` — hero dek, role badges, and the two stale project cards → Vancouver AI + Futureproof cards
- `templates/single.html` — per-post author bio line
- `patterns/hero-gradient.php` — unused pattern, names swapped for hygiene

Already live (REST, no deploy): `indigenomics.ai` → `indigenomics.com` on /about/ + /work/ (kept as past work).

Deploy = wp-admin theme zip upload + Pagely purge (SFTP blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)