### PR TITLE
Sync schema + llms.txt project orgs (Vancouver AI + Futureproof)

### DIFF
--- a/fixes/llms.txt
+++ b/fixes/llms.txt
@@ -38,7 +38,7 @@
 ## Projects and communities
 
 - [BC + AI Ecosystem](https://bc-ai.ca/): Community infrastructure for responsible, inclusive, place-rooted AI in British Columbia
-- [Indigenomics.ai](https://indigenomics.ai/): Indigenous economic sovereignty and evidence-systems work Kris has supported through prior CTO work
+- [Indigenomics.ai](https://indigenomics.com/): Indigenous economic sovereignty and evidence-systems work Kris has supported through prior CTO work
 - [Vancouver AI Meetup](https://kriskrug.co/?s=vancouver+ai+meetup): Monthly community gathering archive and related posts
 
 ## Archives and policies

--- a/fixes/schema-snippets-deployed.php
+++ b/fixes/schema-snippets-deployed.php
@@ -36,8 +36,8 @@ function kk_schema_constants() {
         ),
         'works_for' => array(
             array('name' => 'BC + AI Ecosystem Industry Association', 'url' => 'https://bc-ai.ca/'),
-            array('name' => 'Indigenomics.ai',                        'url' => 'https://indigenomics.ai/'),
-            array('name' => 'The Upgrade AI',                         'url' => 'https://www.theupgrade.ai/'),
+            array('name' => 'Vancouver AI',                           'url' => 'https://vancouver.ai/'),
+            array('name' => 'Futureproof Festival',                   'url' => 'https://futureproof.website/'),
         ),
         'knows_about' => array(
             'Generative AI', 'AI Strategy', 'AI for Creative Professionals',


### PR DESCRIPTION
Mirrors the live Code Snippets (schema worksFor + llms.txt) already fixed via REST. Drops Indigenomics.ai + The Upgrade AI from current orgs, adds Vancouver AI + Futureproof, corrects Indigenomics link to .com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)