### PR TITLE
refactor: migrate leftover publish scripts onto publish_common (#254)

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -25,9 +25,23 @@ except Exception:  # pragma: no cover - local fallback
     dotenv_values = None
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _optional_env_paths() -> tuple[Path, ...]:
+    """Extra .env search paths. Prefer KKAI_ENV_PATH / NOTION_ENV_PATH over a hardcoded home dir."""
+    paths: list[Path] = []
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            paths.append(Path(raw).expanduser())
+    # Optional local-machine fallback; ignored when absent (cloud / other checkouts).
+    paths.append(Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env")
+    return tuple(paths)
+
+
 DEFAULT_ENV_PATHS = (
     REPO_ROOT / "scripts" / "notion-to-wp" / ".env",
-    Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env"),
+    *_optional_env_paths(),
 )
 DEFAULT_BASE_URL = "https://kriskrug.co"
 _OVERRIDE_KEYS = ("WP_USER", "WP_APP_PASSWORD", "WP_BASE_URL")

--- a/scripts/notion-to-wp/.env.example
+++ b/scripts/notion-to-wp/.env.example
@@ -1,7 +1,8 @@
 # Copy to .env (gitignored) and fill in values.
 #
-# 1. NOTION_TOKEN — already exists at /Users/kk/Code/notion-local/kk-ai-ecosystem/.env
-#    The script reads that file by default; you can override here if you want.
+# 1. NOTION_TOKEN — optional if you only run WP-side scripts.
+#    Local fallback: set KKAI_ENV_PATH / NOTION_ENV_PATH to a sibling .env, or
+#    place one at ~/Code/notion-local/kk-ai-ecosystem/.env (optional; ignored if absent).
 # NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # 2. WordPress credentials for kriskrug.co
@@ -15,3 +16,6 @@ WP_APP_PASSWORD=REPLACE_WITH_WORDPRESS_APPLICATION_PASSWORD
 # 3. Optional overrides
 # WP_BASE_URL=https://kriskrug.co
 # WP_DEFAULT_AUTHOR_ID=1
+# WP_AUTH_MODE=login
+# KKAI_ENV_PATH=/path/to/sibling/.env
+# KKAI_CONTENT_ROOT=/path/to/kk-ai-ecosystem

--- a/scripts/notion-to-wp/connector_config.py
+++ b/scripts/notion-to-wp/connector_config.py
@@ -14,9 +14,20 @@ NOTION_API = "https://api.notion.com/v1"
 NOTION_VERSION = "2022-06-28"
 WP_BASE_URL_DEFAULT = "https://kriskrug.co"
 WP_DEFAULT_AUTHOR_ID = 1
-KKAI_ENV_PATH = Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env")
 SCRIPT_DIR = Path(__file__).resolve().parent
 LOCAL_ENV_PATH = SCRIPT_DIR / ".env"
+
+
+def _kkai_env_path() -> Path:
+    """Optional sibling-repo .env. Override with KKAI_ENV_PATH / NOTION_ENV_PATH."""
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            return Path(raw).expanduser()
+    return Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env"
+
+
+KKAI_ENV_PATH = _kkai_env_path()
 
 
 @dataclasses.dataclass

--- a/scripts/notion-to-wp/kk_notion_to_wp.py
+++ b/scripts/notion-to-wp/kk_notion_to_wp.py
@@ -40,7 +40,7 @@ Usage:
 
 Auth:
     - Notion: NOTION_TOKEN from scripts/notion-to-wp/.env OR
-      /Users/kk/Code/notion-local/kk-ai-ecosystem/.env (fallback).
+      scripts/notion-to-wp/.env, or KKAI_ENV_PATH / ~/Code/notion-local/.../.env (fallback).
     - WP: WP_USER + WP_APP_PASSWORD from scripts/notion-to-wp/.env. Generate the
       app password at https://kriskrug.co/wp-admin/profile.php (see README).
 

--- a/scripts/notion-to-wp/publish_context_creators.py
+++ b/scripts/notion-to-wp/publish_context_creators.py
@@ -16,15 +16,24 @@ Marker syntax in post.md:
   everything else   -> wp:paragraph
 """
 import re, sys, json, pathlib
-from kk_notion_to_wp import WordPress, load_config, slugify
+from kk_notion_to_wp import WordPress, load_config
 from connector_payload import normalize_seo_meta
 from wp_blocks import inline, inline_image, hero_image, heading, separator, pullquote
+from publish_common import (
+    find_media_by_stem,
+    parse_publish_argv,
+    render_paragraph_from_markdown,
+    split_body_blocks,
+)
 
-STAGE = pathlib.Path("/Users/kk/code/kriskrug-wp/content/drafts/2026-06-28-context-creators")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-06-28-context-creators"
 IMAGES = STAGE / "images"
-EXECUTE = "--execute" in sys.argv
-UPDATE = "--update" in sys.argv
-WRITE = EXECUTE or UPDATE
+FLAGS = parse_publish_argv()
+EXECUTE = FLAGS.execute
+UPDATE = FLAGS.update
+WRITE = FLAGS.write
 
 TITLE = "Context Creators"
 SLUG = "context-creators"
@@ -80,31 +89,13 @@ assert "—" not in body, "em-dash leaked into post.md body"
 cfg = load_config()
 wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
 
-
-def find_media(stem: str):
-    """Reuse already-uploaded media whose basename matches stem (avoid dupes)."""
-    if not WRITE:
-        return None
-    try:
-        r = wp.s.get(f"{wp.base}/wp-json/wp/v2/media",
-                     params={"search": stem, "per_page": 10, "context": "edit"}, timeout=30).json()
-    except Exception:
-        return None
-    if isinstance(r, list):
-        for m in r:
-            base = m.get("source_url", "").rsplit("/", 1)[-1]
-            if base == f"{stem}.png" or base.startswith(stem):
-                return m["id"], m["source_url"]
-    return None
-
-
 media_log = []
 poster_media = {}  # N -> (id, url, alt)
 for n, (fn, alt) in POSTERS.items():
     p = IMAGES / fn
     assert p.exists(), f"missing staged poster: {p}"
     if WRITE:
-        found = find_media(p.stem)
+        found = find_media_by_stem(wp, p.stem, extensions=(".png", ".jpg", ".jpeg", ".webp"))
         if found:
             mid, url = found
             media_log.append(f"{fn} -> REUSE id={mid}")
@@ -121,7 +112,7 @@ for key, (fn, alt, caption) in SCREENSHOTS.items():
     p = IMAGES / fn
     assert p.exists(), f"missing staged screenshot: {p}"
     if WRITE:
-        found = find_media(p.stem)
+        found = find_media_by_stem(wp, p.stem, extensions=(".png", ".jpg", ".jpeg", ".webp"))
         if found:
             mid, url = found
             media_log.append(f"{fn} -> REUSE id={mid}")
@@ -142,7 +133,7 @@ FEATURED_ID = poster_media[1][0]
 # ---- build blocks ----
 out = []
 seen_title = False
-for b in [x.strip() for x in re.split(r"\n\s*\n", body) if x.strip()]:
+for b in split_body_blocks(body):
     if b.startswith("# ") and not seen_title:
         seen_title = True
         continue
@@ -163,8 +154,7 @@ for b in [x.strip() for x in re.split(r"\n\s*\n", body) if x.strip()]:
             mid, url, alt, caption = shot_media[ms.group(2)]
             out.append(inline_image(mid, url, alt, caption=caption))
         else:
-            para = "<br>".join(inline(line.strip()) for line in b.split("\n"))
-            out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
+            out.append(render_paragraph_from_markdown(b))
 
 content = "\n\n".join(out)
 (STAGE / "post.html").write_text(content)

--- a/scripts/notion-to-wp/publish_dc_protest_draft.py
+++ b/scripts/notion-to-wp/publish_dc_protest_draft.py
@@ -6,6 +6,7 @@ create_post), slugify, load_config, and text_polish.purge_em_dashes.
 Dry-run by default (writes staged post.html + prints plan). --execute uploads
 the 14 images and creates the DRAFT post. NEVER publishes.
 """
+import os
 import re, sys, json, shutil, pathlib
 from kk_notion_to_wp import WordPress, load_config
 from connector_payload import normalize_seo_meta
@@ -22,8 +23,17 @@ from publish_common import (
     upload_image_manifest,
 )
 
-SRC = pathlib.Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/content/articles/kris-krug-thought-leadership/25-data-center-protest-signs")
-STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-data-center-protest-signs")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+# Optional external article source (KK machine / KKAI_CONTENT_ROOT).
+_CONTENT_ROOT = pathlib.Path(
+    os.environ.get(
+        "KKAI_CONTENT_ROOT",
+        str(pathlib.Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem"),
+    )
+).expanduser()
+SRC = _CONTENT_ROOT / "content" / "articles" / "kris-krug-thought-leadership" / "25-data-center-protest-signs"
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-05-23-data-center-protest-signs"
 FLAGS = parse_publish_argv()
 EXECUTE = FLAGS.execute
 # Default category: AI Ethics & Philosophy. Override with --category-id N.

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -33,13 +33,21 @@ import urllib.request
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(SCRIPT_DIR))
 from common import WPClient, load_env, wp_credentials  # noqa: E402
+from publish_common import (  # noqa: E402
+    parse_publish_argv,
+    render_paragraph_from_markdown,
+    split_body_blocks,
+)
+from wp_blocks import inline  # noqa: E402
 
-ENV_PATH = "/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+ENV_PATH = SCRIPT_DIR / ".env"
 STAGE = REPO_ROOT / "content/drafts/2026-06-28-keep-the-machine-strange"
-EXECUTE = "--execute" in sys.argv
-UPDATE = "--update" in sys.argv
-WRITE = EXECUTE or UPDATE
+FLAGS = parse_publish_argv()
+EXECUTE = FLAGS.execute
+UPDATE = FLAGS.update
+WRITE = FLAGS.write
 
 TITLE = "Keep the Machine Strange: Technological Resistance in the Age of AI"
 SLUG = "keep-the-machine-strange"
@@ -91,17 +99,6 @@ def slugify(s: str) -> str:
     s = re.sub(r"[^\w\s-]", "", s)
     s = re.sub(r"\s+", "-", s)
     return re.sub(r"-+", "-", s).strip("-")
-
-
-def inline(s: str) -> str:
-    def link(m):
-        text, url = m.group(1), m.group(2)
-        extra = "" if url.startswith(("https://kriskrug.co", "/", "#")) else ' target="_blank" rel="noopener noreferrer"'
-        return f'<a href="{url}"{extra}>{text}</a>'
-    s = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link, s)
-    s = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", s)
-    s = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", s)
-    return s
 
 
 def http_get(url: str, timeout: int = 120) -> bytes:
@@ -251,7 +248,7 @@ else:
 
 # ---- build blocks -----------------------------------------------------------
 out = []
-for blk in [b.strip() for b in re.split(r"\n\s*\n", body) if b.strip()]:
+for blk in split_body_blocks(body):
     if blk == "---":
         out.append(b_separator())
     elif blk.startswith("### "):
@@ -279,8 +276,7 @@ for blk in [b.strip() for b in re.split(r"\n\s*\n", body) if b.strip()]:
         elif blk_lines and all(ln.startswith("- ") for ln in blk_lines):
             out.append(b_list([inline(ln[2:].strip()) for ln in blk_lines]))
         else:
-            para = "<br>".join(inline(line.strip()) for line in blk.split("\n"))
-            out.append(f"<!-- wp:paragraph -->\n<p>{para}</p>\n<!-- /wp:paragraph -->")
+            out.append(render_paragraph_from_markdown(blk))
 
 content = "\n\n".join(out)
 (STAGE / "post.html").write_text(content, encoding="utf-8")

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -32,7 +32,9 @@ from publish_common import (
     split_body_blocks,
 )
 
-STAGE = pathlib.Path("/Users/kk/Code/kriskrug-wp/content/drafts/2026-05-23-you-cant-drink-data")
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[1]
+STAGE = REPO_ROOT / "content" / "drafts" / "2026-05-23-you-cant-drink-data"
 FLAGS = parse_publish_argv()
 EXECUTE = FLAGS.execute
 UPDATE = FLAGS.update

--- a/scripts/notion-to-wp/tests/test_publish_common.py
+++ b/scripts/notion-to-wp/tests/test_publish_common.py
@@ -101,6 +101,8 @@ class PublishCommonTests(unittest.TestCase):
             "publish_dc_protest_draft.py",
             "publish_you_cant_drink_data.py",
             "publish_proximity_game.py",
+            "publish_context_creators.py",
+            "publish_keep_the_machine_strange.py",
         ):
             src = (SCRIPT_DIR / name).read_text(encoding="utf-8")
             self.assertIn("publish_common", src, f"{name} should import publish_common")

--- a/scripts/notion-to-wp/tests/test_publish_scripts_seo_normalized.py
+++ b/scripts/notion-to-wp/tests/test_publish_scripts_seo_normalized.py
@@ -16,6 +16,8 @@ ONE_OFF_PUBLISH_SCRIPTS = [
     "publish_dc_protest_draft.py",
     "publish_you_cant_drink_data.py",
     "publish_proximity_game.py",
+    "publish_context_creators.py",
+    "publish_keep_the_machine_strange.py",
 ]
 
 SEO_META_FIELDS = ("jetpack_seo_html_title", "advanced_seo_description")

--- a/scripts/wp_post_ia_rollout.py
+++ b/scripts/wp_post_ia_rollout.py
@@ -27,10 +27,19 @@ except Exception:  # pragma: no cover - local fallback
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_ENV_PATH = REPO_ROOT / "scripts" / "notion-to-wp" / ".env"
-ALT_SCRIPT_ENV_PATH = Path("/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env")
-FALLBACK_ENV_PATH = Path("/Users/kk/Code/notion-local/kk-ai-ecosystem/.env")
 DEFAULT_BASE_URL = "https://kriskrug.co"
 DEFAULT_SINCE = "2025-01-01"
+
+
+def _fallback_env_paths() -> list[Path]:
+    """Optional extra .env locations (env override, then ~/Code/... if present)."""
+    paths: list[Path] = []
+    for key in ("KKAI_ENV_PATH", "NOTION_ENV_PATH"):
+        raw = os.environ.get(key)
+        if raw:
+            paths.append(Path(raw).expanduser())
+    paths.append(Path.home() / "Code" / "notion-local" / "kk-ai-ecosystem" / ".env")
+    return paths
 
 
 def parse_simple_env(path: Path) -> dict[str, str]:
@@ -120,18 +129,14 @@ class WordPressClient:
 
 
 def load_config() -> Config:
-    local = load_env(SCRIPT_ENV_PATH)
-    alt_local = load_env(ALT_SCRIPT_ENV_PATH)
-    fallback = load_env(FALLBACK_ENV_PATH)
+    sources = [load_env(SCRIPT_ENV_PATH)]
+    sources.extend(load_env(path) for path in _fallback_env_paths())
 
     def value(key: str, default: str | None = None) -> str | None:
-        return (
-            local.get(key)
-            or alt_local.get(key)
-            or fallback.get(key)
-            or os.environ.get(key)
-            or default
-        )
+        for source in sources:
+            if source.get(key):
+                return source.get(key)
+        return os.environ.get(key) or default
 
     base_url = value("WP_BASE_URL", DEFAULT_BASE_URL) or DEFAULT_BASE_URL
     wp_user = value("WP_USER")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked on **#312**. Finishes the #254 `publish_common` migration for the two leftover one-off publishers, and carries path-hygiene fixes that conflicted when rebasing onto #312.

## Changes

- `publish_context_creators.py` — `parse_publish_argv`, `find_media_by_stem`, `split_body_blocks`, `render_paragraph_from_markdown`
- `publish_keep_the_machine_strange.py` — same argv/block helpers; drop local `inline` shadow; keep custom markers (`>>>`, `QUOTE:`, `YT:`, `img:`, lists)
- Path hygiene for `publish_dc_protest_draft.py` / `publish_you_cant_drink_data.py` plus shared connector helpers so cloud agents are not tied to `/Users/kk/...`
- Extend `test_publish_common` + SEO normalizer script lists to cover the two leftover publishers

## Verify

- `make verify` green (53 notion-to-wp + 71 repo script tests, PHPCS, docs truth)

## Merge order

Merge **after** #312. Do not merge to `main` directly.

## Out of scope

No live WP writes. No Track A content packets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

