### PR TITLE
fix: restore Open Graph and Twitter metadata

### DIFF
--- a/content/drafts/2026-07-07-the-cheer-is-a-cap-table/seo-meta.md
+++ b/content/drafts/2026-07-07-the-cheer-is-a-cap-table/seo-meta.md
@@ -7,7 +7,7 @@
 | WP post ID | 12479 |
 | Category | AI Ethics & Philosophy |
 | Tags | Both Hands Full, AI Ethics, AI Hype, Effective Accelerationism, Documentary, Apocaloptimism |
-| Featured | YES (image 01, the marionette) — images still pending manual upload |
+| Featured | YES (media 12480, the marionette); four body images are live |
 | Meta title | The AI Doc: Watch Who's Smiling |
 | Meta description | A follow-the-money take on the documentary The AI Doc: Or How I Became an Apocaloptimist. Gorgeous, honest, and quietly sold to you by the people most invested in AI going their way. |
 | Excerpt | The AI Doc is beautifully made and worth your two hours. It's also a comfort machine, and the cheeriest voices in it are the people holding the biggest positions in the thing they're cheering for. Follow the money and the mood follows it. |

--- a/fixes/og-restore-snippet.php
+++ b/fixes/og-restore-snippet.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * KK OG Restore — kriskrug.co
+ *
+ * Temporary production bridge for social link previews while Aurora 1.3.37 is
+ * reviewed and deployed. The live Code Snippet must match this file exactly,
+ * without the opening PHP tag.
+ *
+ * Rollback: deactivate the "Open Graph + Twitter Card meta (social link
+ * previews)" snippet. Retire it after Aurora 1.3.37 is live and verified.
+ */
+
+if (!defined('KK_OG_SNIPPET_ACTIVE')) {
+    define('KK_OG_SNIPPET_ACTIVE', true);
+}
+
+add_action('wp_head', function (): void {
+    if (is_feed()) {
+        return;
+    }
+
+    $site = get_bloginfo('name');
+    $tags = [
+        'og:site_name'        => $site,
+        'og:title'            => wp_get_document_title(),
+        'og:type'             => 'website',
+        'og:url'              => home_url('/'),
+        'og:description'      => get_bloginfo('description'),
+        'twitter:site'        => '@feelmoreplants',
+    ];
+
+    if (is_singular()) {
+        $post = get_queried_object();
+        if ($post instanceof WP_Post) {
+            $description = get_the_excerpt($post);
+            if ($description === '') {
+                $description = wp_trim_words(wp_strip_all_tags($post->post_content), 40);
+            }
+
+            $tags['og:title'] = get_the_title($post);
+            $tags['og:type'] = is_singular('post') ? 'article' : 'website';
+            $tags['og:url'] = get_permalink($post);
+            $tags['og:description'] = $description;
+
+            $image = get_the_post_thumbnail_url($post, 'large');
+            if (!$image && preg_match('/<img[^>]+src=["\']([^"\']+)/i', $post->post_content, $match)) {
+                $image = $match[1];
+            }
+            if ($image) {
+                $tags['og:image'] = $image;
+                $tags['og:image:secure_url'] = $image;
+            }
+        }
+    }
+
+    if (empty($tags['og:image']) && has_site_icon()) {
+        $tags['og:image'] = get_site_icon_url(512);
+        $tags['og:image:secure_url'] = $tags['og:image'];
+    }
+
+    if (function_exists('KKAurora\\work_page_open_graph_fallback')) {
+        $tags = KKAurora\work_page_open_graph_fallback($tags);
+    }
+    if (function_exists('KKAurora\\writing_archive_open_graph_fallback')) {
+        $tags = KKAurora\writing_archive_open_graph_fallback($tags);
+    }
+    if (function_exists('KKAurora\\twitter_card_tag_fallbacks')) {
+        $tags = KKAurora\twitter_card_tag_fallbacks($tags);
+    }
+
+    $tags['og:description'] = mb_substr(wp_strip_all_tags((string) ($tags['og:description'] ?? '')), 0, 300);
+    $tags['twitter:card'] = empty($tags['og:image']) ? 'summary' : 'summary_large_image';
+    $tags['twitter:title'] = $tags['twitter:title'] ?? $tags['og:title'];
+    $tags['twitter:description'] = $tags['twitter:description'] ?? $tags['og:description'];
+    if (!empty($tags['og:image'])) {
+        $tags['twitter:image'] = $tags['twitter:image'] ?? $tags['og:image'];
+    }
+
+    foreach ($tags as $name => $value) {
+        if (!is_scalar($value) || $value === '') {
+            continue;
+        }
+        $attribute = str_starts_with($name, 'twitter:') ? 'name' : 'property';
+        printf(
+            '<meta %s="%s" content="%s" />' . "\n",
+            $attribute,
+            esc_attr($name),
+            esc_attr((string) $value)
+        );
+    }
+}, 5);

--- a/scripts/og_snippet_deploy.py
+++ b/scripts/og_snippet_deploy.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Safely create, inspect, activate, or deactivate the temporary OG snippet."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from common import WPClient
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_PATH = Path("/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env")
+MIRROR_PATH = REPO_ROOT / "fixes" / "og-restore-snippet.php"
+SNIPPET_NAME = "Open Graph + Twitter Card meta (social link previews)"
+
+
+def snippet_api(client: WPClient, path: str) -> str:
+    return f"{client.base}/wp-json/code-snippets/v1{path}"
+
+
+def snippet_code() -> str:
+    return MIRROR_PATH.read_text(encoding="utf-8").removeprefix("<?php\n").lstrip("\n")
+
+
+def list_snippets(client: WPClient) -> tuple[Any, list[dict[str, Any]]]:
+    response = client.get(snippet_api(client, "/snippets"))
+    if isinstance(response, list):
+        return response, response
+    if isinstance(response, dict):
+        for key in ("items", "snippets", "data"):
+            items = response.get(key)
+            if isinstance(items, list):
+                return response, items
+    raise RuntimeError("Code Snippets inventory returned an unexpected shape")
+
+
+def write_snapshot(raw_inventory: Any) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = Path("/private/tmp") / f"kriskrug-code-snippets-{timestamp}.json"
+    path.write_text(json.dumps(raw_inventory, indent=2), encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def create(client: WPClient) -> None:
+    raw_inventory, snippets = list_snippets(client)
+    snapshot = write_snapshot(raw_inventory)
+    matches = [item for item in snippets if item.get("name") == SNIPPET_NAME]
+    if len(matches) > 1:
+        raise RuntimeError(f"Refusing to continue: {len(matches)} snippets share the target name")
+    if matches:
+        existing = matches[0]
+        if existing.get("active"):
+            raise RuntimeError(f"Refusing to replace active snippet id={existing.get('id')}")
+        if existing.get("code") != snippet_code():
+            raise RuntimeError(f"Inactive snippet id={existing.get('id')} has different code")
+        print(f"snapshot={snapshot} mode=0600")
+        print(f"reusing id={existing.get('id')} active=false code_round_trip=ok")
+        return
+
+    payload = {
+        "name": SNIPPET_NAME,
+        "desc": "Temporary direct OG/Twitter metadata bridge. Retire after Aurora 1.3.37 is live.",
+        "code": snippet_code(),
+        "scope": "front-end",
+        "priority": 5,
+        "active": False,
+    }
+    created = client.post(snippet_api(client, "/snippets"), payload)
+    snippet_id = int(created["id"])
+    readback = client.get(snippet_api(client, f"/snippets/{snippet_id}"))
+    if readback.get("code") != payload["code"]:
+        raise RuntimeError("Created snippet code did not round-trip")
+    if readback.get("active") is not False:
+        raise RuntimeError("Created snippet was unexpectedly active")
+    if readback.get("scope") != payload["scope"]:
+        raise RuntimeError("Created snippet scope did not round-trip")
+    print(f"snapshot={snapshot} mode=0600")
+    print(f"created id={snippet_id} active=false scope=front-end code_round_trip=ok")
+
+
+def set_active(client: WPClient, snippet_id: int, active: bool) -> None:
+    action = "activate" if active else "deactivate"
+    try:
+        client.request(
+            "PATCH",
+            snippet_api(client, f"/snippets/{snippet_id}"),
+            {"active": active},
+        )
+    except Exception as error:
+        print(f"PATCH failed ({error}); trying POST /{action}")
+        client.post(snippet_api(client, f"/snippets/{snippet_id}/{action}"))
+    readback = client.get(snippet_api(client, f"/snippets/{snippet_id}"))
+    if bool(readback.get("active")) is not active:
+        raise RuntimeError(f"Snippet id={snippet_id} did not become active={active}")
+    print(f"id={snippet_id} active={str(active).lower()} name={readback.get('name')!r}")
+
+
+def status(client: WPClient, snippet_id: int) -> None:
+    readback = client.get(snippet_api(client, f"/snippets/{snippet_id}"))
+    print(
+        f"id={snippet_id} active={str(bool(readback.get('active'))).lower()} "
+        f"scope={readback.get('scope')} name={readback.get('name')!r}"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) not in (2, 3):
+        raise SystemExit("usage: og_snippet_deploy.py create|status|activate|deactivate [id]")
+    os.environ["WP_AUTH_MODE"] = "login"
+    client = WPClient.from_env(ENV_PATH)
+    command = sys.argv[1]
+    if command == "create" and len(sys.argv) == 2:
+        create(client)
+        return
+    if command in {"status", "activate", "deactivate"} and len(sys.argv) == 3:
+        snippet_id = int(sys.argv[2])
+        if command == "status":
+            status(client, snippet_id)
+        else:
+            set_active(client, snippet_id, command == "activate")
+        return
+    raise SystemExit("usage: og_snippet_deploy.py create|status|activate|deactivate [id]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- tracks the exact Code Snippet now active on kriskrug.co as snippet **12**
- adds an idempotent cookie-login deploy/status/rollback helper
- corrects the local post-12479 SEO snapshot to reflect media 12480 and four live body images

Refs #319

## Live verification

- Created inactive, exact code/scope readback passed, then activated.
- Pre-change Code Snippets snapshot saved privately with mode 0600.
- Pagely PressCACHE purge returned `Cache Purge: Success`.
- Canonical checks passed for post 12479, Artists Learn. Machines Extract., and the older SXSW backfill sample.
- Normal, Twitterbot, and Facebook crawler cache-miss checks all emitted the expected tags.
- Final canonical gateway-cache hits retained exactly one required OG/Twitter tag set.
- All three `og:image` URLs returned HTTP 200.
- Post 12479 title, slug, body, and `featured_media: 12480` remained unchanged.

## Validation

- `php -l fixes/og-restore-snippet.php`
- `python3 -m py_compile scripts/og_snippet_deploy.py`
- `python3 -m ruff check scripts/og_snippet_deploy.py`
- `make test` — 137 tests plus sidebar-promos smoke passed
- `git diff --check`
- Local `make validate` could not run because Composer/PHPCS is not installed; the PR PHP validation check must pass before review.

## Rollback

Deactivate snippet 12:

```bash
/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.venv/bin/python scripts/og_snippet_deploy.py deactivate 12
```

The live bridge remains active until Aurora 1.3.37 is separately approved, deployed, and verified.