### PR TITLE
Fix: canonicalize Blog pagination and Open Graph URLs

### DIFF
--- a/scripts/tests/test_issue_347_blog_canonical.py
+++ b/scripts/tests/test_issue_347_blog_canonical.py
@@ -1,0 +1,136 @@
+import json
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
+
+
+def render_archive_identity(*, page: int, page_url: str, is_home: bool = True) -> dict:
+    functions_path = json.dumps(str(FUNCTIONS))
+    page_url_literal = json.dumps(page_url)
+    is_home_literal = "true" if is_home else "false"
+    php = textwrap.dedent(
+        f"""
+        <?php
+        define('ABSPATH', __DIR__);
+
+        $GLOBALS['kk_test_hooks'] = [];
+        $GLOBALS['kk_test_page'] = {page};
+        $GLOBALS['kk_test_page_url'] = {page_url_literal};
+        $GLOBALS['kk_test_is_home'] = {is_home_literal};
+
+        function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {{
+            $GLOBALS['kk_test_hooks'][] = compact('hook', 'callback', 'priority', 'accepted_args');
+        }}
+        function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {{}}
+        function is_home() {{ return $GLOBALS['kk_test_is_home']; }}
+        function is_front_page() {{ return false; }}
+        function get_query_var($name, $default = '') {{
+            return $name === 'paged' ? $GLOBALS['kk_test_page'] : $default;
+        }}
+        function get_pagenum_link($page, $escape = true) {{
+            return $GLOBALS['kk_test_page_url'];
+        }}
+        function wp_parse_url($url, $component = -1) {{ return parse_url($url, $component); }}
+        function home_url($path = '') {{ return 'https://kriskrug.co' . $path; }}
+        function get_option($name, $default = false) {{
+            return $name === 'page_for_posts' ? 4242 : $default;
+        }}
+        function get_permalink($post = 0) {{ return 'https://kriskrug.co/blog/'; }}
+        function get_post_meta($post_id, $key, $single = false) {{ return ''; }}
+        function wp_strip_all_tags($value) {{ return strip_tags($value); }}
+        function trailingslashit($value) {{ return rtrim($value, '/') . '/'; }}
+        function user_trailingslashit($value, $type = '') {{ return trailingslashit($value); }}
+        function esc_url($value) {{ return $value; }}
+        function esc_url_raw($value) {{ return $value; }}
+
+        require {functions_path};
+
+        $canonical = KK_Aurora\\writing_archive_canonical_url();
+        ob_start();
+        KK_Aurora\\render_writing_archive_canonical();
+        $link = ob_get_clean();
+        $tags = KK_Aurora\\writing_archive_open_graph_fallback([
+            'og:url' => 'https://kriskrug.co/',
+            'og:title' => 'Writing — Kris Krug',
+        ]);
+        $canonical_hooks = array_values(array_filter(
+            $GLOBALS['kk_test_hooks'],
+            fn($row) => $row['callback'] === 'KK_Aurora\\\\render_writing_archive_canonical'
+        ));
+
+        echo json_encode([
+            'canonical' => $canonical,
+            'link' => $link,
+            'tags' => $tags,
+            'canonical_hooks' => $canonical_hooks,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        """
+    ).lstrip()
+
+    with tempfile.NamedTemporaryFile("w", suffix=".php", encoding="utf-8") as handle:
+        handle.write(php)
+        handle.flush()
+        result = subprocess.run(
+            ["php", handle.name],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return json.loads(result.stdout)
+
+
+class Issue347BlogCanonicalTests(unittest.TestCase):
+    def test_page_one_strips_irrelevant_query_parameters(self):
+        result = render_archive_identity(
+            page=1,
+            page_url="https://kriskrug.co/blog/?utm_source=canonical-test",
+        )
+
+        self.assertEqual("https://kriskrug.co/blog/", result["canonical"])
+        self.assertEqual(result["canonical"], result["tags"]["og:url"])
+        self.assertEqual(
+            '<link rel="canonical" href="https://kriskrug.co/blog/" />',
+            result["link"].strip(),
+        )
+        self.assertEqual(1, result["link"].count('rel="canonical"'))
+
+    def test_page_two_keeps_its_own_clean_paginated_url(self):
+        result = render_archive_identity(
+            page=2,
+            page_url="https://kriskrug.co/blog/page/2/?utm_medium=canonical-test",
+        )
+
+        self.assertEqual("https://kriskrug.co/blog/page/2/", result["canonical"])
+        self.assertEqual(result["canonical"], result["tags"]["og:url"])
+        self.assertIn('href="https://kriskrug.co/blog/page/2/"', result["link"])
+        self.assertEqual("Writing — Kris Krug", result["tags"]["og:title"])
+
+    def test_non_blog_routes_do_not_gain_an_archive_canonical(self):
+        result = render_archive_identity(
+            page=1,
+            page_url="https://kriskrug.co/about/",
+            is_home=False,
+        )
+
+        self.assertEqual("", result["canonical"])
+        self.assertEqual("", result["link"])
+        self.assertEqual("https://kriskrug.co/", result["tags"]["og:url"])
+
+    def test_canonical_renderer_has_one_early_head_hook(self):
+        result = render_archive_identity(
+            page=1,
+            page_url="https://kriskrug.co/blog/",
+        )
+
+        self.assertEqual(1, len(result["canonical_hooks"]))
+        self.assertLess(result["canonical_hooks"][0]["priority"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -542,6 +542,38 @@ function public_meta_description(): string {
 }
 
 /**
+ * Resolve the clean URL for the current page of the Writing archive.
+ */
+function writing_archive_canonical_url(): string {
+    if (!is_home() || is_front_page()) {
+        return '';
+    }
+
+    $paged = max(1, (int) get_query_var('paged'));
+    $page_url = get_pagenum_link($paged, false);
+    $path = wp_parse_url($page_url, PHP_URL_PATH);
+
+    if (!is_string($path) || $path === '') {
+        return '';
+    }
+
+    return home_url($path);
+}
+
+/**
+ * Give the posts archive the canonical that WordPress core omits.
+ */
+function render_writing_archive_canonical(): void {
+    $canonical = writing_archive_canonical_url();
+    if ($canonical === '') {
+        return;
+    }
+
+    printf('<link rel="canonical" href="%s" />' . "\n", esc_url($canonical));
+}
+add_action('wp_head', __NAMESPACE__ . '\\render_writing_archive_canonical', 4);
+
+/**
  * Build the site's canonical search, Open Graph, and Twitter Card values.
  *
  * @return array<string, string>
@@ -683,8 +715,12 @@ function writing_archive_open_graph_fallback(array $tags): array {
 
     $image = 'https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/02/06-mycelial-action-network.png?fit=1200%2C686&ssl=1';
     $description = writing_archive_meta_description();
+    $canonical = writing_archive_canonical_url();
 
     $tags['og:title'] = 'Writing — Kris Krug';
+    if ($canonical !== '') {
+        $tags['og:url'] = $canonical;
+    }
     $tags['og:description'] = $description;
     $tags['og:image'] = $image;
     $tags['og:image:secure_url'] = $image;


### PR DESCRIPTION
## Summary

- resolve a clean self URL for each valid Blog archive page using WordPress pagination and parsed path data
- emit the missing canonical before Aurora’s social metadata
- use that same clean URL for the Blog archive’s `og:url`
- discard tracking and irrelevant query parameters without collapsing page N to page one
- leave all non-Blog routes and existing archive title/description/image metadata unchanged

## Evidence

Production `/blog/`, `/blog/page/2/`, and `/blog/page/3/` return `200`, are indexable, and have one H1, but emit no canonical and incorrectly use the homepage as `og:url`. Read-only Search Console inspection reports `/blog/` as submitted/indexed, with Google currently selecting the correct canonical while `userCanonical` is absent.

## Verification

- `python3 -m unittest scripts.tests.test_issue_347_blog_canonical` (4 executable PHP cases)
- `php -l theme/kk-aurora/functions.php`
- `make test` (54 publisher, 165 operational, 3 inventory, 68 SEO tests, plus JS and both plugin smokes)
- `make docs-truth-check`
- `git diff --check`

## Safety

No Aurora version bump, package, deployment, live WordPress write, content change, option/snippet edit, Search Console write, or credential exposure was performed. Production and crawler verification remain part of the combined release gate.

Refs #347