### PR TITLE
Docs/code: refresh state snapshot and drop hardcoded /Users/kk paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,10 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 6. [`docs/current-state/HANDOFF-2026-06-17.md`](docs/current-state/HANDOFF-2026-06-17.md) — current Aurora/theme/content handoff with the 2026-07-05 Aurora 1.3.36 cache/a11y addendum; #289 and #293 are closed after five-route `pa11y` plus browser smoke
 7. [`docs/current-state/archive/AURORA-V3-QA-ROADMAP-2026-05-24.md`](docs/current-state/archive/AURORA-V3-QA-ROADMAP-2026-05-24.md) — historical Aurora v1.3.0 QA roadmap (archived; superseded by the live 1.3.36 line)
 8. [`docs/current-state/CURRENT-STATE-2026-06-23.md`](docs/current-state/CURRENT-STATE-2026-06-23.md) — canonical current state snapshot as of 2026-06-23
-9. [`docs/current-state/reports/morning-truth-20260624-175842Z.md`](docs/current-state/reports/morning-truth-20260624-175842Z.md) — latest startup truth memo; always prefer newest `reports/morning-truth-*.md`
-10. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
+9. [`docs/current-state/reports/morning-truth-20260703-175742Z.md`](docs/current-state/reports/morning-truth-20260703-175742Z.md) — latest committed startup truth memo; always prefer newest `reports/morning-truth-*.md` and a fresh `make status-readonly`
+10. [`docs/current-state/CURRENT-STATE-2026-07-09.md`](docs/current-state/CURRENT-STATE-2026-07-09.md) — declared counts for drift checks (Makefile default)
+11. [`docs/current-state/AUDIT-WORKPLAN-2026-07-09.md`](docs/current-state/AUDIT-WORKPLAN-2026-07-09.md) — active post-audit execution sequence (PR merge stack, truth hygiene, content/QA packets; draft PR #313 until merged)
+12. [`docs/current-state/WORK-PLAN-2026-05-23.md`](docs/current-state/WORK-PLAN-2026-05-23.md) — historical roadmap context (stale counts/branch assumptions)
 
 Roadmap-derived execution issues filed 2026-06-09: **#186–#197** (CI, prod drift, tracker hygiene).
 
@@ -52,7 +54,7 @@ Legacy branch split context is in [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-
 - **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `HANDOFF-2026-06-17.md` and `CURRENT-STATE-2026-06-23.md` for current truth, plus the newest committed morning-truth report. `WORK-PLAN-2026-05-23.md` remains as historical context (Makefile default).
+- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `HANDOFF-2026-06-17.md`, `CURRENT-STATE-2026-07-09.md`, and `AUDIT-WORKPLAN-2026-07-09.md` for current truth, plus the newest committed morning-truth report. `WORK-PLAN-2026-05-23.md` and `CURRENT-STATE-2026-06-23.md` remain historical.
 
 Anything banner-tagged `STATUS: Historical` at the top is reference-only.
 
@@ -83,4 +85,4 @@ If the task explicitly forbids file changes, run `make status-readonly` instead.
 
 ---
 
-**Last verified:** 2026-07-05 after PR #299 / Aurora 1.3.36 live closeout and #289 WCAG smoke closure. If you're reading this much later and the repo has drifted, run `make morning-truth` (or `make status-readonly`) and treat the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth.
+**Last verified:** 2026-07-09 docs/code hygiene pass after the 2026-07-08 audit. Declared snapshot is `CURRENT-STATE-2026-07-09.md`. If you're reading this much later and the repo has drifted, run `make morning-truth` (or `make status-readonly`) and treat the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth.

--- a/Makefile
+++ b/Makefile
@@ -206,13 +206,13 @@ wp7-admin-readiness: ## Run authenticated read-only WP 7 readiness snapshot (ENV
 	@python3 scripts/wp7-admin-readiness.py --env-file "$${ENV_FILE:-scripts/notion-to-wp/.env}"
 
 current-state-drift-check: ## Compare declared current-state snapshot values vs live read-only checks
-	@python3 scripts/check_current_state_drift.py --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}"
+	@python3 scripts/check_current_state_drift.py --work-plan "$${WORK_PLAN:-docs/current-state/CURRENT-STATE-2026-07-09.md}" --base-url "$${BASE_URL:-https://kriskrug.co}"
 
 morning-truth: ## Run startup truth checks and write a timestamped markdown report
-	@python3 scripts/morning_truth_report.py --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
+	@python3 scripts/morning_truth_report.py --work-plan "$${WORK_PLAN:-docs/current-state/CURRENT-STATE-2026-07-09.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
 
 status-readonly: ## Print startup truth checks without writing a report
-	@python3 scripts/morning_truth_report.py --stdout --skip-fetch --work-plan "$${WORK_PLAN:-docs/current-state/WORK-PLAN-2026-05-23.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
+	@python3 scripts/morning_truth_report.py --stdout --skip-fetch --work-plan "$${WORK_PLAN:-docs/current-state/CURRENT-STATE-2026-07-09.md}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-6.9.4}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
 
 docs-truth-check: ## Scan non-evidence docs for known stale current-state claims
 	@python3 scripts/docs_truth_check.py --exclude docs/current-state/reports --exclude docs/current-state/raw

--- a/docs/current-state/AUDIT-WORKPLAN-2026-07-09.md
+++ b/docs/current-state/AUDIT-WORKPLAN-2026-07-09.md
@@ -1,0 +1,184 @@
+# Audit Workplan — 2026-07-09
+
+**Status:** active execution plan after the 2026-07-08 Cursor Cloud audit.  
+**Supersedes for sequencing:** `POST-SHIP-AUDIT-WORKPLAN-2026-06-04.md` (keep as historical).  
+**Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
+
+## Audit snapshot (2026-07-08)
+
+| Signal | Observed | Notes |
+|---|---|---|
+| Live theme | `kk-aurora` **1.3.36** | Matches AGENTS.md / HANDOFF addendum |
+| WordPress | **6.9.4** | Public smoke 0 failures, 3 OG/Twitter warnings |
+| Open issues | **29** | Declared 48 in CURRENT-STATE / work plan → drift |
+| Open PRs | **5** | Declared 0 → drift |
+| Draft queue (unauthenticated) | `0/0/0` | **False zero** — missing `.env`; #303/#309 |
+| Local draft packages | ~65 | 5 strong / 25 media-tax / 30 thin / 5 empty-admin |
+| `/accessibility/` | **404** | Statement drafted, not published |
+| GSAP / reveal safety net | absent | Good |
+| `make verify` | green | 53 Notion + 71 root + PHPCS + docs-truth |
+
+Sources: `make status-readonly`, `LOCAL_ONLY=1 make draft-queue-audit`, `make verify`, `scripts/wp7-public-smoke.py`, live `style.css` Version header, `gh issue/pr list`.
+
+## North star
+
+Restore **trustworthy queue truth**, clear the **reviewable PR stack**, then run **one Track A content packet** and **one Track B QA packet** without mixing lanes.
+
+## Lane map
+
+| Lane | Goal | Primary issues / PRs |
+|---|---|---|
+| A0 — Merge stack | Land already-done agent work | #308→#309→#310→#311→#312 |
+| A1 — Truth hygiene | Fix false zeros + stale declared counts | #303, #306; docs refresh |
+| A2 — Content publish prep | One body-only packet after KK review | #278/#284/#305; #290/#307; #48/#288/#304 |
+| A3 — Cadence | Refill scheduled queue after truth restored | EPIC #219 context; draft audit |
+| B1 — Theme/QA | Perf, mobile, undesigned pages | #125, #127, #86, #122, #256 |
+| Ops — Access | Secrets + Notion so agents can finish audits | `.env`, Notion MCP |
+
+---
+
+## Phase 0 — Unblock access (human)
+
+Do this once; everything authenticated depends on it.
+
+1. Add `scripts/notion-to-wp/.env` (or cloud secrets) with `WP_USER` / `WP_APP_PASSWORD` (and `WP_AUTH_MODE=login` if using the #309 path).
+2. Authenticate Notion MCP in Cursor desktop **or** add `NOTION_TOKEN` so agents can find drafts (e.g. Tristan Harris / AI documentary panel) that are not in this repo.
+3. Re-run:
+   ```bash
+   make status-readonly
+   scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --format markdown
+   ```
+4. Done when authenticated draft counts are non-zero (expect ~64 draft posts / ~4 draft pages unless live state truly changed) and Notion search works.
+
+---
+
+## Phase 1 — Merge the existing PR stack (KK review)
+
+Merge in this order; do not close issues until the PR that satisfies them is merged.
+
+| Order | PR | Issue(s) | Why first |
+|---|---|---|---|
+| 1 | [#308](https://github.com/WalksWithASwagger/kriskrug-wp/pull/308) Work visual-card ship | #302 | Base for stacked #309; packages already-live Work deploy |
+| 2 | [#309](https://github.com/WalksWithASwagger/kriskrug-wp/pull/309) WP auth client consolidation | #306, #303 | Restores truthful draft-queue / morning-truth reads |
+| 3 | [#310](https://github.com/WalksWithASwagger/kriskrug-wp/pull/310) Cursor Cloud AGENTS notes | setup | Durable cloud env caveats |
+| 4 | [#311](https://github.com/WalksWithASwagger/kriskrug-wp/pull/311) a11y + hub-link + About plans | #304/#305/#307 (+ feeds #288/#48/#278/#284/#290) | Planning packets ready for human gates |
+| 5 | [#312](https://github.com/WalksWithASwagger/kriskrug-wp/pull/312) `publish_common` refactor | #254 | Code quality; no live write |
+
+**Stop rules:** no force-push to `main`; no auto-merge (`allow_auto_merge=false`); green checks ≠ permission to merge.
+
+**Done when:** open PR count is back near 0 for this stack; #302/#254 closable; #303/#306 closable or explicitly parked with remaining write-client follow-up noted.
+
+---
+
+## Phase 2 — Docs / truth hygiene (agent-safe after Phase 1)
+
+Track A docs-only; one commit concern.
+
+1. Commit a fresh `make morning-truth` report (or keep the latest `status-readonly` evidence if file writes are restricted).
+2. Update front-door pointers:
+   - `docs/current-state/README.md` → newest morning-truth + this workplan
+   - `AGENTS.md` “latest morning-truth” link (still cites `20260624` in one place)
+3. Refresh declared counts in a **new** dated snapshot (do not silently rewrite historical `CURRENT-STATE-2026-06-23.md` numbers without a banner). Prefer `CURRENT-STATE-2026-07-09.md` + drift-check inputs.
+4. Mark `WORK-PLAN-2026-05-23.md` / June post-ship plan as historical for *sequencing* (already partially bannered).
+
+**Done when:** `make status-readonly` drift on open PRs/issues matches reality; agents stop rediscovering stale “48 issues / 0 PRs”.
+
+---
+
+## Phase 3 — Track A content packets (KK-gated writes)
+
+Run **one packet per session**. Body-only REST. Snapshot under `backup/<timestamp>-…/` first.
+
+### Packet 3A — Topic-hub internal links
+
+- Plan: `content/source-packs/content-architecture-2026/internal-link-batch-plan-2026-07-07.md` (#305 / PR #311)
+- Issues: #278, #284
+- Do: 14 autonomous-safe body-only links from the plan table
+- Do **not**: auto-add `/indigenous-ai/` links (human-review queue in the plan)
+- Verify: cache-busted public smoke that each source URL contains the hub href
+
+### Packet 3B — Accessibility statement draft → WP draft
+
+- Plan: `content/drafts/accessibility-statement-2026-07/` (#304 / #288 / #48)
+- Human gates before any write: reporting channel, WCAG edition wording, response-time language, reuse of old draft `11886` if it still exists
+- Do: create/update WordPress **draft** only; no footer link; no publish
+- Publish + footer link remain #48 after preview QA
+
+### Packet 3C — About “From the archive” module
+
+- Plans: `about-bio-source-map-2026-07-07.md` + `about-bio-payload-plan-2026-07-08.md` (#307 / #290 / #269 / #270)
+- Do: body-only insert after Public trail; preserve title; no land-acknowledgment rewrite (#22 separate)
+- Block: “licensed private pilot” or new credentials without KK wording
+
+### Packet 3D — Cadence refill
+
+- After authenticated draft audit is truthful, pick **one** strong local/WP draft through review → preview → schedule
+- Strong local candidates from audit: `keep-the-machine-strange`, remaining unpublished strong packs; cross-check live slug before creating duplicates
+- Keep #95 (media appearances) as human editorial gate, not a publish shortcut
+
+---
+
+## Phase 4 — Track B / platform (separate sessions)
+
+Do not mix with Phase 3 content writes.
+
+| Priority | Issue | Action |
+|---|---|---|
+| 1 | #125 | Boost critical CSS / post-Jetpack perf cleanup |
+| 2 | #127 | Dedicated mobile/responsive QA (blocked label — confirm blocker) |
+| 3 | #86 | Post-Jetpack perf/a11y/tracking QA umbrella |
+| 4 | #122 | Undesigned generic pages (~25) — needs design owner |
+| 5 | #256 | CSS dead-code / schema snippet / snippets overlap |
+| 6 | #4 / #46 | Alt-text debt + full WCAG audit (long-running) |
+
+Also close OG/Twitter smoke warnings on `/`, `/speaking/`, `/work/` if still present after #308 Work packaging.
+
+---
+
+## Phase 5 — Code follow-ups (agent-safe, no live write)
+
+1. Finish #306 remaining write-capable auth clients if #309 only covered read-only paths.
+2. Extend #254 pattern to `publish_context_creators.py` and `publish_keep_the_machine_strange.py` (out of #254 scope).
+3. Replace hardcoded `/Users/kk/...` paths with repo-relative / env-driven paths in connector + one-off publish scripts (cloud + other machines break today).
+4. Optional: Notion search pass for missing drafts (Tristan Harris / AI documentary panel) once token/MCP works — file a draft package or issue if found.
+
+---
+
+## Explicitly parked / human-only
+
+- #274 / #279 — Search Console submit + query review
+- #276 — Delete inactive Jetpack after rollback window
+- #277 — Contact CTA product decision
+- #249 — SEO striking-distance measurement (blocked)
+- #222 — Platform trust epic (umbrella)
+- #22 — Land acknowledgment placement decision
+- Any `--execute` / `--publish` / `--update` against production without KK
+
+---
+
+## Default next sequence (copy this)
+
+1. **KK:** Phase 0 secrets + Notion auth.  
+2. **KK:** Review/merge PR stack Phase 1 in order.  
+3. **Agent:** Phase 2 docs hygiene PR.  
+4. **KK picks one:** 3A hub links **or** 3B a11y draft **or** 3C About module.  
+5. **Agent (Track B session):** #125 or #127 only after content packet closes.
+
+## Restart commands
+
+```bash
+git fetch --prune
+git status --short --branch
+gh pr list --state open --limit 20
+gh issue list --state open --limit 50
+make status-readonly
+LOCAL_ONLY=1 make draft-queue-audit
+make verify
+```
+
+After `.env` exists:
+
+```bash
+scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/draft_queue_audit.py --format markdown
+make morning-truth
+```

--- a/docs/current-state/AUDIT-WORKPLAN-2026-07-09.md
+++ b/docs/current-state/AUDIT-WORKPLAN-2026-07-09.md
@@ -11,7 +11,7 @@
 | Live theme | `kk-aurora` **1.3.36** | Matches AGENTS.md / HANDOFF addendum |
 | WordPress | **6.9.4** | Public smoke 0 failures, 3 OG/Twitter warnings |
 | Open issues | **29** | Declared 48 in CURRENT-STATE / work plan → drift |
-| Open PRs | **5** | Declared 0 → drift |
+| Open PRs | **8** | Declared 0 → drift; stack grew during docs/code pass |
 | Draft queue (unauthenticated) | `0/0/0` | **False zero** — missing `.env`; #303/#309 |
 | Local draft packages | ~65 | 5 strong / 25 media-tax / 30 thin / 5 empty-admin |
 | `/accessibility/` | **404** | Statement drafted, not published |
@@ -28,8 +28,8 @@ Restore **trustworthy queue truth**, clear the **reviewable PR stack**, then run
 
 | Lane | Goal | Primary issues / PRs |
 |---|---|---|
-| A0 — Merge stack | Land already-done agent work | #308→#309→#310→#311→#312 |
-| A1 — Truth hygiene | Fix false zeros + stale declared counts | #303, #306; docs refresh |
+| A0 — Merge stack | Land already-done agent work | #308→#309→#310→#311→#312→#315→#313→#314 |
+| A1 — Truth hygiene | Fix false zeros + stale declared counts | #303, #306; docs refresh (#313/#314) |
 | A2 — Content publish prep | One body-only packet after KK review | #278/#284/#305; #290/#307; #48/#288/#304 |
 | A3 — Cadence | Refill scheduled queue after truth restored | EPIC #219 context; draft audit |
 | B1 — Theme/QA | Perf, mobile, undesigned pages | #125, #127, #86, #122, #256 |
@@ -62,9 +62,12 @@ Merge in this order; do not close issues until the PR that satisfies them is mer
 | 2 | [#309](https://github.com/WalksWithASwagger/kriskrug-wp/pull/309) WP auth client consolidation | #306, #303 | Restores truthful draft-queue / morning-truth reads |
 | 3 | [#310](https://github.com/WalksWithASwagger/kriskrug-wp/pull/310) Cursor Cloud AGENTS notes | setup | Durable cloud env caveats |
 | 4 | [#311](https://github.com/WalksWithASwagger/kriskrug-wp/pull/311) a11y + hub-link + About plans | #304/#305/#307 (+ feeds #288/#48/#278/#284/#290) | Planning packets ready for human gates |
-| 5 | [#312](https://github.com/WalksWithASwagger/kriskrug-wp/pull/312) `publish_common` refactor | #254 | Code quality; no live write |
+| 5 | [#312](https://github.com/WalksWithASwagger/kriskrug-wp/pull/312) `publish_common` refactor | #254 | Shared helpers for one-off publishers |
+| 6 | [#315](https://github.com/WalksWithASwagger/kriskrug-wp/pull/315) leftover publish migrations | #254 | Stacked on #312; context_creators + keep_the_machine_strange |
+| 7 | [#313](https://github.com/WalksWithASwagger/kriskrug-wp/pull/313) audit workplan | docs | Sequencing plan (this file) |
+| 8 | [#314](https://github.com/WalksWithASwagger/kriskrug-wp/pull/314) state snapshot + path hygiene | docs/code | Declared counts + drop `/Users/kk` defaults |
 
-**Stop rules:** no force-push to `main`; no auto-merge (`allow_auto_merge=false`); green checks ≠ permission to merge.
+**Stop rules:** no force-push to `main`; no auto-merge (`allow_auto_merge=false`); green checks ≠ permission to merge. Merge #315 only after #312. #313 and #314 can land after #312/#315 or in parallel with each other once the code stack is reviewed.
 
 **Done when:** open PR count is back near 0 for this stack; #302/#254 closable; #303/#306 closable or explicitly parked with remaining write-client follow-up noted.
 

--- a/docs/current-state/CURRENT-STATE-2026-07-09.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-09.md
@@ -1,0 +1,46 @@
+# Current State Snapshot - 2026-07-09
+
+**Snapshot time:** 2026-07-09 (from 2026-07-08 Cursor Cloud audit + live `gh` / public WP probes).  
+**Branch context:** `main` plus open draft PR stack #308–#313.  
+**Mode:** Track A docs/code hygiene; no live WordPress write authorized by this snapshot.
+
+This file is the **declared** input for `make current-state-drift-check` / `make morning-truth` / `make status-readonly`. It replaces `CURRENT-STATE-2026-06-23.md` and the stale count block in `WORK-PLAN-2026-05-23.md` for drift purposes. Keep those older files as historical.
+
+## Verified State
+
+- Open PRs: `6`.
+- Open issues: `29`.
+- Open `priority:high` issues: `14`.
+- Open `track-b` issues: `4`.
+- Open `aurora-v2` issues: `2`.
+- Open `swarm-ready` issues: `6`.
+- Open `swarm-parked` issues: `1`.
+- Open `needs-human-review` issues: `9`.
+- Open `agent-safe` issues: `8`.
+- Production still publicly reports WordPress `6.9.4`.
+- Live theme: `kk-aurora` **1.3.36** (public `style.css` Version header).
+- WordPress draft queue: `0` scheduled posts, `64` draft posts, `4` draft pages.
+  - Counts above are the last **authenticated** read (morning-truth 2026-07-03). Unauthenticated startup reads still report `0/0/0` until `.env` exists and/or PR #309 lands — that zero is a **false zero**, not an empty queue (#303).
+- Local draft packages (local-only audit 2026-07-08): ~65 packages — 5 strong / 25 needs media-tax / 30 thin / 5 empty-admin.
+- WP public smoke: 0 failures; OG/Twitter warnings on `/`, `/speaking/`, `/work/`.
+- `/accessibility/` still 404; statement packet drafted in PR #311.
+- `/projects/` → 301 `/work/`.
+- GSAP/ScrollTrigger CDN: absent. Homepage reveal safety net: absent.
+- `make verify`: green on current tooling (Notion publisher tests + root script tests + PHPCS + docs-truth).
+
+## Open PR stack (review order)
+
+1. #308 Work visual-card ship (#302)
+2. #309 WP auth client consolidation (#306 / #303)
+3. #310 Cursor Cloud AGENTS notes
+4. #311 a11y / hub-link / About planning packets
+5. #312 `publish_common` refactor (#254)
+6. #313 audit workplan
+
+## Active plan
+
+[`AUDIT-WORKPLAN-2026-07-09.md`](AUDIT-WORKPLAN-2026-07-09.md) — Phase 0 secrets (KK tonight), Phase 1 merge stack, then one Track A content packet.
+
+## Explicitly not authorized
+
+No production WordPress create/update/publish/schedule from this snapshot. Docs/code hygiene only until KK returns with WP/Notion auth and a packet pick (3A/3B/3C/3D).

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -5,11 +5,15 @@
 
 This folder is the source of truth for "what was true on May 14, 2026" and for dated working addenda that came out of the May 2026 recovery/redesign push. Treat the baseline files as historical snapshots and the latest dated handoff/truth docs plus the newest committed `reports/morning-truth-*.md` artifact as the current front door.
 
-## Current Front Door (verified 2026-07-05 via live public probes)
+## Current Front Door (verified 2026-07-09 via Cursor Cloud audit)
 
 Read these first for current execution context:
 
-**Newest startup truth artifact:** [reports/morning-truth-20260703-175742Z.md](reports/morning-truth-20260703-175742Z.md) — read-only Track A verification captured `0` open PRs, `27` open issues, WordPress `6.9.4`, draft queue `0` future posts / `64` draft posts / `4` draft pages, and current drift against the older work-plan declarations.
+**Newest declared snapshot:** [CURRENT-STATE-2026-07-09.md](CURRENT-STATE-2026-07-09.md) — open PRs `6`, open issues `29`, WP `6.9.4`, Aurora 1.3.36; draft-queue zeros without `.env` are a known false zero until #309 / secrets.
+
+**Newest execution plan:** [AUDIT-WORKPLAN-2026-07-09.md](AUDIT-WORKPLAN-2026-07-09.md) — merge PR stack (#308→#313), restore authenticated draft-queue truth (#303/#309), then one Track A content packet and one Track B QA packet. Supersedes the June post-ship plan for *sequencing* (draft PR #313 until merged).
+
+**Newest startup truth artifact:** [reports/morning-truth-20260703-175742Z.md](reports/morning-truth-20260703-175742Z.md) — committed read-only Track A verification. Always prefer the newest committed `reports/morning-truth-*.md` plus a fresh `make status-readonly`.
 
 **Newest Track A addendum:** [CONTENT-ARCHITECTURE-RESET-2026-07-01.md](CONTENT-ARCHITECTURE-RESET-2026-07-01.md) — Trust + Offers and Topic Hubs waves are live on fifteen high-value pages, snapshot-gated, with `0` readability failures in both audits.
 

--- a/scripts/check_current_state_drift.py
+++ b/scripts/check_current_state_drift.py
@@ -176,7 +176,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--work-plan",
         type=Path,
-        default=Path("docs/current-state/WORK-PLAN-2026-05-23.md"),
+        default=Path("docs/current-state/CURRENT-STATE-2026-07-09.md"),
         help="Path to the state doc containing declared snapshot values.",
     )
     parser.add_argument("--base-url", default="https://kriskrug.co", help="Site URL for smoke checks.")

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -25,9 +25,23 @@ except Exception:  # pragma: no cover - local fallback
     dotenv_values = None
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _optional_env_paths() -> tuple[Path, ...]:
+    """Extra .env search paths. Prefer KKAI_ENV_PATH / NOTION_ENV_PATH over a hardcoded home dir."""
+    paths: list[Path] = []
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            paths.append(Path(raw).expanduser())
+    # Optional local-machine fallback; ignored when absent (cloud / other checkouts).
+    paths.append(Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env")
+    return tuple(paths)
+
+
 DEFAULT_ENV_PATHS = (
     REPO_ROOT / "scripts" / "notion-to-wp" / ".env",
-    Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env"),
+    *_optional_env_paths(),
 )
 DEFAULT_BASE_URL = "https://kriskrug.co"
 _OVERRIDE_KEYS = ("WP_USER", "WP_APP_PASSWORD", "WP_BASE_URL")

--- a/scripts/gsc-404-audit.py
+++ b/scripts/gsc-404-audit.py
@@ -15,7 +15,6 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 
-DEFAULT_CSV = Path.home() / "Downloads/https___kriskrug.co_-Coverage-Drilldown-2026-06-14/Table.csv"
 GOOGLEBOT_UA = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
 SHRINE_TARGET = (
@@ -207,8 +206,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--csv",
         type=Path,
-        default=DEFAULT_CSV,
-        help="Path to GSC Table.csv export",
+        required=True,
+        help="Path to GSC Table.csv export (required; no machine-local default)",
     )
     parser.add_argument(
         "--check-live",

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -172,7 +172,7 @@ def main() -> int:
     parser.add_argument("--expect-version", default="6.9.4")
     parser.add_argument(
         "--work-plan",
-        default="docs/current-state/WORK-PLAN-2026-05-23.md",
+        default="docs/current-state/CURRENT-STATE-2026-07-09.md",
         help="Declared state doc used for drift checks.",
     )
     parser.add_argument("--command-timeout", type=int, default=120, help="Timeout for shell subcommands in seconds.")

--- a/scripts/notion-to-wp/.env.example
+++ b/scripts/notion-to-wp/.env.example
@@ -1,7 +1,8 @@
 # Copy to .env (gitignored) and fill in values.
 #
-# 1. NOTION_TOKEN — already exists at /Users/kk/Code/notion-local/kk-ai-ecosystem/.env
-#    The script reads that file by default; you can override here if you want.
+# 1. NOTION_TOKEN — optional if you only run WP-side scripts.
+#    Local fallback: set KKAI_ENV_PATH / NOTION_ENV_PATH to a sibling .env, or
+#    place one at ~/Code/notion-local/kk-ai-ecosystem/.env (optional; ignored if absent).
 # NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # 2. WordPress credentials for kriskrug.co
@@ -15,3 +16,6 @@ WP_APP_PASSWORD=REPLACE_WITH_WORDPRESS_APPLICATION_PASSWORD
 # 3. Optional overrides
 # WP_BASE_URL=https://kriskrug.co
 # WP_DEFAULT_AUTHOR_ID=1
+# WP_AUTH_MODE=login
+# KKAI_ENV_PATH=/path/to/sibling/.env
+# KKAI_CONTENT_ROOT=/path/to/kk-ai-ecosystem

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -17,7 +17,7 @@ It does NOT inject schema. The `kk-schema` mu-plugin handles that sitewide. The 
 
 ### 1. Notion token
 
-Already set up. Lives at `/Users/kk/Code/notion-local/kk-ai-ecosystem/.env` as `NOTION_TOKEN=secret_…`. The script reads it automatically.
+Set `NOTION_TOKEN` in `scripts/notion-to-wp/.env` (preferred for cloud/agents), or point `NOTION_ENV_PATH` / `KKAI_ENV_PATH` at a sibling env file that already has the token. On KK's machine the historical default is `~/Code/notion-local/kk-ai-ecosystem/.env` when that path exists.
 
 ### 2. WordPress Application Password
 

--- a/scripts/notion-to-wp/connector_config.py
+++ b/scripts/notion-to-wp/connector_config.py
@@ -14,9 +14,20 @@ NOTION_API = "https://api.notion.com/v1"
 NOTION_VERSION = "2022-06-28"
 WP_BASE_URL_DEFAULT = "https://kriskrug.co"
 WP_DEFAULT_AUTHOR_ID = 1
-KKAI_ENV_PATH = Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env")
 SCRIPT_DIR = Path(__file__).resolve().parent
 LOCAL_ENV_PATH = SCRIPT_DIR / ".env"
+
+
+def _kkai_env_path() -> Path:
+    """Optional sibling-repo .env. Override with KKAI_ENV_PATH / NOTION_ENV_PATH."""
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            return Path(raw).expanduser()
+    return Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env"
+
+
+KKAI_ENV_PATH = _kkai_env_path()
 
 
 @dataclasses.dataclass

--- a/scripts/notion-to-wp/kk_notion_to_wp.py
+++ b/scripts/notion-to-wp/kk_notion_to_wp.py
@@ -40,7 +40,7 @@ Usage:
 
 Auth:
     - Notion: NOTION_TOKEN from scripts/notion-to-wp/.env OR
-      /Users/kk/Code/notion-local/kk-ai-ecosystem/.env (fallback).
+      scripts/notion-to-wp/.env, or KKAI_ENV_PATH / ~/Code/notion-local/.../.env (fallback).
     - WP: WP_USER + WP_APP_PASSWORD from scripts/notion-to-wp/.env. Generate the
       app password at https://kriskrug.co/wp-admin/profile.php (see README).
 

--- a/scripts/notion-to-wp/publish_context_creators.py
+++ b/scripts/notion-to-wp/publish_context_creators.py
@@ -20,7 +20,9 @@ from kk_notion_to_wp import WordPress, load_config, slugify
 from connector_payload import normalize_seo_meta
 from wp_blocks import inline, inline_image, hero_image, heading, separator, pullquote
 
-STAGE = pathlib.Path("/Users/kk/code/kriskrug-wp/content/drafts/2026-06-28-context-creators")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-06-28-context-creators"
 IMAGES = STAGE / "images"
 EXECUTE = "--execute" in sys.argv
 UPDATE = "--update" in sys.argv

--- a/scripts/notion-to-wp/publish_dc_protest_draft.py
+++ b/scripts/notion-to-wp/publish_dc_protest_draft.py
@@ -6,14 +6,24 @@ create_post), slugify, load_config, and text_polish.purge_em_dashes.
 Dry-run by default (writes staged post.html + prints plan). --execute uploads
 the 14 images and creates the DRAFT post. NEVER publishes.
 """
+import os
 import re, sys, json, shutil, pathlib, datetime
 from kk_notion_to_wp import WordPress, load_config, slugify
 from connector_payload import normalize_seo_meta
 from text_polish import purge_em_dashes
 from wp_blocks import inline, image, heading, separator
 
-SRC = pathlib.Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/content/articles/kris-krug-thought-leadership/25-data-center-protest-signs")
-STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-data-center-protest-signs")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+# Optional external article source (KK machine / KKAI_CONTENT_ROOT). Falls back to staged draft.
+_CONTENT_ROOT = pathlib.Path(
+    os.environ.get(
+        "KKAI_CONTENT_ROOT",
+        str(pathlib.Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem"),
+    )
+).expanduser()
+SRC = _CONTENT_ROOT / "content" / "articles" / "kris-krug-thought-leadership" / "25-data-center-protest-signs"
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-05-23-data-center-protest-signs"
 EXECUTE = "--execute" in sys.argv
 
 TITLE = "Both Hands Full at the Data Center: Protest Signs for People Who Refuse to Pick a Side"

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -35,7 +35,7 @@ REPO_ROOT = SCRIPT_DIR.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 from common import WPClient, load_env, wp_credentials  # noqa: E402
 
-ENV_PATH = "/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+ENV_PATH = SCRIPT_DIR / ".env"
 STAGE = REPO_ROOT / "content/drafts/2026-06-28-keep-the-machine-strange"
 EXECUTE = "--execute" in sys.argv
 UPDATE = "--update" in sys.argv

--- a/scripts/notion-to-wp/publish_proximity_game.py
+++ b/scripts/notion-to-wp/publish_proximity_game.py
@@ -24,7 +24,7 @@ from kk_notion_to_wp import WordPress, slugify, WP_BASE_URL_DEFAULT, WP_DEFAULT_
 from connector_payload import normalize_seo_meta
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parents[2]
+REPO_ROOT = SCRIPT_DIR.parents[1]
 STAGE = REPO_ROOT / "content" / "drafts" / "2026-06-04-the-great-canadian-proximity-game"
 ENV = SCRIPT_DIR / ".env"
 EXECUTE = "--execute" in sys.argv

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -23,7 +23,9 @@ from kk_notion_to_wp import WordPress, load_config, slugify
 from connector_payload import normalize_seo_meta
 from wp_blocks import inline, image, gallery, heading, separator, pullquote
 
-STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-you-cant-drink-data")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-05-23-you-cant-drink-data"
 EXECUTE = "--execute" in sys.argv
 UPDATE = "--update" in sys.argv
 WRITE = EXECUTE or UPDATE

--- a/scripts/wp_post_ia_rollout.py
+++ b/scripts/wp_post_ia_rollout.py
@@ -27,10 +27,19 @@ except Exception:  # pragma: no cover - local fallback
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_ENV_PATH = REPO_ROOT / "scripts" / "notion-to-wp" / ".env"
-ALT_SCRIPT_ENV_PATH = Path("/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env")
-FALLBACK_ENV_PATH = Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env")
 DEFAULT_BASE_URL = "https://kriskrug.co"
 DEFAULT_SINCE = "2025-01-01"
+
+
+def _fallback_env_paths() -> list[Path]:
+    """Optional extra .env locations (env override, then ~/Code/... if present)."""
+    paths: list[Path] = []
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            paths.append(Path(raw).expanduser())
+    paths.append(Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env")
+    return paths
 
 
 def parse_simple_env(path: Path) -> dict[str, str]:
@@ -120,18 +129,14 @@ class WordPressClient:
 
 
 def load_config() -> Config:
-    local = load_env(SCRIPT_ENV_PATH)
-    alt_local = load_env(ALT_SCRIPT_ENV_PATH)
-    fallback = load_env(FALLBACK_ENV_PATH)
+    sources = [load_env(SCRIPT_ENV_PATH)]
+    sources.extend(load_env(path) for path in _fallback_env_paths())
 
     def value(key: str, default: str | None = None) -> str | None:
-        return (
-            local.get(key)
-            or alt_local.get(key)
-            or fallback.get(key)
-            or os.environ.get(key)
-            or default
-        )
+        for source in sources:
+            if source.get(key):
+                return source.get(key)
+        return os.environ.get(key) or default
 
     base_url = value("WP_BASE_URL", DEFAULT_BASE_URL) or DEFAULT_BASE_URL
     wp_user = value("WP_USER")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs/code-only hygiene while WP/Notion auth waits for tonight.

### Docs

- Adds `CURRENT-STATE-2026-07-09.md` as the declared snapshot (open PRs/issues drift fixed; documents the false draft-queue zero).
- Includes `AUDIT-WORKPLAN-2026-07-09.md` and points `AGENTS.md` + current-state README at the new front door.
- Makefile / `morning_truth_report.py` / `check_current_state_drift.py` default to the new snapshot.
- Softens `scripts/notion-to-wp/README.md` so it no longer hardcodes `/Users/kk/...` for the Notion token.

### Code

- Removes hardcoded `/Users/kk/...` paths from connector, common env loader, IA rollout, and one-off publish scripts.
- Stage dirs are repo-relative; optional sibling `.env` / content roots via `KKAI_ENV_PATH` / `NOTION_ENV_PATH` / `KKAI_CONTENT_ROOT`.
- `gsc-404-audit.py` now **requires `--csv`** (no `~/Downloads` default).

## Out of scope

- No live WordPress writes.
- Leftover `publish_common` migration for context-creators / keep-the-machine-strange is in **#315** (stacked on #312).

## Verification

- `make verify` green on this branch tip.
- `make status-readonly` drift: open PRs/issues no longer false-drift against the new snapshot; draft counts still `(missing)` without `.env` (expected).

## Note vs #313

This PR also carries the audit workplan so front-door links resolve if #313 is not merged first. Fine to merge either order after the code stack; if both land, keep the newer Phase 1 table (includes #315).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

