### PR TITLE
SEO: prepare AI second brain review handoff

### DIFF
--- a/fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.json
+++ b/fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 1,
+  "issue": 336,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "evidence": {
+    "window_start": "2026-06-12",
+    "window_end": "2026-07-09",
+    "page": {
+      "impressions": 1053,
+      "clicks": 10,
+      "ctr_percent": 0.95,
+      "average_position": 11.27
+    },
+    "query": {
+      "text": "ai second brain",
+      "impressions": 46,
+      "clicks": 2,
+      "average_position": 17.52
+    },
+    "source": "GitHub issue #279 comment; digest-safe aggregate only"
+  },
+  "target": {
+    "id": 8802,
+    "slug": "how-to-build-an-ai-second-brain-that-actually-works-for-you",
+    "status": "publish",
+    "modified": "2026-06-28T20:27:34",
+    "url": "https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/",
+    "post_title": "How to Build an AI Second Brain That Actually Works for You"
+  },
+  "current_public_metadata": {
+    "observed_on": "2026-07-13",
+    "http_status": 200,
+    "canonical": "https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/",
+    "document_title_chars": 116,
+    "standard_meta_description_present": false,
+    "open_graph_description_chars": 262,
+    "twitter_description_chars": 262,
+    "robots": "max-image-preview:large",
+    "h1_count": 1,
+    "authenticated_rest_meta_keys": [
+      "footnotes"
+    ],
+    "jetpack_seo_meta_fields_exposed": false
+  },
+  "proposed_metadata": {
+    "field_values": {
+      "jetpack_seo_html_title": "Build an AI Second Brain That Actually Works for You",
+      "advanced_seo_description": "Build an AI second brain that works with your thought patterns, captures creative chaos, and turns scattered notes and voice memos into finished work."
+    },
+    "field_lengths": {
+      "jetpack_seo_html_title": 52,
+      "advanced_seo_description": 150
+    },
+    "post_title_change": false,
+    "requires": [
+      "Aurora 1.3.38 standard-description owner verified on production",
+      "fresh WordPress editor readback of both SEO fields",
+      "human approval of the exact title and description",
+      "public readback of standard, Open Graph, and Twitter descriptions"
+    ]
+  },
+  "link_patches": [
+    {
+      "priority": 1,
+      "source_id": 9774,
+      "source_slug": "what-journalists-need-to-know-about-ai-right-now",
+      "source_url": "https://kriskrug.co/2025/06/24/what-journalists-need-to-know-about-ai-right-now/",
+      "source_modified": "2026-06-14T20:05:53",
+      "needle": "AI as a second brain",
+      "replacement": "<a href=\"https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/\">AI as a second brain</a>",
+      "expected_needle_count": 1,
+      "expected_target_href_count_before": 0,
+      "copy_change": false
+    },
+    {
+      "priority": 2,
+      "source_id": 12327,
+      "source_slug": "storyhive-haus-of-owl-jordan-dack",
+      "source_url": "https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/",
+      "source_modified": "2026-06-17T19:47:06",
+      "needle": "knowledge bases and named assistants",
+      "replacement": "<a href=\"https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/\">knowledge bases and named assistants</a>",
+      "expected_needle_count": 1,
+      "expected_target_href_count_before": 0,
+      "copy_change": false
+    }
+  ],
+  "future_write_boundary_if_separately_approved": {
+    "target_allowed_rest_top_level_keys": [
+      "meta"
+    ],
+    "target_allowed_meta_keys": [
+      "jetpack_seo_html_title",
+      "advanced_seo_description"
+    ],
+    "source_allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "categories",
+      "tags",
+      "excerpt"
+    ],
+    "requires": [
+      "fresh authenticated ID, slug, status, and modified-date checks",
+      "target metadata and source content.raw snapshots before writes",
+      "no REST metadata write while the two Jetpack fields are unregistered",
+      "human review of the exact metadata and link wrappers",
+      "one write and public readback at a time",
+      "retained rollback snapshots"
+    ]
+  },
+  "next_digest": {
+    "earliest_full_days_after_live_change": 14,
+    "query": "ai second brain",
+    "landing_page": "https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/",
+    "compare": [
+      "page_impressions",
+      "page_clicks",
+      "page_ctr_percent",
+      "page_average_position",
+      "query_impressions",
+      "query_clicks",
+      "query_average_position"
+    ],
+    "success_signal": {
+      "page_average_position_below": 10.0,
+      "page_ctr_percent_above": 1.2,
+      "query_average_position_below": 15.0
+    },
+    "note": "Compare only after approved production changes are public, verified, and given 14 full days to be recrawled."
+  }
+}

--- a/fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.md
+++ b/fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.md
@@ -1,0 +1,135 @@
+# Issue #336: AI Second Brain SEO Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.json`
+
+## Decision
+
+This is the strongest current on-page opportunity on KrisKrug.co. The article
+already matches the search intent and has an established URL, so the smallest
+useful move is a tighter search title, a concise description, and two links
+from existing relevant copy. No new article or speculative content is needed.
+
+This handoff does not publish, deploy, update WordPress, purge cache, or change
+Search Console, GA4, DNS, schema, taxonomies, or theme code.
+
+## Digest-Safe Evidence
+
+The 28-day Search Console review covers 2026-06-12 through 2026-07-09:
+
+| Surface | Impressions | Clicks | CTR | Average position |
+| --- | ---: | ---: | ---: | ---: |
+| Target page | 1,053 | 10 | 0.95% | 11.27 |
+| Query `ai second brain` | 46 | 2 | n/a | 17.52 |
+
+Only aggregate values copied into GitHub issue #279 are retained. No Search
+Console export, OAuth material, private analytics row, or person-level data is
+included.
+
+## Public Mapping
+
+Read-only public HTML and authenticated WordPress REST checks on 2026-07-13
+mapped the opportunity to post 8802:
+
+- URL: https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/
+- Slug: `how-to-build-an-ai-second-brain-that-actually-works-for-you`
+- Public modified value: `2026-06-28T20:27:34`
+- Status: `publish`
+- HTTP: `200`
+- Canonical: self-referencing and correct
+- H1 count: 1
+- Robots: indexable, with `max-image-preview:large`
+
+The current document title is 116 characters after Aurora appends the site
+descriptor. The page has no standard meta description and uses the 262-character
+excerpt for Open Graph and Twitter descriptions.
+
+The authenticated REST response currently exposes only the `footnotes` meta
+key. It does not expose `jetpack_seo_html_title` or
+`advanced_seo_description`. A publisher must not attempt a generic REST meta
+write while those fields are unregistered.
+
+## Review-Ready Metadata
+
+These are SEO fields only. Do not change the public post title, excerpt, body,
+slug, status, date, or taxonomies.
+
+| Field | Proposed value | Characters |
+| --- | --- | ---: |
+| `jetpack_seo_html_title` | Build an AI Second Brain That Actually Works for You | 52 |
+| `advanced_seo_description` | Build an AI second brain that works with your thought patterns, captures creative chaos, and turns scattered notes and voice memos into finished work. | 150 |
+
+The title keeps the exact topic and the article's real promise. The description
+is grounded in the article's existing material about thought patterns, creative
+chaos, scattered notes, voice memos, and finished work.
+
+Aurora 1.3.38 should be live and verified as the standard-description owner
+before this metadata change is judged. If the Jetpack fields remain absent from
+REST, use the reviewed WordPress editor fields after a fresh readback. Do not
+add another theme override or metadata snippet for one post.
+
+## Review-Ready Link Patches
+
+Both public source bodies contain the listed needle exactly once and currently
+contain zero links to the target. Each patch wraps existing words only.
+
+### Priority 1: AI for Journalists
+
+- Source post: 9774
+- URL: https://kriskrug.co/2025/06/24/what-journalists-need-to-know-about-ai-right-now/
+- Public modified value: `2026-06-14T20:05:53`
+- Existing phrase: `AI as a second brain`
+- Review replacement:
+
+  ```html
+  <a href="https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/">AI as a second brain</a>
+  ```
+
+### Priority 2: STORYHIVE Interview
+
+- Source post: 12327
+- URL: https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/
+- Public modified value: `2026-06-17T19:47:06`
+- Existing phrase: `knowledge bases and named assistants`
+- Review replacement:
+
+  ```html
+  <a href="https://kriskrug.co/2025/04/01/how-to-build-an-ai-second-brain-that-actually-works-for-you/">knowledge bases and named assistants</a>
+  ```
+
+## Separate Publisher Gate
+
+Do not apply this handoff from the worker lane. In a future publisher session
+with explicit approval for these exact WordPress edits:
+
+1. Confirm Aurora 1.3.38 is live and emits one standard, Open Graph, and Twitter
+   description on the target.
+2. Fetch the target and both sources by ID. Confirm slug, published status, and
+   modified values. Stop if any guard changed.
+3. Snapshot target metadata plus public HTML and each source's `content.raw`
+   plus public HTML. Record checksums before writing.
+4. Review the exact metadata values and link wrappers with the human.
+5. Apply the two target SEO fields through a registered endpoint or the
+   WordPress editor. Do not use REST while those fields are unregistered.
+6. Apply one source link at a time. The only allowed top-level source REST key
+   is `content`; do not send title, excerpt, slug, status, date, categories,
+   tags, or meta.
+7. Read back each write before continuing. Verify the target remains `200`,
+   self-canonical, indexable, and one-H1, and verify each source has one visible
+   contextual link.
+8. Retain the snapshots as rollback payloads. Restore only the changed fields
+   if any public readback fails.
+
+## Next Digest Verification
+
+Wait at least 14 full days after the approved live change, then compare the
+query and landing page together:
+
+- Page baseline: 1,053 impressions, 10 clicks, 0.95% CTR, position 11.27
+- Query baseline: 46 impressions, 2 clicks, position 17.52
+- Success signals: page position below 10, page CTR above 1.2%, and query
+  position below 15
+
+Do not attribute movement to this handoff until the production changes are
+approved, applied, publicly verified, and recrawled.

--- a/scripts/tests/test_issue_336_ai_second_brain_seo_handoff.py
+++ b/scripts/tests/test_issue_336_ai_second_brain_seo_handoff.py
@@ -1,0 +1,157 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-336-ai-second-brain-seo-handoff-2026-07-13.md"
+
+
+class Issue336AiSecondBrainSeoHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_digest_safe_evidence_is_exact(self):
+        evidence = self.data["evidence"]
+
+        self.assertEqual("2026-06-12", evidence["window_start"])
+        self.assertEqual("2026-07-09", evidence["window_end"])
+        self.assertEqual(
+            {
+                "impressions": 1053,
+                "clicks": 10,
+                "ctr_percent": 0.95,
+                "average_position": 11.27,
+            },
+            evidence["page"],
+        )
+        self.assertEqual("ai second brain", evidence["query"]["text"])
+        self.assertEqual(46, evidence["query"]["impressions"])
+        self.assertEqual(2, evidence["query"]["clicks"])
+        self.assertEqual(17.52, evidence["query"]["average_position"])
+
+    def test_target_identity_and_public_state_are_locked(self):
+        target = self.data["target"]
+        public = self.data["current_public_metadata"]
+
+        self.assertEqual(8802, target["id"])
+        self.assertEqual("publish", target["status"])
+        self.assertEqual(
+            target["url"],
+            f"https://kriskrug.co/2025/04/01/{target['slug']}/",
+        )
+        self.assertEqual(target["url"], public["canonical"])
+        self.assertEqual(200, public["http_status"])
+        self.assertEqual(1, public["h1_count"])
+        self.assertFalse(public["standard_meta_description_present"])
+        self.assertFalse(public["jetpack_seo_meta_fields_exposed"])
+        self.assertEqual(["footnotes"], public["authenticated_rest_meta_keys"])
+
+    def test_proposed_metadata_is_narrow_and_within_policy(self):
+        proposed = self.data["proposed_metadata"]
+        fields = proposed["field_values"]
+        lengths = proposed["field_lengths"]
+
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(fields),
+        )
+        for key, value in fields.items():
+            self.assertEqual(len(value), lengths[key])
+
+        self.assertLessEqual(lengths["jetpack_seo_html_title"], 60)
+        self.assertGreaterEqual(lengths["advanced_seo_description"], 150)
+        self.assertLessEqual(lengths["advanced_seo_description"], 160)
+        self.assertIn("AI Second Brain", fields["jetpack_seo_html_title"])
+        self.assertFalse(proposed["post_title_change"])
+
+    def test_link_patches_only_wrap_existing_copy(self):
+        target_url = self.data["target"]["url"]
+        source_ids = set()
+
+        for patch in self.data["link_patches"]:
+            match = re.fullmatch(
+                r'<a href="([^"]+)">([^<]+)</a>',
+                patch["replacement"],
+            )
+            self.assertIsNotNone(match)
+            self.assertEqual(target_url, match.group(1))
+            self.assertEqual(patch["needle"], match.group(2))
+            self.assertEqual(1, patch["expected_needle_count"])
+            self.assertEqual(0, patch["expected_target_href_count_before"])
+            self.assertFalse(patch["copy_change"])
+            self.assertNotIn(patch["source_id"], source_ids)
+            source_ids.add(patch["source_id"])
+
+        self.assertEqual({9774, 12327}, source_ids)
+
+    def test_future_write_boundaries_are_explicit(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+
+        self.assertEqual(["meta"], boundary["target_allowed_rest_top_level_keys"])
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(boundary["target_allowed_meta_keys"]),
+        )
+        self.assertEqual(
+            ["content"],
+            boundary["source_allowed_rest_top_level_keys"],
+        )
+        self.assertTrue(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "excerpt",
+            }.issubset(boundary["forbidden_rest_top_level_keys"])
+        )
+        self.assertIn(
+            "no REST metadata write while the two Jetpack fields are unregistered",
+            boundary["requires"],
+        )
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+    def test_handoff_keeps_production_and_secrets_out_of_scope(self):
+        text = HANDOFF.read_text(encoding="utf-8")
+        normalized_text = " ".join(text.split())
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply this handoff from the worker lane.", text)
+        self.assertIn(
+            "must not attempt a generic REST meta write",
+            normalized_text,
+        )
+
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "oauth",
+        ):
+            self.assertNotIn(marker, serialized)
+
+    def test_next_digest_has_a_measurable_wait_and_signal(self):
+        verification = self.data["next_digest"]
+
+        self.assertEqual(14, verification["earliest_full_days_after_live_change"])
+        self.assertEqual(self.data["evidence"]["query"]["text"], verification["query"])
+        self.assertEqual(self.data["target"]["url"], verification["landing_page"])
+        self.assertEqual(
+            {
+                "page_average_position_below": 10.0,
+                "page_ctr_percent_above": 1.2,
+                "query_average_position_below": 15.0,
+            },
+            verification["success_signal"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- lock the 28-day aggregate evidence and live identity for the AI second brain opportunity
- propose one 52-character SEO title, one 150-character description, and two copy-preserving contextual links
- record stale-write guards, the currently unregistered Jetpack REST fields, snapshot/readback requirements, rollback, and a 14-day measurement gate

## Verification

- `python3 -m unittest scripts.tests.test_issue_336_ai_second_brain_seo_handoff -v`
- `make test`
- `make docs-truth-check`
- `git diff --check`
- `gitleaks dir . --no-banner --redact`

All 247 functional checks pass. Local PHPCS was not run because Composer is unavailable in this checkout; GitHub CI is the authoritative PHP gate.

## Production boundary

Repo-only human-review handoff. No WordPress write, deployment, cache purge, Search Console/GA4/DNS change, or indexing request was performed.

Refs #336.