### PR TITLE
seo: add you can't drink data review handoff

### DIFF
--- a/fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.json
+++ b/fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": 1,
+  "issue": 249,
+  "status": "human-review-required",
+  "scope": {
+    "reserved_contextual_links": 1,
+    "selected_surface": "about",
+    "live_wordpress_write_performed": false,
+    "publish_or_deploy_performed": false
+  },
+  "evidence": {
+    "observed_on": "2026-07-12",
+    "sources": [
+      "public WordPress REST responses",
+      "public rendered HTML",
+      "GitHub issue #249",
+      "repository source packs and publishing instructions"
+    ],
+    "private_analytics_export_included": false
+  },
+  "baseline": {
+    "source": "GitHub issue #249 comment created 2026-07-12T22:00:35Z",
+    "window": {
+      "start": "2026-06-12",
+      "end": "2026-07-09",
+      "days": 28
+    },
+    "landing_page": {
+      "url": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+      "impressions": 294,
+      "clicks": 6,
+      "ctr_percent": 2.04,
+      "average_position": 7.96
+    },
+    "normalized_query_cluster": {
+      "query": "you cant drink data",
+      "impressions_present": true,
+      "clicks": 0,
+      "average_position_range": {
+        "min": 8.4,
+        "max": 8.7
+      }
+    }
+  },
+  "target": {
+    "type": "post",
+    "id": 11936,
+    "slug": "you-cant-drink-data",
+    "url": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+    "status": "publish",
+    "modified": "2026-06-28T18:40:25",
+    "title_rendered": "You Can&#8217;t Drink Data",
+    "canonical": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+    "expected_public_http_status": 200
+  },
+  "source_selection": {
+    "selected": {
+      "type": "page",
+      "id": 1208,
+      "slug": "about",
+      "url": "https://kriskrug.co/about/",
+      "status": "publish",
+      "modified": "2026-07-01T11:33:51",
+      "canonical": "https://kriskrug.co/about/",
+      "expected_public_http_status": 200,
+      "content_marker": "content-architecture-2026:about",
+      "repo_payload": "content/source-packs/content-architecture-2026/wp-payloads/about.html",
+      "repo_payload_sha256": "1b3957ab6cbe9bb9b2401dc4fe9bd5006726de1ec70d1d86ac7711a0ccd8fb26",
+      "expected_anchor_count_before": 0,
+      "expected_target_href_count_before": 0,
+      "reason": "The opening About copy already connects technology, activism, AI, and human capacity, and the body has a tracked repo payload and marker."
+    },
+    "homepage_not_selected": {
+      "type": "page",
+      "id": 3930,
+      "slug": "empowering-events-organizations-for-the-ai-age",
+      "url": "https://kriskrug.co/",
+      "status": "publish",
+      "modified": "2026-06-29T16:49:49",
+      "canonical": "https://kriskrug.co/",
+      "expected_anchor_count_before": 0,
+      "expected_target_href_count_before": 0,
+      "reason": "The front page has a legacy internal slug and less direct surrounding copy than the tracked About introduction."
+    }
+  },
+  "link_proposal": {
+    "proposal_type": "single-sentence-paragraph-extension",
+    "phrase_present_before": false,
+    "anchor_text": "you can't drink data",
+    "href": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+    "current_paragraph_html": "<p>I have spent two decades documenting technology, art, activism, conferences, communities, and the back rooms where culture actually changes. These days, most of that work points at one question: how do we use AI to increase human capacity instead of flattening human judgment?</p>",
+    "added_sentence_html": "That question includes the physical costs of AI infrastructure, which I confronted on the streets of Vancouver and wrote about in <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">you can't drink data</a>.",
+    "added_sentence_text": "That question includes the physical costs of AI infrastructure, which I confronted on the streets of Vancouver and wrote about in you can't drink data.",
+    "replacement_paragraph_html": "<p>I have spent two decades documenting technology, art, activism, conferences, communities, and the back rooms where culture actually changes. These days, most of that work points at one question: how do we use AI to increase human capacity instead of flattening human judgment? That question includes the physical costs of AI infrastructure, which I confronted on the streets of Vancouver and wrote about in <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">you can't drink data</a>.</p>",
+    "expected_current_paragraph_count": 1,
+    "expected_anchor_count_after": 1,
+    "expected_target_href_count_after": 1,
+    "copy_change": true,
+    "sentences_added": 1
+  },
+  "future_publisher_gate": {
+    "stale_guard": {
+      "read_endpoint": "/wp-json/wp/v2/pages/1208?context=edit&_fields=id,slug,status,modified,content",
+      "expected_identity": {
+        "id": 1208,
+        "slug": "about",
+        "status": "publish",
+        "modified": "2026-07-01T11:33:51"
+      },
+      "expected_current_paragraph_count": 1,
+      "expected_target_href_count": 0,
+      "stop_if_any_guard_differs": true
+    },
+    "snapshot": {
+      "directory_pattern": "backup/<UTC>-issue-249-ycdd-about-backlink",
+      "required_before_write": true,
+      "required_files": [
+        "before-page-1208-edit.json",
+        "before-page-1208-public.html",
+        "sha256sums.txt"
+      ],
+      "required_edit_snapshot_fields": [
+        "id",
+        "slug",
+        "status",
+        "modified",
+        "content.raw"
+      ]
+    },
+    "write": {
+      "endpoint": "/wp-json/wp/v2/pages/1208",
+      "allowed_rest_top_level_keys": [
+        "content"
+      ],
+      "forbidden_rest_top_level_keys": [
+        "title",
+        "slug",
+        "status",
+        "date",
+        "date_gmt",
+        "author",
+        "excerpt",
+        "featured_media",
+        "comment_status",
+        "ping_status",
+        "format",
+        "meta",
+        "template",
+        "parent",
+        "menu_order"
+      ],
+      "body_rule": "Start from the freshly fetched content.raw and replace exactly one current_paragraph_html with replacement_paragraph_html.",
+      "requires_human_review_of_exact_diff": true
+    },
+    "rollback": {
+      "payload_source": "before-page-1208-edit.json content.raw",
+      "allowed_rest_top_level_keys": [
+        "content"
+      ],
+      "precondition": "Current page modified value must equal the recorded post-write modified value; stop if a later edit exists.",
+      "readback_required": true
+    },
+    "public_readback": {
+      "source_url": "https://kriskrug.co/about/",
+      "target_url": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+      "checks": [
+        "source returns HTTP 200 and keeps its self-referencing canonical",
+        "source renders the target href exactly once with anchor text you can't drink data",
+        "target returns HTTP 200 and keeps its self-referencing canonical",
+        "source ID, slug, status, title, and all non-content fields remain unchanged",
+        "authenticated content.raw readback matches the reviewed after-body"
+      ]
+    }
+  },
+  "next_digest": {
+    "measurement_gate": {
+      "minimum_full_days_after_verified_live_edit": 7,
+      "requires_recorded_live_edit_timestamp": true,
+      "requires_public_link_readback": true
+    },
+    "query_cluster": "you cant drink data",
+    "landing_page": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+    "required_metrics": [
+      "impressions",
+      "clicks",
+      "ctr_percent",
+      "average_position"
+    ],
+    "comparison": {
+      "landing_page_baseline": "baseline.landing_page",
+      "query_cluster_baseline": "baseline.normalized_query_cluster",
+      "preserve_28_day_window_length": true
+    },
+    "positive_signal": {
+      "query_cluster_clicks_at_least": 1,
+      "query_cluster_average_position_below": 8.4
+    },
+    "inconclusive_rule": "If the measurement gate is not met or impressions are zero, record the result as not yet measurable rather than an SEO loss.",
+    "attribution_rule": "Do not attribute movement to this handoff before the live edit is approved, applied, publicly verified, and recrawled."
+  },
+  "github_handoff": {
+    "pull_request_reference": "Refs #249",
+    "issue_remains_open": true,
+    "remaining_gate": "Human approval, snapshot, body-only WordPress application, public readback, and next-digest remeasurement."
+  }
+}

--- a/fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.md
+++ b/fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.md
@@ -1,0 +1,134 @@
+# Issue #249: You Can't Drink Data SEO Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.json`
+
+## Decision
+
+Use the single backlink reserved by issue #249 on the About page. The current
+About introduction already joins technology, activism, AI, and human capacity,
+and it has a canonical repo payload with a stable content marker. The homepage
+has a legacy internal slug and less direct surrounding copy.
+
+Neither surface currently contains the preferred phrase or target URL. This
+handoff therefore proposes one sentence for human review instead of pretending
+there is existing copy that can simply be wrapped in a link.
+
+This PR does not publish, deploy, update WordPress, change Search Console, GA4,
+DNS, analytics, schema, theme code, snippets, or secrets. It does not claim a
+ranking improvement. The issue stays open until a separate publisher session
+is approved, snapshotted, applied, publicly verified, and remeasured.
+
+## Issue Baseline
+
+Issue #249 records a 28-day baseline for 2026-06-12 through 2026-07-09:
+
+| Surface | Impressions | Clicks | CTR | Average position |
+|---|---:|---:|---:|---:|
+| Landing page | 294 | 6 | 2.04% | 7.96 |
+| Normalized `you cant drink data` variants | Present | 0 | Not provided | 8.4-8.7 |
+
+These are issue-level aggregates only. No private Search Console export,
+account identifier, or person-level analytics data is included.
+
+## Target Mapping
+
+Read-only public REST and HTML checks on 2026-07-12 mapped the target to:
+
+- Post ID: `11936`
+- Slug: `you-cant-drink-data`
+- URL: `https://kriskrug.co/2026/05/23/you-cant-drink-data/`
+- Status: `publish`
+- Public modified value: `2026-06-28T18:40:25`
+- Canonical: self-referencing target URL
+- Public HTTP status: `200`
+
+Any future publisher must stop if ID, slug, status, or modified value differs.
+
+## Source Mapping
+
+The selected source is the About page:
+
+- Page ID: `1208`
+- Slug: `about`
+- URL: `https://kriskrug.co/about/`
+- Status: `publish`
+- Public modified value: `2026-07-01T11:33:51`
+- Canonical: `https://kriskrug.co/about/`
+- Content marker: `content-architecture-2026:about`
+- Repo payload: `content/source-packs/content-architecture-2026/wp-payloads/about.html`
+- Repo payload SHA-256: `1b3957ab6cbe9bb9b2401dc4fe9bd5006726de1ec70d1d86ac7711a0ccd8fb26`
+
+The current About body contains zero instances of the preferred anchor and
+zero links to the target. Its opening paragraph appears exactly once in the
+tracked payload.
+
+The homepage was also checked. It is page `3930`, with internal slug
+`empowering-events-organizations-for-the-ai-age`, public URL `/`, published
+status, and modified value `2026-06-29T16:49:49`. It also contains zero target
+links, but the About introduction is the more coherent and better-guarded fit.
+
+## Sentence-Level Proposal
+
+Current paragraph:
+
+```html
+<p>I have spent two decades documenting technology, art, activism, conferences, communities, and the back rooms where culture actually changes. These days, most of that work points at one question: how do we use AI to increase human capacity instead of flattening human judgment?</p>
+```
+
+Review-ready replacement:
+
+```html
+<p>I have spent two decades documenting technology, art, activism, conferences, communities, and the back rooms where culture actually changes. These days, most of that work points at one question: how do we use AI to increase human capacity instead of flattening human judgment? That question includes the physical costs of AI infrastructure, which I confronted on the streets of Vancouver and wrote about in <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">you can't drink data</a>.</p>
+```
+
+The only copy change is the final sentence. It adds the preferred anchor once,
+opens in the same tab like other internal links, and makes no new ranking or
+outcome claim.
+
+## Separate Publisher Gate
+
+Do not apply this proposal from this PR. In a future session with explicit
+approval for the one live body edit:
+
+1. Fetch page `1208` with edit context and only `id`, `slug`, `status`,
+   `modified`, and `content`. Confirm the exact identity and modified guard
+   above. Stop if any value differs.
+2. Confirm `content.raw` contains the current paragraph exactly once and the
+   target URL zero times. Stop for review if either count differs.
+3. Create `backup/<UTC>-issue-249-ycdd-about-backlink/` containing the full
+   edit-context response, public About HTML, and SHA-256 checksums before any
+   write.
+4. Build the after-body from the freshly fetched `content.raw`. Replace only
+   the one paragraph shown above and review that exact body diff.
+5. Send only the top-level REST key `content` to page `1208`. Do not send title,
+   slug, status, dates, author, excerpt, media, comments, format, meta,
+   template, parent, or menu order.
+6. Read back authenticated raw content and public HTML. Confirm one visible
+   anchor, one target href, unchanged source identity and non-content fields,
+   source and target HTTP `200`, and both self-referencing canonicals.
+7. Retain the before snapshot as the rollback body. Before rollback, require
+   the current modified value to match the recorded post-write value; stop if
+   someone has edited the page since the backlink write. Restore only
+   `content`, then repeat the readback checks.
+
+## Next Digest Verification
+
+Measure only in the first SEO Growth Digest with at least seven full days after
+the approved edit and public readback. Preserve a 28-day comparison window and
+record the live-edit timestamp.
+
+For both the landing page and normalized `you cant drink data` query variants,
+record impressions, clicks, CTR, and average position. Compare the page with
+`294 / 6 / 2.04% / 7.96` and the query cluster with `0` clicks and position
+`8.4-8.7`.
+
+A positive directional signal requires at least one query-cluster click and an
+average position below `8.4`. If the seven-day gate is not met or impressions
+are zero, record the result as not yet measurable. Do not claim causation from
+this handoff or PR.
+
+The PR must use `Refs #249`, not `Closes #249`. The remaining publisher gate is
+human approval, snapshot, body-only application, public readback, and the next
+eligible digest.

--- a/scripts/tests/test_issue_249_seo_handoff.py
+++ b/scripts/tests/test_issue_249_seo_handoff.py
@@ -1,0 +1,159 @@
+import hashlib
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.json"
+HANDOFF = ROOT / "fixes/issue-249-you-cant-drink-data-seo-handoff-2026-07-12.md"
+
+
+class Issue249SeoHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_issue_baseline_is_exact_and_digest_safe(self):
+        baseline = self.data["baseline"]
+        page = baseline["landing_page"]
+        query = baseline["normalized_query_cluster"]
+
+        self.assertEqual(249, self.data["issue"])
+        self.assertEqual(
+            {"start": "2026-06-12", "end": "2026-07-09", "days": 28},
+            baseline["window"],
+        )
+        self.assertEqual(
+            {"impressions": 294, "clicks": 6, "ctr_percent": 2.04, "average_position": 7.96},
+            {key: page[key] for key in ("impressions", "clicks", "ctr_percent", "average_position")},
+        )
+        self.assertEqual("you cant drink data", query["query"])
+        self.assertTrue(query["impressions_present"])
+        self.assertEqual(0, query["clicks"])
+        self.assertEqual({"min": 8.4, "max": 8.7}, query["average_position_range"])
+        self.assertFalse(self.data["evidence"]["private_analytics_export_included"])
+
+    def test_target_and_source_identity_guards_are_stable(self):
+        target = self.data["target"]
+        source = self.data["source_selection"]["selected"]
+        stale_guard = self.data["future_publisher_gate"]["stale_guard"]
+
+        self.assertEqual(11936, target["id"])
+        self.assertEqual("you-cant-drink-data", target["slug"])
+        self.assertEqual("publish", target["status"])
+        self.assertEqual("2026-06-28T18:40:25", target["modified"])
+        self.assertEqual(target["url"], target["canonical"])
+
+        self.assertEqual(1208, source["id"])
+        self.assertEqual("about", source["slug"])
+        self.assertEqual("publish", source["status"])
+        self.assertEqual("2026-07-01T11:33:51", source["modified"])
+        self.assertEqual(source["url"], source["canonical"])
+        self.assertEqual(
+            {key: source[key] for key in ("id", "slug", "status", "modified")},
+            stale_guard["expected_identity"],
+        )
+        self.assertTrue(stale_guard["stop_if_any_guard_differs"])
+
+    def test_selected_source_payload_and_marker_have_not_drifted(self):
+        source = self.data["source_selection"]["selected"]
+        payload_path = ROOT / source["repo_payload"]
+        payload = payload_path.read_text(encoding="utf-8")
+        digest = hashlib.sha256(payload_path.read_bytes()).hexdigest()
+
+        self.assertEqual(source["repo_payload_sha256"], digest)
+        self.assertEqual(1, payload.count(source["content_marker"]))
+        self.assertEqual(
+            self.data["link_proposal"]["expected_current_paragraph_count"],
+            payload.count(self.data["link_proposal"]["current_paragraph_html"]),
+        )
+        self.assertEqual(0, payload.lower().count("you can't drink data"))
+        self.assertEqual(0, payload.count(self.data["target"]["url"]))
+
+    def test_sentence_proposal_adds_one_contextual_internal_link(self):
+        proposal = self.data["link_proposal"]
+        current = proposal["current_paragraph_html"]
+        replacement = proposal["replacement_paragraph_html"]
+        sentence = proposal["added_sentence_html"]
+        anchor_match = re.fullmatch(
+            r'.*<a href="([^"]+)">([^<]+)</a>\.',
+            sentence,
+        )
+
+        self.assertFalse(proposal["phrase_present_before"])
+        self.assertIsNotNone(anchor_match)
+        self.assertEqual(self.data["target"]["url"], anchor_match.group(1))
+        self.assertEqual("you can't drink data", anchor_match.group(2))
+        self.assertEqual(current[:-4] + " " + sentence + "</p>", replacement)
+        self.assertEqual(1, replacement.count("<a "))
+        self.assertEqual(1, proposal["sentences_added"])
+        self.assertEqual(1, proposal["expected_anchor_count_after"])
+        self.assertEqual(1, proposal["expected_target_href_count_after"])
+        self.assertNotIn("target=", sentence)
+        self.assertNotIn("rel=", sentence)
+
+    def test_future_write_and_rollback_are_body_only(self):
+        gate = self.data["future_publisher_gate"]
+        write = gate["write"]
+        rollback = gate["rollback"]
+        snapshot = gate["snapshot"]
+
+        self.assertEqual(["content"], write["allowed_rest_top_level_keys"])
+        self.assertEqual(["content"], rollback["allowed_rest_top_level_keys"])
+        self.assertTrue(write["requires_human_review_of_exact_diff"])
+        self.assertTrue(snapshot["required_before_write"])
+        self.assertEqual(
+            {"id", "slug", "status", "modified", "content.raw"},
+            set(snapshot["required_edit_snapshot_fields"]),
+        )
+        self.assertTrue(
+            {"title", "slug", "status", "date", "author", "excerpt", "featured_media", "meta"}
+            <= set(write["forbidden_rest_top_level_keys"])
+        )
+        self.assertFalse(self.data["scope"]["live_wordpress_write_performed"])
+        self.assertFalse(self.data["scope"]["publish_or_deploy_performed"])
+
+    def test_handoff_contains_no_credentials_or_live_action_claim(self):
+        artifacts = json.dumps(self.data) + HANDOFF.read_text(encoding="utf-8")
+        lowered = artifacts.lower()
+
+        for marker in (
+            "authorization:",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "client_secret",
+            "access_token",
+            "refresh_token",
+            "application password",
+        ):
+            self.assertNotIn(marker, lowered)
+
+        self.assertIn("no live WordPress write", artifacts)
+        self.assertIn("Do not apply this proposal from this PR.", artifacts)
+        self.assertIn("Refs #249", artifacts)
+        self.assertIsNone(re.search(r"(?m)^(?:Closes|Fixes) #249\b", artifacts))
+
+    def test_next_digest_gate_and_success_signal_are_measurable(self):
+        verification = self.data["next_digest"]
+        gate = verification["measurement_gate"]
+        signal = verification["positive_signal"]
+
+        self.assertEqual(7, gate["minimum_full_days_after_verified_live_edit"])
+        self.assertTrue(gate["requires_recorded_live_edit_timestamp"])
+        self.assertTrue(gate["requires_public_link_readback"])
+        self.assertEqual(self.data["target"]["url"], verification["landing_page"])
+        self.assertEqual(
+            {"impressions", "clicks", "ctr_percent", "average_position"},
+            set(verification["required_metrics"]),
+        )
+        self.assertTrue(verification["comparison"]["preserve_28_day_window_length"])
+        self.assertEqual(1, signal["query_cluster_clicks_at_least"])
+        self.assertEqual(8.4, signal["query_cluster_average_position_below"])
+        self.assertTrue(self.data["github_handoff"]["issue_remains_open"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- map the public target post and compare the homepage and About source surfaces
- reserve the single contextual backlink on About page 1208 with an exact one-sentence proposal
- document identity and modified-date guards, snapshot, content-only write, rollback, and public readback steps
- lock the issue #249 baseline and next-digest measurement gate with focused tests

## Verification

- `python3 -m unittest scripts.tests.test_issue_249_seo_handoff -v`
- `make verify`
- fresh public REST guard checks for post 11936 and page 1208

## Scope

Repo-only human-review handoff. No WordPress write, publish, deploy, Search Console, GA4, DNS, theme, snippet, or secret change was performed. No ranking improvement is claimed.

## Remaining publisher gate

Issue #249 remains open until a human separately approves the exact About sentence, captures the required before snapshot, applies only the `content` field, completes authenticated and public readback, and remeasures the query and landing page in the first eligible digest after at least seven full days.

Refs #249
