### PR TITLE
seo: add most benevolent review handoff

### DIFF
--- a/fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.json
+++ b/fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "issue": 328,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "evidence": {
+    "query": "most benevolent",
+    "impressions": 20,
+    "average_position": 8.4,
+    "ctr_percent": 0.0,
+    "source": "GitHub issue #328; digest-safe aggregate copied from its source digest"
+  },
+  "target": {
+    "id": 3814,
+    "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+    "url": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+    "modified": "2026-06-28T20:37:13",
+    "title": "Most Benevolent Outcomes Prayer for AI & All Living Things"
+  },
+  "current_public_metadata": {
+    "observed_on": "2026-07-12",
+    "document_title": "Most Benevolent Outcomes Prayer for AI & All Living Things \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+    "document_title_chars": 115,
+    "standard_meta_description_present": false,
+    "open_graph_description_present": true,
+    "seo_backfill_title_state": "skipped-too-long",
+    "seo_backfill_report": "docs/current-state/reports/seo-backfill-20260614-220932Z.md"
+  },
+  "link_patches": [
+    {
+      "priority": 1,
+      "source_id": 2950,
+      "source_slug": "community-weaving-how-digital-interactions-shape-our-physical-world",
+      "source_url": "https://kriskrug.co/2023/09/01/community-weaving-how-digital-interactions-shape-our-physical-world/",
+      "source_modified": "2026-06-28T20:38:58",
+      "needle": "Most Benevolent Outcomes",
+      "replacement": "<a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">Most Benevolent Outcomes</a>",
+      "expected_needle_count": 1,
+      "expected_target_href_count_before": 0,
+      "copy_change": false
+    },
+    {
+      "priority": 2,
+      "source_id": 2665,
+      "source_slug": "embracing-the-future-my-journey-with-generative-ai-and-building-a-learning-community-on-discord",
+      "source_url": "https://kriskrug.co/2023/07/09/embracing-the-future-my-journey-with-generative-ai-and-building-a-learning-community-on-discord/",
+      "source_modified": "2026-06-28T20:39:43",
+      "needle": "cultivating the most benevolent outcomes",
+      "replacement": "<a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">cultivating the most benevolent outcomes</a>",
+      "expected_needle_count": 1,
+      "expected_target_href_count_before": 0,
+      "copy_change": false
+    }
+  ],
+  "future_write_boundary_if_separately_approved": {
+    "allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "categories",
+      "tags",
+      "meta"
+    ],
+    "requires": [
+      "fresh authenticated ID, slug, status, and modified-date check",
+      "content.raw snapshot before each write",
+      "human review of each exact link wrapper",
+      "public readback and a retained rollback snapshot"
+    ]
+  },
+  "next_digest": {
+    "query": "most benevolent",
+    "landing_page": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+    "compare": [
+      "impressions",
+      "clicks",
+      "ctr_percent",
+      "average_position"
+    ],
+    "success_signal": {
+      "average_position_below": 7.0,
+      "clicks_at_least": 1
+    },
+    "note": "Compare only after the handoff is applied, publicly verified, and given time to be recrawled."
+  }
+}

--- a/fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.md
+++ b/fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.md
@@ -1,0 +1,118 @@
+# Issue #328: Most Benevolent SEO Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.json
+
+## Decision
+
+The ranking page and the best contextual source paragraphs live in WordPress,
+not in a canonical repo payload. This PR therefore stops at a precise handoff.
+It does not publish, deploy, update WordPress, or change Search Console, GA4,
+DNS, analytics, schema, or theme code.
+
+A post-specific theme override or another metadata snippet would create a
+second owner and a much wider blast radius than issue #328 warrants. The
+smallest safe move is to prepare two copy-preserving contextual links for a
+separately approved publisher session.
+
+## Digest-Safe Evidence
+
+The same-date digest file named by the issue was not present in the local
+notion-local or kk-kb mirrors. This handoff uses only the aggregate values
+copied into the live issue:
+
+| Query | Impressions | Average position | CTR |
+|---|---:|---:|---:|
+| most benevolent | 20 | 8.4 | 0.0% |
+
+No Search Console export, OAuth material, private analytics rows, or
+person-level data is included.
+
+## Public Mapping
+
+Read-only public HTML and WordPress REST checks on 2026-07-12 mapped the query
+to post 3814:
+
+- URL: https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/
+- Slug: the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things
+- Public modified value: 2026-06-28T20:37:13
+- HTTP: 200
+- Canonical: self-referencing and correct
+- Exact phrase: present in the visible title, headings, and body
+
+The current document title is 115 characters after Aurora appends the site
+descriptor. The page does not currently render a standard meta description;
+it does render Open Graph and Twitter descriptions from the excerpt. The
+earlier repo backfill skipped a custom SEO title for post 3814 because the
+generated title was too long.
+
+Those metadata observations are recorded for a future owner-confirmation pass,
+but this handoff does not recommend a target-specific theme or snippet change.
+
+## Review-Ready Link Patches
+
+Both public source bodies contain the listed needle exactly once and currently
+contain zero links to the target URL. Apply only after a fresh readback confirms
+the same ID, slug, published status, and modified value.
+
+### Priority 1: Community Weaving
+
+- Source post: 2950
+- URL: https://kriskrug.co/2023/09/01/community-weaving-how-digital-interactions-shape-our-physical-world/
+- Public modified value: 2026-06-28T20:38:58
+- Existing phrase:
+
+    Most Benevolent Outcomes
+
+- Review replacement:
+
+    <a href="https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/">Most Benevolent Outcomes</a>
+
+### Priority 2: Embracing the Future
+
+- Source post: 2665
+- URL: https://kriskrug.co/2023/07/09/embracing-the-future-my-journey-with-generative-ai-and-building-a-learning-community-on-discord/
+- Public modified value: 2026-06-28T20:39:43
+- Existing phrase:
+
+    cultivating the most benevolent outcomes
+
+- Review replacement:
+
+    <a href="https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/">cultivating the most benevolent outcomes</a>
+
+These replacements wrap existing words only. They add no sentence, claim, or
+keyword repetition, and they make no title, taxonomy, metadata, status, slug,
+or date change.
+
+## Separate Publisher Gate
+
+Do not apply these patches from this PR. In a future session with explicit
+approval for live WordPress edits:
+
+1. Fetch each source by ID and confirm slug, published status, and modified
+   value. Stop for human review if any guard has changed.
+2. Snapshot content.raw and rendered HTML for each source before editing.
+3. Confirm the needle still occurs exactly once and the target href occurs
+   zero times.
+4. Review the exact body-only diff. The only allowed top-level REST key is
+   content.
+5. Apply one source at a time. Do not send title, slug, status, date,
+   categories, tags, or meta.
+6. Read back the source, verify the visible link and target 200 response, then
+   retain the before snapshot as the rollback payload.
+
+## Next Digest Verification
+
+The next SEO Growth Digest should keep the query and landing page paired:
+
+- Query: most benevolent
+- Landing page: post 3814 URL above
+- Baseline: 20 impressions, 0 clicks, 0.0% CTR, average position 8.4
+- Compare: impressions, clicks, CTR, and average position
+- Success signal: average position below 7 and at least one click
+
+Record whether and when the two link patches were applied. Do not attribute
+movement to this PR before the live links are approved, applied, publicly
+verified, and recrawled.

--- a/scripts/tests/test_issue_328_seo_handoff.py
+++ b/scripts/tests/test_issue_328_seo_handoff.py
@@ -1,0 +1,107 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.json"
+HANDOFF = ROOT / "fixes/issue-328-most-benevolent-seo-handoff-2026-07-12.md"
+
+
+class Issue328SeoHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_evidence_is_limited_to_the_issue_aggregate(self):
+        evidence = self.data["evidence"]
+        self.assertEqual("most benevolent", evidence["query"])
+        self.assertEqual(20, evidence["impressions"])
+        self.assertEqual(8.4, evidence["average_position"])
+        self.assertEqual(0.0, evidence["ctr_percent"])
+
+    def test_target_identity_and_metadata_observation_are_stable(self):
+        target = self.data["target"]
+        metadata = self.data["current_public_metadata"]
+
+        self.assertEqual(3814, target["id"])
+        self.assertEqual(
+            target["url"],
+            f"https://kriskrug.co/2023/11/04/{target['slug']}/",
+        )
+        self.assertEqual(
+            metadata["document_title_chars"],
+            len(metadata["document_title"]),
+        )
+        self.assertFalse(metadata["standard_meta_description_present"])
+        self.assertTrue(metadata["open_graph_description_present"])
+
+    def test_link_replacements_only_wrap_existing_copy(self):
+        target_url = self.data["target"]["url"]
+        source_ids = set()
+
+        for patch in self.data["link_patches"]:
+            match = re.fullmatch(
+                r'<a href="([^"]+)">([^<]+)</a>',
+                patch["replacement"],
+            )
+            self.assertIsNotNone(match)
+            self.assertEqual(target_url, match.group(1))
+            self.assertEqual(patch["needle"], match.group(2))
+            self.assertEqual(1, patch["expected_needle_count"])
+            self.assertEqual(0, patch["expected_target_href_count_before"])
+            self.assertFalse(patch["copy_change"])
+            self.assertTrue(patch["source_url"].startswith("https://kriskrug.co/"))
+            self.assertNotIn(patch["source_id"], source_ids)
+            source_ids.add(patch["source_id"])
+
+        self.assertEqual({2950, 2665}, source_ids)
+
+    def test_future_write_boundary_is_body_only(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+        self.assertEqual(["content"], boundary["allowed_rest_top_level_keys"])
+        self.assertEqual(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "meta",
+            },
+            set(boundary["forbidden_rest_top_level_keys"]),
+        )
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+    def test_handoff_keeps_live_and_private_surfaces_out_of_scope(self):
+        text = HANDOFF.read_text(encoding="utf-8")
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply these patches from this PR.", text)
+        self.assertIn("The only allowed top-level REST key is", text)
+
+        serialized = json.dumps(self.data).lower()
+        for secret_marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "oauth",
+        ):
+            self.assertNotIn(secret_marker, serialized)
+
+    def test_next_digest_has_a_page_pair_and_measurable_signal(self):
+        verification = self.data["next_digest"]
+        self.assertEqual(self.data["evidence"]["query"], verification["query"])
+        self.assertEqual(self.data["target"]["url"], verification["landing_page"])
+        self.assertEqual(
+            {"impressions", "clicks", "ctr_percent", "average_position"},
+            set(verification["compare"]),
+        )
+        self.assertEqual(7.0, verification["success_signal"]["average_position_below"])
+        self.assertEqual(1, verification["success_signal"]["clicks_at_least"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a review-only Track A handoff for the `most benevolent` query cluster
- map the ranking target to public post 3814 and two copy-preserving contextual-link candidates
- add a machine-checkable manifest with ID, slug, modified-date, and body-only safety guards
- add focused evals for aggregate-only evidence, exact link wrappers, forbidden REST fields, secret markers, and next-digest verification

## Why

Issue #328 reports 20 impressions, average position 8.4, and 0.0% CTR for `most benevolent`.

Read-only public inspection mapped the query to post 3814. Posts 2950 and 2665 each contain one natural phrase match and zero links to the target. The relevant bodies and SEO fields live in WordPress rather than a canonical repo payload, so this PR leaves a precise human-review handoff instead of adding a post-specific theme override or touching live CMS state.

The handoff also records that the public document title is 115 characters, the page currently has no standard meta description, and the earlier SEO backfill skipped a custom title as too long. Metadata ownership should be confirmed separately rather than introducing another generator here.

## Safety

- no WordPress publish or update
- no deployment or Search Console, GA4, DNS, analytics, schema, or theme change
- no credentials, OAuth material, Search Console export, private analytics rows, or speculative copy claims
- any future publisher session must snapshot first, re-check ID/slug/status/modified guards, and send a body-only `content` payload

## Verification

- `python3 -m unittest scripts.tests.test_issue_328_seo_handoff -v` - 6 passed
- `make verify` - 54 publisher tests, 91 operational tests, 3 SEO inventory tests, 68 SEO backfill/link-safety tests, JavaScript syntax, two plugin smokes, docs truth, and PHPCS passed
- `git diff --cached --check` - passed before commit
- public target returned HTTP 200 with a self-referencing canonical
- each proposed source needle occurred once and the target href occurred zero times

Closes #328
