### PR TITLE
[REFACTOR] Consolidate read-only WP auth clients

### DIFF
--- a/docs/current-state/WP-AUTH-CLIENT-INVENTORY-2026-07-08.md
+++ b/docs/current-state/WP-AUTH-CLIENT-INVENTORY-2026-07-08.md
@@ -1,0 +1,44 @@
+# WordPress Auth Client Inventory - 2026-07-08
+
+Scope: issue #306, stacked on PR #308 (`codex/issue-302-work-visual-cards`). This was a read-only platform/tooling refactor. No `.env` values were changed, no secrets were printed, and no live WordPress writes were run.
+
+## Summary
+
+`scripts/common.py` is now the shared stdlib WordPress REST client for low-risk read-only ops scripts. This pass normalized application-password spacing at the shared credential boundary and migrated the read-only queue-count/audit paths that were most likely to report false zeroes after generic HTTP 400s.
+
+## Migrated This Pass
+
+| File | Previous auth pattern | New path | Risk | Notes |
+|---|---|---|---|---|
+| `scripts/morning_truth_report.py` | Parsed `scripts/notion-to-wp/.env`, built Basic auth inline, returned `0` on any HTTP 400 queue-count response | `WPClient.from_env(env_path)` + `wp_queue_counts()` | Low | Read-only startup truth. Queue errors now render as unavailable with stderr instead of zero. |
+| `scripts/check_current_state_drift.py` | Same inline Basic-auth queue counter as morning truth | `WPClient.from_env(env_path)` + `wp_queue_counts()` | Low | Keeps the morning-truth drift table aligned with the same shared read-only count source. |
+| `scripts/notion-to-wp/draft_queue_audit.py` | Imported the Notion connector's requests client and skipped HTTP 400 responses while listing queue items / slug matches | `WPClient.from_env()` for read-only list/get calls | Low | Removes the Notion token dependency from draft audit collection and lets HTTP errors surface. |
+
+## Remaining Duplicated Callsites
+
+| File or family | Pattern | Risk | Suggested next step |
+|---|---|---|---|
+| `scripts/wp_post_ia_rollout.py` | Requests session with inline Basic auth | High | Write-capable `--execute` path for media alt text and excerpts; migrate only with dry-run/snapshot tests preserved. |
+| `scripts/notion-to-wp/wp_client.py`, `kk_notion_to_wp.py`, one-off `publish_*.py` scripts | Package-specific requests client and direct media/post/term writes | High | Keep separate until a dedicated publisher-client design covers uploads, terms, slug guards, and update safety. |
+| `scripts/notion-to-wp/publish_keep_the_machine_strange.py` | Uses `WPClient` but reaches into private `c._auth` for raw media upload | High | Add a shared media upload method or explicit auth-header helper before migrating other publish scripts. |
+| `scripts/seo-backfill/*.py` | Inline Basic auth in write-capable metadata/category backfills | High | Treat as a separate SEO backfill safety pass with dry-run fixtures and rollback notes. |
+| `scripts/marquee/wp_sync.py`, `scripts/marquee/sync.py` | Requests session / env credential gate for sync execution | Medium-high | Migrate after confirming execute/dry-run boundaries and existing tests. |
+| `scripts/public_image_audit.py` | Requests auth session for authenticated image/media audit | Medium | Likely safe once caller expectations around `requests.Session` are separated from auth creation. |
+| `scripts/jetpack_feedback_audit.py` | Inline Basic auth for authenticated feedback reads | Medium | Privacy-sensitive read-only audit; migrate with tests that avoid dumping feedback payloads. |
+| `scripts/wp7-admin-readiness.py`, `scripts/wordcamp-mcp-smoke.py` | Inline Basic auth for admin/readiness probes | Medium | Good future low-risk candidates, but keep separate from this queue-count fix. |
+| `scripts/mcp-wordpress-remote.sh` | Shell env export from WP credentials into MCP vars | Medium | Leave as shell-specific unless the MCP launch path is refactored. |
+| `scripts/seo-audit/inventory.py` | Credential gate against `WP_USER` / `WP_APP_PASSWORD` | Low-medium | Review with the rest of the SEO audit tooling. |
+
+## Verification Notes
+
+- Added unit coverage for shared app-password normalization and read-only queue-count targets.
+- Added regression coverage that HTTP 400 from the migrated queue counters is reported as an error rather than converted to zero.
+- Added draft-audit tests confirming `WPClient.from_env()` is used and HTTP 400 is not swallowed.
+- `python3 -m unittest scripts.tests.test_common` passed: 22 tests.
+- `python3 -m unittest discover -s scripts/tests -v` passed: 82 tests.
+- `scripts/notion-to-wp/.venv/bin/python -m unittest discover -s scripts/notion-to-wp/tests -v` passed: 44 tests.
+- `make status-readonly` passed and reported draft queue truth as `0` future posts, `64` draft posts, `4` draft pages; no live writes were run.
+
+## Follow-Up Boundary
+
+The next safe slice is either the admin/readiness probes (`wp7-admin-readiness.py`, `wordcamp-mcp-smoke.py`) or a dedicated write-client design for publisher/media uploads. Do not fold write-capable publish/backfill scripts into `WPClient` casually; they need explicit dry-run, slug/ID, rollback, and media-upload tests.

--- a/scripts/check_current_state_drift.py
+++ b/scripts/check_current_state_drift.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import base64
 import argparse
 import json
 import re
@@ -12,9 +11,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+
+from common import WPClient, wp_queue_counts
 
 
 @dataclass
@@ -80,43 +78,9 @@ def fetch_wp_queue_counts(repo_root: Path) -> tuple[dict[str, int] | None, str |
     if not env_path.exists():
         return None, f"missing env file: {env_path}"
 
-    values: dict[str, str] = {}
-    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        values[key.strip()] = value.strip().strip('"').strip("'")
-
-    base_url = values.get("WP_BASE_URL", "https://kriskrug.co").rstrip("/")
-    user = values.get("WP_USER", "")
-    app_password = (values.get("WP_APP_PASSWORD", "") or "").replace(" ", "")
-    if not user or not app_password:
-        return None, "WordPress credentials missing in scripts/notion-to-wp/.env"
-
-    token = base64.b64encode(f"{user}:{app_password}".encode()).decode()
-    headers = {"Authorization": f"Basic {token}", "Accept": "application/json"}
-
-    def count(kind: str, status: str) -> int:
-        query = urlencode({"status": status, "per_page": 1, "context": "edit"})
-        url = f"{base_url}/wp-json/wp/v2/{kind}?{query}"
-        request = Request(url, headers=headers)
-        try:
-            with urlopen(request, timeout=30) as response:
-                return int(response.headers.get("X-WP-Total", "0") or "0")
-        except HTTPError as exc:
-            if exc.code == 400:
-                return 0
-            raise
-        except URLError:
-            raise
-
     try:
-        return {
-            "future_posts": count("posts", "future"),
-            "draft_posts": count("posts", "draft"),
-            "draft_pages": count("pages", "draft"),
-        }, None
+        client = WPClient.from_env(env_path, timeout=30)
+        return wp_queue_counts(client), None
     except Exception as exc:
         return None, f"failed to fetch live draft queue counts: {exc}"
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -78,10 +78,10 @@ def load_env(path: Path | str | None = None, *, overlay_os: bool = True) -> dict
 
 
 def wp_credentials(env: dict[str, str] | None = None) -> tuple[str, str, str]:
-    """Return (base_url, user, app_password). Raises if credentials are missing."""
+    """Return (base_url, user, normalized app_password). Raises if missing."""
     env = env if env is not None else load_env()
     user = env.get("WP_USER", "")
-    app_password = env.get("WP_APP_PASSWORD", "")
+    app_password = (env.get("WP_APP_PASSWORD", "") or "").replace(" ", "")
     base_url = env.get("WP_BASE_URL", DEFAULT_BASE_URL)
     if not user or not app_password:
         raise RuntimeError(
@@ -244,3 +244,23 @@ class WPClient:
             if len(batch) < per_page:
                 break
         return items
+
+
+def wp_queue_counts(client: WPClient | None = None) -> dict[str, int]:
+    """Return read-only counts for the queue surfaces used in startup truth."""
+    wp = client or WPClient.from_env()
+
+    def count(kind: str, status: str) -> int:
+        return len(
+            wp.get_all(
+                kind,
+                params={"status": status, "context": "edit", "_fields": "id"},
+                per_page=100,
+            )
+        )
+
+    return {
+        "future_posts": count("posts", "future"),
+        "draft_posts": count("posts", "draft"),
+        "draft_pages": count("pages", "draft"),
+    }

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import base64
 import argparse
 import json
 import re
@@ -13,9 +12,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
+
+from common import WPClient, wp_queue_counts
 
 
 @dataclass
@@ -111,43 +109,9 @@ def fetch_wp_queue_counts(repo_root: Path) -> tuple[dict[str, int] | None, str |
     if not env_path.exists():
         return None, f"missing env file: {env_path}"
 
-    values: dict[str, str] = {}
-    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        values[key.strip()] = value.strip().strip('"').strip("'")
-
-    base_url = values.get("WP_BASE_URL", "https://kriskrug.co").rstrip("/")
-    user = values.get("WP_USER", "")
-    app_password = (values.get("WP_APP_PASSWORD", "") or "").replace(" ", "")
-    if not user or not app_password:
-        return None, "WordPress credentials missing in scripts/notion-to-wp/.env"
-
-    token = base64.b64encode(f"{user}:{app_password}".encode()).decode()
-    headers = {"Authorization": f"Basic {token}", "Accept": "application/json"}
-
-    def count(kind: str, status: str) -> int:
-        query = urlencode({"status": status, "per_page": 1, "context": "edit"})
-        url = f"{base_url}/wp-json/wp/v2/{kind}?{query}"
-        request = Request(url, headers=headers)
-        try:
-            with urlopen(request, timeout=30) as response:
-                return int(response.headers.get("X-WP-Total", "0") or "0")
-        except HTTPError as exc:
-            if exc.code == 400:
-                return 0
-            raise
-        except URLError:
-            raise
-
     try:
-        return {
-            "future_posts": count("posts", "future"),
-            "draft_posts": count("posts", "draft"),
-            "draft_pages": count("pages", "draft"),
-        }, None
+        client = WPClient.from_env(env_path, timeout=30)
+        return wp_queue_counts(client), None
     except Exception as exc:
         return None, f"failed to fetch live draft queue counts: {exc}"
 
@@ -308,11 +272,13 @@ def main() -> int:
         )
 
     label_counts = build_label_counts(issues_json or [])
-    draft_counts = {
-        "future_posts": queue_counts["future_posts"] if queue_counts else 0,
-        "draft_posts": queue_counts["draft_posts"] if queue_counts else 0,
-        "draft_pages": queue_counts["draft_pages"] if queue_counts else 0,
-    }
+    draft_queue_summary = (
+        f"future posts `{queue_counts['future_posts']}`, "
+        f"draft posts `{queue_counts['draft_posts']}`, "
+        f"draft pages `{queue_counts['draft_pages']}`"
+        if queue_counts
+        else "`unavailable` (see Draft Queue Counts stderr)"
+    )
 
     smoke_failures = 0
     smoke_warnings = 0
@@ -340,7 +306,7 @@ def main() -> int:
         f"- Open PRs: `{len(prs_json or [])}`",
         f"- Open issues: `{len(issues_json or [])}`",
         f"- WordPress version (smoke): `{observed_wp_version}`",
-        f"- Draft queue: future posts `{draft_counts['future_posts']}`, draft posts `{draft_counts['draft_posts']}`, draft pages `{draft_counts['draft_pages']}`",
+        f"- Draft queue: {draft_queue_summary}",
         f"- `/projects/` status: `{projects_status}`",
         f"- `/recent-projects-include/` og:image: `{work_og_image}`",
         f"- Homepage reveal safety net detected: `{'yes' if has_reveal_safety_net else 'no'}`",

--- a/scripts/notion-to-wp/draft_queue_audit.py
+++ b/scripts/notion-to-wp/draft_queue_audit.py
@@ -18,6 +18,12 @@ from typing import Any
 
 import yaml
 
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from common import WPClient  # noqa: E402
+
 
 STATUSES = ("future", "draft", "pending", "private")
 
@@ -129,26 +135,8 @@ def collect_local_drafts(repo_root: Path) -> list[LocalDraft]:
     return [local_draft_metrics(path) for path in sorted(drafts_root.iterdir()) if path.is_dir()]
 
 
-def collect_wp_items(wp: Any, kind: str, status: str) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
-    page = 1
-    while True:
-        response = wp.s.get(
-            f"{wp.base}/wp-json/wp/v2/{kind}",
-            params={"status": status, "per_page": 100, "page": page, "context": "edit"},
-            timeout=30,
-        )
-        if response.status_code == 400:
-            break
-        response.raise_for_status()
-        batch = response.json()
-        if not batch:
-            break
-        items.extend(batch)
-        if page >= int(response.headers.get("X-WP-TotalPages", "1") or "1"):
-            break
-        page += 1
-    return items
+def collect_wp_items(wp: WPClient, kind: str, status: str) -> list[dict[str, Any]]:
+    return wp.get_all(kind, params={"status": status, "context": "edit"}, per_page=100)
 
 
 def wp_draft_metrics(kind: str, post: dict[str, Any]) -> WPDraft:
@@ -174,19 +162,15 @@ def wp_draft_metrics(kind: str, post: dict[str, Any]) -> WPDraft:
     )
 
 
-def collect_slug_matches(wp: Any, slugs: list[str]) -> dict[str, list[WPMatch]]:
+def collect_slug_matches(wp: WPClient, slugs: list[str]) -> dict[str, list[WPMatch]]:
     matches: dict[str, list[WPMatch]] = {slug: [] for slug in slugs}
     for slug in slugs:
         for kind in ("posts", "pages"):
-            response = wp.s.get(
-                f"{wp.base}/wp-json/wp/v2/{kind}",
+            items = wp.get(
+                kind,
                 params={"slug": slug, "status": "any", "per_page": 100, "context": "edit"},
-                timeout=30,
             )
-            if response.status_code == 400:
-                continue
-            response.raise_for_status()
-            for item in response.json():
+            for item in items or []:
                 title = item.get("title") or {}
                 matches[slug].append(
                     WPMatch(
@@ -201,10 +185,7 @@ def collect_slug_matches(wp: Any, slugs: list[str]) -> dict[str, list[WPMatch]]:
 
 
 def collect_wp_audit(slugs: list[str] | None = None) -> tuple[list[dict[str, Any]], list[WPDraft], dict[str, list[WPMatch]]]:
-    from kk_notion_to_wp import WordPress, load_config
-
-    cfg = load_config()
-    wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
+    wp = WPClient.from_env(timeout=30)
     summary: list[dict[str, Any]] = []
     drafts: list[WPDraft] = []
     for kind in ("posts", "pages"):

--- a/scripts/notion-to-wp/tests/test_draft_queue_audit.py
+++ b/scripts/notion-to-wp/tests/test_draft_queue_audit.py
@@ -2,6 +2,8 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError
 
 
 SCRIPT_DIR = Path(__file__).resolve().parents[1]
@@ -117,6 +119,61 @@ class DraftQueueAuditTests(unittest.TestCase):
         self.assertEqual(frontmatter["title"], "Loose Draft")
         self.assertEqual(frontmatter["slug"], "loose-draft")
         self.assertEqual(body, "Body copy.\n")
+
+    def test_collect_wp_items_uses_shared_client_without_400_fallback(self):
+        wp = mock.MagicMock()
+        wp.get_all.side_effect = HTTPError("http://x", 400, "bad", hdrs=None, fp=None)
+
+        with self.assertRaises(HTTPError):
+            draft_queue_audit.collect_wp_items(wp, "posts", "draft")
+
+        wp.get_all.assert_called_once_with(
+            "posts",
+            params={"status": "draft", "context": "edit"},
+            per_page=100,
+        )
+
+    def test_collect_wp_audit_uses_wpclient_from_env(self):
+        wp = mock.MagicMock()
+        wp.get_all.side_effect = [
+            [],
+            [
+                {
+                    "id": 123,
+                    "status": "draft",
+                    "slug": "example-draft",
+                    "title": {"raw": "Example Draft"},
+                    "date": "2026-05-22T12:00:00",
+                    "modified": "2026-05-22T12:00:00",
+                    "content": {"raw": "<!-- wp:paragraph --><p>Words here.</p>"},
+                    "featured_media": 456,
+                    "categories": [1665],
+                    "tags": [],
+                }
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        ]
+        wp.get.return_value = [
+            {
+                "id": 123,
+                "status": "draft",
+                "title": {"raw": "Example Draft"},
+                "link": "https://kriskrug.co/?p=123",
+            }
+        ]
+
+        with mock.patch.object(draft_queue_audit.WPClient, "from_env", return_value=wp) as from_env:
+            summary, drafts, matches = draft_queue_audit.collect_wp_audit(["example-draft"])
+
+        from_env.assert_called_once_with(timeout=30)
+        self.assertEqual(summary[1], {"kind": "posts", "status": "draft", "count": 1})
+        self.assertEqual(drafts[0].wp_id, 123)
+        self.assertEqual(matches["example-draft"][0].wp_id, 123)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_current_state_drift.py
+++ b/scripts/tests/test_check_current_state_drift.py
@@ -1,0 +1,56 @@
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_current_state_drift  # noqa: E402
+
+
+def _http_error(code: int) -> HTTPError:
+    err = HTTPError("http://x", code, f"err{code}", hdrs=None, fp=io.BytesIO(b""))
+    err.close()
+    return err
+
+
+class CurrentStateDriftQueueCountsTests(unittest.TestCase):
+    def test_fetch_wp_queue_counts_uses_shared_wpclient(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            env_path = repo_root / "scripts" / "notion-to-wp" / ".env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("WP_USER=u\nWP_APP_PASSWORD=p a s s\n", encoding="utf-8")
+            client = object()
+            counts = {"future_posts": 1, "draft_posts": 2, "draft_pages": 3}
+
+            with mock.patch.object(check_current_state_drift.WPClient, "from_env", return_value=client) as from_env, \
+                 mock.patch.object(check_current_state_drift, "wp_queue_counts", return_value=counts) as queue_counts:
+                result, error = check_current_state_drift.fetch_wp_queue_counts(repo_root)
+
+        self.assertEqual(result, counts)
+        self.assertIsNone(error)
+        from_env.assert_called_once_with(env_path, timeout=30)
+        queue_counts.assert_called_once_with(client)
+
+    def test_fetch_wp_queue_counts_reports_http_400_instead_of_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            env_path = repo_root / "scripts" / "notion-to-wp" / ".env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("WP_USER=u\nWP_APP_PASSWORD=p\n", encoding="utf-8")
+
+            with mock.patch.object(check_current_state_drift.WPClient, "from_env", return_value=object()), \
+                 mock.patch.object(check_current_state_drift, "wp_queue_counts", side_effect=_http_error(400)):
+                result, error = check_current_state_drift.fetch_wp_queue_counts(repo_root)
+
+        self.assertIsNone(result)
+        self.assertIn("failed to fetch live draft queue counts", error)
+        self.assertIn("HTTP Error 400", error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_common.py
+++ b/scripts/tests/test_common.py
@@ -8,7 +8,7 @@ from urllib.error import HTTPError
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import common  # noqa: E402
-from common import WPClient, load_env, parse_simple_env, wp_credentials  # noqa: E402
+from common import WPClient, load_env, parse_simple_env, wp_credentials, wp_queue_counts  # noqa: E402
 
 
 def _fake_response(body: str):
@@ -76,8 +76,8 @@ class LoadEnvTests(_EnvFileMixin, unittest.TestCase):
 
 class WpCredentialsTests(unittest.TestCase):
     def test_returns_tuple_and_strips_base_slash(self):
-        env = {"WP_USER": "u", "WP_APP_PASSWORD": "p", "WP_BASE_URL": "https://example.com/"}
-        self.assertEqual(wp_credentials(env), ("https://example.com", "u", "p"))
+        env = {"WP_USER": "u", "WP_APP_PASSWORD": "p a s s", "WP_BASE_URL": "https://example.com/"}
+        self.assertEqual(wp_credentials(env), ("https://example.com", "u", "pass"))
 
     def test_defaults_base_url(self):
         base, _, _ = wp_credentials({"WP_USER": "u", "WP_APP_PASSWORD": "p"})
@@ -210,6 +210,29 @@ class WPClientPaginationTests(unittest.TestCase):
         client = WPClient("https://example.com", "u", "p")
         with mock.patch.object(client, "request", return_value=[]):
             self.assertEqual(client.get_all("posts"), [])
+
+
+class WPQueueCountsTests(unittest.TestCase):
+    def test_counts_expected_read_only_queue_surfaces(self):
+        client = mock.MagicMock()
+        client.get_all.side_effect = [
+            [{"id": 1}],
+            [{"id": 2}, {"id": 3}],
+            [],
+        ]
+
+        self.assertEqual(
+            wp_queue_counts(client),
+            {"future_posts": 1, "draft_posts": 2, "draft_pages": 0},
+        )
+        self.assertEqual(
+            client.get_all.call_args_list,
+            [
+                mock.call("posts", params={"status": "future", "context": "edit", "_fields": "id"}, per_page=100),
+                mock.call("posts", params={"status": "draft", "context": "edit", "_fields": "id"}, per_page=100),
+                mock.call("pages", params={"status": "draft", "context": "edit", "_fields": "id"}, per_page=100),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_morning_truth_report.py
+++ b/scripts/tests/test_morning_truth_report.py
@@ -1,0 +1,63 @@
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import morning_truth_report  # noqa: E402
+
+
+def _http_error(code: int) -> HTTPError:
+    err = HTTPError("http://x", code, f"err{code}", hdrs=None, fp=io.BytesIO(b""))
+    err.close()
+    return err
+
+
+class MorningTruthQueueCountsTests(unittest.TestCase):
+    def test_fetch_wp_queue_counts_uses_shared_wpclient(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            env_path = repo_root / "scripts" / "notion-to-wp" / ".env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("WP_USER=u\nWP_APP_PASSWORD=p a s s\n", encoding="utf-8")
+            client = object()
+            counts = {"future_posts": 1, "draft_posts": 2, "draft_pages": 3}
+
+            with mock.patch.object(morning_truth_report.WPClient, "from_env", return_value=client) as from_env, \
+                 mock.patch.object(morning_truth_report, "wp_queue_counts", return_value=counts) as queue_counts:
+                result, error = morning_truth_report.fetch_wp_queue_counts(repo_root)
+
+        self.assertEqual(result, counts)
+        self.assertIsNone(error)
+        from_env.assert_called_once_with(env_path, timeout=30)
+        queue_counts.assert_called_once_with(client)
+
+    def test_fetch_wp_queue_counts_reports_http_400_instead_of_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            env_path = repo_root / "scripts" / "notion-to-wp" / ".env"
+            env_path.parent.mkdir(parents=True)
+            env_path.write_text("WP_USER=u\nWP_APP_PASSWORD=p\n", encoding="utf-8")
+
+            with mock.patch.object(morning_truth_report.WPClient, "from_env", return_value=object()), \
+                 mock.patch.object(morning_truth_report, "wp_queue_counts", side_effect=_http_error(400)):
+                result, error = morning_truth_report.fetch_wp_queue_counts(repo_root)
+
+        self.assertIsNone(result)
+        self.assertIn("failed to fetch live draft queue counts", error)
+        self.assertIn("HTTP Error 400", error)
+
+    def test_missing_env_file_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result, error = morning_truth_report.fetch_wp_queue_counts(Path(tmp))
+
+        self.assertIsNone(result)
+        self.assertIn("missing env file", error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Inventory duplicated WordPress auth/env callsites and risk levels in `docs/current-state/WP-AUTH-CLIENT-INVENTORY-2026-07-08.md`.
- Normalize spaced `WP_APP_PASSWORD` values at the shared `scripts/common.py` credential boundary and add `wp_queue_counts()` for read-only queue truth.
- Migrate `scripts/morning_truth_report.py`, `scripts/check_current_state_drift.py`, and `scripts/notion-to-wp/draft_queue_audit.py` to `WPClient.from_env()` so generic HTTP 400 responses are reported as errors instead of converted to zero/empty queues.

## Dependency / Issue

Refs #306. This is stacked on draft PR #308 and targets `codex/issue-302-work-visual-cards` until #308 merges. Do not close #306 from this PR alone unless KK wants the remaining duplicated write-capable clients handled separately.

## Safety

- No `.env` values changed.
- No secrets, Authorization headers, cookies, or session tokens printed.
- No live WordPress writes, deploys, publishes, or admin mutations run.
- `make status-readonly` was used only for read-only verification.

## Verification

- `python3 -m unittest scripts.tests.test_common` — passed, 22 tests.
- `python3 -m unittest discover -s scripts/tests -v` — passed, 82 tests.
- `scripts/notion-to-wp/.venv/bin/python -m unittest discover -s scripts/notion-to-wp/tests -v` — passed, 44 tests.
- `make status-readonly` — passed; draft queue now reports `0` future posts, `64` draft posts, `4` draft pages, and the drift checker observes the same counts.