### PR TITLE
Fix: remove remaining machine-local execution defaults

### DIFF
--- a/scripts/gsc-404-audit.py
+++ b/scripts/gsc-404-audit.py
@@ -15,7 +15,6 @@ from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 
-DEFAULT_CSV = Path.home() / "Downloads/https___kriskrug.co_-Coverage-Drilldown-2026-06-14/Table.csv"
 GOOGLEBOT_UA = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 
 SHRINE_TARGET = (
@@ -207,7 +206,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--csv",
         type=Path,
-        default=DEFAULT_CSV,
+        required=True,
         help="Path to GSC Table.csv export",
     )
     parser.add_argument(

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -17,7 +17,7 @@ It does NOT inject schema. The `kk-schema` mu-plugin handles that sitewide. The 
 
 ### 1. Notion token
 
-Already set up. Lives at `/Users/kk/Code/notion-local/kk-ai-ecosystem/.env` as `NOTION_TOKEN=secret_…`. The script reads it automatically.
+Set `NOTION_TOKEN` in `scripts/notion-to-wp/.env`, or point `NOTION_ENV_PATH` / `KKAI_ENV_PATH` at a sibling env file that already contains it. The optional local fallback is `~/Code/notion-local/kk-ai-ecosystem/.env` when that path exists.
 
 ### 2. WordPress Application Password
 

--- a/scripts/og_snippet_deploy.py
+++ b/scripts/og_snippet_deploy.py
@@ -14,7 +14,7 @@ from common import WPClient
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-ENV_PATH = Path("/Users/kk/Code/kriskrug-wp/scripts/notion-to-wp/.env")
+ENV_PATH = REPO_ROOT / "scripts" / "notion-to-wp" / ".env"
 MIRROR_PATH = REPO_ROOT / "fixes" / "og-restore-snippet.php"
 SNIPPET_NAME = "Open Graph + Twitter Card meta (social link previews)"
 

--- a/scripts/tests/test_machine_local_defaults.py
+++ b/scripts/tests/test_machine_local_defaults.py
@@ -1,0 +1,61 @@
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / filename)
+    module = importlib.util.module_from_spec(spec)
+    scripts_dir = str(ROOT / "scripts")
+    sys.modules[name] = module
+    sys.path.insert(0, scripts_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(scripts_dir)
+    return module
+
+
+class MachineLocalDefaultsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.gsc_audit = load_script("gsc_404_audit", "gsc-404-audit.py")
+        cls.og_deploy = load_script("og_snippet_deploy", "og_snippet_deploy.py")
+
+    def test_gsc_audit_requires_explicit_csv(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as error:
+                self.gsc_audit.main([])
+
+        self.assertEqual(error.exception.code, 2)
+
+    def test_gsc_audit_accepts_explicit_csv(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            csv_path = Path(tmp) / "Table.csv"
+            csv_path.write_text(
+                "URL,Last crawled\nhttps://kriskrug.co/quote-request/,2026-07-01\n",
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = self.gsc_audit.main(["--csv", str(csv_path)])
+
+        self.assertEqual(result, 0)
+        self.assertIn("URLs audited: 1", output.getvalue())
+
+    def test_og_deploy_env_path_is_repo_relative(self):
+        self.assertEqual(
+            self.og_deploy.ENV_PATH,
+            ROOT / "scripts" / "notion-to-wp" / ".env",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require an explicit `--csv` path for the GSC 404 audit instead of a dated Downloads default
- resolve the OG snippet deploy env file from the repository checkout
- document portable Notion token lookup without publishing a machine-local absolute path
- add offline behavior coverage for the executable path contracts

This is the still-useful residue from stale PR #314. Its older state docs and already-landed auth/publisher refactors are intentionally excluded.

## Verification

- `python3 -m unittest scripts/tests/test_machine_local_defaults.py -v` — passed, 3 tests
- `make test` — passed: 54 publisher, 85 operational, 3 SEO inventory, 68 SEO backfill/link-safety, JavaScript syntax, and both plugin smokes
- `make docs-truth-check` — passed
- Python compile and `git diff --check` — passed

No live WordPress calls, writes, or deploys were performed.

Closes #325

Supersedes #314 after merge.
