### PR TITLE
[SEO] Replace legacy BC AI links with canonical routes

### DIFF
--- a/fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.json
+++ b/fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.json
@@ -1,0 +1,618 @@
+{
+  "schema_version": 1,
+  "issue": 340,
+  "status": "human-review-required",
+  "observed_on": "2026-07-13",
+  "live_wordpress_write_performed": false,
+  "summary": {
+    "source_post_count": 13,
+    "legacy_link_count": 41,
+    "approved_replacement_count": 30,
+    "unresolved_link_count": 11
+  },
+  "measurement_baseline": {
+    "window": "2026-06-13 to 2026-07-10",
+    "query": "bc ai",
+    "landing_page": "https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/",
+    "current": {
+      "clicks": 0,
+      "impressions": 49,
+      "ctr_percent": 0.0,
+      "average_position": 8.73
+    },
+    "prior": {
+      "window": "2026-05-16 to 2026-06-12",
+      "clicks": 0,
+      "impressions": 50,
+      "ctr_percent": 0.0,
+      "average_position": 9.2
+    },
+    "source": "Growth Mirror exact 28-day aggregate query-page rows"
+  },
+  "legacy_destination_evidence": {
+    "root_url": "https://bc-ai.net/",
+    "root_status": 302,
+    "root_final_url": "https://vancouver.bc-ai.net/ecosystem",
+    "final_document_title": "Notion",
+    "final_canonical": null,
+    "final_robots": "noindex",
+    "note": "Other audited legacy subdomains also resolve to generic Notion surfaces with no canonical and inconsistent noindex posture."
+  },
+  "approved_mappings": [
+    {
+      "old_href": "https://bc-ai.net/",
+      "new_href": "https://bc-ai.ca/"
+    },
+    {
+      "old_href": "https://www.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/"
+    },
+    {
+      "old_href": "https://vancouver.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/communities/vancouver-ai"
+    },
+    {
+      "old_href": "https://vancouver.bc-ai.net/ai-ethical-futures-lab",
+      "new_href": "https://bc-ai.ca/communities/futures-lab"
+    },
+    {
+      "old_href": "https://surrey.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/communities/surrey"
+    },
+    {
+      "old_href": "https://mac.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/communities/mac"
+    },
+    {
+      "old_href": "http://mac.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/communities/mac"
+    },
+    {
+      "old_href": "https://mind.bc-ai.net/",
+      "new_href": "https://bc-ai.ca/communities/mac"
+    }
+  ],
+  "canonical_targets": [
+    {
+      "url": "https://bc-ai.ca/",
+      "status": 200,
+      "canonical": "https://bc-ai.ca",
+      "indexable": true,
+      "sitemap_count": 1
+    },
+    {
+      "url": "https://bc-ai.ca/communities/vancouver-ai",
+      "status": 200,
+      "canonical": "https://bc-ai.ca/communities/vancouver-ai",
+      "indexable": true,
+      "sitemap_count": 1
+    },
+    {
+      "url": "https://bc-ai.ca/communities/futures-lab",
+      "status": 200,
+      "canonical": "https://bc-ai.ca/communities/futures-lab",
+      "indexable": true,
+      "sitemap_count": 1
+    },
+    {
+      "url": "https://bc-ai.ca/communities/surrey",
+      "status": 200,
+      "canonical": "https://bc-ai.ca/communities/surrey",
+      "indexable": true,
+      "sitemap_count": 1
+    },
+    {
+      "url": "https://bc-ai.ca/communities/mac",
+      "status": 200,
+      "canonical": "https://bc-ai.ca/communities/mac",
+      "indexable": true,
+      "sitemap_count": 1
+    }
+  ],
+  "sources": [
+    {
+      "id": 11620,
+      "slug": "applied-ethical-ai-responsible-ai-professional-certification-rap",
+      "url": "https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/",
+      "modified": "2026-07-01T16:24:33",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://vancouver.bc-ai.net/ai-ethical-futures-lab",
+          "new_href": "https://bc-ai.ca/communities/futures-lab",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "AEFL (AI Ethical Futures Lab) community"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    },
+    {
+      "id": 11252,
+      "slug": "name-the-bias",
+      "url": "https://kriskrug.co/2026/02/03/name-the-bias/",
+      "modified": "2026-06-28T20:26:47",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Vancouver AI"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    },
+    {
+      "id": 11171,
+      "slug": "both-hands-full",
+      "url": "https://kriskrug.co/2026/01/24/both-hands-full/",
+      "modified": "2026-06-28T20:26:51",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Vancouver AI,"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    },
+    {
+      "id": 9549,
+      "slug": "ai-ate-the-future",
+      "url": "https://kriskrug.co/2025/06/09/ai-ate-the-future/",
+      "modified": "2026-06-28T20:27:00",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 2,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "BC + AI Ecosystem Industry Association",
+            "BC + AI Industry Association"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 2,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Vancouver\u2019s AI community",
+            "the communities forming around it"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    },
+    {
+      "id": 9374,
+      "slug": "bc-ai-is-live-and-were-building-the-future-we-actually-want",
+      "url": "https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/",
+      "modified": "2026-06-28T20:27:04",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "BC + AI Ecosystem Association"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Vancouver AI meetups"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "https://hackathon.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "\u201cWhat does it mean to be Canadian in the age of AI?\u201d"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 9197,
+      "slug": "vancouver-ai-meetup-16-where-tech-creativity-and-community-collide",
+      "url": "https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/",
+      "modified": "2026-06-28T20:27:08",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://mac.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/mac",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Mind, AI & Consciousness Reading Group"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://surrey.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/surrey",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Surrey AI Meetup"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "https://hackathon.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "Data Storytelling Hackathon"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 9044,
+      "slug": "vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future",
+      "url": "https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/",
+      "modified": "2026-06-28T20:27:13",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 2,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "grassroots BC+AI ecosystem",
+            "you cannot step into the same river twice"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://mac.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/mac",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Mind AI & Consciousness"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://surrey.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/surrey",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Surrey AI"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "https://squamish.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "Squamish AI"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 8947,
+      "slug": "web-summit-vancouver-2025-survival-guide",
+      "url": "https://kriskrug.co/2025/04/13/web-summit-vancouver-2025-survival-guide/",
+      "modified": "2026-06-28T20:27:17",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "BC + AI ecosystem"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    },
+    {
+      "id": 8859,
+      "slug": "we-dont-do-panels-we-do-portals",
+      "url": "https://kriskrug.co/2025/04/07/we-dont-do-panels-we-do-portals/",
+      "modified": "2026-06-28T20:27:28",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "http://mac.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/mac",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "mac.bc-ai.net"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "sub-communities, specialized collectives, and grassroots movements"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://mind.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/mac",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Mind, AI, and Consciousness Working Group"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://surrey.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/surrey",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Surrey AI"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "fertile soil we planted together"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "http://hackathon.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "hackathon.bc-ai.net"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        },
+        {
+          "href": "https://squamish.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "Squamish AI"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 8663,
+      "slug": "is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid",
+      "url": "https://kriskrug.co/2025/03/20/is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid/",
+      "modified": "2026-06-28T20:27:38",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "BC + AI Ecosystem"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Vancouver AI community meetups"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "http://hackathon.bc-ai.net",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "Vancouver AI Data Storytelling Hackathon"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        },
+        {
+          "href": "https://hackathon.bc-ai.net/",
+          "expected_href_count": 2,
+          "anchor_texts": [
+            "Data Storytelling Hackathon",
+            "hackathon"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 8508,
+      "slug": "data-storytelling-hackathon-where-ai-meets-art-and-data-sings-its-truth",
+      "url": "https://kriskrug.co/2025/03/06/data-storytelling-hackathon-where-ai-meets-art-and-data-sings-its-truth/",
+      "modified": "2026-06-28T20:30:10",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "vancouver.bc-ai.net"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "https://hackathon.bc-ai.net/",
+          "expected_href_count": 2,
+          "anchor_texts": [
+            "Registration for Hackathon 1",
+            "https://hackathon.bc-ai.net/"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 8418,
+      "slug": "vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap",
+      "url": "https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/",
+      "modified": "2026-06-28T20:30:15",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 2,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "emerging BC + Ai Ecosystem.",
+            "no flagship AI institute despite our concentration of talent"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://vancouver.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/communities/vancouver-ai",
+          "expected_old_href_count": 2,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "We adapt, we connect, we create meaning in the darkness",
+            "our Vancouver AI community"
+          ],
+          "copy_change": false
+        },
+        {
+          "old_href": "https://www.bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "The future isn\u2019t something happening to us; it\u2019s something we\u2019re creating together, one community at a time"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": [
+        {
+          "href": "https://hackathon.bc-ai.net/",
+          "expected_href_count": 1,
+          "anchor_texts": [
+            "$10,000 Vancouver AI Data Storytelling Hackathon"
+          ],
+          "reason": "no_truthful_indexed_successor"
+        }
+      ]
+    },
+    {
+      "id": 8314,
+      "slug": "bcs-ai-ecosystem-a-mycelial-network-of-creation",
+      "url": "https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/",
+      "modified": "2026-06-28T20:30:24",
+      "status": "publish",
+      "link_patches": [
+        {
+          "old_href": "https://bc-ai.net/",
+          "new_href": "https://bc-ai.ca/",
+          "expected_old_href_count": 1,
+          "expected_new_href_count_before": 0,
+          "anchor_texts": [
+            "Meanwhile, in BC"
+          ],
+          "copy_change": false
+        }
+      ],
+      "unresolved_links": []
+    }
+  ],
+  "future_write_boundary_if_separately_approved": {
+    "allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "categories",
+      "tags",
+      "meta",
+      "featured_media"
+    ],
+    "requires": [
+      "fresh authenticated ID, slug, status, and modified-date check",
+      "content.raw snapshot with SHA-256 before each write",
+      "exact old and new href count checks",
+      "human review of every href-only diff",
+      "one-post-at-a-time write and public readback",
+      "retained rollback payload for every changed post"
+    ]
+  },
+  "next_digest": {
+    "query": "bc ai",
+    "landing_page": "https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/",
+    "compare_after_days": [
+      14,
+      28
+    ],
+    "metrics": [
+      "impressions",
+      "clicks",
+      "ctr_percent",
+      "average_position"
+    ],
+    "note": "Start the comparison clock only after a separately approved live publisher session and clean public readback."
+  }
+}

--- a/fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.md
+++ b/fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.md
@@ -1,0 +1,94 @@
+# Issue #340: Legacy BC + AI Link Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.json`
+
+## Decision
+
+A public read-only audit found 41 `bc-ai.net` links across 13 published
+KrisKrug.co posts. Thirty links have exact successors on the indexed
+`bc-ai.ca` site. The other 11 point to historical Hackathon or Squamish
+surfaces without a truthful one-to-one successor.
+
+This handoff prepares only the 30 exact href replacements. It leaves all
+visible copy unchanged and records the 11 ambiguous links without modifying
+them. Do not apply these patches from this PR.
+
+## Why This Matters
+
+The legacy organization root currently returns a temporary `302` to
+`https://vancouver.bc-ai.net/ecosystem`. The destination renders the generic
+title `Notion`, declares `noindex`, and has no canonical. Other audited legacy
+subdomains have the same generic metadata and no canonical, with inconsistent
+`noindex` posture.
+
+The current BC + AI organization and community routes all return `200`, are
+self-canonical or canonical-equivalent, are indexable, and each appears once
+in the live sitemap.
+
+The measured query-page pair also supports the repair. For the 28-day window
+from 2026-06-13 through 2026-07-10, the query `bc ai` produced 49 impressions,
+0 clicks, 0% CTR, and average position 8.73 for:
+
+`https://kriskrug.co/2025/02/16/bcs-ai-ecosystem-a-mycelial-network-of-creation/`
+
+The prior 28-day window produced 50 impressions, 0 clicks, and average
+position 9.2. The page's only BC AI link currently points to the legacy
+noindex surface.
+
+## Approved Mappings
+
+| Legacy destination | Indexed canonical destination |
+|---|---|
+| `https://bc-ai.net/` and `https://www.bc-ai.net/` | `https://bc-ai.ca/` |
+| `https://vancouver.bc-ai.net/` | `https://bc-ai.ca/communities/vancouver-ai` |
+| `https://vancouver.bc-ai.net/ai-ethical-futures-lab` | `https://bc-ai.ca/communities/futures-lab` |
+| `https://surrey.bc-ai.net/` | `https://bc-ai.ca/communities/surrey` |
+| `https://mac.bc-ai.net/`, `http://mac.bc-ai.net/`, and `https://mind.bc-ai.net/` | `https://bc-ai.ca/communities/mac` |
+
+The manifest records each post ID, slug, public modified timestamp, exact old
+href, exact replacement href, expected counts, and existing anchor text.
+
+## Intentionally Unresolved
+
+- Nine historical Data Storytelling Hackathon links remain unchanged. The
+  current Build Night page is related but is not a truthful replacement for
+  the historical registration and event references.
+- Two Squamish AI links remain unchanged because `bc-ai.ca` does not currently
+  expose a dedicated Squamish community page.
+
+Do not send either group to a generic events or communities index merely to
+eliminate a legacy hostname.
+
+## Separate Publisher Gate
+
+Any future live session requires exact action-time approval. Then:
+
+1. Fetch all 13 posts by ID and confirm slug, published status, and modified
+   timestamp. Stop if any guard changed.
+2. Snapshot each `content.raw` body with a SHA-256 checksum.
+3. Confirm every expected legacy href count and every expected new href count.
+4. Generate and review an href-only diff. Visible anchor text and all other
+   body markup must remain byte-for-byte unchanged.
+5. Send only the `content` top-level REST key, one post at a time. Do not send
+   title, slug, status, date, taxonomies, metadata, or featured media.
+6. Read back each changed post, verify its source page and destination return
+   `200`, and retain the before snapshot as the rollback payload.
+7. Stop and roll back the individual post if any link count, canonical, or
+   public-render invariant fails.
+
+## Measurement
+
+Start the clock only after a separately approved publisher session and clean
+public readback. Compare the `bc ai` query and Mycelial Network landing page
+after 14 full days and again after 28 full days using impressions, clicks,
+CTR, and average position. Do not attribute movement to this repo-only PR.
+
+## Out Of Scope
+
+- No WordPress write, deployment, cache purge, Search Console request, GA4
+  change, DNS change, Notion change, or analytics change.
+- No visible article copy, title, description, schema, taxonomy, media, or
+  publication-date edit.
+- No guessed replacement for the Hackathon or Squamish links.

--- a/scripts/tests/test_issue_340_legacy_bcai_links_handoff.py
+++ b/scripts/tests/test_issue_340_legacy_bcai_links_handoff.py
@@ -1,0 +1,177 @@
+import json
+import unittest
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-340-legacy-bcai-links-handoff-2026-07-13.md"
+
+
+def canonical_key(url: str) -> str:
+    parts = urlsplit(url)
+    path = parts.path.rstrip("/")
+    return f"{parts.scheme}://{parts.netloc}{path}"
+
+
+class Issue340LegacyBcaiLinksHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_inventory_and_link_counts_are_complete(self):
+        summary = self.data["summary"]
+        sources = self.data["sources"]
+        replacements = sum(
+            patch["expected_old_href_count"]
+            for source in sources
+            for patch in source["link_patches"]
+        )
+        unresolved = sum(
+            link["expected_href_count"]
+            for source in sources
+            for link in source["unresolved_links"]
+        )
+
+        self.assertEqual(13, summary["source_post_count"])
+        self.assertEqual(41, summary["legacy_link_count"])
+        self.assertEqual(30, summary["approved_replacement_count"])
+        self.assertEqual(11, summary["unresolved_link_count"])
+        self.assertEqual(summary["source_post_count"], len(sources))
+        self.assertEqual(summary["approved_replacement_count"], replacements)
+        self.assertEqual(summary["unresolved_link_count"], unresolved)
+        self.assertEqual(summary["legacy_link_count"], replacements + unresolved)
+
+    def test_every_source_has_stable_public_guards(self):
+        expected_ids = {
+            11620,
+            11252,
+            11171,
+            9549,
+            9374,
+            9197,
+            9044,
+            8947,
+            8859,
+            8663,
+            8508,
+            8418,
+            8314,
+        }
+        sources = self.data["sources"]
+
+        self.assertEqual(expected_ids, {source["id"] for source in sources})
+        for source in sources:
+            self.assertEqual("publish", source["status"])
+            self.assertTrue(source["slug"])
+            self.assertTrue(source["modified"])
+            self.assertTrue(source["url"].startswith("https://kriskrug.co/"))
+            self.assertTrue(source["link_patches"])
+
+    def test_only_approved_href_mappings_can_be_applied(self):
+        mappings = {
+            mapping["old_href"]: mapping["new_href"]
+            for mapping in self.data["approved_mappings"]
+        }
+        targets = {canonical_key(target["url"]) for target in self.data["canonical_targets"]}
+
+        for source in self.data["sources"]:
+            for patch in source["link_patches"]:
+                self.assertEqual(mappings[patch["old_href"]], patch["new_href"])
+                self.assertIn(canonical_key(patch["new_href"]), targets)
+                self.assertGreater(patch["expected_old_href_count"], 0)
+                self.assertEqual(0, patch["expected_new_href_count_before"])
+                self.assertTrue(patch["anchor_texts"])
+                self.assertFalse(patch["copy_change"])
+
+    def test_canonical_targets_are_indexable_and_in_the_sitemap(self):
+        expected_targets = {
+            canonical_key("https://bc-ai.ca/"),
+            canonical_key("https://bc-ai.ca/communities/vancouver-ai"),
+            canonical_key("https://bc-ai.ca/communities/futures-lab"),
+            canonical_key("https://bc-ai.ca/communities/surrey"),
+            canonical_key("https://bc-ai.ca/communities/mac"),
+        }
+        targets = self.data["canonical_targets"]
+
+        self.assertEqual(expected_targets, {canonical_key(target["url"]) for target in targets})
+        for target in targets:
+            self.assertEqual(200, target["status"])
+            self.assertTrue(target["indexable"])
+            self.assertEqual(1, target["sitemap_count"])
+            self.assertEqual(canonical_key(target["url"]), canonical_key(target["canonical"]))
+
+    def test_ambiguous_hackathon_and_squamish_links_stay_unresolved(self):
+        unresolved = [
+            link
+            for source in self.data["sources"]
+            for link in source["unresolved_links"]
+        ]
+        approved_old_hrefs = {
+            mapping["old_href"] for mapping in self.data["approved_mappings"]
+        }
+
+        self.assertEqual(11, sum(link["expected_href_count"] for link in unresolved))
+        for link in unresolved:
+            self.assertNotIn(link["href"], approved_old_hrefs)
+            self.assertRegex(link["href"], r"(?:hackathon|squamish)\.bc-ai\.net")
+            self.assertEqual("no_truthful_indexed_successor", link["reason"])
+
+    def test_measurement_baseline_is_aggregate_and_page_paired(self):
+        baseline = self.data["measurement_baseline"]
+
+        self.assertEqual("bc ai", baseline["query"])
+        self.assertEqual(
+            "https://kriskrug.co/2025/02/16/"
+            "bcs-ai-ecosystem-a-mycelial-network-of-creation/",
+            baseline["landing_page"],
+        )
+        self.assertEqual(
+            {"clicks": 0, "impressions": 49, "ctr_percent": 0.0, "average_position": 8.73},
+            baseline["current"],
+        )
+        self.assertEqual(50, baseline["prior"]["impressions"])
+        self.assertEqual(9.2, baseline["prior"]["average_position"])
+
+    def test_future_write_boundary_is_body_only_and_review_gated(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+
+        self.assertEqual(["content"], boundary["allowed_rest_top_level_keys"])
+        self.assertEqual(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "meta",
+                "featured_media",
+            },
+            set(boundary["forbidden_rest_top_level_keys"]),
+        )
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+        text = HANDOFF.read_text(encoding="utf-8")
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply these patches from this PR.", text)
+        self.assertIn("exact action-time approval", text)
+        self.assertIn("Nine historical Data Storytelling Hackathon links remain unchanged", text)
+        self.assertIn("Two Squamish AI links remain unchanged", text)
+
+    def test_manifest_contains_no_secret_material(self):
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "client_secret",
+            "refresh_token",
+        ):
+            self.assertNotIn(marker, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Inventory 41 legacy `bc-ai.net` links across 13 published KrisKrug.co posts.
- Record 30 exact replacements to indexed `bc-ai.ca` canonical routes.
- Preserve 11 Hackathon and Squamish links without guessing a replacement.
- Add eight regression tests for counts, mappings, public guards, measurement, and write boundaries.

## Evidence

- A fresh read-only live eval verified all 13 WordPress source posts, all 30 approved hrefs, all 11 unresolved hrefs, and all five canonical targets.
- Each replacement target returned `200`, remained indexable and canonical-equivalent, and appeared once in the live sitemap.

## Safety

- This PR is a repo-only publisher handoff. It performs no WordPress write, deployment, Search Console action, DNS change, or analytics change.
- Any future publisher session remains separately human-gated and body-only, with fresh identity checks, snapshots, href-only diffs, readback, and rollback payloads.

## Verification

- `python3 -m unittest scripts.tests.test_issue_340_legacy_bcai_links_handoff -v`
- `make verify`
- Fresh public WordPress REST and BC + AI canonical-target eval

Closes #340.