### PR TITLE
SEO: refresh Augie Studio review for JWX acquisition

### DIFF
--- a/fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.json
+++ b/fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": 1,
+  "issue": 355,
+  "status": "human-review-required",
+  "live_wordpress_write_performed": false,
+  "evidence": {
+    "source": "Read-only Search Console API evidence recorded from issue #279 and refreshed for the matching landing page",
+    "window_start": "2026-06-12",
+    "window_end": "2026-07-09",
+    "private_analytics_export_included": false,
+    "landing_page": {
+      "impressions": 186,
+      "clicks": 0,
+      "ctr_percent": 0.0,
+      "average_position": 11.62
+    },
+    "queries": [
+      {
+        "text": "augie ai",
+        "impressions": 45,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 12.73
+      },
+      {
+        "text": "augie studio",
+        "impressions": 32,
+        "clicks": 0,
+        "ctr_percent": 0.0,
+        "average_position": 17.19
+      }
+    ]
+  },
+  "target": {
+    "id": 6019,
+    "slug": "augie-studio-review-ai-driven-video-production-analysis",
+    "status": "publish",
+    "modified": "2026-06-14T20:11:57",
+    "url": "https://kriskrug.co/2024/06/18/augie-studio-review-ai-driven-video-production-analysis/",
+    "post_title": "Augie Studio Review: AI-Driven Video Production Analysis"
+  },
+  "current_public_metadata": {
+    "observed_on": "2026-07-13",
+    "http_status": 200,
+    "canonical": "https://kriskrug.co/2024/06/18/augie-studio-review-ai-driven-video-production-analysis/",
+    "h1_count": 1,
+    "robots": "max-image-preview:large",
+    "indexable": true,
+    "document_title": "Augie Studio Review: AI-Driven Video Production Analysis - Kris Krug | AI Keynote Speaker & Creative Technologist",
+    "standard_meta_description_present": false,
+    "og_title": "Augie Studio Review: AI-Driven Video Production Analysis",
+    "og_description": "Lights, camera, AI action! Buckle up as we dive into Augie Studio, the cutting-edge platform revolutionizing video production by putting the power of artificial intelligence directly into creators' hands.",
+    "public_rest_meta_keys": [
+      "footnotes"
+    ],
+    "jetpack_seo_meta_fields_exposed": false
+  },
+  "first_party_sources": {
+    "acquisition": {
+      "url": "https://jwx.com/news/jwx-augie-acquisition",
+      "http_status": 200,
+      "published_on": "2026-01-15",
+      "confirmed_facts": [
+        "JWX acquired Aug X Labs, the company behind Augie Studio",
+        "Augie Studio is being incorporated into JWX Studio",
+        "Augie will sunset its direct-to-consumer product",
+        "the product focus is publishers and media companies"
+      ]
+    },
+    "current_studio": {
+      "url": "https://jwx.com/jwx-studio",
+      "http_status": 200,
+      "confirmed_facts": [
+        "JWX Studio is an AI-assisted video production and repurposing solution",
+        "the intended audience is publishers and media enterprises",
+        "the workflow retains human editorial control"
+      ]
+    },
+    "consumer_transition": {
+      "url": "https://my.augie.studio/",
+      "http_status": 200,
+      "confirmed_facts": [
+        "the consumer product is no longer offered",
+        "existing enterprise users can continue during the transition"
+      ]
+    }
+  },
+  "proposed_metadata": {
+    "field_values": {
+      "jetpack_seo_html_title": "Augie Studio Review: AI Video Tool After JWX Acquisition",
+      "advanced_seo_description": "A hands-on Augie Studio review, updated after JWX acquired Aug X Labs and sunset the consumer product. See what changed and who JWX Studio now serves."
+    },
+    "field_lengths": {
+      "jetpack_seo_html_title": 56,
+      "advanced_seo_description": 150
+    },
+    "post_title_change": false,
+    "metadata_rest_write_allowed_while_fields_unregistered": false
+  },
+  "body_insertion": {
+    "operation": "insert_before_exact_html",
+    "needle": "<p>Hey tech rebels and digital visionaries, <a href=\"https://kriskrug.co/\">Kris Krug</a> here with an exploration of brand spankin new <a href=\"https://augie.studio/\">Augie Studio</a>. This platform is pioneering the AI-driven video creation space, pushing the boundaries of what&#8217;s possible in media production.</p>",
+    "note_html": "<p><strong>Update, July 2026:</strong> <a href=\"https://jwx.com/news/jwx-augie-acquisition\">JWX acquired Aug X Labs</a>, the company behind Augie Studio, in January 2026. JWX is sunsetting Augie&#8217;s direct-to-consumer product and integrating its technology into <a href=\"https://jwx.com/jwx-studio\">JWX Studio</a> for publishers and media enterprises. The hands-on review below is preserved as a snapshot of the 2024 product.</p>",
+    "separator": "\n\n\n\n",
+    "replacement": "<p><strong>Update, July 2026:</strong> <a href=\"https://jwx.com/news/jwx-augie-acquisition\">JWX acquired Aug X Labs</a>, the company behind Augie Studio, in January 2026. JWX is sunsetting Augie&#8217;s direct-to-consumer product and integrating its technology into <a href=\"https://jwx.com/jwx-studio\">JWX Studio</a> for publishers and media enterprises. The hands-on review below is preserved as a snapshot of the 2024 product.</p>\n\n\n\n<p>Hey tech rebels and digital visionaries, <a href=\"https://kriskrug.co/\">Kris Krug</a> here with an exploration of brand spankin new <a href=\"https://augie.studio/\">Augie Studio</a>. This platform is pioneering the AI-driven video creation space, pushing the boundaries of what&#8217;s possible in media production.</p>",
+    "expected_needle_count_before": 1,
+    "expected_update_note_count_before": 0,
+    "expected_update_note_count_after": 1,
+    "original_review_otherwise_byte_preserved": true,
+    "external_links": [
+      {
+        "href": "https://jwx.com/news/jwx-augie-acquisition",
+        "anchor_text": "JWX acquired Aug X Labs"
+      },
+      {
+        "href": "https://jwx.com/jwx-studio",
+        "anchor_text": "JWX Studio"
+      }
+    ]
+  },
+  "future_write_boundary_if_separately_approved": {
+    "body_allowed_rest_top_level_keys": [
+      "content"
+    ],
+    "metadata_editor_fields": [
+      "jetpack_seo_html_title",
+      "advanced_seo_description"
+    ],
+    "metadata_rest_write_allowed": false,
+    "forbidden_rest_top_level_keys": [
+      "title",
+      "slug",
+      "status",
+      "date",
+      "date_gmt",
+      "categories",
+      "tags",
+      "meta",
+      "excerpt",
+      "author",
+      "featured_media",
+      "comment_status",
+      "ping_status",
+      "template",
+      "format",
+      "sticky",
+      "password"
+    ],
+    "requires": [
+      "exact human approval of the metadata and dated update note",
+      "Aurora standard-description ownership verified before judging metadata output",
+      "fresh target ID, slug, status, modified, canonical, and H1 checks",
+      "fresh content.raw contains the exact insertion needle once",
+      "no REST metadata write while the two Jetpack fields are unregistered",
+      "full body diff reviewed before the content-only write"
+    ],
+    "snapshot": {
+      "directory_pattern": "backup/<UTC>-issue-355-augie-jwx-update",
+      "required_before_write": true,
+      "required_files": [
+        "before-post-6019-edit.json",
+        "before-post-6019-content.raw.html",
+        "before-post-6019-public.html",
+        "sha256sums.txt",
+        "rollback-content-only.json"
+      ]
+    },
+    "readback": [
+      "authenticated content.raw equals the reviewed after-body",
+      "public source returns HTTP 200 and remains self-canonical and indexable",
+      "public source retains one H1 and the original visible post title",
+      "the dated update note and both official links render exactly once",
+      "the remainder of the original review is byte-preserved",
+      "all three first-party source URLs return HTTP 200"
+    ],
+    "rollback": [
+      "stop if a later edit changed the post or the current modified value differs from the recorded post-write value",
+      "restore only content from the before snapshot",
+      "restore only the two reviewed SEO fields through their registered editor surface",
+      "repeat authenticated and public readback after rollback"
+    ]
+  },
+  "next_digest": {
+    "earliest_full_days_after_live_change": 14,
+    "second_measurement_full_days_after_live_change": 28,
+    "queries": [
+      "augie ai",
+      "augie studio"
+    ],
+    "landing_page": "https://kriskrug.co/2024/06/18/augie-studio-review-ai-driven-video-production-analysis/",
+    "required_metrics": [
+      "impressions",
+      "clicks",
+      "ctr_percent",
+      "average_position"
+    ],
+    "success_signal": {
+      "combined_query_clicks_at_least": 1,
+      "augie_ai_average_position_below": 10.0,
+      "augie_studio_average_position_below": 15.0,
+      "landing_page_ctr_percent_above": 1.0
+    },
+    "attribution_rule": "Do not attribute movement to this handoff until the live edit is approved, applied, publicly verified, and recrawled."
+  }
+}

--- a/fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.md
+++ b/fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.md
@@ -1,0 +1,141 @@
+# Issue #355: Augie Studio JWX SEO Handoff
+
+**Track:** A - Content + SEO
+**Status:** repo-side human-review handoff; no live WordPress write
+**Manifest:** `fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.json`
+
+## Decision
+
+Preserve the original 2024 hands-on review and add one dated correction before
+it. Augie Studio still has search demand, but its product context changed after
+JWX acquired Aug X Labs in January 2026. The direct-to-consumer product is being
+retired and the technology now serves publishers inside JWX Studio.
+
+The useful change is therefore not a fresh product endorsement or a rewrite of
+Kris's historical experience. It is one transparent status note plus metadata
+that distinguishes the original review from the current enterprise product.
+
+This handoff does not publish, deploy, update WordPress, purge cache, request
+indexing, or change Search Console, GA4, DNS, schema, taxonomies, or theme code.
+
+## Digest-Safe Evidence
+
+The 28-day Search Console evidence covers 2026-06-12 through 2026-07-09:
+
+| Surface | Impressions | Clicks | CTR | Average position |
+| --- | ---: | ---: | ---: | ---: |
+| Landing page | 186 | 0 | 0.00% | 11.62 |
+| Query `augie ai` | 45 | 0 | 0.00% | 12.73 |
+| Query `augie studio` | 32 | 0 | 0.00% | 17.19 |
+
+Only aggregate values are retained. No Search Console export, OAuth material,
+private query row, or person-level analytics data is included.
+
+## Public Mapping
+
+Read-only public REST and HTML checks on 2026-07-13 mapped the opportunity to
+post 6019:
+
+- URL: https://kriskrug.co/2024/06/18/augie-studio-review-ai-driven-video-production-analysis/
+- Slug: `augie-studio-review-ai-driven-video-production-analysis`
+- Status: `publish`
+- Public modified value: `2026-06-14T20:11:57`
+- HTTP: `200`
+- Canonical: self-referencing and correct
+- H1 count: 1
+- Robots: indexable, with `max-image-preview:large`
+- Standard meta description count: 0
+
+The current Open Graph description still calls Augie a cutting-edge platform
+revolutionizing consumer video production. Public REST exposes only the
+`footnotes` meta key, not the two Jetpack SEO fields. A publisher must not use
+a generic REST metadata write while those fields remain unregistered.
+
+## First-Party Product Truth
+
+The update is limited to facts confirmed by current first-party sources:
+
+1. JWX announced the acquisition of Aug X Labs on January 15, 2026:
+   https://jwx.com/news/jwx-augie-acquisition
+2. JWX says Augie Studio is being incorporated into JWX Studio and the
+   direct-to-consumer product will be sunset.
+3. JWX Studio currently describes itself as an AI-assisted video production
+   and repurposing product for publishers and media enterprises:
+   https://jwx.com/jwx-studio
+4. The current Augie sign-in surface says the consumer product is no longer
+   offered while enterprise users transition: https://my.augie.studio/
+
+All three URLs returned HTTP `200` during the read-only check. The packet does
+not include acquisition terms, financial claims, or unannounced roadmap claims.
+
+## Review-Ready Metadata
+
+These are SEO fields only. Do not change the visible post title, excerpt, slug,
+status, date, media, taxonomies, embeds, or original review body.
+
+| Field | Proposed value | Characters |
+| --- | --- | ---: |
+| `jetpack_seo_html_title` | Augie Studio Review: AI Video Tool After JWX Acquisition | 56 |
+| `advanced_seo_description` | A hands-on Augie Studio review, updated after JWX acquired Aug X Labs and sunset the consumer product. See what changed and who JWX Studio now serves. | 150 |
+
+Issue #351's Aurora standard-description release, or its verified successor,
+must own the standard description before these fields are judged in production.
+If the Jetpack fields remain absent from REST, use only their reviewed editor
+surfaces. Do not add a one-post theme override or metadata snippet.
+
+## Review-Ready Status Note
+
+Insert exactly this paragraph before the current opening paragraph:
+
+```html
+<p><strong>Update, July 2026:</strong> <a href="https://jwx.com/news/jwx-augie-acquisition">JWX acquired Aug X Labs</a>, the company behind Augie Studio, in January 2026. JWX is sunsetting Augie&#8217;s direct-to-consumer product and integrating its technology into <a href="https://jwx.com/jwx-studio">JWX Studio</a> for publishers and media enterprises. The hands-on review below is preserved as a snapshot of the 2024 product.</p>
+```
+
+The insertion point is the one current opening paragraph beginning `Hey tech
+rebels and digital visionaries`. A future publisher must find that exact HTML
+once and must find zero existing copies of the update note. The after-body is
+the new paragraph, four newline characters, and the untouched original body.
+
+No sentence, heading, embed, media reference, footer, team name, or historical
+claim after the insertion may change in this batch.
+
+## Separate Publisher Gate
+
+Do not apply this handoff from the worker lane. In a future publisher session
+with explicit approval for these exact changes:
+
+1. Confirm the standard-description owner is live and emits one standard, Open
+   Graph, and Twitter description on the target.
+2. Fetch post 6019 with edit context. Confirm ID, slug, published status,
+   modified value, canonical, visible title, and one-H1 state. Stop on drift.
+3. Confirm `content.raw` contains the exact opening paragraph once and the
+   update note zero times. Stop and regenerate the packet if either count
+   differs.
+4. Snapshot the edit-context response, raw body, public HTML, rollback body,
+   and SHA-256 checksums before any write.
+5. Review the full before/after body diff and the two metadata values with Kris.
+6. Send only the top-level `content` key for the body insertion. Do not send
+   `meta`, title, slug, status, dates, taxonomies, excerpt, author, media,
+   comments, template, format, sticky, or password fields.
+7. Apply the two SEO fields only through a registered endpoint or their exact
+   WordPress editor controls. Do not guess a REST payload.
+8. Read back authenticated raw content and cache-busted public HTML. Confirm
+   the note and both official links appear once, the target remains `200`,
+   self-canonical, indexable, and one-H1, and the original review is otherwise
+   byte-preserved.
+9. Retain the before snapshot as rollback input. Stop before rollback if a later
+   edit changed the post. Restore only content and the two reviewed SEO fields,
+   then repeat public and authenticated readback.
+
+## Next Digest Verification
+
+Wait at least 14 full days after a verified live change, then compare the page
+and both queries against the locked 28-day baseline. Repeat at 28 full days.
+
+Directional success requires at least one combined query click, `augie ai`
+below average position 10, `augie studio` below 15, and landing-page CTR above
+1.0%. Record impressions, clicks, CTR, and average position even when the
+signals are mixed.
+
+Do not attribute movement to this handoff until the changes are approved,
+applied, publicly verified, and recrawled.

--- a/scripts/tests/test_issue_355_augie_jwx_seo_handoff.py
+++ b/scripts/tests/test_issue_355_augie_jwx_seo_handoff.py
@@ -1,0 +1,221 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.json"
+HANDOFF = ROOT / "fixes/issue-355-augie-jwx-seo-handoff-2026-07-13.md"
+
+
+class Issue355AugieJwxSeoHandoffTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.handoff = HANDOFF.read_text(encoding="utf-8")
+
+    def test_digest_safe_evidence_is_exact(self):
+        evidence = self.data["evidence"]
+
+        self.assertEqual("2026-06-12", evidence["window_start"])
+        self.assertEqual("2026-07-09", evidence["window_end"])
+        self.assertFalse(evidence["private_analytics_export_included"])
+        self.assertEqual(
+            {
+                "impressions": 186,
+                "clicks": 0,
+                "ctr_percent": 0.0,
+                "average_position": 11.62,
+            },
+            evidence["landing_page"],
+        )
+        self.assertEqual(
+            [
+                {
+                    "text": "augie ai",
+                    "impressions": 45,
+                    "clicks": 0,
+                    "ctr_percent": 0.0,
+                    "average_position": 12.73,
+                },
+                {
+                    "text": "augie studio",
+                    "impressions": 32,
+                    "clicks": 0,
+                    "ctr_percent": 0.0,
+                    "average_position": 17.19,
+                },
+            ],
+            evidence["queries"],
+        )
+
+    def test_target_identity_and_public_state_are_locked(self):
+        target = self.data["target"]
+        public = self.data["current_public_metadata"]
+
+        self.assertEqual(6019, target["id"])
+        self.assertEqual("publish", target["status"])
+        self.assertEqual("2026-06-14T20:11:57", target["modified"])
+        self.assertEqual(
+            target["url"],
+            f"https://kriskrug.co/2024/06/18/{target['slug']}/",
+        )
+        self.assertEqual(target["url"], public["canonical"])
+        self.assertEqual(200, public["http_status"])
+        self.assertEqual(1, public["h1_count"])
+        self.assertTrue(public["indexable"])
+        self.assertFalse(public["standard_meta_description_present"])
+        self.assertEqual(["footnotes"], public["public_rest_meta_keys"])
+        self.assertFalse(public["jetpack_seo_meta_fields_exposed"])
+
+    def test_first_party_sources_and_claims_are_narrow(self):
+        sources = self.data["first_party_sources"]
+
+        self.assertEqual(
+            {
+                "https://jwx.com/news/jwx-augie-acquisition",
+                "https://jwx.com/jwx-studio",
+                "https://my.augie.studio/",
+            },
+            {source["url"] for source in sources.values()},
+        )
+        self.assertTrue(all(source["http_status"] == 200 for source in sources.values()))
+        self.assertEqual("2026-01-15", sources["acquisition"]["published_on"])
+
+        claims = " ".join(
+            claim
+            for source in sources.values()
+            for claim in source["confirmed_facts"]
+        ).lower()
+        for phrase in (
+            "acquired aug x labs",
+            "sunset its direct-to-consumer product",
+            "publishers and media enterprises",
+            "consumer product is no longer offered",
+        ):
+            self.assertIn(phrase, claims)
+        for forbidden in ("purchase price", "deal value", "millions", "guaranteed"):
+            self.assertNotIn(forbidden, claims)
+
+    def test_proposed_metadata_is_measured_and_within_limits(self):
+        proposed = self.data["proposed_metadata"]
+        fields = proposed["field_values"]
+        lengths = proposed["field_lengths"]
+
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(fields),
+        )
+        for key, value in fields.items():
+            self.assertEqual(len(value), lengths[key])
+        self.assertLessEqual(lengths["jetpack_seo_html_title"], 60)
+        self.assertGreaterEqual(lengths["advanced_seo_description"], 150)
+        self.assertLessEqual(lengths["advanced_seo_description"], 160)
+        self.assertIn("Augie Studio", fields["jetpack_seo_html_title"])
+        self.assertIn("AI", fields["jetpack_seo_html_title"])
+        self.assertIn("JWX", fields["jetpack_seo_html_title"])
+        self.assertFalse(proposed["post_title_change"])
+        self.assertFalse(proposed["metadata_rest_write_allowed_while_fields_unregistered"])
+
+    def test_body_change_is_one_guarded_insertion(self):
+        insertion = self.data["body_insertion"]
+
+        self.assertEqual("insert_before_exact_html", insertion["operation"])
+        self.assertEqual(1, insertion["expected_needle_count_before"])
+        self.assertEqual(0, insertion["expected_update_note_count_before"])
+        self.assertEqual(1, insertion["expected_update_note_count_after"])
+        self.assertTrue(insertion["original_review_otherwise_byte_preserved"])
+        self.assertEqual(
+            insertion["note_html"] + insertion["separator"] + insertion["needle"],
+            insertion["replacement"],
+        )
+        self.assertTrue(insertion["replacement"].endswith(insertion["needle"]))
+
+        note = insertion["note_html"]
+        for phrase in (
+            "Update, July 2026:",
+            "January 2026",
+            "direct-to-consumer product",
+            "publishers and media enterprises",
+            "snapshot of the 2024 product",
+        ):
+            self.assertIn(phrase, note)
+
+        links = dict(
+            re.findall(r'<a href="([^"]+)">([^<]+)</a>', note)
+        )
+        self.assertEqual(
+            {
+                "https://jwx.com/news/jwx-augie-acquisition": "JWX acquired Aug X Labs",
+                "https://jwx.com/jwx-studio": "JWX Studio",
+            },
+            links,
+        )
+
+    def test_future_write_boundary_is_content_only_and_reversible(self):
+        boundary = self.data["future_write_boundary_if_separately_approved"]
+
+        self.assertEqual(["content"], boundary["body_allowed_rest_top_level_keys"])
+        self.assertFalse(boundary["metadata_rest_write_allowed"])
+        self.assertEqual(
+            {"jetpack_seo_html_title", "advanced_seo_description"},
+            set(boundary["metadata_editor_fields"]),
+        )
+        self.assertTrue(
+            {
+                "title",
+                "slug",
+                "status",
+                "date",
+                "categories",
+                "tags",
+                "meta",
+                "excerpt",
+                "featured_media",
+            }.issubset(boundary["forbidden_rest_top_level_keys"])
+        )
+        self.assertIn("before-post-6019-content.raw.html", boundary["snapshot"]["required_files"])
+        self.assertIn("rollback-content-only.json", boundary["snapshot"]["required_files"])
+        self.assertTrue(any("byte-preserved" in item for item in boundary["readback"]))
+        self.assertTrue(any("later edit" in item for item in boundary["rollback"]))
+
+    def test_handoff_keeps_live_actions_and_secrets_out_of_scope(self):
+        normalized = " ".join(self.handoff.split())
+
+        self.assertIn("no live WordPress write", self.handoff)
+        self.assertIn("Do not apply this handoff from the worker lane.", self.handoff)
+        self.assertIn("must not use a generic REST metadata write", normalized)
+        self.assertFalse(self.data["live_wordpress_write_performed"])
+
+        serialized = (json.dumps(self.data) + self.handoff).lower()
+        for marker in (
+            "authorization:",
+            "bearer ",
+            "wp_app_password",
+            "wp_user",
+            "client_secret",
+            "oauth_token",
+        ):
+            self.assertNotIn(marker, serialized)
+
+    def test_next_digest_has_14_and_28_day_measurements(self):
+        verification = self.data["next_digest"]
+
+        self.assertEqual(14, verification["earliest_full_days_after_live_change"])
+        self.assertEqual(28, verification["second_measurement_full_days_after_live_change"])
+        self.assertEqual(["augie ai", "augie studio"], verification["queries"])
+        self.assertEqual(self.data["target"]["url"], verification["landing_page"])
+        self.assertEqual(
+            {
+                "impressions",
+                "clicks",
+                "ctr_percent",
+                "average_position",
+            },
+            set(verification["required_metrics"]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- capture the measured Search Console opportunity for the Augie Studio review
- lock current first-party acquisition and product-transition facts
- provide review-ready metadata and one guarded dated status note
- add rollback, readback, and 14/28-day evaluation gates

## Safety

- no live WordPress write or deployment
- no Search Console, GA4, DNS, schema, taxonomy, or theme change
- generic REST metadata writes remain forbidden while Jetpack SEO fields are unregistered
- any future publisher action requires separate approval and a fresh snapshot

## Verification

- `python3 -m unittest scripts.tests.test_issue_355_augie_jwx_seo_handoff -v` (8 passed)
- `make verify` (all publisher, operational, SEO/link, plugin smoke, docs truth, and PHPCS checks passed)
- all three first-party source URLs returned HTTP 200 on 2026-07-13

Closes #355