### PR TITLE
docs: archive content mine + weekly work plan + INDEX updates

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 | [`current-state/CONTENT_AUDIT.md`](current-state/CONTENT_AUDIT.md) | Per-page review + post inventory + IA proposal |
 | [`current-state/FIX_QUEUE.md`](current-state/FIX_QUEUE.md) | P0 → P3 backlog |
 | [`current-state/ROADMAP.md`](current-state/ROADMAP.md) | Six-phase, 3-month plan; use as longer-range reference after the latest work plan |
+| [`current-state/WORK-PLAN-2026-07-01.md`](current-state/WORK-PLAN-2026-07-01.md) | **Active weekly plan** (rest of week). Live PR/issue readback + execution lanes; supersedes `WORK-PLAN-2026-05-23.md` |
 | [`current-state/FULL-AUDIT-ROADMAP-2026-05-18.md`](current-state/FULL-AUDIT-ROADMAP-2026-05-18.md) | May 18 post-closeout audit, roadmap, and human decision list |
 | [`current-state/HANDOFF-2026-05-24.md`](current-state/HANDOFF-2026-05-24.md) | Current cross-track state (Aurora/theme/content truth, deployment mechanics, open work) |
 | [`current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md`](current-state/AURORA-V3-QA-ROADMAP-2026-05-24.md) | Current Aurora v1.3.0 QA and rollout truth for Track B |
@@ -61,6 +62,7 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 |---|---|
 | [`../scripts/notion-to-wp/README.md`](../scripts/notion-to-wp/README.md) | Notion → WP publisher: setup, dry-run, safety guards |
 | [`kris-krug-roles-module.md`](kris-krug-roles-module.md) | KK's role-switching framework (voice / tone reference) |
+| [`archive-content-mine.md`](archive-content-mine.md) | 20-year blog-archive content mine (2003–2026): bio/credential threads + "from the archives" content backlog, with source links |
 | [`../.claude/context/project-context.md`](../.claude/context/project-context.md) | Mission, values, audience, voice |
 | [`../.claude/agents-vibe.md`](../.claude/agents-vibe.md) | Agent philosophy & community values |
 | [`../.claude/naming-conventions.md`](../.claude/naming-conventions.md) | Code naming standards |
@@ -111,4 +113,4 @@ Each historical doc carries a `STATUS: Historical` banner at the top pointing at
 
 ---
 
-**Last updated:** 2026-05-25 02:19 UTC. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.
+**Last updated:** 2026-07-01. Added the archive content mine and the 2026-07-01 work plan. Note: this index does not exhaustively list every dated file under `docs/current-state/` — the June 2026 snapshots (e.g. `CURRENT-STATE-2026-06-23.md`) are newer than some entries here, so treat `docs/current-state/` itself as the source of truth for the latest dated evidence. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.

--- a/docs/archive-content-mine.md
+++ b/docs/archive-content-mine.md
@@ -1,0 +1,129 @@
+# Blog Archive Content Mine — kriskrug.co (2003–2026)
+
+**Purpose:** A curated catalog of significant, bio- and content-worthy moments mined from
+20+ years of the kriskrug.co archive. Use it to enrich the About page, the short author
+bio, and a "from the archives" content backlog — each entry has a source link, a suggested
+bio angle, and a content-post idea.
+
+**Method / source:** 941 post URLs inventoried from
+[`docs/current-state/raw/sitemap-1.xml`](current-state/raw/sitemap-1.xml) (dates are embedded
+in the post URLs). High-signal posts were triaged by keyword and the marquee ones were
+read in full to verify facts. Where a claim still needs a human confirm, it's flagged.
+
+## The shape of the archive
+
+| Years | Posts | Chapter |
+|------|------|---------|
+| 2003–2007 | ~700 | Web 2.0 builder (Bryght, Drupal, Northern Voice, Flickr, Static Photography) |
+| 2008–2013 | ~80 | Global photojournalist (COP15, TEDxOilSpill, PopTech, UN, Olympics) |
+| 2013–2021 | ~30 | Pilot + Galiano Island (flying, aerial/drone photography, island life) |
+| 2023–2026 | ~265 | AI-era revival (Vancouver AI → BC+AI, manifestos, keynotes) |
+
+---
+
+## Chapter 1 — Web 2.0 builder (2004–2007)
+
+- **Bryght** — co-founded the Vancouver Drupal-hosting startup, one of the early Web 2.0
+  companies. The "before photography/AI, I was a builder" credential.
+  - Bio angle: *"co-founder of Bryght, an early Drupal/Web 2.0 company"*
+  - Content idea: "How a Vancouver Drupal shop taught me everything I know about community."
+- **Northern Voice** — co-organizer of Canada's pioneering blogging/social-media conference
+  (incl. Moose Camp and PhotoCamp). Historic in Canadian web culture.
+  - Source: <https://kriskrug.co/2005/09/16/northern-voice-2006-the-moose-is-loose/>
+  - Bio angle: *"co-organizer of Northern Voice, Canada's first blogging conference"*
+- **Drupal community leader** — Google Summer of Code, Vancouver League of Drupalers.
+  - Source: <https://kriskrug.co/2005/08/10/choosing-drupal/>
+- **Published author** — *BitTorrent For Dummies* (Wiley, 2005), with Susannah Gardner.
+  - Source: <https://kriskrug.co/2005/10/19/book-review-bittorrent-for-dummies-by-susannah-gardner-and-kris-krug/>
+  - ⚠️ Confirm exact authorship credit (co-author vs. contributor) before printing "author of."
+- **Static Photography** — his studio brand, recurring across years (also the studio behind
+  the TEDxOilSpill expedition below).
+- **Raincity Studios** — the web-agency thread of the same era.
+
+## Chapter 2 — Global photojournalist (2008–2013)
+
+- **TEDxOilSpill expedition (June 2010)** — *led a team* to document the BP Deepwater Horizon
+  Gulf oil spill (with Duncan Davidson, Pinar Ozger, Static Photography's Danielle Sipple).
+  Marquee photojournalism.
+  - Source: <https://kriskrug.co/2010/06/13/ted-x-oil-spill-expedition-headed-to-new-orleans-the-gulf-of-mexico/>
+  - Bio angle: *"led a documentary team to the Gulf of Mexico for TEDxOilSpill (2010)"*
+- **COP15, Copenhagen (2009)** — accredited photojournalist at the UN Climate Summit;
+  worked alongside 350.org / TckTckTck.
+  - Source: <https://kriskrug.co/2009/12/14/photo-essay-inside-the-negotiations-cop15/>
+- **Global keynotes + shoots (2011)** — UN Global Youth Summit on HIV in Africa (keynote
+  alongside Crown Princess Mette-Marit of Norway), Midway Atoll ocean-plastic work with
+  Chris Jordan, GeeksOnAPlane.
+  - Source: <https://kriskrug.co/2011/04/27/a-rolling-stone-gathers-no-moss-africa-south-america-the-pacific-ocean/>
+- **PopTech official photographer** (Camden, Maine, 2009) — shooting "the world changers."
+  - Source: <https://kriskrug.co/2009/08/06/returning-to-camden-maine-to-photograph-the-world-changers-of-poptech-2009-america-reimagined/>
+- **RiP: A Remix Manifesto (2010)** — connected to Brett Gaylor's "world's first open-source
+  documentary"; remix culture and Creative Commons.
+  - Source: <https://kriskrug.co/2010/11/25/rip-a-remix-manifesto/>
+- **Also:** Vancouver 2010 Winter Olympics photography; UN HIV digital crowdsourcing
+  campaign (2011); CBC social-media training for journalists.
+
+## Chapter 3 — Pilot + Galiano Island (2013–2021)
+
+- **Pilot school / Private Pilot License (2013)** — already tracked (see the pilot-school
+  issue). The personal-dreams origin beat.
+  - Source: <https://kriskrug.co/2013/09/14/pilot-school-flying-in-the-direction-of-my-dreams/>
+- **Aerial photography = flying + photography (2015)** — the perfect bridge from pilot
+  school; he rolled it into drone work (DJI Phantom 3).
+  - Source: <https://kriskrug.co/2015/09/08/aerial-photography-combining-my-loves-for-flying-and-making-photos/>
+  - Quotable: *"How lucky am I to be alive at the most perfect time in history for my
+    passions for flying and photography to intersect."*
+- **Galiano Island life** — King Fisher Apparel, Access to Media digital-storytelling
+  workshops (Galiano/Penelakut), a printmaking press, bird inventories. A whole "island
+  maker" chapter most bios skip.
+- **Feelmore Plants (2019)** — gardening pop-up shop in Vancouver's West End.
+  - Source: <https://kriskrug.co/2019/06/10/feelmore-plants-a-gardening-pop-up-shop-in-vancouvers-west-end/>
+
+## Chapter 4 — AI-era revival (2023–2026)
+
+- **Vancouver AI Community Meetup founding (Oct 2023)** — the literal genesis of what became
+  BC+AI. Strong origin-story material.
+  - Source: <https://kriskrug.co/2023/10/05/teasing-the-launch-vancouver-ai-community-meetup/>
+- **Google News Initiative pre-launch lab (2023)** — a media-venture thread.
+  - Source: <https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/>
+- **Manifestos** — *"Great Creative Reckoning"* (2024) and *"A Creative Technologist's
+  AI-Age Manifesto"* (2025).
+  - Source: <https://kriskrug.co/2024/11/22/great-creative-reckoning-a-techartists-manifesto-on-generative-artificial-intelligence/>
+  - Quotable: *"When everything is possible, the only thing that matters is what you choose
+    to do with that possibility."*
+
+---
+
+## Quick-win bio additions (punch list)
+
+These are short, high-confidence lines that could strengthen the About page / short bio:
+
+- [ ] Pilot's license + aerial photography (already tracked) — pairs the 2013 + 2015 posts.
+- [ ] "Co-founder of Bryght" (early Drupal/Web 2.0 company).
+- [ ] "Co-organizer of Northern Voice" (Canada's pioneering blogging conference).
+- [ ] "Documented the BP Gulf oil spill with TEDxOilSpill (2010)."
+- [ ] "Accredited photojournalist at the UN's COP15 climate summit (2009)."
+- [ ] "Founder of the Vancouver AI Community → BC+AI."
+- [ ] Published author — *BitTorrent For Dummies* (pending authorship confirm).
+
+## Content backlog — a "From the Archives" series
+
+Each is a ready-made post with built-in internal links back to the original:
+
+1. **"The Gulf, from the air"** — revisit the TEDxOilSpill expedition 15 years on.
+2. **"Before AI, there was Drupal"** — the Bryght / Northern Voice / Web 2.0 origin story.
+3. **"Flying in the direction of my dreams"** — pilot school → aerial → drones throughline.
+4. **"Shooting the world changers"** — PopTech, COP15, UN HIV summit photojournalism.
+5. **"From meetup to movement"** — Vancouver AI Community → BC+AI (tie to existing drafts).
+
+## ⚠️ Attribution cautions (verified during mining)
+
+- **"My Two Years at Bryght"** (2006) is colleague **Richard Eriksson's** reflection that
+  Kris re-shared — not Kris's own words. Bryght-the-company is still genuinely his.
+- **"Desert to Dream: A Decade of Burning Man"** is **Barbara Traub's** photo book that Kris
+  blogged about — not his book. He IS a longtime Burning Man photographer (corroborated by
+  other posts and 2023 art-project coverage), just not the author of that title.
+
+---
+
+*Generated from an archive-mining pass over the kriskrug.co sitemap. Marquee facts were
+verified against the original posts; items marked ⚠️ need a human confirm before publishing.*

--- a/docs/current-state/WORK-PLAN-2026-07-01.md
+++ b/docs/current-state/WORK-PLAN-2026-07-01.md
@@ -1,0 +1,99 @@
+# Work Plan — Week of 2026-06-29 (rest of week)
+
+> **Status:** current. This is the active execution plan; it supersedes
+> `WORK-PLAN-2026-05-23.md` (kept as historical baseline).
+> **Created:** 2026-07-01 (Canada Day) from a live GitHub readback.
+> **Branch:** `claude/pilot-school-bio-28wm61` for this session's docs; execution lanes below run per the two-track model.
+> **Mode:** Track A first (live-site ops, small reversible fixes). Keep Aurora on Track B.
+
+## Verified State (live readback, 2026-07-01)
+
+- Open PRs: **3**
+  - **#271** — `docs: archive mine + weekly plan` (this session, **draft**, docs-only).
+  - **#265** — `perf: KK Asset Diet` (unused plugin CSS/JS). Already live as Code Snippet id 10; PR is ready-for-review.
+  - **#264** — `content: "Keep the Machine Strange"` (WP draft created, not published).
+- Open issues: **16** (includes #269 and #270 filed this session).
+- ⚠️ **Drift:** the `CURRENT-STATE-2026-06-23.md` snapshot recorded 0 PRs / 48 issues. Live is 3 PRs / 16 issues. Run `make current-state-drift-check` and refresh the snapshot before trusting stored counts.
+- Working tree clean; scratchpad temp artifacts cleared.
+
+## This Session's Deliverables (2026-06-30 → 07-01)
+
+- **#269** — pilot-school story → bio + About page (filed).
+- **#270** — About/bio + content backlog from the 20-year archive mine (filed).
+- **PR #271** — `docs/archive-content-mine.md` catalog + this work plan + INDEX update.
+- Confirmed local ↔ remote in sync; cleaned session temp files.
+
+## North Star (unchanged)
+
+Make `kriskrug.co` a trustworthy public operating surface for Kris's creative
+technology, AI community, and publishing work — public pages tell the right
+story, drafts move through review instead of piling up, live fixes are small
+and reversible, and Aurora evolves without leaking theme work into `main`.
+
+## Open PRs — land or decide first
+
+1. **#265 (Asset Diet)** — already live as a snippet; decide merge (version-controls the source of truth) or request changes. Highest "close the loop" value.
+2. **#264 ("Keep the Machine Strange")** — KK content/voice review of the WP draft; publish decision is KK-gated.
+3. **#271 (docs)** — mergeable once reviewed; docs-only, no site impact. Can flip out of draft when ready.
+
+## Lanes (grounded in the 16 open issues)
+
+### Lane 1 — Bio & About follow-through (this session's threads)
+- **#269 / #270** — turn the archive mine into real copy: draft the About-page additions (pilot school + the strongest verified credentials) and the one-line author-bio tweak.
+- Gate: confirm the ⚠️ items (esp. *BitTorrent For Dummies* authorship) before any credential goes in public copy. KK approves voice/placement.
+
+### Lane 2 — Public story polish / content
+- **#122** — ~25 undesigned generic content pages (define template vs. bespoke approach).
+- **#22** — Indigenous land acknowledgment (footer or About; values-aligned, low-risk).
+- **#249** — measure "you can't drink data" striking-distance after the #233 deploy (blocked until data window opens).
+
+### Lane 3 — Accessibility (standing priority:high)
+- **#4** — alt text across images.
+- **#48** — publish an Accessibility Statement at `/accessibility`.
+- **#46** — full WCAG 2.1 AA audit (larger; scope a first slice rather than boiling the ocean).
+
+### Lane 4 — Tech debt & reliability
+- **#256** — CSS dead-code audit + mark canonical schema snippet (Track B for the CSS part).
+- **#255** — CI unit tests for risky root scripts (`wp_post_ia_rollout.py` dry-run guard, `public_image_audit.py`).
+- **#254** — consolidate the one-off `publish_*.py` logic into `publish_common.py`; de-hardcode IDs.
+
+### Lane 5 — Platform trust
+- **#222 (EPIC)** — sequence form-routing verification, publisher hardening, and the sidebar-promos go/no-go. Coordinating epic; don't duplicate linked-issue work. `needs-human-review`.
+
+### Lane 6 — Aurora Track B (blocked / staging-gated)
+- **#86 / #125 / #127** — staging perf + a11y + mobile QA; Jetpack Boost Critical CSS regen. No theme files on `main`; cutover stays blocked until staging QA + rollback gates pass.
+
+## Suggested Sequence — rest of week
+
+_Jul 1 is Canada Day; treat today as a holiday. Actionable days: Thu Jul 2 – Fri Jul 3._
+
+- **Thu Jul 2**
+  1. Decide/merge PR **#265** (asset diet) and flip **#271** out of draft after review.
+  2. Lane 1: draft About-page copy for **#269** + confirm the *BitTorrent For Dummies* credit for **#270**.
+  3. Refresh the current-state snapshot (resolve the 48→16 drift).
+- **Fri Jul 3**
+  1. KK review pass on PR **#264** content draft (publish decision gated).
+  2. Lane 3 quick win: ship the Accessibility Statement (**#48**) or a first alt-text slice (**#4**).
+  3. Groom Lane 4 tech-debt issues into a small, testable first PR (**#255** dry-run guard is the safest start).
+- **Next week carryover:** #122 page-template approach, #46 a11y audit slice, #222 epic sequencing, Aurora Track B staging QA.
+
+## Stop Rules (unchanged)
+
+1. No public publish or schedule without KK approval.
+2. No live WordPress write without exact slug/ID/status checks and a documented rollback.
+3. No second WP draft for a slug that already exists.
+4. No theme file changes on `main` (Aurora stays Track B).
+5. No broad issue swarm until the open-issue list is refreshed live and the checkout is clean.
+
+## Startup / Re-verify Commands
+
+```bash
+git fetch --prune
+git status --short --branch
+# live truth (this repo uses GitHub MCP; gh shown for parity)
+gh pr list --state open --limit 50
+gh issue list --state open --limit 200
+make current-state-drift-check
+make draft-queue-audit
+scripts/notion-to-wp/.venv/bin/python -m unittest discover scripts/notion-to-wp/tests
+```


### PR DESCRIPTION
## Summary

Documentation-only PR from a wind-down/tidy session. Adds durable research + planning docs and keeps the docs index current. No theme/site code changes.

## Related Issue

Relates to #270 (About page + bio: mine the 20-year archive)
Relates to #269 (pilot-school bio addition — first thread from this archive)

## Changes

- **`docs/archive-content-mine.md`** — curated catalog of bio- and content-worthy moments mined from the kriskrug.co archive (2003–2026), organized into four chapters, each with source link, suggested bio angle, and content-post idea. Includes a quick-win bio punch list, a "from the archives" content backlog, and two verified attribution cautions.
- **`docs/current-state/WORK-PLAN-2026-07-01.md`** — active weekly work plan (rest of week) built from a live GitHub readback (3 open PRs, 16 open issues) with execution lanes, suggested Thu–Fri sequencing, and the standing two-track stop rules. Flags drift from the stale 2026-06-23 snapshot.
- **`docs/INDEX.md`** — registers the two new docs and notes the index no longer exhaustively lists the June current-state snapshots (source of truth is `docs/current-state/`).

## Type of Change

- [x] Documentation update

## Testing

Docs-only change. No runtime/site behavior affected.

### Test Results

- [x] Markdown renders correctly; archive source links verified against the original posts during mining
- [x] Work-plan counts taken from a live GitHub readback on 2026-07-01
- [ ] N/A — no `make verify` / PHP validation surface (no code touched)

## Deployment Notes

- [x] No special deployment steps required (reference docs; not published to the live site)

## Additional Notes

Entries flagged ⚠️ in the archive doc (e.g. *BitTorrent For Dummies* authorship) need a human confirm before they go into public-facing copy. Implementation of the actual About-page / bio updates is tracked in #269 / #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)