### PR TITLE
Release: prepare Aurora 1.3.39 SEO metadata package

### DIFF
--- a/backup/aurora-deploy-20260713/DEPLOY-HANDOFF.md
+++ b/backup/aurora-deploy-20260713/DEPLOY-HANDOFF.md
@@ -1,0 +1,96 @@
+# WordPress Theme Upload Package
+
+**Status:** package-ready; production not deployed
+
+- Source: `/Users/kk/.codex/worktrees/kriskrug-wp-issue-351/theme/kk-aurora`
+- Slug: `kk-aurora`
+- Label: `seo-metadata`
+- Version: `1.3.39`
+- Deploy zip: `/Users/kk/Code/kriskrug-wp/backup/aurora-deploy-20260713/kk-aurora-seo-metadata-1.3.39-20260713.zip`
+- Deploy SHA256: `d4a812abe51a1d879be4a290a7381b6d9222a08a4fd1cc2145b1adf67019e86d`
+- Rollback zip: `/Users/kk/Code/kriskrug-wp/backup/aurora-deploy-20260713/kk-aurora-live-rollback-1.3.37-20260713.zip`
+- Rollback version: `1.3.37`
+- Rollback SHA256: `aef9c779b216d04fe5c500868137822f598c8036e31f15477ebb4f5f0e9b62d9`
+- wp-admin upload URL: https://kriskrug.co/wp-admin/theme-install.php?browse=upload
+- Clipboard: not requested
+- Browser: not requested
+
+## Manual Upload Gate
+
+1. Open the wp-admin upload URL.
+2. Upload `kk-aurora-seo-metadata-1.3.39-20260713.zip`.
+3. Choose the WordPress replace/update flow for the existing artifact.
+4. Confirm WordPress reports the expected uploaded version.
+5. Purge PressCACHE/cache layers and run the route-specific verification for the change.
+
+Production upload requires this exact approval:
+
+> Deploy Aurora 1.3.39 to kriskrug.co using the prepared SEO metadata package and run the documented verification.
+
+This package must not be uploaded based only on issue or pull-request approval.
+
+## Release Scope
+
+Included:
+
+- #36: emit one standard meta description from the existing Jetpack SEO fields.
+- #346: preserve the keynote-first homepage Open Graph title when the front-page object title is empty.
+- #347: emit a clean self-canonical and matching `og:url` for every Blog archive page.
+
+Explicitly excluded:
+
+- #316: Person and WebSite schema Code Snippet deployment.
+- #345: WordPress `blogname` change.
+- Any content, analytics, Search Console, DNS, permissions, credential, plugin, or unrelated WordPress write.
+
+## Package Verification
+
+- `make test`: 293 tests passed, including publisher, operational, inventory, Python, JavaScript, and plugin smoke checks.
+- Documentation truth checks passed.
+- PHP syntax checks passed.
+- `make verify` completed the available test and documentation gates, then stopped only because local `phpcs` is not installed. Pull-request CI must run the PHP validation gate before merge.
+- Both archives passed `unzip -t` with no compressed-data errors.
+- Deploy package readback reports Aurora `1.3.39` and contains the homepage-title and Blog-canonical repairs.
+- Rollback package readback reports Aurora `1.3.37`.
+
+## Production Preflight
+
+Fresh read-only evidence from 2026-07-13 records Aurora `1.3.37` as the live theme and Code Snippet 12 as inactive. Immediately before an approved upload:
+
+1. Reconfirm the public theme version is still `1.3.37`.
+2. Reconfirm Code Snippet 12 is inactive and Aurora remains the sole social metadata owner.
+3. Confirm the deploy and rollback hashes still match this handoff.
+4. Stop if any value differs or another WordPress edit is in progress.
+
+## Post-Deploy Verification
+
+After the approved upload, purge PressCACHE and inspect each route in normal, cache-busted, Googlebot, Twitterbot, and Facebook crawler reads:
+
+| Route | Required result |
+| --- | --- |
+| `https://kriskrug.co/` | `200`; one non-empty `og:title`; existing document title unchanged |
+| `https://kriskrug.co/blog/` | `200`; canonical and `og:url` both equal `https://kriskrug.co/blog/` |
+| `https://kriskrug.co/blog/page/2/` | `200`; canonical and `og:url` both equal `https://kriskrug.co/blog/page/2/` |
+| `https://kriskrug.co/about/` | `200`; title and existing social metadata remain unchanged |
+| `https://kriskrug.co/speaking/` | `200`; title and existing social metadata remain unchanged |
+| `https://kriskrug.co/2026/01/24/both-hands-full/` | `200`; one standard description and existing social metadata remain valid |
+
+Across the matrix:
+
+- standard descriptions appear exactly once where configured;
+- titles remain byte-for-byte unchanged from the preflight capture;
+- every page has only one active metadata owner;
+- Blog page N canonicals and `og:url` values agree;
+- JSON-LD remains valid;
+- no route regresses from `200`.
+
+Run read-only Search Console URL Inspection for `/` and `/blog/` after public verification. Do not request indexing for this release.
+
+## Rollback
+
+If any route status, title, description, canonical, Open Graph, ownership, or JSON-LD invariant fails:
+
+1. Upload `kk-aurora-live-rollback-1.3.37-20260713.zip` through the WordPress replace/update flow.
+2. Confirm WordPress reports version `1.3.37`.
+3. Purge PressCACHE and repeat the full route and crawler matrix.
+4. Record the failure and rollback evidence on #351 before any further production write.

--- a/scripts/tests/test_issue_351_aurora_release.py
+++ b/scripts/tests/test_issue_351_aurora_release.py
@@ -1,0 +1,54 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+STYLE = ROOT / "theme/kk-aurora/style.css"
+FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
+README = ROOT / "theme/kk-aurora/readme.txt"
+
+
+class Issue351AuroraReleaseTests(unittest.TestCase):
+    def test_release_version_is_consistent(self):
+        style = STYLE.read_text(encoding="utf-8")
+        functions = FUNCTIONS.read_text(encoding="utf-8")
+
+        style_version = re.search(r"^Version:\s*(\S+)$", style, re.MULTILINE)
+        cache_version = re.search(
+            r"define\('KK_AURORA_VERSION',\s*'([^']+)'\);",
+            functions,
+        )
+
+        self.assertIsNotNone(style_version)
+        self.assertIsNotNone(cache_version)
+        self.assertEqual("1.3.39", style_version.group(1))
+        self.assertEqual(style_version.group(1), cache_version.group(1))
+
+    def test_changelog_names_both_metadata_repairs(self):
+        readme = README.read_text(encoding="utf-8")
+
+        release_start = readme.index("= 1.3.39 =")
+        prior_start = readme.index("= 1.3.38 =")
+        release = readme[release_start:prior_start]
+
+        self.assertLess(release_start, prior_start)
+        self.assertIn("homepage Open Graph title", release)
+        self.assertIn("Blog archive", release)
+        self.assertIn("canonical", release)
+        self.assertIn("Open Graph URL", release)
+        self.assertIn("#346", release)
+        self.assertIn("#347", release)
+
+    def test_release_keeps_the_expected_metadata_owners(self):
+        functions = FUNCTIONS.read_text(encoding="utf-8")
+
+        self.assertIn("function render_social_meta_tags", functions)
+        self.assertIn("KK_OG_SNIPPET_ACTIVE", functions)
+        self.assertIn("function writing_archive_canonical_url", functions)
+        self.assertIn("function render_writing_archive_canonical", functions)
+        self.assertIn("wp_get_document_title()", functions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.38');
+define('KK_AURORA_VERSION', '1.3.39');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,10 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.39 =
+* Preserve the keynote-first homepage Open Graph title when the front-page object title is empty (#346).
+* Give every Blog archive page a clean self-canonical and matching Open Graph URL (#347).
+
 = 1.3.38 =
 * Restore one standard search description from the existing Jetpack SEO fields and align social descriptions to the same source.
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.38
+Version: 1.3.39
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary
- bump Aurora from 1.3.38 to 1.3.39 and record the homepage Open Graph title and Blog canonical repairs
- add a release-contract test for version consistency, changelog coverage, and metadata ownership
- record the verified deploy and rollback packages with explicit production approval, route-matrix, and rollback gates

## Scope
Includes #36, #346, and #347. Excludes the #316 schema snippet and #345 WordPress site-name write. This PR does not upload WordPress, open wp-admin, or claim a live deployment.

## Packages
- deploy: `kk-aurora-seo-metadata-1.3.39-20260713.zip`
  SHA256: `d4a812abe51a1d879be4a290a7381b6d9222a08a4fd1cc2145b1adf67019e86d`
- rollback: `kk-aurora-live-rollback-1.3.37-20260713.zip`
  SHA256: `aef9c779b216d04fe5c500868137822f598c8036e31f15477ebb4f5f0e9b62d9`

## Verification
- `make test`: 293 tests passed plus both plugin smokes
- `make docs-truth-check`: passed
- `php -l theme/kk-aurora/functions.php`: passed
- both archives: `unzip -t` passed
- embedded deploy version and metadata paths read back successfully
- embedded rollback version is 1.3.37
- local `make verify` reaches PHP_CodeSniffer and stops because `phpcs` is not installed; CI must supply that final PHP validation gate

Refs #351
Refs #36
Refs #346
Refs #347