### PR TITLE
Update: align schema identity with keynote positioning

### DIFF
--- a/fixes/issue-316-schema-identity-handoff-2026-07-13.json
+++ b/fixes/issue-316-schema-identity-handoff-2026-07-13.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": 1,
+  "issue": 316,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "live_before": {
+    "observed_on": "2026-07-13",
+    "homepage_document_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+    "homepage_open_graph_site_name": "Kris Krüg | Generative AI Tools & Techniques",
+    "website_schema_name": "Kris Krüg | Generative AI Tools & Techniques",
+    "person_job_title": "Generative AI Strategist, Photographer, Community Builder",
+    "person_description": "Vancouver-based generative AI strategist, photographer, and community builder. Founder of the BC + AI Ecosystem Industry Association.",
+    "person_image_present": false,
+    "person_id": "https://kriskrug.co/#person",
+    "website_id": "https://kriskrug.co/#website",
+    "sample_urls": [
+      {
+        "url": "https://kriskrug.co/",
+        "http_status": 200,
+        "person_nodes": 1,
+        "website_nodes": 1
+      },
+      {
+        "url": "https://kriskrug.co/about/",
+        "http_status": 200,
+        "person_nodes": 1,
+        "website_nodes": 0
+      },
+      {
+        "url": "https://kriskrug.co/2026/01/24/both-hands-full/",
+        "http_status": 200,
+        "person_nodes": 1,
+        "website_nodes": 0
+      }
+    ],
+    "source": "anonymous public HTML and JSON-LD readback"
+  },
+  "guidance": {
+    "google_site_names": "https://developers.google.com/search/docs/appearance/site-names",
+    "decision": "Use one concise, commonly recognized WebSite name on the homepage and provide ordered legitimate alternatives. Keep occupational positioning on the Person node."
+  },
+  "proposed_identity": {
+    "website_name": "Kris Krug",
+    "website_alternate_names": [
+      "Kris Krüg",
+      "kriskrug.co"
+    ],
+    "person_name": "Kris Krüg",
+    "person_alternate_name": "Kris Krug",
+    "person_image": "https://kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg",
+    "person_job": "AI Keynote Speaker and Creative Technologist",
+    "person_description": "Vancouver-based AI keynote speaker, creative technologist, photographer, and community builder. Executive Director of BC + AI, founder of Vancouver AI, and lead curator of Futureproof Festival."
+  },
+  "person_image_evidence": {
+    "url": "https://kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg",
+    "observed_on_page": "https://kriskrug.co/about/",
+    "public_alt_text": "Portrait of Kris Krug",
+    "http_status": 200,
+    "content_type": "image/jpeg",
+    "content_length_bytes": 1226854,
+    "visual_review": "clear square-crop-compatible portrait of Kris Krug"
+  },
+  "repo_sources": {
+    "production_code_snippets_mirror": "fixes/schema-snippets-deployed.php",
+    "future_mu_plugin_source": "fixes/schema-snippets.php",
+    "same_identity_constants_required": true
+  },
+  "future_code_snippets_update_if_separately_approved": {
+    "expected_snippet_id": 5,
+    "expected_current_scope": "active global PHP snippet",
+    "proposed_snippet_name": "KK Schema",
+    "allowed_changes": [
+      "snippet name",
+      "snippet code matching fixes/schema-snippets-deployed.php"
+    ],
+    "requires": [
+      "fresh wp-admin ID and scope verification",
+      "full current snippet rollback snapshot",
+      "byte-reviewed comparison with the merged production mirror",
+      "explicit human approval of the exact identity and portrait",
+      "anonymous and cache-busted public readback before closing"
+    ],
+    "post_deploy_invariants": [
+      "one active Person owner",
+      "one homepage WebSite owner",
+      "zero WebSite nodes on internal pages",
+      "Article author and publisher still reference https://kriskrug.co/#person",
+      "no title, content, taxonomy, theme, analytics, or Search Console change"
+    ]
+  },
+  "post_deploy_evaluation": {
+    "sample_urls": [
+      "https://kriskrug.co/",
+      "https://kriskrug.co/about/",
+      "https://kriskrug.co/speaking/",
+      "https://kriskrug.co/blog/",
+      "https://kriskrug.co/2026/01/24/both-hands-full/"
+    ],
+    "checks": [
+      "authenticated_snippet_readback",
+      "anonymous_public_html",
+      "anonymous_cache_busted_html",
+      "schema_markup_validator",
+      "person_image_http_and_content_type",
+      "homepage_url_inspection_after_priority_quota_queue"
+    ],
+    "expected": [
+      "WebSite name is Kris Krug",
+      "WebSite alternateName is ordered as Kris Krüg then kriskrug.co",
+      "Person jobTitle and description match the keynote-first public positioning",
+      "Person image equals the verified About portrait",
+      "all sampled JSON-LD parses without errors"
+    ],
+    "rollback": [
+      "restore the full captured snippet",
+      "restore the prior snippet name if it changed",
+      "purge only the affected cache surface",
+      "repeat anonymous and cache-busted readback"
+    ],
+    "recrawl_policy": "Do not spend priority indexing quota before the active RAP, FutureProof, and Indigenous AI queue. Natural recrawl is acceptable; request the homepage only if quota remains later."
+  },
+  "out_of_scope": [
+    "Open Graph site-name mismatch",
+    "WordPress site-title setting",
+    "theme or plugin deployment",
+    "post or page content",
+    "Search Console submissions or removals",
+    "analytics, DNS, permissions, or credentials"
+  ]
+}

--- a/fixes/issue-316-schema-identity-handoff-2026-07-13.md
+++ b/fixes/issue-316-schema-identity-handoff-2026-07-13.md
@@ -1,0 +1,89 @@
+# Issue #316: Schema Identity Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-316-schema-identity-handoff-2026-07-13.json`
+
+## Decision
+
+Align the existing Person and WebSite JSON-LD with the public keynote-first
+identity. Keep the current schema ownership model and entity IDs. Do not add a
+second schema plugin, a second Person node, or a theme-side JSON-LD owner.
+
+Google's current site-name guidance recommends one concise, commonly recognized
+`WebSite.name` on the homepage, with legitimate alternatives in
+`alternateName`. The preferred site name is therefore `Kris Krug`, not the
+long document-title descriptor. The accented name and domain are ordered
+alternatives. The keynote positioning belongs on the Person node.
+
+Guidance: https://developers.google.com/search/docs/appearance/site-names
+
+## Live Evidence
+
+Anonymous public HTML on 2026-07-13 showed:
+
+- Homepage document title: `Kris Krug | AI Keynote Speaker & Creative Technologist`
+- WebSite schema name: `Kris Krüg | Generative AI Tools & Techniques`
+- Person job title: `Generative AI Strategist, Photographer, Community Builder`
+- Person image: absent
+- Exactly one Person node on the homepage, About page, and sampled article
+- Exactly one WebSite node on the homepage and none on the internal samples
+- All three sampled routes returned `200`
+
+The output matches `fixes/schema-snippets-deployed.php`, confirming that the
+repo already has the correct production mirror to update.
+
+## Review-Ready Identity
+
+| Field | Proposed value |
+| --- | --- |
+| `WebSite.name` | `Kris Krug` |
+| `WebSite.alternateName` | `Kris Krüg`, then `kriskrug.co` |
+| `Person.name` | `Kris Krüg` unchanged |
+| `Person.alternateName` | `Kris Krug` unchanged |
+| `Person.jobTitle` | `AI Keynote Speaker and Creative Technologist` |
+| `Person.image` | `https://kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg` |
+| `Person.description` | `Vancouver-based AI keynote speaker, creative technologist, photographer, and community builder. Executive Director of BC + AI, founder of Vancouver AI, and lead curator of Futureproof Festival.` |
+
+The portrait is already rendered on the public About page with alt text
+`Portrait of Kris Krug`. Direct readback returned `200`, `image/jpeg`, and a
+1,226,854-byte body. Visual review confirmed it is a clear portrait of Kris.
+
+Both the production Code Snippets mirror and the future mu-plugin source now
+share these identity constants. The future mu-plugin remains inert while its
+unrelated `VERIFY-ME` fields exist.
+
+## Separate Deployment Gate
+
+Do not apply this handoff from the worker lane. A future production session
+needs explicit approval for the exact Code Snippets change.
+
+1. Open Code Snippets and verify that snippet ID 5 is still the active global
+   PHP owner whose public output matches the repo mirror. Stop on any mismatch.
+2. Capture the complete current snippet, name, activation state, scope, and a
+   checksum as the rollback snapshot.
+3. Rename the snippet to `KK Schema` if it is still unnamed.
+4. Replace its code with the reviewed contents of
+   `fixes/schema-snippets-deployed.php`, stripping only the opening PHP tag as
+   required by Code Snippets.
+5. Save one change, then perform authenticated, anonymous, and cache-busted
+   readback before doing anything else.
+6. Verify one Person node sitewide, one homepage-only WebSite node, unchanged
+   Article author/publisher references, the exact identity values above, and a
+   reachable portrait URL.
+7. Validate the homepage and one article with Schema Markup Validator. Google's
+   Rich Results Test does not support site names, so do not use it as the sole
+   site-name check.
+8. Restore the full captured snippet and purge only the affected cache surface
+   if any identity, node-count, JSON parse, or route invariant fails.
+
+The active priority indexing queue remains ahead of this homepage recrawl. Do
+not consume RAP, FutureProof, or Indigenous AI quota for this schema-only
+change. Natural recrawl is acceptable unless spare quota remains later.
+
+## Remaining Identity Lane
+
+The homepage Open Graph site-name mismatch is real but intentionally separate.
+It currently comes from the WordPress site-title value through Aurora's social
+metadata owner. This Track A schema change does not alter a WordPress option or
+mix in Track B theme work. File and verify that correction separately.

--- a/fixes/schema-snippets-deployed.php
+++ b/fixes/schema-snippets-deployed.php
@@ -10,7 +10,7 @@
  * Differences from fixes/schema-snippets.php (the SSH-deployable mu-plugin
  * version):
  *   - VERIFY-ME placeholders replaced with confirmed values
- *   - Headshot omitted (no clean media-library file yet; add later)
+ *   - Person image uses the public portrait already rendered on /about/
  *   - LinkedIn / GitHub / YouTube / Wikipedia omitted (URLs unverified or 404)
  *   - kk_schema_is_ready() guard removed (values are baked in)
  *   - Conditional Person.image / Person.sameAs filtering
@@ -21,13 +21,17 @@
 
 function kk_schema_constants() {
     return array(
-        'site_name'    => 'Kris Krüg | Generative AI Tools & Techniques',
-        'site_url'     => 'https://kriskrug.co',
-        'person_name'  => 'Kris Krüg',
-        'person_alt'   => 'Kris Krug',
-        'person_image' => '',  // TODO: add a real headshot URL once uploaded to media
-        'person_job'   => 'Generative AI Strategist, Photographer, Community Builder',
-        'person_descr' => 'Vancouver-based generative AI strategist, photographer, and community builder. Founder of the BC + AI Ecosystem Industry Association.',
+        'site_name'            => 'Kris Krug',
+        'site_alternate_names' => array(
+            'Kris Krüg',
+            'kriskrug.co',
+        ),
+        'site_url'             => 'https://kriskrug.co',
+        'person_name'          => 'Kris Krüg',
+        'person_alt'           => 'Kris Krug',
+        'person_image'         => 'https://kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg',
+        'person_job'           => 'AI Keynote Speaker and Creative Technologist',
+        'person_descr'         => 'Vancouver-based AI keynote speaker, creative technologist, photographer, and community builder. Executive Director of BC + AI, founder of Vancouver AI, and lead curator of Futureproof Festival.',
         // Only verified, owned URLs. Add LinkedIn etc. when KK confirms.
         'same_as' => array(
             'https://twitter.com/kriskrug',
@@ -93,6 +97,7 @@ function kk_schema_website() {
         '@id'             => $c['site_url'] . '/#website',
         'url'             => $c['site_url'],
         'name'            => $c['site_name'],
+        'alternateName'   => $c['site_alternate_names'],
         'inLanguage'      => 'en-US',
         'publisher'       => array('@id' => $c['site_url'] . '/#person'),
         'potentialAction' => array(

--- a/fixes/schema-snippets.php
+++ b/fixes/schema-snippets.php
@@ -31,14 +31,18 @@
 // ----------------------------------------------------------------------
 function kk_schema_constants() {
     return array(
-        'site_name'        => 'Kris Krüg | Generative AI Tools & Techniques',
+        'site_name'        => 'Kris Krug',
+        'site_alternate_names' => array(
+            'Kris Krüg',
+            'kriskrug.co',
+        ),
         'site_url'         => 'https://kriskrug.co',
         'person_name'      => 'Kris Krüg',
         'person_alt'       => 'Kris Krug',
-        // Confirm the file exists at this path AND is your current headshot.
-        'person_image'     => 'VERIFY-ME-headshot-url',
-        'person_job'       => 'Generative AI Strategist, Photographer, Community Builder',
-        'person_descr'     => 'Vancouver-based generative AI strategist, photographer, and community builder. Founder of the BC + AI Ecosystem Industry Association.',
+        // Public portrait already rendered on /about/.
+        'person_image'     => 'https://kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg',
+        'person_job'       => 'AI Keynote Speaker and Creative Technologist',
+        'person_descr'     => 'Vancouver-based AI keynote speaker, creative technologist, photographer, and community builder. Executive Director of BC + AI, founder of Vancouver AI, and lead curator of Futureproof Festival.',
         // Logo image for publisher schema. Confirm exists.
         'logo_url'         => 'VERIFY-ME-logo-url',
         // Profiles — every URL here is a public CLAIM that this profile is yours.
@@ -128,6 +132,7 @@ function kk_schema_website() {
         '@id'           => $c['site_url'] . '/#website',
         'url'           => $c['site_url'],
         'name'          => $c['site_name'],
+        'alternateName' => $c['site_alternate_names'],
         'inLanguage'    => 'en-US',
         'publisher'     => array('@id' => $c['site_url'] . '/#person'),
         'potentialAction' => array(

--- a/scripts/tests/test_issue_316_schema_identity.py
+++ b/scripts/tests/test_issue_316_schema_identity.py
@@ -1,0 +1,142 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPLOYED = ROOT / "fixes/schema-snippets-deployed.php"
+MU_PLUGIN = ROOT / "fixes/schema-snippets.php"
+MANIFEST = ROOT / "fixes/issue-316-schema-identity-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-316-schema-identity-handoff-2026-07-13.md"
+
+
+def scalar_constant(source: str, key: str) -> str:
+    match = re.search(rf"'{re.escape(key)}'\s*=>\s*'([^']*)'", source)
+    if match is None:
+        raise AssertionError(f"missing scalar schema constant: {key}")
+    return match.group(1)
+
+
+def array_constant(source: str, key: str) -> list[str]:
+    match = re.search(
+        rf"'{re.escape(key)}'\s*=>\s*array\((.*?)\),",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"missing array schema constant: {key}")
+    return re.findall(r"'([^']*)'", match.group(1))
+
+
+class Issue316SchemaIdentityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.deployed = DEPLOYED.read_text(encoding="utf-8")
+        cls.mu_plugin = MU_PLUGIN.read_text(encoding="utf-8")
+
+    def test_live_before_evidence_is_exact(self):
+        live = self.data["live_before"]
+
+        self.assertEqual("2026-07-13", live["observed_on"])
+        self.assertEqual(
+            "Kris Krug | AI Keynote Speaker & Creative Technologist",
+            live["homepage_document_title"],
+        )
+        self.assertEqual(
+            "Kris Krüg | Generative AI Tools & Techniques",
+            live["website_schema_name"],
+        )
+        self.assertEqual(
+            "Generative AI Strategist, Photographer, Community Builder",
+            live["person_job_title"],
+        )
+        self.assertFalse(live["person_image_present"])
+        self.assertEqual(3, len(live["sample_urls"]))
+        self.assertTrue(all(row["http_status"] == 200 for row in live["sample_urls"]))
+
+    def test_concise_site_name_and_alternatives_follow_google_guidance(self):
+        proposed = self.data["proposed_identity"]
+
+        self.assertEqual("Kris Krug", proposed["website_name"])
+        self.assertEqual(
+            ["Kris Krüg", "kriskrug.co"],
+            proposed["website_alternate_names"],
+        )
+        self.assertNotIn("|", proposed["website_name"])
+        self.assertEqual(
+            "https://developers.google.com/search/docs/appearance/site-names",
+            self.data["guidance"]["google_site_names"],
+        )
+
+    def test_both_schema_sources_share_the_reviewed_identity(self):
+        expected = self.data["proposed_identity"]
+
+        for source in (self.deployed, self.mu_plugin):
+            self.assertEqual(expected["website_name"], scalar_constant(source, "site_name"))
+            self.assertEqual(
+                expected["website_alternate_names"],
+                array_constant(source, "site_alternate_names"),
+            )
+            self.assertEqual(expected["person_image"], scalar_constant(source, "person_image"))
+            self.assertEqual(expected["person_job"], scalar_constant(source, "person_job"))
+            self.assertEqual(
+                expected["person_description"],
+                scalar_constant(source, "person_descr"),
+            )
+            self.assertRegex(
+                source,
+                r"'alternateName'\s*=>\s*\$c\['site_alternate_names'\]",
+            )
+            self.assertNotIn("Generative AI Tools & Techniques", source)
+
+    def test_person_image_is_an_existing_public_about_portrait(self):
+        image = self.data["person_image_evidence"]
+
+        self.assertEqual(self.data["proposed_identity"]["person_image"], image["url"])
+        self.assertEqual("https://kriskrug.co/about/", image["observed_on_page"])
+        self.assertEqual("Portrait of Kris Krug", image["public_alt_text"])
+        self.assertEqual(200, image["http_status"])
+        self.assertEqual("image/jpeg", image["content_type"])
+        self.assertGreater(image["content_length_bytes"], 100_000)
+
+    def test_worker_lane_is_repo_only_and_deployment_is_guarded(self):
+        deployment = self.data["future_code_snippets_update_if_separately_approved"]
+
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+        self.assertEqual(5, deployment["expected_snippet_id"])
+        self.assertEqual("KK Schema", deployment["proposed_snippet_name"])
+        self.assertIn("fresh wp-admin ID and scope verification", deployment["requires"])
+        self.assertIn("full current snippet rollback snapshot", deployment["requires"])
+        self.assertIn("one active Person owner", deployment["post_deploy_invariants"])
+        self.assertIn("one homepage WebSite owner", deployment["post_deploy_invariants"])
+
+        text = HANDOFF.read_text(encoding="utf-8")
+        self.assertIn("no live WordPress write", text)
+        self.assertIn("Do not apply this handoff from the worker lane.", text)
+        self.assertIn("Open Graph site-name mismatch", text)
+
+    def test_post_deploy_eval_has_routes_and_rollback(self):
+        evaluation = self.data["post_deploy_evaluation"]
+
+        self.assertEqual(5, len(evaluation["sample_urls"]))
+        self.assertIn("schema_markup_validator", evaluation["checks"])
+        self.assertIn("anonymous_cache_busted_html", evaluation["checks"])
+        self.assertIn("restore the full captured snippet", evaluation["rollback"])
+        self.assertIn("purge only the affected cache surface", evaluation["rollback"])
+
+    def test_packet_contains_no_secret_material(self):
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "oauth",
+        ):
+            self.assertNotIn(marker, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- align the reviewed Person and WebSite schema mirrors with Kris Krug’s keynote-first public identity
- use the concise `Kris Krug` WebSite name plus legitimate alternatives per Google site-name guidance
- add a verified public portrait and a guarded, rollback-ready live deployment handoff
- keep the Open Graph site-name mismatch in a separate approval-gated lane

Guidance: https://developers.google.com/search/docs/appearance/site-names

## Verification

- `python3 -m unittest scripts.tests.test_issue_316_schema_identity`
- `php -l fixes/schema-snippets-deployed.php`
- `php -l fixes/schema-snippets.php`
- real PHP render under WordPress stubs
- `python3 -m json.tool fixes/issue-316-schema-identity-handoff-2026-07-13.json`
- `git diff --check`
- `make test` (275 tests plus JS syntax and plugin smokes)
- `make docs-truth-check`

## Safety

No live WordPress write or deployment was performed. Issue #316 remains open for exact human approval, rollback capture, and live readback.

Refs #316