### PR TITLE
seo: prepare Both Hands Full canonical-link handoff

### DIFF
--- a/fixes/issue-342-both-hands-full-link-handoff-2026-07-13.json
+++ b/fixes/issue-342-both-hands-full-link-handoff-2026-07-13.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 1,
+  "issue": 342,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "evidence": {
+    "current_window": {
+      "start": "2026-06-13",
+      "end": "2026-07-10"
+    },
+    "source_page": {
+      "impressions": 56,
+      "clicks": 3,
+      "ctr_percent": 5.36,
+      "average_position": 8.27
+    },
+    "target_property": {
+      "impressions": 6,
+      "clicks": 0,
+      "ctr_percent": 0.0,
+      "average_position": 21.67
+    },
+    "target_homepage": {
+      "impressions": 4,
+      "clicks": 0,
+      "ctr_percent": 0.0,
+      "average_position": 16.5
+    },
+    "source": "2026-07-13 Growth Mirror monthly readout; digest-safe aggregate only"
+  },
+  "source": {
+    "id": 11171,
+    "slug": "both-hands-full",
+    "status": "publish",
+    "modified": "2026-06-28T20:26:51",
+    "modified_gmt": "2026-06-29T04:26:51",
+    "url": "https://kriskrug.co/2026/01/24/both-hands-full/",
+    "canonical": "https://kriskrug.co/2026/01/24/both-hands-full/",
+    "post_title": "Both Hands Full",
+    "http_status": 200,
+    "h1_count": 1,
+    "robots": "max-image-preview:large"
+  },
+  "target": {
+    "url": "https://www.bothhandsfull.com",
+    "canonical": "https://www.bothhandsfull.com",
+    "http_status": 200,
+    "h1_count": 1,
+    "robots": "index, follow"
+  },
+  "link_patch": {
+    "observed_in": "public_rest_content_rendered",
+    "current_href": "https://kriskrug.notion.site/keynote-both-hands-full?source=copy_link",
+    "replacement_href": "https://www.bothhandsfull.com",
+    "anchor_text": "both hands full",
+    "current_anchor_html": "<a href=\"https://kriskrug.notion.site/keynote-both-hands-full?source=copy_link\">both hands full</a>",
+    "replacement_anchor_html": "<a href=\"https://www.bothhandsfull.com\">both hands full</a>",
+    "context_before": "<p>So I’m asking you to walk forward with <a href=\"https://kriskrug.notion.site/keynote-both-hands-full?source=copy_link\">both hands full</a>.</p>",
+    "context_after": "<p>So I’m asking you to walk forward with <a href=\"https://www.bothhandsfull.com\">both hands full</a>.</p>",
+    "expected_context_count": 1,
+    "expected_current_anchor_count": 1,
+    "expected_target_href_count_before": 0,
+    "expected_target_href_count_after": 1,
+    "copy_change": false,
+    "rel_attribute_added": false,
+    "future_authenticated_raw_guard_required": true
+  },
+  "duplicate_publication_decision": {
+    "source_issue": "WalksWithASwagger/bothhandsfull#103",
+    "decision": "do_not_publish_duplicate",
+    "reason": "The article, title, and slug already exist on KrisKrug.co; repair the existing contextual destination instead."
+  },
+  "future_write_boundary_if_separately_approved": {
+    "publisher_batch_issue": "WalksWithASwagger/kriskrug-wp#339",
+    "allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "categories",
+      "tags",
+      "excerpt",
+      "meta"
+    ],
+    "requires": [
+      "fresh ID, slug, status, and modified-date checks",
+      "retained content.raw rollback snapshot",
+      "exact current-anchor and target-href counts before writing",
+      "human approval of the exact href-only replacement",
+      "one content write followed by authenticated and public readback",
+      "public source and target HTTP 200 plus self-canonical verification"
+    ]
+  },
+  "next_digest": {
+    "earliest_full_days_after_live_change": 14,
+    "secondary_review_days_after_live_change": 28,
+    "source_page": "https://kriskrug.co/2026/01/24/both-hands-full/",
+    "target_homepage": "https://www.bothhandsfull.com",
+    "compare": [
+      "source_page_impressions",
+      "source_page_clicks",
+      "source_page_ctr_percent",
+      "source_page_average_position",
+      "target_property_impressions",
+      "target_property_clicks",
+      "target_homepage_impressions",
+      "target_homepage_clicks",
+      "target_homepage_average_position"
+    ],
+    "note": "Measure only after the approved live edit is public and recrawled. Treat movement as directional evidence, not proof that one link caused it."
+  }
+}

--- a/fixes/issue-342-both-hands-full-link-handoff-2026-07-13.md
+++ b/fixes/issue-342-both-hands-full-link-handoff-2026-07-13.md
@@ -1,0 +1,104 @@
+# Issue #342: Both Hands Full Canonical-Link Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-342-both-hands-full-link-handoff-2026-07-13.json`
+
+## Decision
+
+Do not publish the draft in `WalksWithASwagger/bothhandsfull#103` as a new
+KrisKrug.co post. The public article, title, and slug already exist at:
+
+https://kriskrug.co/2026/01/24/both-hands-full/
+
+Publishing another version would create duplicate content and compete with the
+established URL. The existing article already contains the right contextual
+anchor, but its destination is the old Notion keynote. The smallest useful
+change is to preserve every word and replace only that href with the live
+Both Hands Full canonical homepage.
+
+This handoff does not update WordPress, publish content, deploy code, purge a
+cache, request indexing, or change Search Console, analytics, DNS, metadata,
+taxonomies, or theme code.
+
+## Digest-Safe Evidence
+
+The current 28-day Search Console window is 2026-06-13 through 2026-07-10:
+
+| Surface | Impressions | Clicks | CTR | Average position |
+| --- | ---: | ---: | ---: | ---: |
+| Existing KrisKrug.co article | 56 | 3 | 5.36% | 8.27 |
+| Both Hands Full property | 6 | 0 | 0.0% | 21.67 |
+| Both Hands Full homepage | 4 | 0 | 0.0% | 16.5 |
+
+The article is already earning search visibility. The target property is still
+young enough that one relevant editorial path from the established article is
+a sensible discovery and entity-association improvement. This is not a promise
+that one link will improve rankings.
+
+## Public Mapping
+
+Read-only checks on 2026-07-13 locked the source to WordPress post 11171:
+
+- Slug: `both-hands-full`
+- Status: `publish`
+- Public modified value: `2026-06-28T20:26:51`
+- URL and canonical: `https://kriskrug.co/2026/01/24/both-hands-full/`
+- HTTP: `200`
+- H1 count: 1
+- Robots: `max-image-preview:large`
+
+The target `https://www.bothhandsfull.com` also returns `200`, emits the same
+self-canonical URL, has one H1, and is indexable. Public REST
+`content.rendered` currently has one old Notion anchor and zero editorial hrefs
+to the target. The future publisher must repeat these guards against
+authenticated `content.raw` before writing.
+
+## Exact Href-Only Patch
+
+Current public paragraph:
+
+```html
+<p>So I’m asking you to walk forward with <a href="https://kriskrug.notion.site/keynote-both-hands-full?source=copy_link">both hands full</a>.</p>
+```
+
+Review replacement:
+
+```html
+<p>So I’m asking you to walk forward with <a href="https://www.bothhandsfull.com">both hands full</a>.</p>
+```
+
+The sentence and anchor text stay unchanged. The replacement adds no `rel`
+attribute and makes no metadata, title, excerpt, slug, status, date, taxonomy,
+or unrelated body-copy change.
+
+## Separate Publisher Gate
+
+Do not apply this handoff from the worker lane. Add it to the human-gated July
+publisher batch in #339 and apply it only after explicit approval of this exact
+href replacement.
+
+1. Fetch post 11171 by ID and confirm the slug, `publish` status, and modified
+   value. Stop if any guard changed.
+2. Fetch the raw body and public HTML. Confirm the exact current anchor occurs
+   once and the canonical target href occurs zero times.
+3. Snapshot `content.raw`, the public HTML, and their checksums before writing.
+4. Replace the exact anchor once in the raw body. Send only the top-level
+   `content` field. Do not send title, excerpt, slug, status, date, taxonomies,
+   or meta.
+5. Read back the authenticated raw body and anonymous public page. Confirm the
+   old href is absent, the target href occurs once, and the article remains
+   `200`, self-canonical, indexable, and one-H1.
+6. Confirm the target still returns `200` with its matching self-canonical.
+7. Retain the raw snapshot as the rollback payload. Restore only `content` if
+   any guard or public readback fails.
+
+The source is already indexed and the target homepage already has impressions,
+so this publisher change does not need a separate indexing request.
+
+## Measurement
+
+Wait at least 14 full days after the approved live edit, then compare source
+article and target-property visibility against the locked baseline. Repeat at
+28 full days. Track impressions, clicks, CTR, and average position, but do not
+attribute movement to this one link without broader supporting evidence.

--- a/scripts/tests/test_issue_342_both_hands_full_link_handoff.py
+++ b/scripts/tests/test_issue_342_both_hands_full_link_handoff.py
@@ -1,0 +1,139 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-342-both-hands-full-link-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-342-both-hands-full-link-handoff-2026-07-13.md"
+
+
+class Issue342BothHandsFullLinkHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+    def test_search_evidence_is_digest_safe_and_exact(self):
+        evidence = self.data["evidence"]
+
+        self.assertEqual(
+            {"start": "2026-06-13", "end": "2026-07-10"},
+            evidence["current_window"],
+        )
+        self.assertEqual(
+            {
+                "impressions": 56,
+                "clicks": 3,
+                "ctr_percent": 5.36,
+                "average_position": 8.27,
+            },
+            evidence["source_page"],
+        )
+        self.assertEqual(6, evidence["target_property"]["impressions"])
+        self.assertEqual(0, evidence["target_property"]["clicks"])
+        self.assertEqual(21.67, evidence["target_property"]["average_position"])
+        self.assertEqual(4, evidence["target_homepage"]["impressions"])
+        self.assertEqual(16.5, evidence["target_homepage"]["average_position"])
+
+    def test_source_and_target_public_state_are_locked(self):
+        source = self.data["source"]
+        target = self.data["target"]
+
+        self.assertEqual(11171, source["id"])
+        self.assertEqual("both-hands-full", source["slug"])
+        self.assertEqual("publish", source["status"])
+        self.assertEqual("2026-06-28T20:26:51", source["modified"])
+        self.assertEqual(source["url"], source["canonical"])
+        self.assertEqual(200, source["http_status"])
+        self.assertEqual(1, source["h1_count"])
+
+        self.assertEqual("https://www.bothhandsfull.com", target["url"])
+        self.assertEqual(target["url"], target["canonical"])
+        self.assertEqual(200, target["http_status"])
+        self.assertEqual(1, target["h1_count"])
+
+    def test_patch_changes_only_the_href(self):
+        patch = self.data["link_patch"]
+        anchor_pattern = r'<a href="([^"]+)"(?: rel="([^"]+)")?>([^<]+)</a>'
+        before = re.fullmatch(anchor_pattern, patch["current_anchor_html"])
+        after = re.fullmatch(anchor_pattern, patch["replacement_anchor_html"])
+
+        self.assertIsNotNone(before)
+        self.assertIsNotNone(after)
+        self.assertEqual("both hands full", before.group(3))
+        self.assertEqual(before.group(3), after.group(3))
+        self.assertIsNone(before.group(2))
+        self.assertIsNone(after.group(2))
+        self.assertNotEqual(before.group(1), after.group(1))
+        self.assertEqual(self.data["target"]["url"], after.group(1))
+        self.assertEqual(
+            patch["context_before"].replace(
+                patch["current_anchor_html"], patch["replacement_anchor_html"], 1
+            ),
+            patch["context_after"],
+        )
+        self.assertEqual(1, patch["expected_current_anchor_count"])
+        self.assertEqual(1, patch["expected_context_count"])
+        self.assertEqual(0, patch["expected_target_href_count_before"])
+        self.assertEqual(1, patch["expected_target_href_count_after"])
+        self.assertFalse(patch["copy_change"])
+        self.assertFalse(patch["rel_attribute_added"])
+        self.assertEqual("public_rest_content_rendered", patch["observed_in"])
+        self.assertTrue(patch["future_authenticated_raw_guard_required"])
+
+    def test_future_write_boundary_is_content_only(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+
+        self.assertEqual(["content"], boundary["allowed_rest_top_level_keys"])
+        self.assertTrue(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "excerpt",
+                "meta",
+            }.issubset(boundary["forbidden_rest_top_level_keys"])
+        )
+        self.assertIn(
+            "fresh ID, slug, status, and modified-date checks",
+            boundary["requires"],
+        )
+        self.assertIn("retained content.raw rollback snapshot", boundary["requires"])
+
+    def test_worker_lane_has_no_live_write_or_secret_material(self):
+        self.assertEqual("human-review-required", self.data["status"])
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "oauth",
+        ):
+            self.assertNotIn(marker, serialized)
+
+        text = HANDOFF.read_text(encoding="utf-8")
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply this handoff from the worker lane.", text)
+        self.assertIn("#339", text)
+        self.assertIn("duplicate", text.lower())
+
+    def test_measurement_waits_for_recrawl(self):
+        measurement = self.data["next_digest"]
+
+        self.assertEqual(14, measurement["earliest_full_days_after_live_change"])
+        self.assertEqual(28, measurement["secondary_review_days_after_live_change"])
+        self.assertEqual(self.data["source"]["url"], measurement["source_page"])
+        self.assertEqual(self.data["target"]["url"], measurement["target_homepage"])
+        self.assertIn("source_page_clicks", measurement["compare"])
+        self.assertIn("target_property_impressions", measurement["compare"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- lock the live WordPress post 11171 identity and current 28-day Search Console baseline
- prepare one href-only replacement from the obsolete Notion keynote destination to the Both Hands Full canonical homepage
- document the content-only publisher guard, rollback path, and 14/28-day measurement window
- add contract tests proving there is no duplicate publication, copy change, live WordPress write, or secret material

## Verification

- `python3 -m unittest scripts.tests.test_issue_342_both_hands_full_link_handoff` - 6 passed
- `make test` - 268 tests passed; JavaScript syntax and both plugin smokes passed
- `make docs-truth-check` - passed
- `python3 -m json.tool fixes/issue-342-both-hands-full-link-handoff-2026-07-13.json` - passed
- live read-only guard - source ID/slug/modified matched, old anchor count 1, target href count 0, source and target both 200/self-canonical/one-H1
- `git diff --cached --check` - passed

## Local Environment Note

The full `make verify` reached and passed all tests, plugin smokes, and docs truth checks, then stopped at PHPCS because Composer and `vendor/bin/phpcs` are not installed locally. This PR changes only JSON, Markdown, and Python tests.

## Safety

No live WordPress write, deploy, cache purge, Search Console action, analytics change, or DNS change was performed. The eventual href edit remains human-gated in #339.

Closes #342
Refs WalksWithASwagger/bothhandsfull#103