### PR TITLE
fix: restore standard meta descriptions

### DIFF
--- a/docs/current-state/reports/issue-36-public-description-regression-20260712.md
+++ b/docs/current-state/reports/issue-36-public-description-regression-20260712.md
@@ -1,0 +1,57 @@
+# Issue 36 Public Description Regression
+
+Date: 2026-07-12
+Track: B, Aurora theme
+Status: repo fix prepared; production deployment not performed
+
+## Production Evidence
+
+The current WordPress sitemap contains 1,641 URLs across posts, pages,
+categories, tags, and authors. A deterministic 116-URL sample produced:
+
+- 116 final HTTP `200` responses
+- 116 titles present
+- 116 valid JSON-LD responses
+- 0 standard `<meta name="description">` tags
+- Open Graph and Twitter descriptions still present
+
+Direct cache-normal readback confirmed the same missing standard description on
+the homepage, `/indigenous-ai/`, legacy posts, and taxonomy archives.
+
+## Diagnosis
+
+Aurora 1.3.37 became the direct Open Graph and Twitter metadata owner. Its
+renderer emits `og:description` and `twitter:description`, but it does not emit
+the standard search description. Jetpack's stored SEO values remain populated,
+so this is a render-owner regression rather than a content backfill problem.
+
+## Prepared Fix
+
+Aurora 1.3.38:
+
+- reads the approved front-page option for `/`
+- reads `advanced_seo_description` for singular posts and pages
+- preserves the Writing archive's existing description source
+- uses a term description only when a retained taxonomy archive has one
+- falls back to excerpt/body copy only when a singular page has no stored value
+- aligns Open Graph and Twitter descriptions to the same resolved value
+- suppresses only Jetpack's duplicate `description` field while leaving its
+  `robots` and other SEO fields intact
+- leaves the temporary bridge guard intact for rollback compatibility
+
+Author archives and thin taxonomy archives remain policy work in issue #331.
+
+## Deployment Gate
+
+Do not upload the theme from this PR. A separate approved publisher session must:
+
+1. package Aurora 1.3.38 with current Aurora 1.3.37 as the rollback source
+2. upload through WordPress admin and confirm the reported version
+3. purge PressCACHE
+4. verify exactly one standard, Open Graph, and Twitter description on `/`,
+   `/blog/`, `/about/`, `/indigenous-ai/`, one current post, and one legacy post
+5. confirm no sampled page loses its canonical, title, social image, or robots tag
+6. retain the 1.3.37 package until the public crawl and Search Console readback pass
+
+No WordPress write, deployment, cache purge, or Search Console action occurred
+while preparing this fix.

--- a/scripts/tests/test_swarm_ready_static_checks.py
+++ b/scripts/tests/test_swarm_ready_static_checks.py
@@ -20,7 +20,8 @@ class SwarmReadyStaticChecks(unittest.TestCase):
         home_template = (ROOT / "theme/kk-aurora/templates/home.html").read_text()
 
         self.assertIn("function writing_archive_category_feed_discovery", functions)
-        self.assertIn("function writing_archive_seo_meta_tags", functions)
+        self.assertIn("function public_meta_description", functions)
+        self.assertIn("function suppress_jetpack_meta_description", functions)
         self.assertIn("jetpack_seo_meta_tags", functions)
         self.assertIn("function twitter_card_tag_fallbacks", functions)
         self.assertIn("function render_social_meta_tags", functions)
@@ -34,6 +35,20 @@ class SwarmReadyStaticChecks(unittest.TestCase):
         feed_links = re.findall(r'href=\"/category/[^\"]+/feed/\"', home_template)
         self.assertGreaterEqual(len(feed_links), 8)
         self.assertIn('aria-label="Category RSS feeds"', home_template)
+
+    def test_aurora_owns_one_standard_meta_description(self):
+        functions = (ROOT / "theme/kk-aurora/functions.php").read_text()
+
+        self.assertIn("get_option('advanced_seo_front_page_description', '')", functions)
+        self.assertIn("get_post_meta($post->ID, 'advanced_seo_description', true)", functions)
+        self.assertIn("$description = writing_archive_meta_description();", functions)
+        self.assertIn("$description = term_description();", functions)
+        self.assertIn("$tags['description'] = $description;", functions)
+        self.assertIn("'og:description' => $description !== '' ? $description", functions)
+        self.assertIn("$name === 'description' || str_starts_with($name, 'twitter:')", functions)
+        self.assertIn("unset($tags['description']);", functions)
+        self.assertIn("KK_OG_SNIPPET_ACTIVE", functions)
+        self.assertIn("PHP_INT_MAX", functions)
 
     def test_twitter_card_snippet_uses_current_site_handle(self):
         snippet = (ROOT / "fixes/issue-43-twitter-cards.php").read_text()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.37');
+define('KK_AURORA_VERSION', '1.3.38');
 
 /**
  * Theme setup
@@ -510,32 +510,64 @@ function exclude_current_post_from_related_query(array $query, \WP_Block $block)
 add_filter('query_loop_block_query_vars', __NAMESPACE__ . '\\exclude_current_post_from_related_query', 10, 2);
 
 /**
- * Build the site's canonical Open Graph and Twitter Card values.
+ * Resolve the standard search description from the site's existing SEO fields.
+ */
+function public_meta_description(): string {
+    $description = '';
+
+    if (is_front_page()) {
+        $description = get_option('advanced_seo_front_page_description', '');
+    } elseif (is_home()) {
+        $description = writing_archive_meta_description();
+    } elseif (is_singular()) {
+        $post = get_queried_object();
+        if ($post instanceof \WP_Post) {
+            $description = get_post_meta($post->ID, 'advanced_seo_description', true);
+            if (!is_string($description) || trim($description) === '') {
+                $description = get_the_excerpt($post);
+            }
+            if ($description === '') {
+                $description = wp_trim_words(wp_strip_all_tags($post->post_content), 40);
+            }
+        }
+    } elseif (is_category() || is_tag() || is_tax()) {
+        $description = term_description();
+    }
+
+    if (!is_string($description) || trim($description) === '') {
+        return '';
+    }
+
+    return mb_substr(wp_strip_all_tags($description), 0, 300);
+}
+
+/**
+ * Build the site's canonical search, Open Graph, and Twitter Card values.
  *
  * @return array<string, string>
  */
 function social_meta_tags(): array {
+    $description = public_meta_description();
+
     $tags = [
         'og:site_name'   => get_bloginfo('name'),
         'og:title'       => wp_get_document_title(),
         'og:type'        => 'website',
         'og:url'         => home_url('/'),
-        'og:description' => get_bloginfo('description'),
+        'og:description' => $description !== '' ? $description : get_bloginfo('description'),
         'twitter:site'   => '@feelmoreplants',
     ];
+
+    if ($description !== '') {
+        $tags['description'] = $description;
+    }
 
     if (is_singular()) {
         $post = get_queried_object();
         if ($post instanceof \WP_Post) {
-            $description = get_the_excerpt($post);
-            if ($description === '') {
-                $description = wp_trim_words(wp_strip_all_tags($post->post_content), 40);
-            }
-
             $tags['og:title'] = get_the_title($post);
             $tags['og:type'] = is_singular('post') ? 'article' : 'website';
             $tags['og:url'] = get_permalink($post);
-            $tags['og:description'] = $description;
 
             $image = get_the_post_thumbnail_url($post, 'large');
             if (!$image && preg_match('/<img[^>]+src=["\']([^"\']+)/i', $post->post_content, $match)) {
@@ -574,7 +606,7 @@ function render_social_meta_tags(): void {
         if (!is_scalar($value) || $value === '') {
             continue;
         }
-        $attribute = str_starts_with($name, 'twitter:') ? 'name' : 'property';
+        $attribute = $name === 'description' || str_starts_with($name, 'twitter:') ? 'name' : 'property';
         printf(
             '<meta %s="%s" content="%s" />' . "\n",
             esc_attr($attribute),
@@ -624,16 +656,16 @@ function writing_archive_meta_description(): string {
     return wp_strip_all_tags($description);
 }
 
-function writing_archive_seo_meta_tags(array $tags): array {
-    if (!is_home() || is_front_page()) {
+function suppress_jetpack_meta_description(array $tags): array {
+    if (defined('KK_OG_SNIPPET_ACTIVE')) {
         return $tags;
     }
 
-    $tags['description'] = writing_archive_meta_description();
+    unset($tags['description']);
 
     return $tags;
 }
-add_filter('jetpack_seo_meta_tags', __NAMESPACE__ . '\\writing_archive_seo_meta_tags', 99);
+add_filter('jetpack_seo_meta_tags', __NAMESPACE__ . '\\suppress_jetpack_meta_description', PHP_INT_MAX);
 
 /**
  * Set archive-specific social metadata for the Writing landing page.

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.38 =
+* Restore one standard search description from the existing Jetpack SEO fields and align social descriptions to the same source.
+
 = 1.3.37 =
 * Add direct Open Graph and Twitter Card metadata with a safe handoff from the temporary production snippet.
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.37
+Version: 1.3.38
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary

- make Aurora 1.3.38 emit one standard search description from the existing front-page and per-post Jetpack SEO fields
- align Open Graph and Twitter descriptions to that same resolved source
- suppress only Jetpack's duplicate `description` field while preserving its `robots` and other SEO metadata
- document the 116-URL production regression sample and a separate human-gated deployment/rollback checklist

## Production evidence

A deterministic sample of 116 URLs from the current 1,641-URL WordPress sitemap returned `200`, titles, and valid JSON-LD, but none emitted `<meta name="description">`. Direct readback confirmed the gap on the homepage, `/indigenous-ai/`, legacy posts, and taxonomy archives. OG/Twitter descriptions remained present.

## Verification

- `python3 -m unittest scripts.tests.test_swarm_ready_static_checks -v`
- `php -l theme/kk-aurora/functions.php`
- `make verify`
- `git diff --check`
- sensitive-marker scan

All functional, smoke, docs-truth, PHPCS, and focused metadata-owner checks pass.

## Deployment gate

This PR does not upload a theme, purge PressCACHE, write WordPress content/settings, or touch Search Console. A separate approved publisher session must package 1.3.38 with 1.3.37 as rollback, deploy through wp-admin, purge cache, and verify exactly one standard/OG/Twitter description across the documented route matrix.

Taxonomy/author sitemap policy remains separate in #331.

Refs #36