### PR TITLE
fix: harden live homepage contrast fallback

### DIFF
--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.34');
+define('KK_AURORA_VERSION', '1.3.36');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.36 =
+* Extended the homepage creative-lab contrast floor to customized FSE templates that still render the live section without the newer contrast class, using plain selectors for cache and audit compatibility.
+
 = 1.3.34 =
 * Added an opaque contrast floor for the homepage creative-lab feature band after the 1.3.33 pa11y closeout.
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.34
+Version: 1.3.36
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -4415,8 +4415,9 @@ body.aurora-theme #aurora-main :where(.aurora-writing-pagination a, .aurora-writ
   -webkit-text-fill-color: currentColor !important;
 }
 
-/* Aurora 1.3.34 homepage feature-band contrast hardening */
-body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading {
+/* Aurora 1.3.36 homepage feature-band contrast hardening */
+body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading,
+body.aurora-theme #aurora-main .aurora-offer-band + .aurora-feature-band > .aurora-section-heading {
   background:
     radial-gradient(circle at 8% 0%, rgba(242, 180, 207, 0.08), transparent 22rem),
     #090c11 !important;
@@ -4425,7 +4426,10 @@ body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-h
   padding: clamp(1.25rem, 3vw, 2rem);
 }
 
-body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading :where(h2, p:not(.aurora-kicker)) {
+body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading h2,
+body.aurora-theme #aurora-main .aurora-feature-band-contrast > .aurora-section-heading p:not(.aurora-kicker),
+body.aurora-theme #aurora-main .aurora-offer-band + .aurora-feature-band > .aurora-section-heading h2,
+body.aurora-theme #aurora-main .aurora-offer-band + .aurora-feature-band > .aurora-section-heading p:not(.aurora-kicker) {
   background-color: #090c11 !important;
   box-decoration-break: clone;
   color: #f8f1e6 !important;


### PR DESCRIPTION
## Summary
- Bumps KK Aurora to `1.3.36` across `style.css` and `KK_AURORA_VERSION`.
- Extends the homepage creative-lab contrast floor to the customized live FSE markup that still renders `.aurora-offer-band + .aurora-feature-band` without the newer `.aurora-feature-band-contrast` class.
- Uses expanded plain selectors so optimized CSS bundles and audit tooling do not have to rely on `:where()` for the live fallback.

Relates to #293.

## Live deploy evidence
- Deployed `1.3.36` via wp-admin theme upload after WordPress confirmed installed `1.3.35`, uploaded `1.3.36`, both `KK Aurora`.
- PressCACHE purge returned `Cache Purge: Success` after deploy.
- Cache-busted public stylesheet readback at `2026-07-05T17:40:35Z` reported `Version: 1.3.36` and includes the `.aurora-offer-band + .aurora-feature-band` fallback selectors.
- Fresh/cache-busted public render uses Boost bundle `5639ab62b5.min.css`; that bundle contains the fallback selector.
- Pa11y API on a cache-busted public page reported `issueCount: 0`; computed styles for the #293 elements are `rgb(248, 241, 230)` on `rgb(9, 12, 17)`.

## Current blocker
- Canonical `https://kriskrug.co/` is still an ARES gateway `HIT` serving stale Boost bundle `a55f5152ba.min.css`, which does not include this hotfix.
- `wp-admin -> Pagely -> PressCACHE -> Purge page cache` did not invalidate the ARES edge for `/`.
- Atomic dashboard purge is needed for immediate canonical pa11y green; Atomic is currently at login in the browser session.

## Verification
- `make test` passed: 42 Notion publisher tests, 71 repo script tests, sidebar promos smoke.
- `make verify` ran tests and `docs-truth-check`, then stopped at `validate` because `phpcs` is not installed locally.
- `npx --yes pa11y@latest --standard WCAG2AA https://kriskrug.co/?pa11y_probe=<timestamp>` via the pa11y API returned `issueCount: 0` for the cache-busted public render.
- `npx --yes pa11y@latest --standard WCAG2AA https://kriskrug.co/` still fails on #293 selectors while `/` remains a stale ARES cache hit.
