### PR TITLE
Add: root script CI coverage

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -21,6 +21,7 @@ jobs:
       has_js: ${{ steps.changed-files.outputs.has_js }}
       has_docs: ${{ steps.changed-files.outputs.has_docs }}
       has_notion: ${{ steps.changed-files.outputs.has_notion }}
+      has_root_scripts: ${{ steps.changed-files.outputs.has_root_scripts }}
       has_sidebar_promos: ${{ steps.changed-files.outputs.has_sidebar_promos }}
     steps:
       - uses: actions/checkout@v4
@@ -45,14 +46,20 @@ jobs:
               ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'Makefile', 'scripts/docs_truth_check.py'].includes(name)
             );
             const hasNotion = names.some((name) => name.startsWith('scripts/notion-to-wp/'));
+            const hasRootScripts = names.some((name) =>
+              name === 'scripts/wp_post_ia_rollout.py' ||
+              name === 'scripts/public_image_audit.py' ||
+              name.startsWith('scripts/tests/')
+            );
             const hasSidebarPromos = names.some((name) => name.startsWith('plugins/kk-sidebar-promos/'));
 
             core.info(`Changed files: ${names.length}`);
-            core.info(`has_php=${hasPhp} has_js=${hasJs} has_docs=${hasDocs} has_notion=${hasNotion} has_sidebar_promos=${hasSidebarPromos}`);
+            core.info(`has_php=${hasPhp} has_js=${hasJs} has_docs=${hasDocs} has_notion=${hasNotion} has_root_scripts=${hasRootScripts} has_sidebar_promos=${hasSidebarPromos}`);
             core.setOutput('has_php', hasPhp ? 'true' : 'false');
             core.setOutput('has_js', hasJs ? 'true' : 'false');
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
             core.setOutput('has_notion', hasNotion ? 'true' : 'false');
+            core.setOutput('has_root_scripts', hasRootScripts ? 'true' : 'false');
             core.setOutput('has_sidebar_promos', hasSidebarPromos ? 'true' : 'false');
 
       - name: Check PR title format
@@ -132,6 +139,25 @@ jobs:
       - name: Run Notion publisher unit tests
         run: python -m unittest discover -s scripts/notion-to-wp/tests -v
 
+  # Root script unit tests
+  root-script-tests:
+    needs: validate
+    runs-on: ubuntu-latest
+    if: needs.validate.outputs.has_root_scripts == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install root script test dependencies
+        run: pip install requests
+
+      - name: Run root script unit tests
+        run: python -m unittest discover -s scripts/tests -v
+
   # JavaScript/Node validation
   javascript-validation:
     needs: validate
@@ -205,7 +231,7 @@ jobs:
 
   # Summarize all checks
   summary:
-    needs: [validate, php-validation, notion-tests, javascript-validation, docs-truth-check, security-scan]
+    needs: [validate, php-validation, notion-tests, root-script-tests, javascript-validation, docs-truth-check, security-scan]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/tests/test_public_image_audit.py
+++ b/scripts/tests/test_public_image_audit.py
@@ -1,9 +1,18 @@
+import argparse
 import unittest
 import sys
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from public_image_audit import ImageParser, is_filename_style_alt, media_id_from_class, summarize
+from public_image_audit import (
+    ImageParser,
+    audit_images,
+    collect_urls,
+    is_filename_style_alt,
+    media_id_from_class,
+    summarize,
+)
 
 
 class PublicImageAuditTests(unittest.TestCase):
@@ -35,6 +44,82 @@ class PublicImageAuditTests(unittest.TestCase):
         self.assertEqual(stats["decorative_empty"], 1)
         self.assertEqual(stats["filename_style"], 1)
         self.assertEqual(stats["missing_attr"], 1)
+
+    def test_collect_urls_normalizes_explicit_relative_urls(self):
+        args = argparse.Namespace(
+            base_url="https://kriskrug.co",
+            urls=["/about/", "https://example.com/custom/"],
+            ids=[],
+            default_urls=False,
+            kind=["post", "page"],
+            limit=50,
+            since="2025-01-01",
+        )
+
+        items = collect_urls(args)
+
+        self.assertEqual(items[0]["link"], "https://kriskrug.co/about/")
+        self.assertEqual(items[0]["slug"], "about")
+        self.assertEqual(items[1]["link"], "https://example.com/custom/")
+
+    def test_audit_images_parses_public_html_and_probes_image_urls(self):
+        class FakeResponse:
+            status_code = 200
+            encoding = "utf-8"
+            headers = {"content-length": "1234"}
+
+            def __init__(self, body=""):
+                self.body = body.encode("utf-8")
+
+            def raise_for_status(self):
+                return None
+
+            def iter_content(self, chunk_size=65536):
+                yield self.body
+
+        class FakeSession:
+            def __init__(self):
+                self.head_calls = []
+
+            def get(self, url, stream=False, timeout=None, **kwargs):
+                return FakeResponse(
+                    """
+                    <img class="wp-image-77" src="/wp-content/uploads/photo.jpg" alt="Useful alt" loading="lazy" srcset="a 1x">
+                    <img class="tracking-pixel" src="/pixel.gif" alt="">
+                    """
+                )
+
+            def head(self, src, allow_redirects=True, timeout=20):
+                self.head_calls.append(src)
+                return FakeResponse()
+
+        fake_session = FakeSession()
+        args = argparse.Namespace(
+            base_url="https://kriskrug.co",
+            urls=["/example/"],
+            ids=[],
+            default_urls=False,
+            kind=["post", "page"],
+            limit=50,
+            since="2025-01-01",
+            timeout=20,
+            check_urls=True,
+        )
+
+        with mock.patch("public_image_audit.public_session", return_value=fake_session):
+            rows = audit_images(args)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0].src, "https://kriskrug.co/wp-content/uploads/photo.jpg")
+        self.assertEqual(rows[0].media_id, 77)
+        self.assertEqual(rows[0].alt_state, "ok")
+        self.assertEqual(rows[0].status, 200)
+        self.assertEqual(rows[0].content_length, 1234)
+        self.assertEqual(rows[1].alt_state, "decorative-empty")
+        self.assertEqual(fake_session.head_calls, [
+            "https://kriskrug.co/wp-content/uploads/photo.jpg",
+            "https://kriskrug.co/pixel.gif",
+        ])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_wp_post_ia_rollout.py
+++ b/scripts/tests/test_wp_post_ia_rollout.py
@@ -1,0 +1,136 @@
+import io
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import wp_post_ia_rollout as rollout  # noqa: E402
+
+
+PILOT_MEDIA_ALT = "Cover image for Make Culture, Not Content, highlighting Kris Krug's culture-first AI message."
+
+
+class FakeWP:
+    def __init__(self):
+        self.posts = []
+
+    def post(self, endpoint, payload):
+        self.posts.append((endpoint, payload))
+        return {"ok": True}
+
+
+def audit(
+    post_id=42,
+    slug="make-culture-not-content",
+    featured_media=11264,
+    missing_excerpt=True,
+    missing_featured=False,
+    missing_featured_alt=True,
+):
+    return rollout.PostAudit(
+        post_id=post_id,
+        slug=slug,
+        link=f"https://kriskrug.co/{slug}/",
+        title="Make Culture, Not Content",
+        featured_media=featured_media,
+        featured_alt="",
+        has_excerpt=not missing_excerpt,
+        has_featured=featured_media > 0,
+        has_featured_alt=not missing_featured_alt,
+        missing_excerpt=missing_excerpt,
+        missing_featured=missing_featured,
+        missing_featured_alt=missing_featured_alt,
+    )
+
+
+class WpPostIaRolloutDryRunTests(unittest.TestCase):
+    def test_dry_run_builds_plan_without_wordpress_writes_or_snapshot(self):
+        fake_wp = FakeWP()
+        before_audits = [audit()]
+        after_audits = [
+            audit(
+                missing_excerpt=False,
+                missing_featured=False,
+                missing_featured_alt=False,
+            )
+        ]
+
+        with mock.patch.object(sys, "argv", ["wp_post_ia_rollout.py", "--since", "2026-01-01"]), \
+             mock.patch.object(rollout, "load_config", return_value=rollout.Config("https://example.com", "u", "p")), \
+             mock.patch.object(rollout, "WordPressClient", return_value=fake_wp), \
+             mock.patch.object(rollout, "fetch_posts", side_effect=[["before"], ["after"]]), \
+             mock.patch.object(rollout, "audit_posts", side_effect=[before_audits, after_audits]), \
+             mock.patch.object(rollout, "fetch_media", return_value={"alt_text": ""}), \
+             mock.patch.object(
+                 rollout,
+                 "post_content",
+                 return_value="<p>This is the first sentence. This second sentence makes a useful excerpt.</p>",
+             ), \
+             mock.patch.object(rollout, "public_page_probe", return_value={
+                 "featured_alt": "alt",
+                 "og_alt": "og alt",
+                 "hierarchy_ok": True,
+                 "hardcoded_field_note": False,
+                 "schema_has_image": True,
+             }), \
+             mock.patch.object(rollout, "write_report") as write_report, \
+             mock.patch.object(rollout, "snapshot_targets") as snapshot_targets, \
+             mock.patch("sys.stdout", new_callable=io.StringIO) as stdout:
+            rollout.main()
+
+        self.assertEqual(fake_wp.posts, [])
+        snapshot_targets.assert_not_called()
+        write_report.assert_called_once()
+        output = stdout.getvalue()
+        self.assertIn("[dry-run] planned writes: media=1 excerpt=1", output)
+        self.assertIn("media_updates=1 excerpt_updates=1", output)
+
+    def test_execute_path_snapshots_before_wordpress_writes(self):
+        fake_wp = FakeWP()
+        before_audits = [audit()]
+        after_audits = [
+            audit(
+                missing_excerpt=False,
+                missing_featured=False,
+                missing_featured_alt=False,
+            )
+        ]
+        snapshot_path = Path("/tmp/pre-write-snapshot.json")
+
+        with mock.patch.object(sys, "argv", ["wp_post_ia_rollout.py", "--execute", "--since", "2026-01-01"]), \
+             mock.patch.object(rollout, "load_config", return_value=rollout.Config("https://example.com", "u", "p")), \
+             mock.patch.object(rollout, "WordPressClient", return_value=fake_wp), \
+             mock.patch.object(rollout, "fetch_posts", side_effect=[["before"], ["after"]]), \
+             mock.patch.object(rollout, "audit_posts", side_effect=[before_audits, after_audits]), \
+             mock.patch.object(rollout, "fetch_media", return_value={"alt_text": ""}), \
+             mock.patch.object(
+                 rollout,
+                 "post_content",
+                 return_value="<p>This is the first sentence. This second sentence makes a useful excerpt.</p>",
+             ), \
+             mock.patch.object(rollout, "public_page_probe", return_value={
+                 "featured_alt": "alt",
+                 "og_alt": "og alt",
+                 "hierarchy_ok": True,
+                 "hardcoded_field_note": False,
+                 "schema_has_image": True,
+             }), \
+             mock.patch.object(rollout, "write_report"), \
+             mock.patch.object(rollout, "snapshot_targets", return_value=snapshot_path) as snapshot_targets, \
+             mock.patch("sys.stdout", new_callable=io.StringIO):
+            rollout.main()
+
+        snapshot_targets.assert_called_once()
+        self.assertEqual(
+            fake_wp.posts,
+            [
+                ("/wp-json/wp/v2/media/11264", {"alt_text": PILOT_MEDIA_ALT}),
+                ("/wp-json/wp/v2/posts/42", {"excerpt": "This is the first sentence. This second sentence makes a useful excerpt."}),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add unit coverage for `wp_post_ia_rollout.py` dry-run/no-write behavior and execute-path snapshot-before-write behavior.
- Extend `public_image_audit.py` tests around explicit URL normalization, public HTML parsing, media IDs, alt states, and image URL probing.
- Wire a narrowly triggered `root-script-tests` job into `.github/workflows/test-pr.yml` for the critical root scripts and `scripts/tests/`.

## Tests
- `python3 -m unittest discover -s scripts/tests -v`
- `/tmp/kriskrug-root-tests-venv/bin/python -m unittest discover -s scripts/tests -v` after installing only `requests`
- `make test`

## Gate
Draft until GitHub checks pass and KK approves review/merge.

Fixes #255