### PR TITLE
Fix: restore homepage feature contrast

### DIFF
--- a/scripts/tests/test_aurora_contrast_tokens.py
+++ b/scripts/tests/test_aurora_contrast_tokens.py
@@ -62,6 +62,14 @@ class AuroraContrastTokenTests(unittest.TestCase):
         for color in control_colors:
             self.assertGreaterEqual(contrast_ratio("#FFFAF6", color), 4.5)
 
+    def test_homepage_feature_band_contrast_floor_is_present(self):
+        css = (THEME_DIR / "style.css").read_text(encoding="utf-8")
+        front_page = (THEME_DIR / "templates/front-page.html").read_text(encoding="utf-8")
+
+        self.assertIn("aurora-feature-band-contrast", front_page)
+        self.assertIn(".aurora-feature-band-contrast > .aurora-section-heading", css)
+        self.assertGreaterEqual(contrast_ratio("#f8f1e6", "#090c11"), 4.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.33');
+define('KK_AURORA_VERSION', '1.3.34');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.34 =
+* Added an opaque contrast floor for the homepage creative-lab feature band after the 1.3.33 pa11y closeout.
+
 = 1.3.22 =
 * Darkened Aurora primary CTA colors to meet WCAG AA contrast with off-white button text.
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.33
+Version: 1.3.34
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -4412,6 +4412,24 @@ body.aurora-theme #aurora-main :where(.aurora-writing-pagination a, .aurora-writ
   background-color: #090c11 !important;
   border-color: #f8f1e6 !important;
   color: #f8f1e6 !important;
+  -webkit-text-fill-color: currentColor !important;
+}
+
+/* Aurora 1.3.34 homepage feature-band contrast hardening */
+body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading {
+  background:
+    radial-gradient(circle at 8% 0%, rgba(242, 180, 207, 0.08), transparent 22rem),
+    #090c11 !important;
+  border: 1px solid rgba(248, 241, 230, 0.12);
+  border-radius: var(--aurora-radius-card);
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading :where(h2, p:not(.aurora-kicker)) {
+  background-color: #090c11 !important;
+  box-decoration-break: clone;
+  color: #f8f1e6 !important;
+  -webkit-box-decoration-break: clone;
   -webkit-text-fill-color: currentColor !important;
 }
 

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -217,7 +217,7 @@
     </div>
   </section>
 
-  <section class="aurora-feature-band" data-reveal>
+  <section class="aurora-feature-band aurora-feature-band-contrast" data-reveal>
     <div class="aurora-section-heading">
       <p class="aurora-kicker">Related creative lab</p>
       <h2>Portals, talks, and training that feed the work.</h2>


### PR DESCRIPTION
## Summary
- Bump KK Aurora to `1.3.34` for a cache-busted homepage contrast fix.
- Add a named `aurora-feature-band-contrast` variant to the homepage creative-lab feature band.
- Give that band heading copy an opaque dark contrast floor while preserving the opal glow direction.
- Add static regression coverage so the front-page class and CSS contrast floor stay present.

## Verification
- Reproduced current live failure: `npx --yes pa11y@latest --standard WCAG2AA https://kriskrug.co/` reports the two known homepage contrast errors.
- Live route set after patch remains: `/about/`, `/blog/`, `/work/`, `/contact/` pass pa11y; `/` still fails until this theme ships.
- Browser injection check with local CSS + class on the live DOM gives `17.45:1` for both failing homepage elements.
- `python3 -m unittest scripts.tests.test_aurora_contrast_tokens -v`
- `php -l theme/kk-aurora/functions.php`
- `git diff --check`
- `make test`
- `python3 scripts/docs_truth_check.py`

## Not run / blocked
- `make verify` reached tests and docs truth, then stopped at `make validate` because local `composer` is not installed and repo-owned PHPCS is unavailable. GitHub CI should run the PHP validation job after this PR opens.

## Deployment note
Do not close #293 or #289 from this PR alone. After merging and deploying Aurora `1.3.34`, rerun `pa11y --standard WCAG2AA` on `/`, `/about/`, `/blog/`, `/work/`, and `/contact/`.

Refs #293
Relates to #289