### PR TITLE
SEO: prepare Lord of the Rings review handoff

### DIFF
--- a/fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.json
+++ b/fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": 1,
+  "issue": 335,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "evidence": {
+    "current_window": {
+      "start": "2026-07-04",
+      "end": "2026-07-10"
+    },
+    "prior_window": {
+      "start": "2026-06-27",
+      "end": "2026-07-03"
+    },
+    "page": {
+      "current": {
+        "impressions": 47,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 10.43
+      },
+      "prior": {
+        "impressions": 35,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 11.54
+      }
+    },
+    "query": {
+      "text": "lord of the rings drinking game",
+      "current": {
+        "impressions": 27,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 9.96
+      },
+      "prior": {
+        "impressions": 12,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 12.67
+      }
+    },
+    "source": "2026-07-13 Growth Mirror digest; digest-safe aggregate only"
+  },
+  "target": {
+    "id": 35,
+    "slug": "the-lord-of-the-rings-drinking-game",
+    "status": "publish",
+    "modified": "2026-06-14T22:30:33",
+    "url": "https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/",
+    "post_title": "The Lord of the Rings Drinking Game"
+  },
+  "current_public_metadata": {
+    "observed_on": "2026-07-13",
+    "http_status": 200,
+    "canonical": "https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/",
+    "document_title_chars": 92,
+    "standard_meta_description_present": false,
+    "open_graph_description_chars": 294,
+    "twitter_description_chars": 308,
+    "robots": "max-image-preview:large",
+    "h1_count": 1,
+    "rest_meta_keys": [
+      "footnotes"
+    ],
+    "jetpack_seo_meta_fields_exposed": false
+  },
+  "proposed_metadata": {
+    "field_values": {
+      "jetpack_seo_html_title": "The Lord of the Rings Drinking Game: 4 Original Rules",
+      "advanced_seo_description": "Four original Lord of the Rings drinking game rules for Frodo, Sam, Legolas, and cliff falls, plus a trilogy marathon option. Play responsibly."
+    },
+    "field_lengths": {
+      "jetpack_seo_html_title": 53,
+      "advanced_seo_description": 143
+    },
+    "post_title_change": false,
+    "excerpt_change": false,
+    "requires": [
+      "Aurora 1.3.38 standard-description owner verified on production",
+      "fresh WordPress editor readback of both SEO fields",
+      "human approval of the exact title and description",
+      "public readback of standard, Open Graph, and Twitter descriptions"
+    ]
+  },
+  "related_link_review": {
+    "decision": "replace irrelevant collection-footer recommendations with one coherent 2004 archive pair",
+    "selected_related_post": {
+      "id": 58,
+      "slug": "mcsweeneys-lists",
+      "status": "publish",
+      "modified": "2026-06-14T22:29:25",
+      "url": "https://kriskrug.co/2004/07/16/mcsweeneys-lists/",
+      "title": "McSweeney's Lists",
+      "relevance": "The post is a 2004 humor-list entry with an Elvish or Yiddish section and belongs to the same Web and Early Blog collection."
+    },
+    "rejected_candidate": {
+      "id": 5236,
+      "url": "https://kriskrug.co/2024/04/05/ai-skills-for-tommorows-storytellers-with-openai-creative-director-souki-mansoor/",
+      "observed_phrase": "Lord of the Rings trilogy",
+      "reason": "The phrase discusses filmmaking technology; linking it to a drinking game would misrepresent the destination."
+    }
+  },
+  "link_patches": [
+    {
+      "priority": 1,
+      "direction": "inbound_to_target",
+      "source_id": 58,
+      "source_slug": "mcsweeneys-lists",
+      "source_url": "https://kriskrug.co/2004/07/16/mcsweeneys-lists/",
+      "source_modified": "2026-06-14T22:29:25",
+      "current_related_href": "https://kriskrug.co/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/",
+      "current_related_anchor": "Building AI Companions w/ John Anthony Hartman of IHAVEROBOTS",
+      "expected_current_related_href_count": 1,
+      "proposed_related_href": "https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/",
+      "proposed_related_anchor": "The Lord of the Rings Drinking Game",
+      "expected_proposed_href_count_before": 0,
+      "exact_raw_patch_ready": false,
+      "human_review_required": true
+    },
+    {
+      "priority": 2,
+      "direction": "outbound_from_target",
+      "source_id": 35,
+      "source_slug": "the-lord-of-the-rings-drinking-game",
+      "source_url": "https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/",
+      "source_modified": "2026-06-14T22:30:33",
+      "current_related_href": "https://kriskrug.co/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/",
+      "current_related_anchor": "Building AI Companions w/ John Anthony Hartman of IHAVEROBOTS",
+      "expected_current_related_href_count": 1,
+      "proposed_related_href": "https://kriskrug.co/2004/07/16/mcsweeneys-lists/",
+      "proposed_related_anchor": "McSweeney's Lists",
+      "expected_proposed_href_count_before": 0,
+      "exact_raw_patch_ready": false,
+      "human_review_required": true
+    }
+  ],
+  "future_write_boundary_if_separately_approved": {
+    "metadata_allowed_fields": [
+      "jetpack_seo_html_title",
+      "advanced_seo_description"
+    ],
+    "content_allowed_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "categories",
+      "tags",
+      "excerpt",
+      "meta"
+    ],
+    "requires": [
+      "fresh ID, slug, publish status, and modified-date checks for posts 35 and 58",
+      "authenticated content.raw snapshots before deriving either exact footer patch",
+      "no REST metadata write while the two Jetpack fields are unregistered",
+      "human review of the exact metadata and related-link pair",
+      "one write and public readback at a time",
+      "retained rollback snapshots"
+    ]
+  },
+  "next_digest": {
+    "earliest_full_days_after_live_change": 14,
+    "secondary_review_days_after_live_change": 28,
+    "query": "lord of the rings drinking game",
+    "landing_page": "https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/",
+    "compare": [
+      "page_impressions",
+      "page_clicks",
+      "page_ctr_percent",
+      "page_average_position",
+      "query_impressions",
+      "query_clicks",
+      "query_ctr_percent",
+      "query_average_position"
+    ],
+    "success_signal": {
+      "page_clicks_at_least": 1,
+      "page_average_position_below": 10.0,
+      "query_clicks_at_least": 1,
+      "query_average_position_below": 9.5
+    },
+    "note": "Compare only after approved production changes are public, verified, and given 14 full days to be recrawled."
+  }
+}

--- a/fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.md
+++ b/fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.md
@@ -1,0 +1,140 @@
+# Issue #335: Lord of the Rings Drinking Game SEO Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.json`
+
+## Decision
+
+The page already satisfies the search intent and its title, H1, URL, and body
+all use the primary query naturally. A new article or body rewrite would add
+risk without solving the visible problem. The smallest useful move is:
+
+1. Keep the public post title and historical body unchanged.
+2. Add a shorter search title and a standard meta description.
+3. Replace two irrelevant automated collection-footer recommendations with a
+   coherent link pair between two humorous 2004 archive posts.
+
+This packet does not publish, deploy, update WordPress, purge cache, request
+indexing, or change Search Console, GA4, DNS, schema, taxonomies, or theme code.
+
+## Digest-Safe Evidence
+
+The current Search Console window is 2026-07-04 through 2026-07-10. The prior
+window is 2026-06-27 through 2026-07-03.
+
+| Surface | Window | Impressions | Clicks | CTR | Average position |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Target page | Current | 47 | 0 | 0% | 10.43 |
+| Target page | Prior | 35 | 0 | 0% | 11.54 |
+| Query `lord of the rings drinking game` | Current | 27 | 0 | 0% | 9.96 |
+| Query `lord of the rings drinking game` | Prior | 12 | 0 | 0% | 12.67 |
+
+The page and primary query are both moving toward page one while still earning
+no clicks. This makes snippet clarity a stronger first move than more content.
+Only aggregate Search Console values are retained here. No exports, OAuth
+material, private analytics rows, or person-level data are included.
+
+## Public Mapping
+
+Read-only public HTML and WordPress REST checks on 2026-07-13 mapped the
+opportunity to post 35:
+
+- URL: https://kriskrug.co/2004/05/27/the-lord-of-the-rings-drinking-game/
+- Slug: `the-lord-of-the-rings-drinking-game`
+- Public modified value: `2026-06-14T22:30:33`
+- Status: `publish`
+- HTTP: `200`
+- Canonical: self-referencing and correct
+- H1 count: 1
+- Robots: indexable, with `max-image-preview:large`
+
+The current document title is 92 characters after Aurora appends the site
+descriptor. The page has no standard meta description. Its Open Graph and
+Twitter descriptions are 294 and 308 characters and begin with the article's
+setup rather than the four game rules.
+
+The public REST response exposes only the `footnotes` meta key. It does not
+expose `jetpack_seo_html_title` or `advanced_seo_description`, so a future
+publisher must not attempt a generic REST metadata write.
+
+## Review-Ready Metadata
+
+These are SEO fields only. Do not change the public post title, excerpt, body,
+slug, status, date, or taxonomies as part of the metadata step.
+
+| Field | Proposed value | Characters |
+| --- | --- | ---: |
+| `jetpack_seo_html_title` | The Lord of the Rings Drinking Game: 4 Original Rules | 53 |
+| `advanced_seo_description` | Four original Lord of the Rings drinking game rules for Frodo, Sam, Legolas, and cliff falls, plus a trilogy marathon option. Play responsibly. | 143 |
+
+The title preserves the exact primary query and adds a specific reason to
+click. The description summarizes only material already present in the post
+and adds a concise responsibility cue.
+
+Aurora 1.3.38 must be live and verified as the standard-description owner
+before this metadata is judged. If the two Jetpack fields remain absent from
+REST, use the reviewed WordPress editor fields after a fresh readback. Do not
+add a page-specific theme override or metadata snippet.
+
+## Related-Link Review
+
+The current collection-footer recommendation on both relevant posts points to
+an unrelated 2023 AI companions article. The review-ready replacement pairs
+the target with [McSweeney's Lists](https://kriskrug.co/2004/07/16/mcsweeneys-lists/),
+post 58. That post is from the same 2004 archive, is explicitly a humor-list
+entry, and includes an `Elvish or Yiddish` section.
+
+Proposed footer destinations:
+
+| Source | Modified guard | Current recommendation | Proposed recommendation |
+| --- | --- | --- | --- |
+| Post 58, `mcsweeneys-lists` | `2026-06-14T22:29:25` | AI companions article | The Lord of the Rings Drinking Game |
+| Post 35, target page | `2026-06-14T22:30:33` | AI companions article | McSweeney's Lists |
+
+These are destination and anchor decisions, not exact write payloads. Only
+public `content.rendered` was inspected. A separately approved publisher must
+snapshot authenticated `content.raw`, derive the exact footer-only patches,
+and stop if either ID, slug, status, or modified guard changed.
+
+One apparent candidate was rejected. Post 5236 contains the phrase `Lord of
+the Rings trilogy`, but it discusses filmmaking technology. Linking that
+phrase to a drinking game would misrepresent the destination.
+
+## Separate Publisher Gate
+
+Do not apply this handoff from the worker lane. In a future publisher session
+with explicit approval for these exact WordPress edits:
+
+1. Confirm Aurora 1.3.38 is live and emits one standard, Open Graph, and
+   Twitter description on the target.
+2. Fetch posts 35 and 58 by ID and confirm slug, `publish` status, and modified
+   values. Stop if any guard changed.
+3. Snapshot target metadata, both posts' authenticated `content.raw`, and
+   their public HTML. Record checksums before writing.
+4. Review the exact metadata and both related-footer destinations with the
+   human.
+5. Apply the target SEO fields through registered WordPress editor fields. Do
+   not use REST while those fields are unregistered.
+6. Derive each footer-only patch from the fresh raw snapshot. The only allowed
+   top-level REST key for a content write is `content`.
+7. Apply one write at a time and read it back before continuing. Do not send
+   title, excerpt, slug, status, date, categories, tags, or meta.
+8. Verify both pages remain `200`, self-canonical, indexable, and one-H1. Verify
+   the target has one contextual inbound link from post 58 and each related
+   footer points to the reviewed destination.
+9. Retain the snapshots as rollback payloads. Restore only the changed fields
+   if any public readback fails.
+
+## Next Digest Verification
+
+Wait at least 14 full days after the approved live change, then compare the
+query and landing page together. Repeat at 28 days if volume remains low.
+
+- Page baseline: 47 impressions, 0 clicks, 0% CTR, position 10.43
+- Query baseline: 27 impressions, 0 clicks, 0% CTR, position 9.96
+- Success signals: at least one page click, at least one query click, page
+  position below 10, and query position below 9.5
+
+Do not attribute movement to this handoff until the production changes are
+approved, applied, publicly verified, and recrawled.

--- a/scripts/tests/test_issue_335_lotr_seo_handoff.py
+++ b/scripts/tests/test_issue_335_lotr_seo_handoff.py
@@ -1,0 +1,150 @@
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-335-lotr-drinking-game-seo-handoff-2026-07-13.md"
+
+
+class Issue335LotrSeoHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_digest_safe_evidence_is_exact(self):
+        evidence = self.data["evidence"]
+
+        self.assertEqual(
+            {"start": "2026-07-04", "end": "2026-07-10"},
+            evidence["current_window"],
+        )
+        self.assertEqual(
+            {
+                "impressions": 47,
+                "clicks": 0,
+                "ctr_percent": 0.0,
+                "average_position": 10.43,
+            },
+            evidence["page"]["current"],
+        )
+        self.assertEqual("lord of the rings drinking game", evidence["query"]["text"])
+        self.assertEqual(27, evidence["query"]["current"]["impressions"])
+        self.assertEqual(0, evidence["query"]["current"]["clicks"])
+        self.assertEqual(9.96, evidence["query"]["current"]["average_position"])
+
+    def test_target_identity_and_public_state_are_locked(self):
+        target = self.data["target"]
+        public = self.data["current_public_metadata"]
+
+        self.assertEqual(35, target["id"])
+        self.assertEqual("publish", target["status"])
+        self.assertEqual(
+            target["url"],
+            f"https://kriskrug.co/2004/05/27/{target['slug']}/",
+        )
+        self.assertEqual(target["url"], public["canonical"])
+        self.assertEqual(200, public["http_status"])
+        self.assertEqual(1, public["h1_count"])
+        self.assertFalse(public["standard_meta_description_present"])
+        self.assertFalse(public["jetpack_seo_meta_fields_exposed"])
+        self.assertEqual(["footnotes"], public["rest_meta_keys"])
+
+    def test_proposed_metadata_is_narrow_and_within_policy(self):
+        proposed = self.data["proposed_metadata"]
+        fields = proposed["field_values"]
+        lengths = proposed["field_lengths"]
+
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(fields),
+        )
+        for key, value in fields.items():
+            self.assertEqual(len(value), lengths[key])
+
+        self.assertLessEqual(lengths["jetpack_seo_html_title"], 60)
+        self.assertGreaterEqual(lengths["advanced_seo_description"], 140)
+        self.assertLessEqual(lengths["advanced_seo_description"], 160)
+        self.assertIn(
+            "The Lord of the Rings Drinking Game",
+            fields["jetpack_seo_html_title"],
+        )
+        self.assertIn("Play responsibly.", fields["advanced_seo_description"])
+        self.assertFalse(proposed["post_title_change"])
+        self.assertFalse(proposed["excerpt_change"])
+
+    def test_related_link_pair_is_relevant_and_not_claimed_write_ready(self):
+        review = self.data["related_link_review"]
+        patches = self.data["link_patches"]
+
+        self.assertEqual(58, review["selected_related_post"]["id"])
+        self.assertIn("Elvish or Yiddish", review["selected_related_post"]["relevance"])
+        self.assertEqual(5236, review["rejected_candidate"]["id"])
+        self.assertEqual(
+            {"inbound_to_target", "outbound_from_target"},
+            {patch["direction"] for patch in patches},
+        )
+        self.assertEqual({35, 58}, {patch["source_id"] for patch in patches})
+        for patch in patches:
+            self.assertFalse(patch["exact_raw_patch_ready"])
+            self.assertTrue(patch["human_review_required"])
+            self.assertEqual(1, patch["expected_current_related_href_count"])
+            self.assertEqual(0, patch["expected_proposed_href_count_before"])
+
+    def test_future_write_boundaries_are_explicit(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+
+        self.assertEqual(["content"], boundary["content_allowed_top_level_keys"])
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(boundary["metadata_allowed_fields"]),
+        )
+        self.assertTrue(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "excerpt",
+                "meta",
+            }.issubset(boundary["forbidden_rest_top_level_keys"])
+        )
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+    def test_handoff_keeps_production_and_secrets_out_of_scope(self):
+        text = HANDOFF.read_text(encoding="utf-8")
+        normalized_text = " ".join(text.split())
+
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply this handoff from the worker lane.", text)
+        self.assertIn(
+            "must not attempt a generic REST metadata write",
+            normalized_text,
+        )
+
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "oauth",
+        ):
+            self.assertNotIn(marker, serialized)
+
+    def test_next_digest_has_a_measurable_wait_and_signal(self):
+        verification = self.data["next_digest"]
+
+        self.assertEqual(14, verification["earliest_full_days_after_live_change"])
+        self.assertEqual(28, verification["secondary_review_days_after_live_change"])
+        self.assertEqual(self.data["evidence"]["query"]["text"], verification["query"])
+        self.assertEqual(self.data["target"]["url"], verification["landing_page"])
+        self.assertEqual(1, verification["success_signal"]["page_clicks_at_least"])
+        self.assertEqual(1, verification["success_signal"]["query_clicks_at_least"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- map issue #335 to the live post, current Search Console baseline, and public metadata state
- propose a 53-character search title and 143-character description while preserving the public post title and historical body
- replace the irrelevant automated related-post recommendation with a human-reviewed 2004 archive pair using `McSweeney's Lists`
- reject a superficially matching AI-filmmaking link because it would misrepresent the destination
- encode stale guards, raw-content snapshot requirements, rollback boundaries, and 14/28-day measurement gates

## Safety

No live WordPress write, deploy, cache purge, indexing request, Search Console change, GA4 change, DNS change, or secret material is included.

The two SEO fields are not exposed through REST. The related-link proposals are destination decisions only and must be rederived from fresh authenticated `content.raw` after separate approval.

## Verification

- `python3 -m unittest scripts.tests.test_issue_335_lotr_seo_handoff -v` (7 passed)
- `make python-test` (54 publisher, 129 operational, 3 inventory, and 68 SEO backfill/link-safety tests passed)
- `git diff --check`

Refs #335
