### PR TITLE
Update: prepare Open Graph site-name handoff

### DIFF
--- a/fixes/issue-345-og-site-name-handoff-2026-07-13.json
+++ b/fixes/issue-345-og-site-name-handoff-2026-07-13.json
@@ -1,0 +1,187 @@
+{
+  "schema_version": 1,
+  "issue": 345,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "live_before": {
+    "observed_on": "2026-07-13",
+    "public_rest_root": {
+      "url": "https://kriskrug.co/wp-json/",
+      "http_status": 200,
+      "raw_name": "Kris Krüg | Generative AI Tools &amp; Techniques",
+      "decoded_name": "Kris Krüg | Generative AI Tools & Techniques",
+      "raw_description": "Empowering Events &amp; Organizations for the AI Age"
+    },
+    "active_aurora_version": "1.3.37",
+    "active_aurora_version_evidence": {
+      "url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+      "http_status": 200,
+      "version_header": "1.3.37"
+    },
+    "active_social_metadata_owner": "theme/kk-aurora/functions.php::render_social_meta_tags",
+    "inactive_bridge_snippet_id": 12,
+    "owner_receipt": "https://github.com/WalksWithASwagger/kriskrug-wp/issues/319#issuecomment-4953532560",
+    "route_matrix": [
+      {
+        "path": "/",
+        "document_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+        "normal_http_status": 200,
+        "cache_busted_http_status": 200,
+        "normal_og_site_name_count": 1,
+        "cache_busted_og_site_name_count": 1,
+        "og_site_name": "Kris Krüg | Generative AI Tools & Techniques"
+      },
+      {
+        "path": "/about/",
+        "document_title": "About Kris Krüg — Kris Krug | AI Keynote Speaker & Creative Technologist",
+        "normal_http_status": 200,
+        "cache_busted_http_status": 200,
+        "normal_og_site_name_count": 1,
+        "cache_busted_og_site_name_count": 1,
+        "og_site_name": "Kris Krüg | Generative AI Tools & Techniques"
+      },
+      {
+        "path": "/speaking/",
+        "document_title": "AI Keynote Speaker Kris Krüg — Kris Krug | AI Keynote Speaker & Creative Technologist",
+        "normal_http_status": 200,
+        "cache_busted_http_status": 200,
+        "normal_og_site_name_count": 1,
+        "cache_busted_og_site_name_count": 1,
+        "og_site_name": "Kris Krüg | Generative AI Tools & Techniques"
+      },
+      {
+        "path": "/blog/",
+        "document_title": "Blog — Kris Krug | AI Keynote Speaker & Creative Technologist",
+        "normal_http_status": 200,
+        "cache_busted_http_status": 200,
+        "normal_og_site_name_count": 1,
+        "cache_busted_og_site_name_count": 1,
+        "og_site_name": "Kris Krüg | Generative AI Tools & Techniques"
+      },
+      {
+        "path": "/2026/01/24/both-hands-full/",
+        "document_title": "Both Hands Full — Kris Krug | AI Keynote Speaker & Creative Technologist",
+        "normal_http_status": 200,
+        "cache_busted_http_status": 200,
+        "normal_og_site_name_count": 1,
+        "cache_busted_og_site_name_count": 1,
+        "og_site_name": "Kris Krüg | Generative AI Tools & Techniques"
+      }
+    ]
+  },
+  "source_map": {
+    "wordpress_option": "blogname",
+    "public_readback": "GET https://kriskrug.co/wp-json/ field name",
+    "active_aurora_reader": "theme/kk-aurora/functions.php social_meta_tags og:site_name",
+    "inactive_bridge_reader": "fixes/og-restore-snippet.php $site",
+    "document_title_owner": "theme/kk-aurora/functions.php filter_document_title_parts"
+  },
+  "proposed_change": {
+    "wordpress_option": "blogname",
+    "current_decoded_value": "Kris Krüg | Generative AI Tools & Techniques",
+    "target_value": "Kris Krug",
+    "allowed_writes": [
+      "wordpress_option:blogname"
+    ],
+    "repo_rendering_code_change_required": false,
+    "reason": "The active and rollback social metadata owners already derive og:site_name from blogname, while Aurora's document-title filter owns the longer keynote descriptor independently."
+  },
+  "future_deployment_if_separately_approved": {
+    "requires": [
+      "explicit approval of the exact blogname change",
+      "fresh authenticated readback of the current blogname",
+      "complete rollback snapshot of the current blogname",
+      "confirmation Aurora remains the active social metadata owner",
+      "confirmation Code Snippet 12 remains inactive",
+      "confirmation no concurrent WordPress settings edit is in progress"
+    ],
+    "allowed_actions": [
+      "set blogname to Kris Krug"
+    ],
+    "forbidden_actions": [
+      "change the WordPress tagline",
+      "activate or edit Code Snippet 12",
+      "upload or edit Aurora",
+      "edit schema Code Snippet 5",
+      "edit posts, pages, media, or taxonomies",
+      "change analytics, Search Console, DNS, permissions, or credentials"
+    ],
+    "immediate_readback": [
+      "authenticated blogname",
+      "public REST root name",
+      "anonymous homepage og:site_name",
+      "cache-busted homepage og:site_name",
+      "homepage document title"
+    ],
+    "rollback": [
+      "restore the exact captured blogname",
+      "purge PressCACHE",
+      "repeat authenticated, public REST, anonymous, and cache-busted readback"
+    ]
+  },
+  "post_deploy_evaluation": {
+    "sample_urls": [
+      "https://kriskrug.co/",
+      "https://kriskrug.co/about/",
+      "https://kriskrug.co/speaking/",
+      "https://kriskrug.co/blog/",
+      "https://kriskrug.co/2026/01/24/both-hands-full/"
+    ],
+    "checks": [
+      "authenticated_blogname",
+      "public_rest_root",
+      "anonymous_normal_html",
+      "anonymous_cache_busted_html",
+      "crawler_user_agents",
+      "rss_feed_title",
+      "document_title",
+      "metadata_owner"
+    ],
+    "crawler_user_agents": [
+      "Twitterbot",
+      "facebookexternalhit",
+      "Googlebot"
+    ],
+    "expected": [
+      "public REST name is Kris Krug",
+      "exactly one og:site_name with value Kris Krug",
+      "document titles remain unchanged",
+      "Aurora remains the only active social metadata owner",
+      "Code Snippet 12 remains inactive",
+      "all sampled routes remain HTTP 200"
+    ],
+    "recrawl_policy": "Do not consume priority Search Console indexing quota for a site-name-only option change. Let normal crawling pick it up after public verification."
+  },
+  "adjacent_findings": {
+    "missing_homepage_og_title": {
+      "issue": 346,
+      "normal_count": 0,
+      "cache_busted_count": 0,
+      "expected_owner": "Aurora",
+      "status": "separately-tracked"
+    },
+    "missing_blog_canonical": {
+      "issue": 347,
+      "normal_count": 0,
+      "cache_busted_count": 0,
+      "present_in_page_sitemap": true,
+      "sitemap": "https://kriskrug.co/wp-sitemap-posts-page-1.xml",
+      "status": "separately-tracked"
+    }
+  },
+  "out_of_scope_issue_numbers": [
+    316,
+    346,
+    347
+  ],
+  "out_of_scope": [
+    "Person and WebSite schema deployment",
+    "homepage Open Graph title repair",
+    "Blog canonical repair",
+    "theme or plugin deployment",
+    "temporary bridge reactivation",
+    "post, page, media, or taxonomy changes",
+    "Search Console submissions or removals",
+    "analytics, DNS, permissions, or credentials"
+  ]
+}

--- a/fixes/issue-345-og-site-name-handoff-2026-07-13.md
+++ b/fixes/issue-345-og-site-name-handoff-2026-07-13.md
@@ -1,0 +1,100 @@
+# Issue #345: WordPress and Open Graph Site-Name Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-345-og-site-name-handoff-2026-07-13.json`
+
+## Decision
+
+Change only the WordPress `blogname` option from
+`Kris Krüg | Generative AI Tools & Techniques` to `Kris Krug` in a future,
+separately approved production session.
+
+No rendering-code change is required. Aurora already reads `blogname` for
+`og:site_name`, while its document-title filter independently preserves the
+longer `Kris Krug | AI Keynote Speaker & Creative Technologist` positioning.
+
+No live WordPress write was performed in this worker lane.
+
+## Live Evidence
+
+Anonymous readback on 2026-07-13 established the current production state:
+
+- `GET https://kriskrug.co/wp-json/` returned `200` and the encoded public name
+  `Kris Krüg | Generative AI Tools &amp; Techniques`.
+- The public Aurora stylesheet returned `200` with version `1.3.37`.
+- The production receipt on issue #319 records Aurora 1.3.37 as the active
+  social metadata owner and Code Snippet 12 as inactive.
+- Homepage, About, Speaking, Blog, and a published article returned `200` in
+  both normal and cache-busted reads.
+- Every sample emitted exactly one `og:site_name`, always with the stale value.
+- Every sample retained its keynote-first document title.
+
+Owner receipt:
+https://github.com/WalksWithASwagger/kriskrug-wp/issues/319#issuecomment-4953532560
+
+The repo matches that ownership model. Aurora's `social_meta_tags()` maps
+`og:site_name` to `get_bloginfo('name')`, and the inactive bridge mirror also
+reads `get_bloginfo('name')`. The longer document-title descriptor is hardcoded
+separately in `filter_document_title_parts()`.
+
+## Exact Future Change
+
+| Field | Before | After |
+| --- | --- | --- |
+| WordPress option | `blogname` | `blogname` |
+| Value | `Kris Krüg | Generative AI Tools & Techniques` | `Kris Krug` |
+
+The future production action may set only `blogname`. It must not change the
+tagline, activate or edit Code Snippet 12, upload Aurora, edit schema Code
+Snippet 5, or modify any content, analytics, Search Console, DNS, permissions,
+or credentials.
+
+## Separate Deployment Gate
+
+Do not apply this handoff from the worker lane.
+
+1. Obtain explicit approval for the exact `blogname` value `Kris Krug`.
+2. Read the authenticated current option and stop if it no longer matches the
+   public evidence in the manifest.
+3. Capture the complete current value as the rollback snapshot.
+4. Confirm Aurora still owns social metadata and Code Snippet 12 is inactive.
+5. Confirm no concurrent WordPress settings edit is in progress.
+6. Change only `blogname`, then stop all further writes.
+7. Read back the authenticated option, public REST root, anonymous homepage,
+   cache-busted homepage, and homepage document title immediately.
+8. Purge PressCACHE only if the public value remains stale after the option is
+   correct, then repeat the readback.
+9. Restore the exact captured value and purge PressCACHE if the site name,
+   title, owner, route status, or metadata-count invariant fails.
+
+## Post-Change Evaluation
+
+Check the homepage, About, Speaking, Blog, and the sampled Both Hands Full
+article with normal, cache-busted, Twitterbot, Facebook, and Googlebot reads.
+
+Expected results:
+
+- public REST `name` is `Kris Krug`;
+- every route returns `200`;
+- every route emits exactly one `og:site_name` with value `Kris Krug`;
+- every document title remains byte-for-byte unchanged from the manifest;
+- Aurora remains the only active social metadata owner;
+- Code Snippet 12 remains inactive;
+- RSS titles reflect the concise site name as an expected consequence.
+
+Do not spend priority Search Console indexing quota on this option-only change.
+Natural recrawl is sufficient after the public checks pass.
+
+## Adjacent Findings
+
+The route matrix exposed two independent defects that must not be folded into
+this one-option production action:
+
+- Issue #346 tracks the homepage's missing `og:title` in both normal and
+  cache-busted HTML.
+- Issue #347 tracks the missing canonical on `/blog/`, which is a `200` URL
+  listed in the page sitemap.
+
+Issue #316 remains the separate Person and WebSite schema deployment lane. A
+site-name approval does not authorize any of those three changes.

--- a/scripts/tests/test_issue_345_og_site_name.py
+++ b/scripts/tests/test_issue_345_og_site_name.py
@@ -1,0 +1,131 @@
+import html
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-345-og-site-name-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-345-og-site-name-handoff-2026-07-13.md"
+THEME_FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
+OG_BRIDGE = ROOT / "fixes/og-restore-snippet.php"
+
+
+class Issue345OpenGraphSiteNameTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.theme = THEME_FUNCTIONS.read_text(encoding="utf-8")
+        cls.bridge = OG_BRIDGE.read_text(encoding="utf-8")
+        cls.handoff = HANDOFF.read_text(encoding="utf-8")
+
+    def test_live_wordpress_identity_and_owner_are_exact(self):
+        live = self.data["live_before"]
+
+        self.assertEqual("2026-07-13", live["observed_on"])
+        self.assertEqual(200, live["public_rest_root"]["http_status"])
+        self.assertEqual(
+            "Kris Krüg | Generative AI Tools &amp; Techniques",
+            live["public_rest_root"]["raw_name"],
+        )
+        self.assertEqual(
+            "Kris Krüg | Generative AI Tools & Techniques",
+            html.unescape(live["public_rest_root"]["raw_name"]),
+        )
+        self.assertEqual("1.3.37", live["active_aurora_version"])
+        self.assertEqual(12, live["inactive_bridge_snippet_id"])
+        self.assertEqual(
+            "theme/kk-aurora/functions.php::render_social_meta_tags",
+            live["active_social_metadata_owner"],
+        )
+
+    def test_route_matrix_proves_the_site_name_mismatch(self):
+        routes = self.data["live_before"]["route_matrix"]
+
+        self.assertEqual(5, len(routes))
+        self.assertEqual(
+            {"/", "/about/", "/speaking/", "/blog/", "/2026/01/24/both-hands-full/"},
+            {route["path"] for route in routes},
+        )
+        for route in routes:
+            self.assertEqual(200, route["normal_http_status"])
+            self.assertEqual(200, route["cache_busted_http_status"])
+            self.assertEqual(1, route["normal_og_site_name_count"])
+            self.assertEqual(1, route["cache_busted_og_site_name_count"])
+            self.assertEqual(
+                "Kris Krüg | Generative AI Tools & Techniques",
+                route["og_site_name"],
+            )
+            self.assertTrue(route["document_title"])
+
+    def test_change_is_one_scoped_wordpress_option(self):
+        change = self.data["proposed_change"]
+
+        self.assertEqual("blogname", change["wordpress_option"])
+        self.assertEqual("Kris Krug", change["target_value"])
+        self.assertEqual(["wordpress_option:blogname"], change["allowed_writes"])
+        self.assertFalse(change["repo_rendering_code_change_required"])
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+    def test_repo_owners_derive_site_name_and_preserve_title_positioning(self):
+        self.assertRegex(
+            self.theme,
+            re.compile(r"'og:site_name'\s*=>\s*get_bloginfo\('name'\)"),
+        )
+        self.assertRegex(
+            self.bridge,
+            re.compile(r"\$site\s*=\s*get_bloginfo\('name'\)"),
+        )
+        self.assertIn(
+            "Kris Krug | AI Keynote Speaker & Creative Technologist",
+            self.theme,
+        )
+        self.assertIn("Code Snippet 12 is inactive", self.handoff)
+        self.assertIn("No live WordPress write was performed", self.handoff)
+
+    def test_deployment_requires_approval_snapshot_and_public_readback(self):
+        deployment = self.data["future_deployment_if_separately_approved"]
+
+        self.assertIn("explicit approval of the exact blogname change", deployment["requires"])
+        self.assertIn("fresh authenticated readback of the current blogname", deployment["requires"])
+        self.assertIn("complete rollback snapshot of the current blogname", deployment["requires"])
+        self.assertEqual(["set blogname to Kris Krug"], deployment["allowed_actions"])
+        self.assertIn("restore the exact captured blogname", deployment["rollback"])
+        self.assertIn("purge PressCACHE", deployment["rollback"])
+
+    def test_post_deploy_eval_preserves_titles_and_one_metadata_owner(self):
+        evaluation = self.data["post_deploy_evaluation"]
+
+        self.assertEqual(5, len(evaluation["sample_urls"]))
+        self.assertIn("public_rest_root", evaluation["checks"])
+        self.assertIn("anonymous_cache_busted_html", evaluation["checks"])
+        self.assertIn("crawler_user_agents", evaluation["checks"])
+        self.assertIn("exactly one og:site_name with value Kris Krug", evaluation["expected"])
+        self.assertIn("document titles remain unchanged", evaluation["expected"])
+        self.assertIn("Aurora remains the only active social metadata owner", evaluation["expected"])
+
+    def test_adjacent_defects_are_separately_tracked(self):
+        adjacent = self.data["adjacent_findings"]
+
+        self.assertEqual(346, adjacent["missing_homepage_og_title"]["issue"])
+        self.assertEqual(347, adjacent["missing_blog_canonical"]["issue"])
+        self.assertIn(316, self.data["out_of_scope_issue_numbers"])
+        self.assertIn(346, self.data["out_of_scope_issue_numbers"])
+        self.assertIn(347, self.data["out_of_scope_issue_numbers"])
+
+    def test_packet_contains_no_secret_material(self):
+        serialized = json.dumps(self.data).lower()
+        for marker in (
+            "authorization",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "client_secret",
+            "refresh_token",
+        ):
+            self.assertNotIn(marker, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- prove the stale WordPress `blogname` is the source of KrisKrug.co’s outdated `og:site_name`
- pin Aurora 1.3.37 as the active owner and Code Snippet 12 as inactive
- define one allowed future write: set `blogname` to `Kris Krug`
- preserve keynote-first document titles and add exact readback and rollback gates
- track the separately discovered homepage `og:title` and Blog canonical defects in #346 and #347

## Verification

- `python3 -m unittest scripts.tests.test_issue_345_og_site_name` (8 tests)
- `make test` (283 tests plus both plugin smokes)
- `make docs-truth-check`
- `python3 -m json.tool fixes/issue-345-og-site-name-handoff-2026-07-13.json`
- `git diff --check`
- live read-only guard: public REST identity, Aurora 1.3.37, and 5 routes x normal/cache-busted

## Safety

No live WordPress write, option change, snippet edit, theme deploy, content change, Search Console action, or credential read was performed. Issue #345 remains open for explicit approval, authenticated preflight, rollback capture, and production readback.

Refs #345