### PR TITLE
SEO: prepare issue #284 topic hub link review packet

### DIFF
--- a/fixes/issue-284-topic-hub-links-handoff-2026-07-12.json
+++ b/fixes/issue-284-topic-hub-links-handoff-2026-07-12.json
@@ -1,0 +1,729 @@
+{
+  "schema_version": 1,
+  "issue": 284,
+  "track": "A - Content + SEO",
+  "status": "repo-only-human-review-handoff",
+  "observed": {
+    "local_date": "2026-07-12",
+    "observed_at_utc": "2026-07-13T05:22:19Z",
+    "public_read_only": true,
+    "wordpress_write_performed": false,
+    "methods": [
+      "public WordPress REST post lookup by exact slug",
+      "public WordPress REST page lookup by exact slug",
+      "public HTTP GET for every source and target URL",
+      "normalized anchor count from content.rendered"
+    ]
+  },
+  "claims": {
+    "links_live_from_this_packet": false,
+    "ranking_lift_claimed": false,
+    "search_console_change_performed": false
+  },
+  "targets": {
+    "ai_ethics": {
+      "id": 12318,
+      "title": "AI Ethics & Philosophy",
+      "slug": "ai-ethics",
+      "url": "https://kriskrug.co/ai-ethics/",
+      "status": "publish",
+      "modified": "2026-07-01T12:27:51",
+      "modified_gmt": "2026-07-01T20:27:51",
+      "public_http_status": 200
+    },
+    "ai_tools": {
+      "id": 12321,
+      "title": "Generative AI Tools",
+      "slug": "ai-tools",
+      "url": "https://kriskrug.co/ai-tools/",
+      "status": "publish",
+      "modified": "2026-07-01T12:27:55",
+      "modified_gmt": "2026-07-01T20:27:55",
+      "public_http_status": 200
+    },
+    "indigenous_ai": {
+      "id": 12322,
+      "title": "Indigenous & Reconciliation in Tech",
+      "slug": "indigenous-ai",
+      "url": "https://kriskrug.co/indigenous-ai/",
+      "status": "publish",
+      "modified": "2026-07-01T12:28:09",
+      "modified_gmt": "2026-07-01T20:28:09",
+      "public_http_status": 200
+    }
+  },
+  "sources": [
+    {
+      "id": 5723,
+      "title": "Unpacking AI Ethics at American Marketing Association#VisionConf2024",
+      "slug": "unpacking-ai-ethics-at-american-marketing-associationvisionconf2024",
+      "url": "https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/",
+      "status": "publish",
+      "modified": "2026-06-28T20:34:21",
+      "modified_gmt": "2026-06-29T04:34:21",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 3,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 5,
+      "total_anchor_count": 16,
+      "repo_mirror": null
+    },
+    {
+      "id": 5489,
+      "title": "Cognitive AI, Creativity, and Ethics w/ Professor Steve DiPaola",
+      "slug": "cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola",
+      "url": "https://kriskrug.co/2024/05/04/cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola/",
+      "status": "publish",
+      "modified": "2026-06-28T20:34:50",
+      "modified_gmt": "2026-06-29T04:34:50",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 1,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 4,
+      "total_anchor_count": 15,
+      "repo_mirror": null
+    },
+    {
+      "id": 4635,
+      "title": "Bridging Innovation and Ethics: Future Proof Creatives and the Path Forward in AI",
+      "slug": "bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai",
+      "url": "https://kriskrug.co/2024/02/13/bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai/",
+      "status": "publish",
+      "modified": "2026-07-01T16:24:10",
+      "modified_gmt": "2026-07-02T00:24:10",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 2,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 6,
+      "total_anchor_count": 6,
+      "repo_mirror": null
+    },
+    {
+      "id": 12030,
+      "title": "Canada Doesn't Need a Bigger AI Machine. It Needs a Better One.",
+      "slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+      "url": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+      "status": "publish",
+      "modified": "2026-06-28T14:14:24",
+      "modified_gmt": "2026-06-28T22:14:24",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 0,
+      "total_anchor_count": 5,
+      "repo_mirror": "content/drafts/2026-05-24-canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/post.html"
+    },
+    {
+      "id": 12257,
+      "title": "Why We Built the Responsible AI Professional Certification",
+      "slug": "why-we-built-the-responsible-ai-professional-certification",
+      "url": "https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/",
+      "status": "publish",
+      "modified": "2026-06-28T20:25:58",
+      "modified_gmt": "2026-06-29T04:25:58",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 1,
+      "total_anchor_count": 11,
+      "repo_mirror": "content/drafts/2026-05-16-why-we-built-the-responsible-ai-professional-certification/post.html"
+    },
+    {
+      "id": 4773,
+      "title": "Creative Toolbox: Best of the Best AI Tools",
+      "slug": "creative-toolbox",
+      "url": "https://kriskrug.co/2024/03/01/creative-toolbox/",
+      "status": "publish",
+      "modified": "2026-06-14T20:08:44",
+      "modified_gmt": "2026-06-15T04:08:44",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 1,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 3,
+      "total_anchor_count": 18,
+      "repo_mirror": null
+    },
+    {
+      "id": 3275,
+      "title": "How AI tools like Midjourney, DALL-E & ChatGPT are reshaping the creative landscape",
+      "slug": "how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape",
+      "url": "https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/",
+      "status": "publish",
+      "modified": "2026-06-14T20:34:30",
+      "modified_gmt": "2026-06-15T04:34:30",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 1,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 2,
+      "total_anchor_count": 24,
+      "repo_mirror": null
+    },
+    {
+      "id": 2781,
+      "title": "Audio Deep Fakes, AI ChatBots and New Web Development Tools",
+      "slug": "audio-deep-fakes-ai-chatbots-and-new-web-development-tools",
+      "url": "https://kriskrug.co/2023/07/30/audio-deep-fakes-ai-chatbots-and-new-web-development-tools/",
+      "status": "publish",
+      "modified": "2026-06-28T20:39:27",
+      "modified_gmt": "2026-06-29T04:39:27",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 2,
+      "total_anchor_count": 10,
+      "repo_mirror": null
+    },
+    {
+      "id": 12035,
+      "title": "AI Won't Fix Your Broken Permit Process",
+      "slug": "ai-wont-fix-your-broken-permit-process",
+      "url": "https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/",
+      "status": "publish",
+      "modified": "2026-07-01T16:24:28",
+      "modified_gmt": "2026-07-02T00:24:28",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 2,
+      "total_anchor_count": 6,
+      "repo_mirror": "content/drafts/2026-05-24-ai-wont-fix-your-broken-permit-process/post.html"
+    },
+    {
+      "id": 7450,
+      "title": "Redefining the Future of Indigenous Economic Sovereignty through AI",
+      "slug": "indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai",
+      "url": "https://kriskrug.co/2024/11/14/indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai/",
+      "status": "publish",
+      "modified": "2026-06-28T20:31:08",
+      "modified_gmt": "2026-06-29T04:31:08",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 1,
+        "ai_tools": 0,
+        "indigenous_ai": 1
+      },
+      "internal_link_count": 8,
+      "total_anchor_count": 12,
+      "repo_mirror": null
+    },
+    {
+      "id": 11905,
+      "title": "Sovereign AI for Whom?",
+      "slug": "sovereign-ai-for-whom",
+      "url": "https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/",
+      "status": "publish",
+      "modified": "2026-07-01T16:24:30",
+      "modified_gmt": "2026-07-02T00:24:30",
+      "public_http_status": 200,
+      "target_href_counts": {
+        "ai_ethics": 0,
+        "ai_tools": 0,
+        "indigenous_ai": 0
+      },
+      "internal_link_count": 2,
+      "total_anchor_count": 81,
+      "repo_mirror": "content/drafts/2026-05-13-sovereign-ai-for-whom/post.html"
+    }
+  ],
+  "review_ready_source_writes": [
+    {
+      "priority": 1,
+      "source_id": 12035,
+      "source_slug": "ai-wont-fix-your-broken-permit-process",
+      "source_modified_guard": "2026-07-01T16:24:28",
+      "publisher_review_required": true,
+      "patches": [
+        {
+          "patch_id": "12035-ai-tools",
+          "target_key": "ai_tools",
+          "operation": "wrap_exact_text",
+          "needle": "AI tools",
+          "replacement": "<a href=\"https://kriskrug.co/ai-tools/\">AI tools</a>",
+          "context_before": "We train people in AI tools every day.",
+          "context_after": "We train people in <a href=\"https://kriskrug.co/ai-tools/\">AI tools</a> every day.",
+          "expected_needle_count_before": 1,
+          "inside_existing_anchor_count_before": 0,
+          "expected_target_href_count_before": 0,
+          "expected_target_href_count_after": 1,
+          "copy_change": false
+        }
+      ]
+    },
+    {
+      "priority": 2,
+      "source_id": 12257,
+      "source_slug": "why-we-built-the-responsible-ai-professional-certification",
+      "source_modified_guard": "2026-06-28T20:25:58",
+      "publisher_review_required": true,
+      "patches": [
+        {
+          "patch_id": "12257-ai-ethics",
+          "target_key": "ai_ethics",
+          "operation": "wrap_exact_text",
+          "needle": "ethical practice",
+          "replacement": "<a href=\"https://kriskrug.co/ai-ethics/\">ethical practice</a>",
+          "context_before": "That gap, between deployment speed and ethical practice, is why we built our new Responsible AI Professional Certification program.",
+          "context_after": "That gap, between deployment speed and <a href=\"https://kriskrug.co/ai-ethics/\">ethical practice</a>, is why we built our new Responsible AI Professional Certification program.",
+          "expected_needle_count_before": 1,
+          "inside_existing_anchor_count_before": 0,
+          "expected_target_href_count_before": 0,
+          "expected_target_href_count_after": 1,
+          "copy_change": false
+        }
+      ]
+    },
+    {
+      "priority": 3,
+      "source_id": 2781,
+      "source_slug": "audio-deep-fakes-ai-chatbots-and-new-web-development-tools",
+      "source_modified_guard": "2026-06-28T20:39:27",
+      "publisher_review_required": true,
+      "patches": [
+        {
+          "patch_id": "2781-ai-tools",
+          "target_key": "ai_tools",
+          "operation": "wrap_exact_text",
+          "needle": "the entire field of AI technology",
+          "replacement": "<a href=\"https://kriskrug.co/ai-tools/\">the entire field of AI technology</a>",
+          "context_before": "This innovation isn't just changing the game-it's reshaping the entire field of AI technology and pushing the boundaries of what's possible.",
+          "context_after": "This innovation isn't just changing the game-it's reshaping <a href=\"https://kriskrug.co/ai-tools/\">the entire field of AI technology</a> and pushing the boundaries of what's possible.",
+          "expected_needle_count_before": 1,
+          "inside_existing_anchor_count_before": 0,
+          "expected_target_href_count_before": 0,
+          "expected_target_href_count_after": 1,
+          "copy_change": false
+        }
+      ]
+    },
+    {
+      "priority": 4,
+      "source_id": 12030,
+      "source_slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+      "source_modified_guard": "2026-06-28T14:14:24",
+      "publisher_review_required": true,
+      "patches": [
+        {
+          "patch_id": "12030-ai-ethics",
+          "target_key": "ai_ethics",
+          "operation": "wrap_exact_text",
+          "needle": "AI ethics",
+          "replacement": "<a href=\"https://kriskrug.co/ai-ethics/\">AI ethics</a>",
+          "context_before": "U.S. dominates frontier models (GPT, Claude) but faces recurring AI ethics crises",
+          "context_after": "U.S. dominates frontier models (GPT, Claude) but faces recurring <a href=\"https://kriskrug.co/ai-ethics/\">AI ethics</a> crises",
+          "expected_needle_count_before": 1,
+          "inside_existing_anchor_count_before": 0,
+          "expected_target_href_count_before": 0,
+          "expected_target_href_count_after": 1,
+          "copy_change": false
+        },
+        {
+          "patch_id": "12030-ai-tools",
+          "target_key": "ai_tools",
+          "operation": "wrap_exact_text",
+          "needle": "community-built tools",
+          "replacement": "<a href=\"https://kriskrug.co/ai-tools/\">community-built tools</a>",
+          "context_before": "publish plain-language model cards for community-built tools",
+          "context_after": "publish plain-language model cards for <a href=\"https://kriskrug.co/ai-tools/\">community-built tools</a>",
+          "expected_needle_count_before": 1,
+          "inside_existing_anchor_count_before": 0,
+          "expected_target_href_count_before": 0,
+          "expected_target_href_count_after": 1,
+          "copy_change": false
+        }
+      ]
+    }
+  ],
+  "indigenous_ai_review_queue": [
+    {
+      "priority_after_human_approval": 1,
+      "source_id": 7450,
+      "source_slug": "indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai",
+      "status": "human-review-required-existing-link-no-op",
+      "human_review_required": true,
+      "expected_target_href_count_before": 1,
+      "proposed_target_href_count_after": 1,
+      "existing_anchor": "<a href=\"https://kriskrug.co/indigenous-ai/\">Indigenous and Reconciliation in Tech</a>",
+      "patch": null,
+      "editorial_context": "The current link is a collection-footer label, not a new in-body contextual endorsement.",
+      "human_decision_required": "Confirm that the existing collection-footer link should remain as-is, or request a separately reviewed in-body placement."
+    },
+    {
+      "priority_after_human_approval": 2,
+      "source_id": 12030,
+      "source_slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+      "status": "human-review-required-proposed-not-live",
+      "human_review_required": true,
+      "expected_target_href_count_before": 0,
+      "proposed_target_href_count_after": 1,
+      "patch": {
+        "patch_id": "12030-indigenous-ai",
+        "target_key": "indigenous_ai",
+        "operation": "wrap_exact_text",
+        "needle": "Indigenous data sovereignty and stewardship",
+        "replacement": "<a href=\"https://kriskrug.co/indigenous-ai/\">Indigenous data sovereignty and stewardship</a>",
+        "expected_needle_count_before": 1,
+        "inside_existing_anchor_count_before": 0,
+        "copy_change": false
+      },
+      "editorial_context": "The phrase summarizes a BC AI JEDI Report claim. A link to Kris's hub could be useful context, but it must not imply that the hub is the authority for the report or for Indigenous data governance.",
+      "human_decision_required": "Approve this exact wrapper, choose a different authoritative destination, revise the placement, or skip it."
+    },
+    {
+      "priority_after_human_approval": 3,
+      "source_id": 12035,
+      "source_slug": "ai-wont-fix-your-broken-permit-process",
+      "status": "human-review-required-proposed-not-live",
+      "human_review_required": true,
+      "expected_target_href_count_before": 0,
+      "proposed_target_href_count_after": 1,
+      "patch": {
+        "patch_id": "12035-indigenous-ai",
+        "target_key": "indigenous_ai",
+        "operation": "wrap_exact_text",
+        "needle": "Indigenous leadership",
+        "replacement": "<a href=\"https://kriskrug.co/indigenous-ai/\">Indigenous leadership</a>",
+        "expected_needle_count_before": 1,
+        "inside_existing_anchor_count_before": 0,
+        "copy_change": false
+      },
+      "editorial_context": "The sentence makes a strong first-person claim and sits beside references to Coast Salish ceremony, UNDRIP, and a named board member. Linking it to a general hub could read as self-validation or implied endorsement.",
+      "human_decision_required": "Confirm the claim, the named-person context, and the hub destination before approving this exact wrapper; otherwise revise or skip."
+    },
+    {
+      "priority_after_human_approval": 4,
+      "source_id": 12257,
+      "source_slug": "why-we-built-the-responsible-ai-professional-certification",
+      "status": "human-review-required-proposed-not-live",
+      "human_review_required": true,
+      "expected_target_href_count_before": 0,
+      "proposed_target_href_count_after": 1,
+      "patch": {
+        "patch_id": "12257-indigenous-ai",
+        "target_key": "indigenous_ai",
+        "operation": "wrap_exact_text",
+        "needle": "Indigenous ceremony",
+        "replacement": "<a href=\"https://kriskrug.co/indigenous-ai/\">Indigenous ceremony</a>",
+        "expected_needle_count_before": 1,
+        "inside_existing_anchor_count_before": 0,
+        "copy_change": false
+      },
+      "editorial_context": "The phrase is followed by a land and territory statement. Turning ceremony into navigational anchor text may feel instrumental unless the page owner and relevant community context support it.",
+      "human_decision_required": "Approve the exact wrapper only if linking ceremony to this hub is respectful and contextually appropriate; otherwise revise or skip."
+    },
+    {
+      "priority_after_human_approval": 5,
+      "source_id": 11905,
+      "source_slug": "sovereign-ai-for-whom",
+      "status": "human-review-required-proposed-not-live",
+      "human_review_required": true,
+      "expected_target_href_count_before": 0,
+      "proposed_target_href_count_after": 1,
+      "patch": {
+        "patch_id": "11905-indigenous-ai",
+        "target_key": "indigenous_ai",
+        "operation": "wrap_exact_text",
+        "needle": "host Nation governance",
+        "replacement": "<a href=\"https://kriskrug.co/indigenous-ai/\">host Nation governance</a>",
+        "expected_needle_count_before": 1,
+        "inside_existing_anchor_count_before": 0,
+        "copy_change": false
+      },
+      "editorial_context": "The phrase appears in a policy argument about consent, fair pay, and host Nation authority. A link to Kris's hub must not substitute for Nation-specific sources or imply authority over host Nation governance.",
+      "human_decision_required": "Approve the hub as appropriate supplemental context, choose a Nation-led source, revise the anchor, or skip it."
+    }
+  ],
+  "before_after_url_manifest": [
+    {
+      "map_order": 1,
+      "source_id": 5723,
+      "source_url": "https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/",
+      "target_key": "ai_ethics",
+      "target_url": "https://kriskrug.co/ai-ethics/",
+      "before_target_href_count": 3,
+      "proposed_after_target_href_count": 3,
+      "disposition": "already-linked-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 2,
+      "source_id": 5489,
+      "source_url": "https://kriskrug.co/2024/05/04/cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola/",
+      "target_key": "ai_ethics",
+      "target_url": "https://kriskrug.co/ai-ethics/",
+      "before_target_href_count": 1,
+      "proposed_after_target_href_count": 1,
+      "disposition": "already-linked-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 3,
+      "source_id": 4635,
+      "source_url": "https://kriskrug.co/2024/02/13/bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai/",
+      "target_key": "ai_ethics",
+      "target_url": "https://kriskrug.co/ai-ethics/",
+      "before_target_href_count": 2,
+      "proposed_after_target_href_count": 2,
+      "disposition": "already-linked-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 4,
+      "source_id": 12030,
+      "source_url": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+      "target_key": "ai_ethics",
+      "target_url": "https://kriskrug.co/ai-ethics/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "review-ready-not-approved",
+      "patch_id": "12030-ai-ethics",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 5,
+      "source_id": 12257,
+      "source_url": "https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/",
+      "target_key": "ai_ethics",
+      "target_url": "https://kriskrug.co/ai-ethics/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "review-ready-not-approved",
+      "patch_id": "12257-ai-ethics",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 6,
+      "source_id": 4773,
+      "source_url": "https://kriskrug.co/2024/03/01/creative-toolbox/",
+      "target_key": "ai_tools",
+      "target_url": "https://kriskrug.co/ai-tools/",
+      "before_target_href_count": 1,
+      "proposed_after_target_href_count": 1,
+      "disposition": "already-linked-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 7,
+      "source_id": 3275,
+      "source_url": "https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/",
+      "target_key": "ai_tools",
+      "target_url": "https://kriskrug.co/ai-tools/",
+      "before_target_href_count": 1,
+      "proposed_after_target_href_count": 1,
+      "disposition": "already-linked-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 8,
+      "source_id": 2781,
+      "source_url": "https://kriskrug.co/2023/07/30/audio-deep-fakes-ai-chatbots-and-new-web-development-tools/",
+      "target_key": "ai_tools",
+      "target_url": "https://kriskrug.co/ai-tools/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "review-ready-not-approved",
+      "patch_id": "2781-ai-tools",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 9,
+      "source_id": 12030,
+      "source_url": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+      "target_key": "ai_tools",
+      "target_url": "https://kriskrug.co/ai-tools/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "review-ready-not-approved",
+      "patch_id": "12030-ai-tools",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 10,
+      "source_id": 12035,
+      "source_url": "https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/",
+      "target_key": "ai_tools",
+      "target_url": "https://kriskrug.co/ai-tools/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "review-ready-not-approved",
+      "patch_id": "12035-ai-tools",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 11,
+      "source_id": 7450,
+      "source_url": "https://kriskrug.co/2024/11/14/indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai/",
+      "target_key": "indigenous_ai",
+      "target_url": "https://kriskrug.co/indigenous-ai/",
+      "before_target_href_count": 1,
+      "proposed_after_target_href_count": 1,
+      "disposition": "human-review-required-existing-link-no-op",
+      "after_state": "unchanged-current-public-state"
+    },
+    {
+      "map_order": 12,
+      "source_id": 12030,
+      "source_url": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+      "target_key": "indigenous_ai",
+      "target_url": "https://kriskrug.co/indigenous-ai/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "human-review-required-proposed-not-live",
+      "patch_id": "12030-indigenous-ai",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 13,
+      "source_id": 12035,
+      "source_url": "https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/",
+      "target_key": "indigenous_ai",
+      "target_url": "https://kriskrug.co/indigenous-ai/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "human-review-required-proposed-not-live",
+      "patch_id": "12035-indigenous-ai",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 14,
+      "source_id": 12257,
+      "source_url": "https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/",
+      "target_key": "indigenous_ai",
+      "target_url": "https://kriskrug.co/indigenous-ai/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "human-review-required-proposed-not-live",
+      "patch_id": "12257-indigenous-ai",
+      "after_state": "proposed-not-live"
+    },
+    {
+      "map_order": 15,
+      "source_id": 11905,
+      "source_url": "https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/",
+      "target_key": "indigenous_ai",
+      "target_url": "https://kriskrug.co/indigenous-ai/",
+      "before_target_href_count": 0,
+      "proposed_after_target_href_count": 1,
+      "disposition": "human-review-required-proposed-not-live",
+      "patch_id": "11905-indigenous-ai",
+      "after_state": "proposed-not-live"
+    }
+  ],
+  "future_write_boundary_if_separately_approved": {
+    "live_write_approved_by_this_packet": false,
+    "allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "date_gmt",
+      "categories",
+      "tags",
+      "meta",
+      "excerpt",
+      "author",
+      "featured_media",
+      "comment_status",
+      "ping_status",
+      "template",
+      "format",
+      "sticky",
+      "password"
+    ],
+    "deterministic_source_write_order": [
+      12035,
+      12257,
+      2781,
+      12030
+    ],
+    "priority_rule": "single exact semantic wrapper first; then broader wrapper; multi-patch and longest source last",
+    "one_source_write_at_a_time": true,
+    "indigenous_ai_requires_separate_per_patch_approval": true,
+    "snapshot_path_template": "backup/<UTC>-issue-284-topic-hub-links/source-<id>/",
+    "required_snapshot_files_per_source": [
+      "before-edit.json",
+      "before-content.raw.html",
+      "before-public.html",
+      "before-sha256sums.txt",
+      "rollback-content-only.json"
+    ],
+    "stale_guards": [
+      "source ID equals the manifest ID",
+      "source slug equals the manifest slug",
+      "source status is publish",
+      "source modified value equals source_modified_guard",
+      "target ID, slug, status, URL, and public HTTP 200 match the manifest",
+      "each exact needle occurs once in authenticated content.raw",
+      "each exact needle is outside an existing anchor",
+      "target href count equals expected_target_href_count_before",
+      "reviewed payload has content as its only top-level REST key"
+    ],
+    "verification_gates": [
+      "source_identity",
+      "target_identity",
+      "per_source_snapshot",
+      "modified_date_stale_guard",
+      "exact_needle_and_href_counts",
+      "body_only_payload",
+      "one_write_at_a_time",
+      "authenticated_readback",
+      "public_source_and_target_smoke",
+      "rollback_ready"
+    ],
+    "readback_after_each_write": [
+      "fetch authenticated edit context and confirm ID, slug, status, title, date, taxonomy, and meta remain unchanged",
+      "confirm each approved anchor wrapper occurs exactly once in content.raw",
+      "fetch cache-busted public source HTML and confirm HTTP 200 plus expected target href count",
+      "fetch every target URL and confirm HTTP 200",
+      "stop before the next source if any check fails"
+    ],
+    "rollback": [
+      "send only content from before-content.raw.html back to the same guarded source ID",
+      "read back authenticated content and public HTML",
+      "confirm the source and target URLs return HTTP 200",
+      "confirm target href counts returned to the before values",
+      "stop the entire batch after any rollback"
+    ],
+    "final_smoke_checks": [
+      "all edited source URLs return HTTP 200",
+      "all three target hub URLs return HTTP 200",
+      "source canonicals and slugs are unchanged",
+      "homepage and blog return HTTP 200",
+      "before/after manifest is updated with observed values, not projected values"
+    ]
+  },
+  "human_decision_required": {
+    "ordinary_batch": "Approve, revise, or reject the four ordered source writes containing five copy-preserving AI Ethics and AI Tools wrappers.",
+    "indigenous_ai": "For each of the five Indigenous AI rows, explicitly choose keep existing, approve exact wrapper, choose a different destination or anchor, or skip.",
+    "live_write": "A separate explicit approval is required before any WordPress content update."
+  }
+}

--- a/fixes/issue-284-topic-hub-links-handoff-2026-07-12.md
+++ b/fixes/issue-284-topic-hub-links-handoff-2026-07-12.md
@@ -1,0 +1,337 @@
+# Issue #284: Topic Hub Link Review Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-only human-review packet; no live WordPress write
+**Manifest:** `fixes/issue-284-topic-hub-links-handoff-2026-07-12.json`
+
+## Decision
+
+This packet prepares the remaining issue #281 candidates for issue #284. It
+does not update WordPress, publish content, change Search Console, or claim a
+ranking lift.
+
+Read-only WordPress evidence changed the proposed batch:
+
+- Six candidate rows already link to their target hub and are now no-ops.
+- Five AI Ethics / AI Tools wrappers remain review-ready across four sources.
+- Every Indigenous AI row remains visibly human-review-required.
+- The Indigenous candidate that already links the hub remains a no-op unless a
+  human explicitly requests a different in-body placement.
+
+The merged issue #328 handoff files and tests remain unchanged.
+
+## Evidence Boundary
+
+Public checks ran on 2026-07-12 America/Vancouver, with the final evidence
+capture at `2026-07-13T05:22:19Z`:
+
+1. Look up every source post by exact slug through public WordPress REST.
+2. Verify source ID, slug, `publish` status, modified values, and public URL.
+3. Look up each target page by exact slug and verify the same identity fields.
+4. Fetch every source and target URL and confirm HTTP 200.
+5. Count normalized target hrefs in `content.rendered`, ignoring query strings
+   and fragments.
+
+This was public, read-only evidence. Authenticated `content.raw` is deliberately
+left for a separately approved publisher session and must pass the stale guards
+below before any write.
+
+## Target Identity
+
+| Target | ID | Slug | Status | Modified | Modified GMT | HTTP |
+|---|---:|---|---|---|---|---:|
+| [AI Ethics & Philosophy](https://kriskrug.co/ai-ethics/) | 12318 | `ai-ethics` | `publish` | `2026-07-01T12:27:51` | `2026-07-01T20:27:51` | 200 |
+| [Generative AI Tools](https://kriskrug.co/ai-tools/) | 12321 | `ai-tools` | `publish` | `2026-07-01T12:27:55` | `2026-07-01T20:27:55` | 200 |
+| [Indigenous & Reconciliation in Tech](https://kriskrug.co/indigenous-ai/) | 12322 | `indigenous-ai` | `publish` | `2026-07-01T12:28:09` | `2026-07-01T20:28:09` | 200 |
+
+## Current Candidate State
+
+The target count is the number of matching hub hrefs in the current public
+WordPress body. Every source below is `publish` and returned HTTP 200.
+
+| Map | Source ID | Slug | Modified | Target | Current count | Disposition |
+|---:|---:|---|---|---|---:|---|
+| 1 | 5723 | `unpacking-ai-ethics-at-american-marketing-associationvisionconf2024` | `2026-06-28T20:34:21` | AI Ethics | 3 | Existing link, no-op |
+| 2 | 5489 | `cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola` | `2026-06-28T20:34:50` | AI Ethics | 1 | Existing link, no-op |
+| 3 | 4635 | `bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai` | `2026-07-01T16:24:10` | AI Ethics | 2 | Existing link, no-op |
+| 4 | 12030 | `canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` | `2026-06-28T14:14:24` | AI Ethics | 0 | Review-ready, not approved |
+| 5 | 12257 | `why-we-built-the-responsible-ai-professional-certification` | `2026-06-28T20:25:58` | AI Ethics | 0 | Review-ready, not approved |
+| 6 | 4773 | `creative-toolbox` | `2026-06-14T20:08:44` | AI Tools | 1 | Existing link, no-op |
+| 7 | 3275 | `how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape` | `2026-06-14T20:34:30` | AI Tools | 1 | Existing link, no-op |
+| 8 | 2781 | `audio-deep-fakes-ai-chatbots-and-new-web-development-tools` | `2026-06-28T20:39:27` | AI Tools | 0 | Review-ready, not approved |
+| 9 | 12030 | `canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` | `2026-06-28T14:14:24` | AI Tools | 0 | Review-ready, not approved |
+| 10 | 12035 | `ai-wont-fix-your-broken-permit-process` | `2026-07-01T16:24:28` | AI Tools | 0 | Review-ready, not approved |
+| 11 | 7450 | `indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai` | `2026-06-28T20:31:08` | Indigenous AI | 1 | **HUMAN REVIEW REQUIRED**, existing link, no-op |
+| 12 | 12030 | `canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` | `2026-06-28T14:14:24` | Indigenous AI | 0 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 13 | 12035 | `ai-wont-fix-your-broken-permit-process` | `2026-07-01T16:24:28` | Indigenous AI | 0 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 14 | 12257 | `why-we-built-the-responsible-ai-professional-certification` | `2026-06-28T20:25:58` | Indigenous AI | 0 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 15 | 11905 | `sovereign-ai-for-whom` | `2026-07-01T16:24:30` | Indigenous AI | 0 | **HUMAN REVIEW REQUIRED**, proposed only |
+
+The JSON manifest also records `modified_gmt`, internal-link counts, total
+anchor counts, exact source URLs, and repo mirrors where they exist.
+
+## Existing Links: No-Op
+
+Do not add another target link to these source/target pairs:
+
+| Source ID | Target | Current exact anchors |
+|---:|---|---|
+| 5723 | AI Ethics | `AI ethics`, `ethical AI`, `AI Ethics and Philosophy` |
+| 5489 | AI Ethics | `AI Ethics and Philosophy` |
+| 4635 | AI Ethics | `ethical AI`, `AI Ethics and Philosophy` |
+| 4773 | AI Tools | `Generative AI Tools` |
+| 3275 | AI Tools | `Generative AI Tools` |
+| 7450 | Indigenous AI | `Indigenous and Reconciliation in Tech` in the collection footer |
+
+## Review-Ready Patches
+
+All five ordinary patches wrap current words only. They add no sentence, claim,
+or keyword repetition. Priority reduces blast radius: a single exact semantic
+wrapper first, then the broader wrapper, with the two-patch and longest source
+last.
+
+### Priority 1: Permit Process to AI Tools
+
+- Source ID: `12035`
+- Modified guard: `2026-07-01T16:24:28`
+- Current target count: `0`
+- Exact needle count: `1`, outside any existing anchor
+
+Before:
+
+```html
+We train people in AI tools every day.
+```
+
+Proposed, not live:
+
+```html
+We train people in <a href="https://kriskrug.co/ai-tools/">AI tools</a> every day.
+```
+
+### Priority 2: Responsible AI Certification to AI Ethics
+
+- Source ID: `12257`
+- Modified guard: `2026-06-28T20:25:58`
+- Current target count: `0`
+- Exact needle count: `1`, outside any existing anchor
+
+Before:
+
+```html
+That gap, between deployment speed and ethical practice, is why we built our new Responsible AI Professional Certification program.
+```
+
+Proposed, not live:
+
+```html
+That gap, between deployment speed and <a href="https://kriskrug.co/ai-ethics/">ethical practice</a>, is why we built our new Responsible AI Professional Certification program.
+```
+
+### Priority 3: Audio Deep Fakes to AI Tools
+
+- Source ID: `2781`
+- Modified guard: `2026-06-28T20:39:27`
+- Current target count: `0`
+- Exact needle count: `1`, outside any existing anchor
+
+Before:
+
+```html
+the entire field of AI technology
+```
+
+Proposed, not live:
+
+```html
+<a href="https://kriskrug.co/ai-tools/">the entire field of AI technology</a>
+```
+
+### Priority 4: Better AI Machine to AI Ethics and AI Tools
+
+- Source ID: `12030`
+- Modified guard: `2026-06-28T14:14:24`
+- Current target counts: AI Ethics `0`; AI Tools `0`
+- Each exact needle occurs once and is outside an existing anchor
+- Apply both approved wrappers in one body write, never as two sequential writes
+
+AI Ethics before:
+
+```html
+AI ethics
+```
+
+AI Ethics proposed, not live:
+
+```html
+<a href="https://kriskrug.co/ai-ethics/">AI ethics</a>
+```
+
+AI Tools before:
+
+```html
+community-built tools
+```
+
+AI Tools proposed, not live:
+
+```html
+<a href="https://kriskrug.co/ai-tools/">community-built tools</a>
+```
+
+## Indigenous AI Review Queue
+
+No item in this section is approved for a live write. Each item needs an
+independent editorial decision, even if the ordinary patch on the same source
+is approved.
+
+### HUMAN REVIEW REQUIRED: Indigenomics Now, ID 7450
+
+Current state: one existing collection-footer link:
+
+```html
+<a href="https://kriskrug.co/indigenous-ai/">Indigenous and Reconciliation in Tech</a>
+```
+
+Editorial context: this is a collection label, not a new in-body contextual
+endorsement.
+
+Decision: keep the footer link as-is, request a separately reviewed in-body
+placement, revise the collection label, or remove it in a different approved
+scope. This packet proposes no additional link.
+
+### HUMAN REVIEW REQUIRED: Better AI Machine, ID 12030
+
+Proposed, not live:
+
+```html
+<a href="https://kriskrug.co/indigenous-ai/">Indigenous data sovereignty and stewardship</a>
+```
+
+Editorial context: the phrase summarizes a BC AI JEDI Report claim. Kris's hub
+may be useful supplemental context, but must not be presented as the authority
+for that report or for Indigenous data governance.
+
+Decision: approve this exact wrapper, choose a different authoritative
+destination, revise the placement, or skip it.
+
+### HUMAN REVIEW REQUIRED: Permit Process, ID 12035
+
+Proposed, not live:
+
+```html
+<a href="https://kriskrug.co/indigenous-ai/">Indigenous leadership</a>
+```
+
+Editorial context: the sentence makes a strong first-person claim and sits
+beside references to Coast Salish ceremony, UNDRIP, and a named board member.
+Linking it to a general hub could read as self-validation or implied
+endorsement.
+
+Decision: confirm the claim, named-person context, and hub destination before
+approving the exact wrapper; otherwise revise or skip.
+
+### HUMAN REVIEW REQUIRED: Responsible AI Certification, ID 12257
+
+Proposed, not live:
+
+```html
+<a href="https://kriskrug.co/indigenous-ai/">Indigenous ceremony</a>
+```
+
+Editorial context: the phrase is followed by a land and territory statement.
+Turning ceremony into navigational anchor text may feel instrumental unless
+the page owner and relevant community context support it.
+
+Decision: approve only if linking ceremony to this hub is respectful and
+contextually appropriate; otherwise revise or skip.
+
+### HUMAN REVIEW REQUIRED: Sovereign AI for Whom, ID 11905
+
+Proposed, not live:
+
+```html
+<a href="https://kriskrug.co/indigenous-ai/">host Nation governance</a>
+```
+
+Editorial context: the phrase appears in a policy argument about consent, fair
+pay, and host Nation authority. Kris's hub must not substitute for Nation-led
+sources or imply authority over host Nation governance.
+
+Decision: approve the hub as supplemental context, choose a Nation-led source,
+revise the anchor, or skip it.
+
+## Before/After URL Manifest
+
+"After" means projected review state only. No proposed after count has been
+verified live.
+
+| Map | Source URL | Target URL | Before | Proposed after | State |
+|---:|---|---|---:|---:|---|
+| 1 | https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/ | https://kriskrug.co/ai-ethics/ | 3 | 3 | No-op |
+| 2 | https://kriskrug.co/2024/05/04/cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola/ | https://kriskrug.co/ai-ethics/ | 1 | 1 | No-op |
+| 3 | https://kriskrug.co/2024/02/13/bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai/ | https://kriskrug.co/ai-ethics/ | 2 | 2 | No-op |
+| 4 | https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/ | https://kriskrug.co/ai-ethics/ | 0 | 1 | Proposed, not live |
+| 5 | https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/ | https://kriskrug.co/ai-ethics/ | 0 | 1 | Proposed, not live |
+| 6 | https://kriskrug.co/2024/03/01/creative-toolbox/ | https://kriskrug.co/ai-tools/ | 1 | 1 | No-op |
+| 7 | https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/ | https://kriskrug.co/ai-tools/ | 1 | 1 | No-op |
+| 8 | https://kriskrug.co/2023/07/30/audio-deep-fakes-ai-chatbots-and-new-web-development-tools/ | https://kriskrug.co/ai-tools/ | 0 | 1 | Proposed, not live |
+| 9 | https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/ | https://kriskrug.co/ai-tools/ | 0 | 1 | Proposed, not live |
+| 10 | https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/ | https://kriskrug.co/ai-tools/ | 0 | 1 | Proposed, not live |
+| 11 | https://kriskrug.co/2024/11/14/indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai/ | https://kriskrug.co/indigenous-ai/ | 1 | 1 | **HUMAN REVIEW REQUIRED**, no-op |
+| 12 | https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/ | https://kriskrug.co/indigenous-ai/ | 0 | 1 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 13 | https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/ | https://kriskrug.co/indigenous-ai/ | 0 | 1 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 14 | https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/ | https://kriskrug.co/indigenous-ai/ | 0 | 1 | **HUMAN REVIEW REQUIRED**, proposed only |
+| 15 | https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/ | https://kriskrug.co/indigenous-ai/ | 0 | 1 | **HUMAN REVIEW REQUIRED**, proposed only |
+
+## Separate Publisher Gate
+
+This PR does not approve or execute these steps. In a future session with an
+explicit live-write approval:
+
+1. Process sources in deterministic order: `12035`, `12257`, `2781`, `12030`.
+2. Before each source, fetch authenticated edit JSON and public HTML. Confirm
+   the manifest ID, slug, `publish` status, modified guard, target identity,
+   target HTTP 200, exact needle counts, and current href counts.
+3. Snapshot each source separately under
+   `backup/<UTC>-issue-284-topic-hub-links/source-<id>/`, including
+   `before-edit.json`, `before-content.raw.html`, `before-public.html`, hashes,
+   and a content-only rollback payload.
+4. Stop and regenerate the packet if any identity, modified value, needle, or
+   link-count guard is stale. Do not silently adapt the patch.
+5. Review the full body diff. The only allowed top-level REST key is
+   `content`; `title`, slug, status, dates, taxonomy, meta, excerpt, author,
+   featured media, comments, template, format, sticky, and password fields are
+   forbidden.
+6. Write one source at a time. For source `12030`, include both approved
+   ordinary wrappers in one content write.
+7. Immediately read back authenticated raw content and cache-busted public
+   HTML. Confirm unchanged identity and non-content fields, exact anchor counts,
+   and HTTP 200 for source and targets before continuing.
+8. If any readback fails, restore only the snapshotted `content.raw` to the same
+   guarded source ID, verify the before counts, and stop the entire batch.
+9. After the batch, smoke all edited sources, all three hubs, the homepage, and
+   `/blog/`. Replace projected manifest values with observed values only after
+   public verification.
+
+The future REST body boundary is exactly:
+
+```json
+{
+  "content": "<full reviewed and stale-guarded content.raw body>"
+}
+```
+
+## Exact Human Decision
+
+Before a publisher session, the human must provide two independent decisions:
+
+1. Approve, revise, or reject the four ordered ordinary source writes that
+   contain five copy-preserving AI Ethics and AI Tools wrappers.
+2. For each of the five Indigenous AI rows, choose one: keep the existing link,
+   approve the exact wrapper, choose a different destination or anchor, or
+   skip.
+
+Even after editorial approval, a fresh explicit go-ahead is required for the
+live WordPress batch. This packet does not make the links live and does not
+attribute any ranking movement to them.

--- a/scripts/tests/test_issue_284_topic_hub_links_handoff.py
+++ b/scripts/tests/test_issue_284_topic_hub_links_handoff.py
@@ -1,0 +1,333 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-284-topic-hub-links-handoff-2026-07-12.json"
+HANDOFF = ROOT / "fixes/issue-284-topic-hub-links-handoff-2026-07-12.md"
+
+
+class Issue284TopicHubLinksHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.handoff = HANDOFF.read_text(encoding="utf-8")
+        cls.sources = {source["id"]: source for source in cls.data["sources"]}
+
+    def test_packet_is_repo_only_and_does_not_claim_live_results(self):
+        self.assertEqual(284, self.data["issue"])
+        self.assertEqual("repo-only-human-review-handoff", self.data["status"])
+        self.assertTrue(self.data["observed"]["public_read_only"])
+        self.assertFalse(self.data["observed"]["wordpress_write_performed"])
+        self.assertFalse(self.data["claims"]["links_live_from_this_packet"])
+        self.assertFalse(self.data["claims"]["ranking_lift_claimed"])
+        self.assertIn("no live WordPress write", self.handoff)
+        self.assertIn("does not make the links live", self.handoff)
+
+    def test_target_identity_is_locked(self):
+        expected = {
+            "ai_ethics": (
+                12318,
+                "ai-ethics",
+                "https://kriskrug.co/ai-ethics/",
+                "2026-07-01T12:27:51",
+            ),
+            "ai_tools": (
+                12321,
+                "ai-tools",
+                "https://kriskrug.co/ai-tools/",
+                "2026-07-01T12:27:55",
+            ),
+            "indigenous_ai": (
+                12322,
+                "indigenous-ai",
+                "https://kriskrug.co/indigenous-ai/",
+                "2026-07-01T12:28:09",
+            ),
+        }
+
+        self.assertEqual(set(expected), set(self.data["targets"]))
+        for key, (target_id, slug, url, modified) in expected.items():
+            target = self.data["targets"][key]
+            self.assertEqual(target_id, target["id"])
+            self.assertEqual(slug, target["slug"])
+            self.assertEqual(url, target["url"])
+            self.assertEqual(modified, target["modified"])
+            self.assertEqual("publish", target["status"])
+            self.assertEqual(200, target["public_http_status"])
+
+    def test_source_identity_and_public_state_are_locked(self):
+        expected = {
+            5723: (
+                "unpacking-ai-ethics-at-american-marketing-associationvisionconf2024",
+                "2026-06-28T20:34:21",
+            ),
+            5489: (
+                "cognitive-ai-creativity-and-ethics-w-professor-steve-dipaola",
+                "2026-06-28T20:34:50",
+            ),
+            4635: (
+                "bridging-innovation-and-ethics-future-proof-creatives-and-the-path-forward-in-ai",
+                "2026-07-01T16:24:10",
+            ),
+            12030: (
+                "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+                "2026-06-28T14:14:24",
+            ),
+            12257: (
+                "why-we-built-the-responsible-ai-professional-certification",
+                "2026-06-28T20:25:58",
+            ),
+            4773: ("creative-toolbox", "2026-06-14T20:08:44"),
+            3275: (
+                "how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape",
+                "2026-06-14T20:34:30",
+            ),
+            2781: (
+                "audio-deep-fakes-ai-chatbots-and-new-web-development-tools",
+                "2026-06-28T20:39:27",
+            ),
+            12035: (
+                "ai-wont-fix-your-broken-permit-process",
+                "2026-07-01T16:24:28",
+            ),
+            7450: (
+                "indigenomics-now-2024-redefining-the-future-of-indigenous-economic-and-digital-sovereignty-through-ai",
+                "2026-06-28T20:31:08",
+            ),
+            11905: ("sovereign-ai-for-whom", "2026-07-01T16:24:30"),
+        }
+
+        self.assertEqual(set(expected), set(self.sources))
+        for source_id, (slug, modified) in expected.items():
+            source = self.sources[source_id]
+            self.assertEqual(slug, source["slug"])
+            self.assertEqual(modified, source["modified"])
+            self.assertEqual("publish", source["status"])
+            self.assertEqual(200, source["public_http_status"])
+            self.assertEqual(
+                {"ai_ethics", "ai_tools", "indigenous_ai"},
+                set(source["target_href_counts"]),
+            )
+            self.assertGreaterEqual(source["total_anchor_count"], source["internal_link_count"])
+
+    def test_url_manifest_matches_source_counts_and_target_urls(self):
+        rows = self.data["before_after_url_manifest"]
+        self.assertEqual(list(range(1, 16)), [row["map_order"] for row in rows])
+
+        for row in rows:
+            source = self.sources[row["source_id"]]
+            target = self.data["targets"][row["target_key"]]
+            self.assertEqual(source["url"], row["source_url"])
+            self.assertEqual(target["url"], row["target_url"])
+            self.assertEqual(
+                source["target_href_counts"][row["target_key"]],
+                row["before_target_href_count"],
+            )
+            self.assertIn(
+                row["after_state"],
+                {"unchanged-current-public-state", "proposed-not-live"},
+            )
+            if row["disposition"] == "already-linked-no-op":
+                self.assertGreater(row["before_target_href_count"], 0)
+                self.assertEqual(
+                    row["before_target_href_count"],
+                    row["proposed_after_target_href_count"],
+                )
+            elif row["after_state"] == "proposed-not-live":
+                self.assertEqual(0, row["before_target_href_count"])
+                self.assertEqual(1, row["proposed_after_target_href_count"])
+
+    def test_review_ready_order_and_exact_anchor_wrappers_are_locked(self):
+        writes = self.data["review_ready_source_writes"]
+        self.assertEqual([1, 2, 3, 4], [write["priority"] for write in writes])
+        self.assertEqual(
+            [12035, 12257, 2781, 12030],
+            [write["source_id"] for write in writes],
+        )
+
+        expected_patches = {
+            "12035-ai-tools": ("https://kriskrug.co/ai-tools/", "AI tools"),
+            "12257-ai-ethics": (
+                "https://kriskrug.co/ai-ethics/",
+                "ethical practice",
+            ),
+            "2781-ai-tools": (
+                "https://kriskrug.co/ai-tools/",
+                "the entire field of AI technology",
+            ),
+            "12030-ai-ethics": ("https://kriskrug.co/ai-ethics/", "AI ethics"),
+            "12030-ai-tools": (
+                "https://kriskrug.co/ai-tools/",
+                "community-built tools",
+            ),
+        }
+        found = {}
+
+        for write in writes:
+            source = self.sources[write["source_id"]]
+            self.assertEqual(source["slug"], write["source_slug"])
+            self.assertEqual(source["modified"], write["source_modified_guard"])
+            self.assertTrue(write["publisher_review_required"])
+            for patch in write["patches"]:
+                found[patch["patch_id"]] = self._assert_copy_preserving_wrapper(patch)
+                self.assertEqual(1, patch["expected_needle_count_before"])
+                self.assertEqual(0, patch["inside_existing_anchor_count_before"])
+                self.assertEqual(0, patch["expected_target_href_count_before"])
+                self.assertEqual(1, patch["expected_target_href_count_after"])
+                self.assertEqual(
+                    patch["context_before"],
+                    patch["context_after"].replace(
+                        patch["replacement"],
+                        patch["needle"],
+                    ),
+                )
+
+        self.assertEqual(expected_patches, found)
+
+    def test_repo_mirrors_contain_reviewed_needles_where_available(self):
+        for write in self.data["review_ready_source_writes"]:
+            source = self.sources[write["source_id"]]
+            if source["repo_mirror"] is None:
+                continue
+            mirror = (ROOT / source["repo_mirror"]).read_text(encoding="utf-8")
+            for patch in write["patches"]:
+                self.assertEqual(1, mirror.count(patch["needle"]))
+
+    def test_every_indigenous_row_is_human_review_required(self):
+        queue = self.data["indigenous_ai_review_queue"]
+        self.assertEqual(5, len(queue))
+        self.assertEqual([1, 2, 3, 4, 5], [item["priority_after_human_approval"] for item in queue])
+
+        for item in queue:
+            self.assertTrue(item["human_review_required"])
+            self.assertIn("human-review-required", item["status"])
+            self.assertTrue(item["editorial_context"])
+            self.assertTrue(item["human_decision_required"])
+            self.assertEqual(
+                self.sources[item["source_id"]]["slug"],
+                item["source_slug"],
+            )
+            if item["patch"] is None:
+                self.assertEqual(1, item["expected_target_href_count_before"])
+                self.assertEqual(1, item["proposed_target_href_count_after"])
+            else:
+                href, text = self._assert_copy_preserving_wrapper(item["patch"])
+                self.assertEqual("https://kriskrug.co/indigenous-ai/", href)
+                self.assertEqual(item["patch"]["needle"], text)
+                self.assertEqual(0, item["expected_target_href_count_before"])
+                self.assertEqual(1, item["proposed_target_href_count_after"])
+
+        indigenous_rows = [
+            row
+            for row in self.data["before_after_url_manifest"]
+            if row["target_key"] == "indigenous_ai"
+        ]
+        self.assertEqual(5, len(indigenous_rows))
+        self.assertTrue(
+            all("human-review-required" in row["disposition"] for row in indigenous_rows)
+        )
+        self.assertGreaterEqual(self.handoff.count("HUMAN REVIEW REQUIRED"), 5)
+
+    def test_future_rest_boundary_is_content_only(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+        self.assertFalse(boundary["live_write_approved_by_this_packet"])
+        self.assertEqual(["content"], boundary["allowed_rest_top_level_keys"])
+        self.assertEqual(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "date_gmt",
+                "categories",
+                "tags",
+                "meta",
+                "excerpt",
+                "author",
+                "featured_media",
+                "comment_status",
+                "ping_status",
+                "template",
+                "format",
+                "sticky",
+                "password",
+            },
+            set(boundary["forbidden_rest_top_level_keys"]),
+        )
+        self.assertTrue(boundary["one_source_write_at_a_time"])
+        self.assertTrue(boundary["indigenous_ai_requires_separate_per_patch_approval"])
+        self.assertEqual(
+            [12035, 12257, 2781, 12030],
+            boundary["deterministic_source_write_order"],
+        )
+
+    def test_snapshot_stale_readback_rollback_and_smoke_gates_are_present(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+        self.assertEqual(
+            {
+                "source_identity",
+                "target_identity",
+                "per_source_snapshot",
+                "modified_date_stale_guard",
+                "exact_needle_and_href_counts",
+                "body_only_payload",
+                "one_write_at_a_time",
+                "authenticated_readback",
+                "public_source_and_target_smoke",
+                "rollback_ready",
+            },
+            set(boundary["verification_gates"]),
+        )
+        self.assertIn("before-edit.json", boundary["required_snapshot_files_per_source"])
+        self.assertIn(
+            "before-content.raw.html",
+            boundary["required_snapshot_files_per_source"],
+        )
+        self.assertIn(
+            "rollback-content-only.json",
+            boundary["required_snapshot_files_per_source"],
+        )
+        self.assertTrue(
+            any("modified" in guard for guard in boundary["stale_guards"])
+        )
+        self.assertTrue(
+            any("content.raw" in check for check in boundary["readback_after_each_write"])
+        )
+        self.assertTrue(
+            any("before-content.raw.html" in step for step in boundary["rollback"])
+        )
+        self.assertTrue(
+            any("homepage and blog" in check for check in boundary["final_smoke_checks"])
+        )
+
+    def test_packet_contains_no_secret_material(self):
+        serialized = (json.dumps(self.data) + self.handoff).lower()
+        for marker in (
+            "authorization:",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "client_secret",
+            "oauth_token",
+        ):
+            self.assertNotIn(marker, serialized)
+
+    def _assert_copy_preserving_wrapper(self, patch):
+        self.assertEqual("wrap_exact_text", patch["operation"])
+        self.assertFalse(patch["copy_change"])
+        match = re.fullmatch(
+            r'<a href="([^"]+)">([^<]+)</a>',
+            patch["replacement"],
+        )
+        self.assertIsNotNone(match)
+        self.assertEqual(patch["needle"], match.group(2))
+        target = self.data["targets"][patch["target_key"]]
+        self.assertEqual(target["url"], match.group(1))
+        return match.group(1), match.group(2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- verifies current public WordPress identity, published status, modified dates, HTTP status, and target-link counts for 3 hubs and 11 unique issue #281 sources
- records the complete 15-row before/proposed-after URL manifest, including 6 already-linked no-ops
- prepares 5 exact copy-preserving AI Ethics and AI Tools wrappers across 4 source writes in deterministic order
- keeps all 5 Indigenous AI rows visibly human-review-required with editorial context and a per-row decision
- adds focused tests for source/target identity, exact wrappers, copy preservation, Indigenous review flags, forbidden REST fields, secret absence, and snapshot/readback/rollback/smoke gates

## Boundary

This is a repo-only review packet. No WordPress content was created, updated, published, or otherwise written. No Search Console action was taken, and no live-link or ranking-lift claim is made.

A future separately approved publisher session is limited to a body-only payload whose sole top-level REST key is `content`. It must snapshot each source, enforce ID/slug/status/modified/needle/href stale guards, write one source at a time, read back immediately, and roll back from that source's snapshot before stopping on any failure.

Issue #284 remains open because the reviewed live batch is still outstanding.

## Verification

- `python3 -m unittest scripts.tests.test_issue_284_topic_hub_links_handoff -v` - 10/10 passed
- fresh public read-only manifest eval - 3 targets, 11 sources, 9 proposed wrappers passed
- `make verify` - 54 publisher tests, 108 operational tests, 3 SEO inventory tests, 68 SEO/link-safety tests, both plugin smokes, docs truth, and PHPCS passed
- `git diff --cached --check` - passed before commit

## Human Decision Needed

1. Approve, revise, or reject the four ordered ordinary source writes containing five copy-preserving AI Ethics and AI Tools wrappers.
2. For each Indigenous AI row, explicitly choose one: keep the existing link, approve the exact wrapper, choose a different destination or anchor, or skip.

Even after editorial approval, a fresh explicit go-ahead is required before any live WordPress write.

Refs #284