### PR TITLE
Add: Guarded body H1 migration for issue #353

### DIFF
--- a/fixes/issue-353-body-h1-migration-2026-07-13.json
+++ b/fixes/issue-353-body-h1-migration-2026-07-13.json
@@ -1,0 +1,338 @@
+{
+  "issue": 353,
+  "status": "repo-only-migration-packet",
+  "generated_at": "2026-07-13T20:27:00-07:00",
+  "timezone": "America/Vancouver",
+  "method": "authenticated context=edit inventory plus source-digest-gated exact heading patches",
+  "observed": {
+    "published_posts_scanned": 967,
+    "published_pages_scanned": 45,
+    "published_posts_and_pages_scanned": 1012,
+    "source_objects_with_body_h1": 15,
+    "migration_targets": 14,
+    "target_body_h1_total": 44,
+    "authenticated_read_performed": true,
+    "wordpress_write_performed": false,
+    "search_console_write_performed": false
+  },
+  "claims": {
+    "migration_live_from_this_packet": false,
+    "ranking_lift_claimed": false,
+    "credentials_committed": false
+  },
+  "homepage_exclusion": {
+    "id": 3930,
+    "endpoint": "pages",
+    "type": "page",
+    "slug": "empowering-events-organizations-for-the-ai-age",
+    "status": "publish",
+    "modified_gmt": "2026-06-30T00:49:49",
+    "url": "https://kriskrug.co/",
+    "raw_sha256": "c94b1d028e7d8ecc6f74473f447ccf44e81b636137d3fe858d4f3dde934eac48",
+    "raw_length": 4549,
+    "body_h1_count": 1,
+    "format": "gutenberg",
+    "heading_texts": [
+      "Kris Krüg, Generative AI for Creative Professionals"
+    ],
+    "reason": "intentional-homepage-hero-h1"
+  },
+  "targets": [
+    {
+      "id": 11358,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "spa-at-the-end-of-time",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:26:43",
+      "url": "https://kriskrug.co/2026/02/20/spa-at-the-end-of-time/",
+      "raw_sha256": "9b10466fd29f4bbb22990591be213715388451a8f28f9eff856c5d4afa100ccb",
+      "raw_length": 14818,
+      "expected_after_sha256": "9b193011643464cfa5aaae370af38b3718737545bff93847a4edce43d5616154",
+      "expected_after_length": 14818,
+      "body_h1_count": 9,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "What you’re walking into",
+        "The images: comfort tech turns into cosmic interface",
+        "The voice: a medium, not a narrator",
+        "The AI part: a haunted paintbrush",
+        "The dome does something to your body",
+        "The room: artists, weirdos, and people who actually make things",
+        "Why it landed: it’s a spa, it’s a warning, it’s a love letter",
+        "Receipts",
+        "Challenger idea"
+      ]
+    },
+    {
+      "id": 7927,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "ais-next-chapter-notes-from-bcs-ai-ecosystem",
+      "status": "publish",
+      "modified_gmt": "2026-06-15T04:06:58",
+      "url": "https://kriskrug.co/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/",
+      "raw_sha256": "979c550f2d4c2aba75abeadb4a4a6f45bdd304dd37e598017bc3f07bdb5b4fd7",
+      "raw_length": 23916,
+      "expected_after_sha256": "69c68a5e549a453856c675d0bc3bed19f213cc14f3d5a39a7aea2c36aea62b3c",
+      "expected_after_length": 23916,
+      "body_h1_count": 5,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "The Inside Out Revolution",
+        "ChatGPT's Reality Check",
+        "The Growing Pains",
+        "The 2025 Vision",
+        "AI Education & Adoption in British Columbia AI Ecosystem"
+      ]
+    },
+    {
+      "id": 6453,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "small-file-rebellion-hacking-the-digital-carbon-footprint-at-our-networks-2024",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:33:11",
+      "url": "https://kriskrug.co/2024/07/28/small-file-rebellion-hacking-the-digital-carbon-footprint-at-our-networks-2024/",
+      "raw_sha256": "305ffb31101b7f27d7f994ed92e24fe2778009021293a805e9dff3c955b528c5",
+      "raw_length": 11998,
+      "expected_after_sha256": "beb09f77edb4572960a4045fd58c2c9a3559ee7b0e57b2217027c4a2f48562c3",
+      "expected_after_length": 11998,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "#SmallFileRebellion #OurNetworks2024 #DigitalDiet #EcoFriendlyPixels"
+      ]
+    },
+    {
+      "id": 6435,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "digital-rebellion-w-lori-emersons-at-our-networks-2024",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:33:21",
+      "url": "https://kriskrug.co/2024/07/27/digital-rebellion-w-lori-emersons-at-our-networks-2024/",
+      "raw_sha256": "a8c8a906c137cd2ad76aa6dcbfc1600f1650b51fad2d356904bab3b3e7678e19",
+      "raw_length": 14678,
+      "expected_after_sha256": "8a2e68dd71a686457cdfdea62a15c1a7750b4859ccf7d23bb2fe2cef88e0ba68",
+      "expected_after_length": 14678,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "#DigitalRebellion #OurNetworks2024 #UnpluggedAndUnchained"
+      ]
+    },
+    {
+      "id": 6344,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "fuck-the-status-quo-ais-messy-love-child-with-creativity",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:33:25",
+      "url": "https://kriskrug.co/2024/07/19/fuck-the-status-quo-ais-messy-love-child-with-creativity/",
+      "raw_sha256": "ca5290eacbaba865cb5de4ddecd10aad78a3a0ab7d2d8da3cdd89ad86e87491e",
+      "raw_length": 33112,
+      "expected_after_sha256": "27fbafc572787dda74cfc1461d79e07672ac3e078e7f046625c6c5906810b6a9",
+      "expected_after_length": 33112,
+      "body_h1_count": 9,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "SUMMARY",
+        "IDEAS:",
+        "INSIGHTS:",
+        "QUOTES:",
+        "HABITS:",
+        "FACTS:",
+        "REFERENCES:",
+        "ONE-SENTENCE TAKEAWAY",
+        "RECOMMENDATIONS:"
+      ]
+    },
+    {
+      "id": 4826,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "join-the-future-proof-creatives-community",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:36:09",
+      "url": "https://kriskrug.co/2024/03/05/join-the-future-proof-creatives-community/",
+      "raw_sha256": "59306ae2ade276de6ae3bbe93745fafbaa6ca4d2a0f74ae12920d1e4aecf87a8",
+      "raw_length": 19853,
+      "expected_after_sha256": "043a542624a6fecfa48b510d4e797416d00f2dcb8b466dc05c5bc76c10a11399",
+      "expected_after_length": 19853,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Appendix: FAQs"
+      ]
+    },
+    {
+      "id": 4174,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "2024-the-year-of-ai-revolution-a-rebels-guide-to-predicting-the-future",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:36:36",
+      "url": "https://kriskrug.co/2024/01/19/2024-the-year-of-ai-revolution-a-rebels-guide-to-predicting-the-future/",
+      "raw_sha256": "b968d719dcb30bdb1661b03860de75d8fee7e7376a9573661ed3001e27a53b0c",
+      "raw_length": 15430,
+      "expected_after_sha256": "67552b93060dd76d01a6e5c52a6c8b2fa5e9b28ac2ebd7c1f34301e7a7bf3cc6",
+      "expected_after_length": 15430,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Navigating the AI Landscape in 2024"
+      ]
+    },
+    {
+      "id": 4372,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "building-ai-companions-w-john-anthony-hartman-of-ihaverobots",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:36:40",
+      "url": "https://kriskrug.co/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/",
+      "raw_sha256": "1b2368b8bab5781f3f5487691bcf3ad9e402645b72cf7cc17daa567a31b6e282",
+      "raw_length": 8238,
+      "expected_after_sha256": "5998ffd6513ff8c85b0bf53d69ff89d72b73a0f79cf3eb2453cd790913c0be88",
+      "expected_after_length": 8238,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Chasing the Muses: John Anthony Hartman's Art Residency w/ MØTLEYKRÜG Media"
+      ]
+    },
+    {
+      "id": 3908,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "web3-will-fail-if-it-doesnt-put-people-before-profits-and-technology",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:37:17",
+      "url": "https://kriskrug.co/2023/11/01/web3-will-fail-if-it-doesnt-put-people-before-profits-and-technology/",
+      "raw_sha256": "ea43cecce97779b772672cefa38263f40262716c8c0851d1a02406df445a92be",
+      "raw_length": 9847,
+      "expected_after_sha256": "a593beea5f867a5de8fc8cc7d49c32f7524fcad8bf2569004d369aa150c003f8",
+      "expected_after_length": 9847,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Reimagining Web3's Foundation"
+      ]
+    },
+    {
+      "id": 3567,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "community-art-project-development-process-guide",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:38:07",
+      "url": "https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/",
+      "raw_sha256": "0cf92d30ac25aa29e46a4df26a134cd996c4a691416bac4f983917ba859f446e",
+      "raw_length": 14618,
+      "expected_after_sha256": "ad72cac290ebb23cca31650d2c0c6ee3d4a6c0493eb3461e4a23948003831a75",
+      "expected_after_length": 14618,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Building Community Through Art: A Guide to Navigating the Complexities of Community Art Projects"
+      ]
+    },
+    {
+      "id": 3151,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "newsletter-002-rebirth-and-revolution",
+      "status": "publish",
+      "modified_gmt": "2026-06-15T04:36:04",
+      "url": "https://kriskrug.co/2023/09/18/newsletter-002-rebirth-and-revolution/",
+      "raw_sha256": "189796c84ae753ac732619f139fd2e40ddcddb8cb83740fde5b26265434f1916",
+      "raw_length": 76450,
+      "expected_after_sha256": "6233abf4bb8e06f05ce2398e17a3004922ce1b4c79e1cf32ef2022fad2e8af09",
+      "expected_after_length": 76450,
+      "body_h1_count": 6,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "Hello Friends!",
+        "Upcoming Events:",
+        "Community Shoutouts:",
+        "News & Updates:",
+        "New MØTLEYKRÜG Podcast Episodes:",
+        "New Videoblogs on YOUTUBE:"
+      ]
+    },
+    {
+      "id": 2857,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "through-my-lens-new-projects-and-updates-from-kris-krug",
+      "status": "publish",
+      "modified_gmt": "2026-06-29T04:39:15",
+      "url": "https://kriskrug.co/2023/08/22/through-my-lens-new-projects-and-updates-from-kris-krug/",
+      "raw_sha256": "c6b1ce00c4cf5cc8289ea21530b6c3580ae60312101d389788c9c1ffffec15de",
+      "raw_length": 50617,
+      "expected_after_sha256": "4202e03fc8436ecd8e8645bbdc00f941ff56389084c5e70126e94daaa70376e1",
+      "expected_after_length": 50617,
+      "body_h1_count": 6,
+      "expected_after_body_h1_count": 0,
+      "format": "gutenberg",
+      "heading_texts": [
+        "News & Updates:",
+        "Upcoming:",
+        "Highlight: Generative AI's Role in Art and Creativity: A Deep Dive on YouTube",
+        "Shout-Outs:",
+        "Lets Work Together: 778.898.3076",
+        "Get In Touch:"
+      ]
+    },
+    {
+      "id": 1547,
+      "endpoint": "posts",
+      "type": "post",
+      "slug": "photo-essay-inside-the-negotiations-cop15",
+      "status": "publish",
+      "modified_gmt": "2026-07-11T19:45:56",
+      "url": "https://kriskrug.co/2009/12/14/photo-essay-inside-the-negotiations-cop15/",
+      "raw_sha256": "1264538397e97058ca23a0874eab6ac8bcdd247b43126b46988e6c1b0aed22b0",
+      "raw_length": 6306,
+      "expected_after_sha256": "5fdcbaedca580757dac223bfdcdcbeb98f5057c73b8f404b3611499c89500d7f",
+      "expected_after_length": 6306,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "classic",
+      "heading_texts": [
+        "COP15 United Nations Climate Change Summit"
+      ]
+    },
+    {
+      "id": 12013,
+      "endpoint": "pages",
+      "type": "page",
+      "slug": "photography",
+      "status": "publish",
+      "modified_gmt": "2026-06-17T16:02:00",
+      "url": "https://kriskrug.co/photography/",
+      "raw_sha256": "bf8dabd8d52e5c975866459ce6a4f80bb2f7a37046dd9e3f95dfff22ea5034e5",
+      "raw_length": 12504,
+      "expected_after_sha256": "5aca1f05b16edc79f0cf3e4fbcd1df98bf36344f53cdb7fe0e1ea5b423f02185",
+      "expected_after_length": 12504,
+      "body_h1_count": 1,
+      "expected_after_body_h1_count": 0,
+      "format": "classic",
+      "heading_texts": [
+        "Two decades in the room, with a camera."
+      ]
+    }
+  ]
+}

--- a/fixes/issue-353-body-h1-migration-2026-07-13.md
+++ b/fixes/issue-353-body-h1-migration-2026-07-13.md
@@ -1,0 +1,151 @@
+# Issue #353: Legacy Body H1 Migration Packet
+
+**Track:** A - Content + SEO
+**Status:** repo-only migration packet; no live WordPress write
+**Manifest:** `fixes/issue-353-body-h1-migration-2026-07-13.json`
+**Tool:** `scripts/body_h1_migration.py`
+
+## Decision
+
+Fourteen published routes render the template title plus at least one body H1.
+This packet prepares exact source-digest-gated changes from body H1 to H2. It
+does not change titles, copy, slugs, dates, links, media, taxonomy, metadata,
+publication status, Search Console, or the intentional homepage hero H1.
+
+This packet does not claim a ranking lift. The repair gives each affected route
+one clear document-level H1 and removes an avoidable heading-structure defect.
+
+## Evidence Boundary
+
+An authenticated, read-only WordPress `context=edit` inventory ran on July 13,
+2026 in America/Vancouver:
+
+- 967 published posts and 45 published pages were scanned.
+- 15 source objects contained body H1 elements.
+- Homepage page ID `3930` is the intentional exception and remains unchanged.
+- The other 14 sources contain 44 body H1 elements.
+- Twelve targets use Gutenberg `core/heading` level-1 blocks.
+- Two targets contain one source-digest-locked classic H1 element each.
+- No credential, application password, raw body, or private snapshot is stored
+  in this packet.
+
+## Locked Scope
+
+| ID | Type | Body H1s | Format | Source SHA-256 prefix | URL |
+|---:|---|---:|---|---|---|
+| 11358 | Post | 9 | Gutenberg | `9b10466fd29f` | `https://kriskrug.co/2026/02/20/spa-at-the-end-of-time/` |
+| 7927 | Post | 5 | Gutenberg | `979c550f2d4c` | `https://kriskrug.co/2024/12/31/ais-next-chapter-notes-from-bcs-ai-ecosystem/` |
+| 6453 | Post | 1 | Gutenberg | `305ffb31101b` | `https://kriskrug.co/2024/07/28/small-file-rebellion-hacking-the-digital-carbon-footprint-at-our-networks-2024/` |
+| 6435 | Post | 1 | Gutenberg | `a8c8a906c137` | `https://kriskrug.co/2024/07/27/digital-rebellion-w-lori-emersons-at-our-networks-2024/` |
+| 6344 | Post | 9 | Gutenberg | `ca5290eacbab` | `https://kriskrug.co/2024/07/19/fuck-the-status-quo-ais-messy-love-child-with-creativity/` |
+| 4826 | Post | 1 | Gutenberg | `59306ae2ade2` | `https://kriskrug.co/2024/03/05/join-the-future-proof-creatives-community/` |
+| 4174 | Post | 1 | Gutenberg | `b968d719dcb3` | `https://kriskrug.co/2024/01/19/2024-the-year-of-ai-revolution-a-rebels-guide-to-predicting-the-future/` |
+| 4372 | Post | 1 | Gutenberg | `1b2368b8bab5` | `https://kriskrug.co/2023/12/28/building-ai-companions-w-john-anthony-hartman-of-ihaverobots/` |
+| 3908 | Post | 1 | Gutenberg | `ea43cecce977` | `https://kriskrug.co/2023/11/01/web3-will-fail-if-it-doesnt-put-people-before-profits-and-technology/` |
+| 3567 | Post | 1 | Gutenberg | `0cf92d30ac25` | `https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/` |
+| 3151 | Post | 6 | Gutenberg | `189796c84ae7` | `https://kriskrug.co/2023/09/18/newsletter-002-rebirth-and-revolution/` |
+| 2857 | Post | 6 | Gutenberg | `c6b1ce00c4cf` | `https://kriskrug.co/2023/08/22/through-my-lens-new-projects-and-updates-from-kris-krug/` |
+| 1547 | Post | 1 | Classic | `1264538397e9` | `https://kriskrug.co/2009/12/14/photo-essay-inside-the-negotiations-cop15/` |
+| 12013 | Page | 1 | Classic | `bf8dabd8d52e` | `https://kriskrug.co/photography/` |
+
+The manifest records each exact ID, endpoint, type, slug, status, modified GMT
+timestamp, URL, raw length, before digest, expected-after digest, body H1 count,
+format, and heading text.
+
+## Homepage Exclusion
+
+Page ID `3930`, `https://kriskrug.co/`, contains the intentional homepage hero
+H1. Its ID, slug, URL, modified timestamp, length, digest, format, and heading
+text are locked separately in the manifest. The migration target list cannot
+contain ID `3930`, and the inventory audit fails if its source or H1 count
+changes unexpectedly.
+
+## Transformation Contract
+
+For Gutenberg targets, the tool parses each complete `wp:heading` comment and
+its JSON attributes. It changes only reviewed blocks whose parsed `level` is
+`1`: the level value becomes `2`, and that block's opening and closing H1 tags
+become H2. It rejects loose H1 markup, malformed blocks, unexpected counts, or
+an after digest that differs from the manifest.
+
+For the two classic targets, the tool changes only the opening and closing tag
+names of the single complete H1 element. The full authenticated source digest,
+length, identity, modified timestamp, and count must all match first.
+
+The exact patch keeps heading text, order, classes, anchors, and every
+non-heading byte unchanged.
+
+## Read-Only Audit And Plan
+
+The default command performs a full authenticated inventory. It accepts the 14
+reviewed sources in either their exact pending or exact migrated state, preserves
+the homepage exception, accepts new H2/H3-only content, and rejects any new
+non-homepage body H1 source.
+
+```bash
+python3 scripts/body_h1_migration.py audit \
+  --env-path "$HOME/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+```
+
+Plan one target without writing or printing its body:
+
+```bash
+python3 scripts/body_h1_migration.py plan \
+  --target-id 11358 \
+  --env-path "$HOME/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+```
+
+## Separately Approved Production Run
+
+No live action is authorized by this packet. A future publisher session needs
+Kris's exact action-time approval, then must process one target at a time:
+
+1. Run the full audit and stop on any drift.
+2. Run `plan` for one approved target and review both digests and H1 counts.
+3. Use the exact per-target confirmation string printed below.
+4. Let the tool write a complete private raw-body snapshot before its only POST.
+5. Let the tool read the same target back and verify identity, expected digest,
+   expected length, and zero body H1s.
+6. Complete public normal, cache-busted, and Googlebot readback before the next
+   target.
+
+The guarded command shape is:
+
+```bash
+python3 scripts/body_h1_migration.py apply \
+  --target-id 11358 \
+  --confirm APPLY-ISSUE-353-TARGET-11358 \
+  --env-path "$HOME/Code/kriskrug-wp/scripts/notion-to-wp/.env"
+```
+
+The confirmation string is a technical interlock, not permission. The tool
+refuses a batch apply and cannot accept more than one target ID.
+
+## Snapshot And Rollback
+
+Before the POST, the tool creates
+`/private/tmp/kriskrug-issue-353-<id>-<UTC timestamp>.json` with mode `0600`.
+It contains the complete authenticated raw body, identity fields, modified GMT
+timestamp, rollback digest, and expected-after digest. The snapshot is local and
+must not be committed.
+
+If write or readback verification fails, stop the batch. In a separately
+approved rollback session, verify the same ID, type, slug, status, and URL, then
+restore only `content` from that target's snapshot and verify the snapshot
+digest. Do not automate a blind rollback over intervening edits.
+
+## Per-Target Completion Gate
+
+Each approved route must pass all of these before the next target:
+
+- WordPress readback matches the expected-after source digest and contains zero
+  body H1 elements.
+- Normal, cache-busted, and Googlebot HTTP requests return `200`.
+- Rendered HTML contains exactly one H1, supplied by the template title.
+- The canonical is self-referential and unique.
+- The route remains indexable and present in the correct post/page sitemap.
+- Title, slug, status, dates, copy, links, media, taxonomy, and metadata remain
+  unchanged.
+
+Do not request Search Console indexing for this migration. Ordinary crawling is
+sufficient after the content repair.

--- a/scripts/body_h1_migration.py
+++ b/scripts/body_h1_migration.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Audit and prepare the issue #353 legacy body-H1 migration.
+
+The default command is a read-only full inventory. Live writes require the
+explicit ``apply`` command, one target ID, and a target-specific confirmation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from common import WPClient
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "fixes/issue-353-body-h1-migration-2026-07-13.json"
+DEFAULT_ENV_PATH = REPO_ROOT / "scripts/notion-to-wp/.env"
+DEFAULT_SNAPSHOT_DIR = Path("/private/tmp")
+REST_FIELDS = "id,type,slug,status,modified_gmt,link,content"
+
+H1_OPEN_RE = re.compile(r"<h1(?=[\s>])", flags=re.IGNORECASE)
+H1_CLOSE_RE = re.compile(r"</h1\s*>", flags=re.IGNORECASE)
+H1_ELEMENT_RE = re.compile(
+    r"(?P<open><h1(?=[\s>])[^>]*>)(?P<body>.*?)(?P<close></h1\s*>)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+GUTENBERG_HEADING_RE = re.compile(
+    r"(?P<prefix><!--\s+wp:heading\s+)"
+    r"(?P<attrs>\{.*?\})"
+    r"(?P<suffix>\s+-->)"
+    r"(?P<body>.*?)"
+    r"(?P<close><!--\s+/wp:heading\s+-->)",
+    flags=re.DOTALL,
+)
+LEVEL_ONE_ATTR_RE = re.compile(r'("level"\s*:\s*)1(?=\s*[,}])')
+
+
+class MigrationError(RuntimeError):
+    pass
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def count_h1(value: str) -> int:
+    return len(H1_OPEN_RE.findall(value))
+
+
+def confirmation_for(target_id: int) -> str:
+    return f"APPLY-ISSUE-353-TARGET-{target_id}"
+
+
+def _rewrite_gutenberg_h1(raw: str, expected_count: int) -> str:
+    converted = 0
+
+    def patch_block(match: re.Match[str]) -> str:
+        nonlocal converted
+        attrs_text = match.group("attrs")
+        try:
+            attrs = json.loads(attrs_text)
+        except json.JSONDecodeError as exc:
+            raise MigrationError("invalid Gutenberg heading attributes") from exc
+        if attrs.get("level") != 1:
+            return match.group(0)
+
+        body = match.group("body")
+        if count_h1(body) != 1 or len(H1_CLOSE_RE.findall(body)) != 1:
+            raise MigrationError(
+                "a reviewed Gutenberg level-1 block does not contain exactly one H1"
+            )
+        new_attrs, attr_count = LEVEL_ONE_ATTR_RE.subn(
+            r"\g<1>2",
+            attrs_text,
+            count=1,
+        )
+        if attr_count != 1:
+            raise MigrationError("could not change the reviewed Gutenberg level attribute")
+        new_body, open_count = H1_OPEN_RE.subn("<h2", body, count=1)
+        new_body, close_count = H1_CLOSE_RE.subn("</h2>", new_body, count=1)
+        if open_count != 1 or close_count != 1:
+            raise MigrationError("could not change the reviewed Gutenberg H1 tags")
+
+        converted += 1
+        return (
+            match.group("prefix")
+            + new_attrs
+            + match.group("suffix")
+            + new_body
+            + match.group("close")
+        )
+
+    rewritten = GUTENBERG_HEADING_RE.sub(patch_block, raw)
+    if converted != expected_count or count_h1(rewritten) != 0:
+        raise MigrationError(
+            "body H1s are not fully contained in the reviewed Gutenberg level-1 blocks"
+        )
+    return rewritten
+
+
+def _rewrite_classic_h1(raw: str, expected_count: int) -> str:
+    def patch_element(match: re.Match[str]) -> str:
+        opening = H1_OPEN_RE.sub("<h2", match.group("open"), count=1)
+        return opening + match.group("body") + "</h2>"
+
+    rewritten, converted = H1_ELEMENT_RE.subn(patch_element, raw)
+    if converted != expected_count or count_h1(rewritten) != 0:
+        raise MigrationError("classic body H1 elements do not match the reviewed count")
+    return rewritten
+
+
+def rewrite_h1(raw: str, *, content_format: str, expected_count: int) -> str:
+    actual_count = count_h1(raw)
+    if actual_count != expected_count:
+        raise MigrationError(
+            f"expected {expected_count} body H1 elements, found {actual_count}"
+        )
+    if content_format == "gutenberg":
+        return _rewrite_gutenberg_h1(raw, expected_count)
+    if content_format == "classic":
+        return _rewrite_classic_h1(raw, expected_count)
+    raise MigrationError(f"unsupported content format: {content_format}")
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("issue") != 353:
+        raise MigrationError("manifest is not for issue #353")
+    if not isinstance(data.get("targets"), list) or not data["targets"]:
+        raise MigrationError("manifest has no migration targets")
+    return data
+
+
+def targets_by_id(manifest: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    targets = {int(target["id"]): target for target in manifest["targets"]}
+    if len(targets) != len(manifest["targets"]):
+        raise MigrationError("manifest contains duplicate target IDs")
+    return targets
+
+
+def _raw_content(item: dict[str, Any]) -> str:
+    content = item.get("content")
+    raw = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(raw, str):
+        raise MigrationError("authenticated WordPress response did not include content.raw")
+    return raw
+
+
+def _validate_identity(
+    item: dict[str, Any],
+    target: dict[str, Any],
+    *,
+    include_modified: bool,
+) -> None:
+    checks = {
+        "id": target["id"],
+        "type": target["type"],
+        "slug": target["slug"],
+        "status": target["status"],
+        "link": target["url"],
+    }
+    if include_modified:
+        checks["modified_gmt"] = target["modified_gmt"]
+    for field, expected in checks.items():
+        if item.get(field) != expected:
+            raise MigrationError(
+                f"target {target['id']} {field} drift: expected {expected!r}, "
+                f"found {item.get(field)!r}"
+            )
+
+
+def plan_target(item: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    _validate_identity(item, target, include_modified=True)
+    raw = _raw_content(item)
+    if len(raw) != target["raw_length"]:
+        raise MigrationError(
+            f"target {target['id']} raw length drift: expected {target['raw_length']}, "
+            f"found {len(raw)}"
+        )
+    before_sha = sha256_text(raw)
+    if before_sha != target["raw_sha256"]:
+        raise MigrationError(
+            f"target {target['id']} raw SHA-256 drift: expected "
+            f"{target['raw_sha256']}, found {before_sha}"
+        )
+    after = rewrite_h1(
+        raw,
+        content_format=target["format"],
+        expected_count=target["body_h1_count"],
+    )
+    after_sha = sha256_text(after)
+    if after_sha != target["expected_after_sha256"]:
+        raise MigrationError(
+            f"target {target['id']} planned SHA-256 does not match the reviewed patch"
+        )
+    if len(after) != target["expected_after_length"]:
+        raise MigrationError(
+            f"target {target['id']} planned length does not match the reviewed patch"
+        )
+    return {
+        "target_id": target["id"],
+        "content_after": after,
+        "before_raw_sha256": before_sha,
+        "after_raw_sha256": after_sha,
+        "body_h1_count_before": target["body_h1_count"],
+        "body_h1_count_after": 0,
+    }
+
+
+def fetch_target(client: WPClient, target: dict[str, Any]) -> dict[str, Any]:
+    return client.get(
+        f"{target['endpoint']}/{target['id']}",
+        params={"context": "edit", "_fields": REST_FIELDS},
+    )
+
+
+def fetch_inventory(client: WPClient) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for endpoint in ("posts", "pages"):
+        items.extend(
+            client.get_all(
+                endpoint,
+                params={
+                    "status": "publish",
+                    "context": "edit",
+                    "_fields": REST_FIELDS,
+                },
+                per_page=100,
+            )
+        )
+    return items
+
+
+def _target_state(item: dict[str, Any], target: dict[str, Any]) -> str:
+    raw = _raw_content(item)
+    current_sha = sha256_text(raw)
+    if current_sha == target["raw_sha256"]:
+        plan_target(item, target)
+        return "pending"
+    if current_sha == target["expected_after_sha256"]:
+        _validate_identity(item, target, include_modified=False)
+        if len(raw) != target["expected_after_length"] or count_h1(raw) != 0:
+            raise MigrationError(f"target {target['id']} migrated content failed validation")
+        return "migrated"
+    raise MigrationError(
+        f"target {target['id']} raw SHA-256 matches neither reviewed state"
+    )
+
+
+def audit_inventory(
+    items: list[dict[str, Any]],
+    targets: dict[int, dict[str, Any]],
+    homepage: dict[str, Any],
+) -> dict[str, Any]:
+    found_ids = {int(item["id"]) for item in items}
+    required_ids = set(targets) | {int(homepage["id"])}
+    missing = sorted(required_ids - found_ids)
+    if missing:
+        raise MigrationError(f"published inventory is missing reviewed IDs: {missing}")
+
+    states: dict[int, str] = {}
+    unknown_h1: list[tuple[int, int]] = []
+    for item in items:
+        item_id = int(item["id"])
+        raw = _raw_content(item)
+        body_h1_count = count_h1(raw)
+        if item_id in targets:
+            states[item_id] = _target_state(item, targets[item_id])
+        elif item_id == int(homepage["id"]):
+            _validate_identity(item, homepage, include_modified=True)
+            if sha256_text(raw) != homepage["raw_sha256"]:
+                raise MigrationError("homepage raw SHA-256 drifted from the reviewed exclusion")
+            if len(raw) != homepage["raw_length"]:
+                raise MigrationError("homepage raw length drifted from the reviewed exclusion")
+            if body_h1_count != homepage["body_h1_count"]:
+                raise MigrationError("homepage body H1 count drifted from the reviewed exclusion")
+        elif body_h1_count:
+            unknown_h1.append((item_id, body_h1_count))
+
+    if unknown_h1:
+        raise MigrationError(f"unreviewed non-homepage body H1s found: {unknown_h1}")
+    return {
+        "published_posts_and_pages_scanned": len(items),
+        "pending_targets": sorted(
+            target_id for target_id, state in states.items() if state == "pending"
+        ),
+        "migrated_targets": sorted(
+            target_id for target_id, state in states.items() if state == "migrated"
+        ),
+        "homepage_exclusion_id": homepage["id"],
+        "unreviewed_body_h1_sources": [],
+    }
+
+
+def _snapshot_target(
+    item: dict[str, Any],
+    target: dict[str, Any],
+    plan: dict[str, Any],
+    *,
+    snapshot_dir: Path,
+    now: dt.datetime,
+) -> Path:
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    stamp = now.astimezone(dt.timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+    path = snapshot_dir / f"kriskrug-issue-353-{target['id']}-{stamp}.json"
+    payload = {
+        "issue": 353,
+        "captured_at": now.astimezone(dt.timezone.utc).isoformat(),
+        "target_id": target["id"],
+        "endpoint": target["endpoint"],
+        "slug": item["slug"],
+        "status": item["status"],
+        "modified_gmt": item["modified_gmt"],
+        "url": item["link"],
+        "raw_sha256": plan["before_raw_sha256"],
+        "expected_after_sha256": plan["after_raw_sha256"],
+        "content_raw": _raw_content(item),
+    }
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(path, flags, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+    return path
+
+
+def _verify_readback(item: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
+    _validate_identity(item, target, include_modified=False)
+    raw = _raw_content(item)
+    current_sha = sha256_text(raw)
+    if current_sha != target["expected_after_sha256"]:
+        raise MigrationError(
+            f"target {target['id']} readback SHA-256 does not match the reviewed patch"
+        )
+    if len(raw) != target["expected_after_length"]:
+        raise MigrationError(f"target {target['id']} readback length mismatch")
+    body_h1_count = count_h1(raw)
+    if body_h1_count != 0:
+        raise MigrationError(f"target {target['id']} readback still contains body H1s")
+    return {
+        "readback_raw_sha256": current_sha,
+        "readback_body_h1_count": body_h1_count,
+        "readback_modified_gmt": item.get("modified_gmt"),
+    }
+
+
+def apply_target(
+    client: WPClient,
+    target: dict[str, Any],
+    *,
+    confirmation: str,
+    snapshot_dir: Path = DEFAULT_SNAPSHOT_DIR,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    expected_confirmation = confirmation_for(int(target["id"]))
+    if confirmation != expected_confirmation:
+        raise MigrationError(
+            f"exact confirmation required: {expected_confirmation}"
+        )
+
+    before = fetch_target(client, target)
+    plan = plan_target(before, target)
+    captured_at = now or dt.datetime.now(dt.timezone.utc)
+    snapshot_path = _snapshot_target(
+        before,
+        target,
+        plan,
+        snapshot_dir=snapshot_dir,
+        now=captured_at,
+    )
+    print(f"pre-write snapshot={snapshot_path}", flush=True)
+    client.post(
+        f"{target['endpoint']}/{target['id']}",
+        {"content": plan["content_after"]},
+    )
+    readback = fetch_target(client, target)
+    result = _verify_readback(readback, target)
+    result.update(
+        {
+            "target_id": target["id"],
+            "snapshot_path": str(snapshot_path),
+        }
+    )
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        nargs="?",
+        default="audit",
+        choices=("audit", "plan", "apply"),
+    )
+    parser.add_argument("--target-id", type=int)
+    parser.add_argument("--confirm", default="")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--env-path", type=Path, default=DEFAULT_ENV_PATH)
+    parser.add_argument("--snapshot-dir", type=Path, default=DEFAULT_SNAPSHOT_DIR)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    targets = targets_by_id(manifest)
+    client = WPClient.from_env(args.env_path, timeout=30)
+
+    if args.command == "audit":
+        if args.target_id is not None:
+            raise MigrationError("audit is a full inventory; omit --target-id")
+        result = audit_inventory(
+            fetch_inventory(client),
+            targets,
+            manifest["homepage_exclusion"],
+        )
+        print(json.dumps(result, indent=2))
+        return
+
+    if args.target_id is None:
+        raise MigrationError(f"{args.command} requires --target-id")
+    if args.target_id not in targets:
+        raise MigrationError(f"target ID {args.target_id} is not in the reviewed manifest")
+    target = targets[args.target_id]
+
+    if args.command == "plan":
+        plan = plan_target(fetch_target(client, target), target)
+        plan.pop("content_after")
+        print(json.dumps(plan, indent=2))
+        return
+
+    result = apply_target(
+        client,
+        target,
+        confirmation=args.confirm,
+        snapshot_dir=args.snapshot_dir,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_issue_353_body_h1_migration.py
+++ b/scripts/tests/test_issue_353_body_h1_migration.py
@@ -1,0 +1,349 @@
+import copy
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import body_h1_migration as migration  # noqa: E402
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-353-body-h1-migration-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-353-body-h1-migration-2026-07-13.md"
+
+
+class FakeWP:
+    def __init__(self, before, after):
+        self.responses = [before, after]
+        self.gets = []
+        self.posts = []
+
+    def get(self, path, *, params=None):
+        self.gets.append((path, params))
+        return self.responses.pop(0)
+
+    def post(self, path, payload):
+        self.posts.append((path, payload))
+        return {"id": payload}
+
+
+def target_for(raw, **overrides):
+    expected_after = migration.rewrite_h1(
+        raw,
+        content_format="classic",
+        expected_count=1,
+    )
+    target = {
+        "id": 42,
+        "endpoint": "posts",
+        "type": "post",
+        "slug": "example-post",
+        "status": "publish",
+        "modified_gmt": "2026-07-13T12:00:00",
+        "url": "https://kriskrug.co/2026/07/13/example-post/",
+        "raw_sha256": migration.sha256_text(raw),
+        "raw_length": len(raw),
+        "expected_after_sha256": migration.sha256_text(expected_after),
+        "expected_after_length": len(expected_after),
+        "body_h1_count": 1,
+        "format": "classic",
+        "heading_texts": ["Example heading"],
+    }
+    target.update(overrides)
+    return target
+
+
+def wp_item(target, raw, *, modified_gmt=None):
+    return {
+        "id": target["id"],
+        "type": target["type"],
+        "slug": target["slug"],
+        "status": target["status"],
+        "modified_gmt": modified_gmt or target["modified_gmt"],
+        "link": target["url"],
+        "content": {"raw": raw},
+    }
+
+
+class Issue353PacketTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.handoff = HANDOFF.read_text(encoding="utf-8")
+
+    def test_packet_locks_exact_scope_and_remains_repo_only(self):
+        expected = {
+            11358: (9, "gutenberg"),
+            7927: (5, "gutenberg"),
+            6453: (1, "gutenberg"),
+            6435: (1, "gutenberg"),
+            6344: (9, "gutenberg"),
+            4826: (1, "gutenberg"),
+            4174: (1, "gutenberg"),
+            4372: (1, "gutenberg"),
+            3908: (1, "gutenberg"),
+            3567: (1, "gutenberg"),
+            3151: (6, "gutenberg"),
+            2857: (6, "gutenberg"),
+            1547: (1, "classic"),
+            12013: (1, "classic"),
+        }
+        targets = {target["id"]: target for target in self.data["targets"]}
+
+        self.assertEqual(353, self.data["issue"])
+        self.assertEqual("repo-only-migration-packet", self.data["status"])
+        self.assertEqual(expected.keys(), targets.keys())
+        self.assertEqual(44, sum(target["body_h1_count"] for target in targets.values()))
+        self.assertEqual(1012, self.data["observed"]["published_posts_and_pages_scanned"])
+        self.assertFalse(self.data["observed"]["wordpress_write_performed"])
+        self.assertFalse(self.data["observed"]["search_console_write_performed"])
+        self.assertFalse(self.data["claims"]["ranking_lift_claimed"])
+
+        for target_id, (count, content_format) in expected.items():
+            target = targets[target_id]
+            self.assertEqual(count, target["body_h1_count"])
+            self.assertEqual(content_format, target["format"])
+            self.assertEqual(count, len(target["heading_texts"]))
+            self.assertEqual(64, len(target["raw_sha256"]))
+            self.assertEqual(64, len(target["expected_after_sha256"]))
+            self.assertNotEqual(target["raw_sha256"], target["expected_after_sha256"])
+            self.assertEqual(target["raw_length"], target["expected_after_length"])
+            self.assertEqual("publish", target["status"])
+            self.assertIn(target["endpoint"], {"posts", "pages"})
+
+        self.assertIn("no live WordPress write", self.handoff)
+        self.assertIn("one target at a time", self.handoff)
+        self.assertIn("does not claim a ranking lift", self.handoff)
+
+    def test_homepage_body_h1_is_explicitly_excluded(self):
+        homepage = self.data["homepage_exclusion"]
+        self.assertEqual(3930, homepage["id"])
+        self.assertEqual("https://kriskrug.co/", homepage["url"])
+        self.assertEqual(1, homepage["body_h1_count"])
+        self.assertEqual("intentional-homepage-hero-h1", homepage["reason"])
+        self.assertNotIn(3930, {target["id"] for target in self.data["targets"]})
+
+
+class H1RewriteTests(unittest.TestCase):
+    def test_gutenberg_rewrite_preserves_non_heading_bytes(self):
+        raw = (
+            '<p data-note="keep">Before</p>'
+            '<!-- wp:heading {"level":1} -->\n'
+            '<h1 class="wp-block-heading">Example heading</h1>\n'
+            '<!-- /wp:heading -->'
+            '<p>After</p>'
+        )
+
+        actual = migration.rewrite_h1(raw, content_format="gutenberg", expected_count=1)
+
+        self.assertEqual(
+            (
+                '<p data-note="keep">Before</p>'
+                '<!-- wp:heading {"level":2} -->\n'
+                '<h2 class="wp-block-heading">Example heading</h2>\n'
+                '<!-- /wp:heading -->'
+                '<p>After</p>'
+            ),
+            actual,
+        )
+        self.assertEqual(0, migration.count_h1(actual))
+
+    def test_gutenberg_rewrite_changes_every_reviewed_h1_block(self):
+        block = '<!-- wp:heading {"level":1} --><h1>%s</h1><!-- /wp:heading -->'
+        raw = f"<p>Before</p>{block % 'One'}{block % 'Two'}<p>After</p>"
+
+        actual = migration.rewrite_h1(raw, content_format="gutenberg", expected_count=2)
+
+        self.assertEqual(0, migration.count_h1(actual))
+        self.assertEqual(2, actual.count('{"level":2}'))
+        self.assertEqual(2, actual.count("<h2>"))
+        self.assertTrue(actual.startswith("<p>Before</p>"))
+        self.assertTrue(actual.endswith("<p>After</p>"))
+
+    def test_classic_rewrite_changes_only_h1_tag_names(self):
+        raw = '<section><h1 class="legacy">Example heading</h1><p>Keep me</p></section>'
+
+        actual = migration.rewrite_h1(raw, content_format="classic", expected_count=1)
+
+        self.assertEqual(
+            '<section><h2 class="legacy">Example heading</h2><p>Keep me</p></section>',
+            actual,
+        )
+
+    def test_gutenberg_rewrite_rejects_unmodeled_classic_h1(self):
+        raw = '<!-- wp:paragraph --><p>Text</p><!-- /wp:paragraph --><h1>Loose heading</h1>'
+
+        with self.assertRaisesRegex(migration.MigrationError, "reviewed Gutenberg"):
+            migration.rewrite_h1(raw, content_format="gutenberg", expected_count=1)
+
+    def test_rewrite_rejects_h1_count_drift(self):
+        with self.assertRaisesRegex(migration.MigrationError, "expected 1 body H1"):
+            migration.rewrite_h1(
+                "<h2>Already changed</h2>",
+                content_format="classic",
+                expected_count=1,
+            )
+
+
+class MigrationGuardTests(unittest.TestCase):
+    def setUp(self):
+        self.raw = "<h1>Example heading</h1><p>Body</p>"
+        self.target = target_for(self.raw)
+
+    def test_plan_rejects_modified_timestamp_or_raw_hash_drift(self):
+        stale_time = wp_item(self.target, self.raw, modified_gmt="2026-07-13T12:00:01")
+        stale_body = wp_item(self.target, self.raw.replace("Body", "B0dy"))
+
+        with self.assertRaisesRegex(migration.MigrationError, "modified_gmt"):
+            migration.plan_target(stale_time, self.target)
+        with self.assertRaisesRegex(migration.MigrationError, "raw SHA-256"):
+            migration.plan_target(stale_body, self.target)
+
+    def test_apply_requires_exact_per_target_confirmation_before_any_api_call(self):
+        client = FakeWP(wp_item(self.target, self.raw), wp_item(self.target, self.raw))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(migration.MigrationError, "exact confirmation"):
+                migration.apply_target(
+                    client,
+                    self.target,
+                    confirmation="issue-353",
+                    snapshot_dir=Path(tmp),
+                )
+
+        self.assertEqual([], client.gets)
+        self.assertEqual([], client.posts)
+
+    def test_apply_snapshots_before_one_content_write_and_verifies_readback(self):
+        after_raw = "<h2>Example heading</h2><p>Body</p>"
+        before = wp_item(self.target, self.raw)
+        after = wp_item(self.target, after_raw, modified_gmt="2026-07-13T12:01:00")
+        client = FakeWP(before, after)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch("builtins.print") as output:
+                result = migration.apply_target(
+                    client,
+                    self.target,
+                    confirmation=migration.confirmation_for(self.target["id"]),
+                    snapshot_dir=Path(tmp),
+                    now=datetime(2026, 7, 14, 3, 0, tzinfo=timezone.utc),
+                )
+            snapshot_path = Path(result["snapshot_path"])
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            mode = stat.S_IMODE(snapshot_path.stat().st_mode)
+
+        self.assertEqual(0o600, mode)
+        self.assertEqual(self.raw, snapshot["content_raw"])
+        self.assertEqual(self.target["raw_sha256"], snapshot["raw_sha256"])
+        self.assertEqual(
+            [("posts/42", {"content": after_raw})],
+            client.posts,
+        )
+        self.assertEqual(2, len(client.gets))
+        output.assert_called_once_with(
+            f"pre-write snapshot={snapshot_path}",
+            flush=True,
+        )
+        self.assertEqual(0, result["readback_body_h1_count"])
+        self.assertEqual(migration.sha256_text(after_raw), result["readback_raw_sha256"])
+
+    def test_default_cli_mode_is_read_only_audit(self):
+        args = migration.parse_args([])
+
+        self.assertEqual("audit", args.command)
+        self.assertIsNone(args.target_id)
+
+
+class InventoryRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.raw = "<h1>Example heading</h1><p>Body</p>"
+        self.target = target_for(self.raw)
+        self.home_raw = "<h1>Intentional homepage heading</h1><p>Home</p>"
+        self.homepage = {
+            "id": 3930,
+            "endpoint": "pages",
+            "type": "page",
+            "slug": "home-source",
+            "status": "publish",
+            "modified_gmt": "2026-07-13T11:00:00",
+            "url": "https://kriskrug.co/",
+            "raw_sha256": migration.sha256_text(self.home_raw),
+            "raw_length": len(self.home_raw),
+            "body_h1_count": 1,
+        }
+
+    def test_inventory_accepts_pending_target_homepage_and_h2_h3_only_content(self):
+        ordinary = {
+            "id": 99,
+            "type": "post",
+            "slug": "ordinary",
+            "status": "publish",
+            "modified_gmt": "2026-07-13T13:00:00",
+            "link": "https://kriskrug.co/ordinary/",
+            "content": {"raw": "<h2>Section</h2><h3>Detail</h3>"},
+        }
+        result = migration.audit_inventory(
+            [
+                wp_item(self.target, self.raw),
+                wp_item(self.homepage, self.home_raw),
+                ordinary,
+            ],
+            {self.target["id"]: self.target},
+            self.homepage,
+        )
+
+        self.assertEqual([42], result["pending_targets"])
+        self.assertEqual([], result["migrated_targets"])
+        self.assertEqual([], result["unreviewed_body_h1_sources"])
+
+    def test_inventory_accepts_exact_migrated_target_state(self):
+        after_raw = "<h2>Example heading</h2><p>Body</p>"
+        result = migration.audit_inventory(
+            [
+                wp_item(
+                    self.target,
+                    after_raw,
+                    modified_gmt="2026-07-14T03:01:00",
+                ),
+                wp_item(self.homepage, self.home_raw),
+            ],
+            {self.target["id"]: self.target},
+            self.homepage,
+        )
+
+        self.assertEqual([], result["pending_targets"])
+        self.assertEqual([42], result["migrated_targets"])
+
+    def test_inventory_rejects_new_non_homepage_body_h1(self):
+        unexpected = {
+            "id": 99,
+            "type": "post",
+            "slug": "unexpected",
+            "status": "publish",
+            "modified_gmt": "2026-07-13T13:00:00",
+            "link": "https://kriskrug.co/unexpected/",
+            "content": {"raw": "<h1>Unexpected heading</h1>"},
+        }
+
+        with self.assertRaisesRegex(migration.MigrationError, "unreviewed"):
+            migration.audit_inventory(
+                [
+                    wp_item(self.target, self.raw),
+                    wp_item(self.homepage, self.home_raw),
+                    unexpected,
+                ],
+                {self.target["id"]: self.target},
+                self.homepage,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- lock the 14 published duplicate-body-H1 routes to authenticated WordPress identity, timestamp, length, and before/after SHA-256 digests
- add a read-only full inventory regression audit that preserves homepage ID 3930 and rejects any new non-homepage body H1 source
- add exact Gutenberg and classic H1-to-H2 patches plus a one-target-at-a-time, confirmation-gated, mode-0600 snapshot-backed apply path
- document the production approval, rollback, public readback, canonical, indexability, and sitemap gates

Tracks #353. This PR intentionally does not close the issue because no live WordPress migration has been authorized or performed.

## Live read-only evidence

`python3 scripts/body_h1_migration.py audit --env-path <local-env>`

- 1,012 published posts and pages scanned
- 14 reviewed targets match the exact pending state
- homepage exclusion ID 3930 matches
- zero unreviewed body H1 sources
- no WordPress POST and no Search Console write

Single-target plan for ID 11358 also matched the manifest: 9 body H1s before, 0 planned after, exact before and after digests.

## Verification

- `python3 -m unittest scripts.tests.test_issue_353_body_h1_migration` (14 passed)
- `make python-test` (307 passed)
- `make test` portions invoked by `make verify`: Python, JavaScript syntax, and plugin smoke passed
- `python3 scripts/docs_truth_check.py` passed
- `git diff --cached --check` passed before commit

Local `make validate` could not run because this fresh worktree does not have repo-owned PHPCS dependencies installed. No PHP file changes in this PR, so the conditional CI PHP job should be skipped.

## Safety

This is repo-only preparation. Production application remains high-risk and requires Kris's exact action-time approval. The technical confirmation string is not permission. The tool processes one target ID, snapshots the complete raw body before its only content POST, emits the snapshot path before writing, verifies readback, and stops on any drift. It does not change titles, slugs, status, dates, metadata, Search Console, analytics, DNS, or the homepage H1.
