### PR TITLE
SEO: enforce archive sitemap and indexability policy

### DIFF
--- a/docs/current-state/reports/issue-331-archive-policy-20260712.md
+++ b/docs/current-state/reports/issue-331-archive-policy-20260712.md
@@ -1,0 +1,74 @@
+# Issue #331 Archive Sitemap and Indexability Receipt
+
+**Date:** 2026-07-12 (America/Vancouver)
+
+**Status:** Repo-only; production is human-gated
+
+**Issue:** [WalksWithASwagger/kriskrug-wp#331](https://github.com/WalksWithASwagger/kriskrug-wp/issues/331)
+
+**Canonical implementation:** `fixes/issue-331-archive-sitemap-policy.php`
+
+## Decision
+
+No author, tag, or category archive has enough demonstrated query value for a sitemap allowlist. Exclude all three archive classes from WordPress core sitemap output and emit `noindex,follow` on their public landing pages. Keep every archive publicly accessible.
+
+Posts and pages are outside this policy and remain unchanged. `/sitemap.xml` must keep its permanent handoff to `/wp-sitemap.xml`.
+
+## Query Evidence Reviewed
+
+The Growth Mirror live API rehearsal supplied these query-page aggregates:
+
+| Window | Author archives | Tag archives | Category rows | Clicks |
+|---|---:|---:|---:|---:|
+| Current 28 days | 2 impressions | 4 impressions | 1 impression | 0 |
+| Prior 28 days | 4 impressions | 2 impressions | 3 impressions | 0 |
+
+The category rows were `/category/.../feed/` URLs, not category landing pages. Across both windows, the archive evidence totals 16 impressions and zero clicks. It therefore supports no retained category, tag, or author archive exception.
+
+## Sitemap Counts
+
+| URL class | Before | Expected after | Policy |
+|---|---:|---:|---|
+| Published posts | 967 | 967 | Unchanged |
+| Published pages | 45 | 45 | Unchanged |
+| Category archives | 14 | 0 | Exclude |
+| Tag archives | 613 | 0 | Exclude |
+| Author archives | 2 | 0 | Exclude |
+| **Total** | **1,641** | **1,012** | **Remove 629 archive URLs** |
+
+The expected post-change inventory is 1,012 URLs: 967 posts + 45 pages. Retained archive URLs: none. If the live post or page inventory changes before deployment, stop and refresh the baseline instead of treating 1,012 as a forced count.
+
+## Exact Policy
+
+- Filter the WordPress core `users` sitemap provider so author archives are absent.
+- Remove only the `category` and `post_tag` subtypes from the WordPress core taxonomy sitemap provider.
+- Do not filter `wp_sitemaps_post_types`; the shared `posts` provider and its `post` and `page` subtypes remain intact.
+- On `is_author()`, `is_tag()`, or `is_category()`, preserve unrelated robots directives, remove conflicting `index`, `nofollow`, or `none`, and add `noindex,follow`.
+- Do not redirect any archive. Do not delete terms or users. Do not change permalinks. Do not submit or remove Search Console rows.
+- Do not change the existing `/sitemap.xml` redirect or any post/page membership from this policy.
+
+## Deployment Gate
+
+Do not deploy from this worker lane. A separate human-approved production pass must:
+
+1. Reconfirm the live child-sitemap inventory and snapshot the Code Snippets inventory before any write.
+2. Create an inactive Code Snippets entry from the canonical PHP file, with only the opening `<?php` removed, and compare the saved source back to the repository.
+3. Activate only after the source comparison, PHP syntax check, and rollback owner are recorded.
+4. Purge the approved WordPress/Pagely cache only after activation.
+
+## Production Readback Gate
+
+The approved deployer must record all of the following before calling the change complete:
+
+1. `/sitemap.xml` still makes its permanent handoff to `/wp-sitemap.xml`.
+2. The sitemap index contains post and page child sitemaps, contains no users child sitemap, and contains no category or tag child sitemap.
+3. A complete crawl counts 967 post URLs and 45 page URLs from this baseline, for 1,012 total retained URLs, with no independently introduced redirect or deletion mixed into the result.
+4. Representative author, tag, and category landing pages return `200`, do not redirect, and emit exactly one robots meta policy containing `noindex,follow` under normal, Googlebot, and cache-busted requests.
+5. Representative posts and pages remain publicly reachable, indexable, and present in their WordPress core sitemap provider.
+6. Search Console sitemap status is read back at 24 hours and 72 hours without repeated resubmission or temporary URL removals. API indexed counts are recorded as reported, not interpreted as a verified zero.
+
+## Rollback Gate
+
+If provider membership, robots output, public access, or post/page regression checks fail, deactivate the snippet, purge the approved production cache, and repeat the sitemap plus representative route readback. The rollback must restore the prior provider behavior without editing content, terms, users, permalinks, redirects, or Search Console rows.
+
+No deployment, cache purge, WordPress content/settings write, Search Console action, or issue closure was performed by this repository-only implementation.

--- a/fixes/issue-331-archive-sitemap-policy.php
+++ b/fixes/issue-331-archive-sitemap-policy.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * KK archive sitemap and indexability policy.
+ *
+ * Canonical source for the production Code Snippets entry. When pasting into
+ * Code Snippets, remove the opening PHP tag. Production deployment remains a
+ * separate human-approved step documented in the issue #331 receipt.
+ *
+ * Rollback: deactivate this snippet, purge the approved production cache, and
+ * repeat the sitemap and representative archive readback.
+ */
+
+/**
+ * Exclude author archives from the WordPress core sitemap registry.
+ *
+ * @param mixed  $provider Sitemap provider instance.
+ * @param string $name     Sitemap provider name.
+ * @return mixed
+ */
+function kk_archive_policy_sitemap_provider($provider, string $name) {
+    if ('users' === $name) {
+        return false;
+    }
+
+    return $provider;
+}
+add_filter('wp_sitemaps_add_provider', 'kk_archive_policy_sitemap_provider', PHP_INT_MAX, 2);
+
+/**
+ * Exclude category and tag archives from WordPress core taxonomy sitemaps.
+ *
+ * @param array $taxonomies Public taxonomy objects keyed by taxonomy name.
+ * @return array
+ */
+function kk_archive_policy_sitemap_taxonomies(array $taxonomies): array {
+    unset($taxonomies['category'], $taxonomies['post_tag']);
+
+    return $taxonomies;
+}
+add_filter('wp_sitemaps_taxonomies', 'kk_archive_policy_sitemap_taxonomies', PHP_INT_MAX);
+
+/**
+ * Mark public author, tag, and category archives noindex while retaining links.
+ *
+ * @param array $robots Existing robots directives.
+ * @return array
+ */
+function kk_archive_policy_robots(array $robots): array {
+    if (!is_author() && !is_tag() && !is_category()) {
+        return $robots;
+    }
+
+    unset($robots['index'], $robots['nofollow'], $robots['none']);
+    $robots['noindex'] = true;
+    $robots['follow']  = true;
+
+    return $robots;
+}
+add_filter('wp_robots', 'kk_archive_policy_robots', PHP_INT_MAX);

--- a/scripts/tests/test_issue_331_archive_policy.py
+++ b/scripts/tests/test_issue_331_archive_policy.py
@@ -1,0 +1,167 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SNIPPET = ROOT / "fixes/issue-331-archive-sitemap-policy.php"
+RECEIPT = ROOT / "docs/current-state/reports/issue-331-archive-policy-20260712.md"
+
+
+class Issue331ArchivePolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = SNIPPET.read_text(encoding="utf-8")
+        cls.receipt = RECEIPT.read_text(encoding="utf-8")
+        cls.behavior = cls._run_php_harness()
+
+    @staticmethod
+    def _run_php_harness():
+        snippet_path = json.dumps(str(SNIPPET))
+        harness = f"""<?php
+$archive_context = 'single';
+
+function add_filter() {{
+    return true;
+}}
+
+function is_author() {{
+    global $archive_context;
+    return 'author' === $archive_context;
+}}
+
+function is_tag() {{
+    global $archive_context;
+    return 'tag' === $archive_context;
+}}
+
+function is_category() {{
+    global $archive_context;
+    return 'category' === $archive_context;
+}}
+
+require {snippet_path};
+
+$provider          = new stdClass();
+$users_result      = kk_archive_policy_sitemap_provider($provider, 'users');
+$posts_result      = kk_archive_policy_sitemap_provider($provider, 'posts');
+$taxonomies_result = kk_archive_policy_sitemap_taxonomies(
+    array('category' => new stdClass(), 'post_tag' => new stdClass(), 'genre' => new stdClass())
+);
+
+$robots_results = array();
+foreach (array('author', 'tag', 'category') as $context) {{
+    $archive_context = $context;
+    $robots_results[$context] = kk_archive_policy_robots(
+        array(
+            'index'             => true,
+            'nofollow'          => true,
+            'none'              => true,
+            'max-image-preview' => 'large',
+        )
+    );
+}}
+
+$archive_context = 'single';
+$singular_robots = array('max-image-preview' => 'large');
+$singular_result = kk_archive_policy_robots($singular_robots);
+
+echo json_encode(
+    array(
+        'sitemaps' => array(
+            'users_removed'   => false === $users_result,
+            'posts_preserved' => $provider === $posts_result,
+            'taxonomy_keys'   => array_keys($taxonomies_result),
+        ),
+        'robots' => array(
+            'archives'           => $robots_results,
+            'singular_unchanged' => $singular_robots === $singular_result,
+        ),
+    ),
+    JSON_THROW_ON_ERROR
+);
+"""
+        result = subprocess.run(
+            ["php"],
+            input=harness,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_snippet_has_valid_php_and_registers_only_narrow_filters(self):
+        result = subprocess.run(
+            ["php", "-l", str(SNIPPET)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        self.assertIn("No syntax errors detected", result.stdout)
+        self.assertEqual(3, self.source.count("add_filter("))
+        for registration in (
+            "add_filter('wp_sitemaps_add_provider', "
+            "'kk_archive_policy_sitemap_provider', PHP_INT_MAX, 2);",
+            "add_filter('wp_sitemaps_taxonomies', "
+            "'kk_archive_policy_sitemap_taxonomies', PHP_INT_MAX);",
+            "add_filter('wp_robots', 'kk_archive_policy_robots', PHP_INT_MAX);",
+        ):
+            self.assertIn(registration, self.source)
+        self.assertNotIn("template_redirect", self.source)
+        self.assertNotIn("wp_sitemaps_post_types", self.source)
+
+    def test_archive_providers_are_removed_without_touching_posts_or_pages(self):
+        sitemaps = self.behavior["sitemaps"]
+
+        self.assertTrue(sitemaps["users_removed"])
+        self.assertEqual(["genre"], sitemaps["taxonomy_keys"])
+        self.assertTrue(sitemaps["posts_preserved"])
+
+    def test_archive_robots_are_noindex_follow_without_conflicts(self):
+        for context, robots in self.behavior["robots"]["archives"].items():
+            with self.subTest(context=context):
+                self.assertIs(True, robots["noindex"])
+                self.assertIs(True, robots["follow"])
+                self.assertEqual("large", robots["max-image-preview"])
+                self.assertNotIn("index", robots)
+                self.assertNotIn("nofollow", robots)
+                self.assertNotIn("none", robots)
+
+        self.assertTrue(self.behavior["robots"]["singular_unchanged"])
+
+    def test_receipt_locks_counts_and_query_evidence(self):
+        for expected in (
+            "1,641",
+            "1,012",
+            "967 posts + 45 pages",
+            "629 archive URLs",
+            "16 impressions and zero clicks",
+            "category rows were `/category/.../feed/` URLs",
+        ):
+            self.assertIn(expected, self.receipt)
+
+    def test_receipt_keeps_production_and_search_console_human_gated(self):
+        for expected in (
+            "Repo-only; production is human-gated",
+            "Do not deploy from this worker lane",
+            "Do not redirect any archive",
+            "Do not delete terms or users",
+            "Do not change permalinks",
+            "Do not submit or remove Search Console rows",
+            "24 hours",
+            "72 hours",
+            "deactivate the snippet",
+        ):
+            self.assertIn(expected, self.receipt)
+
+    def test_receipt_preserves_canonical_sitemap_handoff(self):
+        self.assertIn(
+            "`/sitemap.xml` must keep its permanent handoff to `/wp-sitemap.xml`",
+            self.receipt,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- exclude the WordPress core users sitemap provider and only the category/post_tag taxonomy subtypes
- emit noindex,follow on public author, tag, and category archives while preserving unrelated robots directives
- keep post/page sitemap membership and the /sitemap.xml handoff unchanged
- record the 1,641 URL baseline, 1,012 URL expectation, query evidence, and human deployment/readback/rollback gates

## Verification

- `python3 -m unittest scripts.tests.test_issue_331_archive_policy -v` (6 passed)
- `bash skills/github-workflow-automation/scripts/validate_wordpress.sh --files fixes/issue-331-archive-sitemap-policy.php` (passed)
- `make verify` (passed: 240 automated tests/checks, plugin smokes, JavaScript syntax, docs truth, PHPCS)

## Production boundary

Repo-only implementation. Production is human-gated. No deployment, cache purge, WordPress content/settings write, Search Console action, redirect, deletion, permalink change, merge, or issue closure was performed.

Refs #331