### PR TITLE
Docs: document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,17 @@ Run `make morning-truth` at session start (or before execution) to emit a timest
 
 If the task explicitly forbids file changes, run `make status-readonly` instead. It prints the same startup truth shape to stdout and does not write a report file.
 
+## Cursor Cloud specific instructions
+
+This repo is CLI tooling + a WordPress theme/plugins line — there is **no local web app or server to boot**. "Running" it means executing the Python CLIs (`scripts/notion-to-wp/`, `scripts/*.py`) and the PHP lint/smoke checks. Standard commands (`make test`, `make validate`, `make verify`, connector usage) are already documented in `CONTRIBUTING.md`, `Makefile`, and `scripts/notion-to-wp/README.md`; use those.
+
+Non-obvious caveats for future agents (the update script already installs deps):
+
+- The Python venv lives at `scripts/notion-to-wp/.venv` and **many `Makefile` targets call `scripts/notion-to-wp/.venv/bin/python` directly** (e.g. `seo-audit`, `seo-backfill`, `draft-queue-audit`). If that venv is missing those targets break, so it must exist — the update script (re)creates it.
+- PHP is **8.3** here (CI pins 8.2). This does not affect linting: `phpcs.xml.dist` sets `testVersion 8.1-` as a static target, so `make validate` / `make plugin-smoke` run fine on 8.3.
+- Without `scripts/notion-to-wp/.env` (WP application password) and a Notion token, all connector/audit/report commands are effectively read-only/dry-run: the live publisher and `create_local_wp_draft.py` **hard-exit requiring creds even in dry-run**, so exercise the credential-free paths instead — `LOCAL_ONLY=1 make draft-queue-audit` and `make status-readonly` (the latter just logs a `missing env file` soft error and still completes).
+- `make morning-truth`, `make status-readonly`, and the audit targets make live HTTP calls to `https://kriskrug.co` when reachable; they degrade gracefully but expect outbound network for the WP smoke portions.
+
 ---
 
 **Last verified:** 2026-07-05 after PR #299 / Aurora 1.3.36 live closeout and #289 WCAG smoke closure. If you're reading this much later and the repo has drifted, run `make morning-truth` (or `make status-readonly`) and treat the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `kriskrug-wp` in Cursor Cloud, and records durable, non-obvious startup caveats in `AGENTS.md` so future agents can run the tooling without re-discovering them.

This repo is CLI tooling + a WordPress theme/plugins line — there is **no local web app/server to boot**. "Running" it means executing the Python CLIs and the PHP lint/smoke checks.

## Changes

- `AGENTS.md`: adds a `## Cursor Cloud specific instructions` section covering the `scripts/notion-to-wp/.venv` requirement (many `Makefile` targets call it directly), the PHP 8.3-vs-CI-8.2 note (irrelevant to `phpcs.xml.dist testVersion 8.1-` lint), the credential-free paths to use when `.env`/Notion token are absent, and the live-HTTP behavior of the report/audit targets.

## Environment setup (baked into snapshot / update script)

- System deps: `python3.12-venv`, PHP 8.3 (`php-cli`, `php-xml`, `php-mbstring`), Composer 2.
- Update script (dependency refresh only): creates `scripts/notion-to-wp/.venv` + `pip install -r requirements.txt`, then `composer install`.

## Testing

- ✅ `make test` — 42 Notion publisher tests + 71 root-script tests + KK Sidebar Promos smoke, all pass.
- ✅ `make validate` — PHPCS/WordPress standards, 7/7 files, no violations.
- ✅ `make verify` — full local gate (test + docs-truth-check + validate) green.
- ✅ `LOCAL_ONLY=1 make draft-queue-audit` — core connector-adjacent functionality (reads local draft packages, reports quality metrics).
- ✅ `make status-readonly` — mandated session-start truth report completes.

[make_verify.log](https://cursor.com/artifacts/c/art-b33e76a1-f22a-4cc0-ada5-e5ffbca4ed71)
[hello_world_draft_audit.log](https://cursor.com/artifacts/c/art-7cf3a454-f75f-4690-bce1-fee5b2cca01e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

