### PR TITLE
Fix: render approved Aurora search titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test python-test javascript-syntax plugin-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
+.PHONY: help test python-test javascript-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check clean
 
 PYTHON ?= python3
 JAVASCRIPT_FILES := \
@@ -29,6 +29,7 @@ test: ## Run test suite
 	@$(MAKE) python-test
 	@$(MAKE) javascript-syntax
 	@$(MAKE) plugin-smoke
+	@$(MAKE) theme-smoke
 
 python-test: ## Run all declared Python test suites
 	@$(PYTHON) -c 'import dotenv, pytest, requests, yaml' || { \
@@ -52,6 +53,10 @@ plugin-smoke: ## Run lightweight plugin smoke tests
 	@command -v php >/dev/null 2>&1 || { echo "ERROR: php is required for plugin smoke tests."; exit 1; }
 	@php plugins/kk-sidebar-promos/tests/smoke.php
 	@php plugins/kk-marquee-board/tests/smoke.php
+
+theme-smoke: ## Run lightweight theme behavior smoke tests
+	@command -v php >/dev/null 2>&1 || { echo "ERROR: php is required for theme smoke tests."; exit 1; }
+	@php theme/kk-aurora/tests/seo-title-smoke.php
 
 verify: ## Run the standard local verification suite
 	@$(MAKE) test

--- a/docs/current-state/AURORA-SEO-TITLES-1.3.40-HANDOFF-2026-07-14.md
+++ b/docs/current-state/AURORA-SEO-TITLES-1.3.40-HANDOFF-2026-07-14.md
@@ -1,0 +1,57 @@
+# Aurora 1.3.40 Search Title Handoff
+
+Issue: [#357](https://github.com/WalksWithASwagger/kriskrug-wp/issues/357)
+
+## Why This Exists
+
+Aurora 1.3.39 restores standard descriptions, but the singular document-title path does not read the approved `jetpack_seo_html_title` post meta field. The June live-write receipt records the metadata as written, while production still emits the public post title plus the global site descriptor.
+
+The July 14 Growth Mirror window surfaced the impact on post `5236`:
+
+- Query: `"creator community specialist" openai`
+- Current window: 31 impressions, 0 clicks, 0.00% CTR, average position 6.97
+- Approved search title: `AI Skills for Storytellers: OpenAI's Souki Mansoor`
+- Live title before this release: the longer public post title plus the global site descriptor
+
+A deterministic public check covered all 19 batch-4 posts with approved search titles. None emitted its approved value as the exact document title.
+
+## Release Behavior
+
+- Singular posts and pages use the trimmed, tag-free `jetpack_seo_html_title` value when it is a non-empty string.
+- The approved value is exact. Aurora does not append the site descriptor.
+- Missing, empty, invalid, archive, search, taxonomy, front-page, and 404 paths retain existing behavior.
+- Public H1s, post titles, slugs, canonicals, body copy, and Open Graph titles are unchanged.
+
+## Regression Sample
+
+| Shape | Post ID | Expected document title |
+|---|---:|---|
+| Search opportunity | 5236 | `AI Skills for Storytellers: OpenAI's Souki Mansoor` |
+| Long public title | 4011 | `Brandt Designs: Pool Tables as Art Installations` |
+| Short approved title | 6552 | `AI and Music: A Digital Renaissance` |
+| Unicode punctuation | 4960 | `Broetry, Content Farms, TL;DR — Is the Internet OK?` |
+| Proper-name correction | 4495 | `Inside the Inaugural Vancouver AI Community Meetup` |
+
+## Verification
+
+Local completion gate:
+
+```bash
+make verify
+```
+
+The theme smoke checks exact custom-title output plus empty, invalid, non-singular, and unexpected-object fallbacks. The operational static test verifies the module include, metadata key, sanitization, hook, and last-priority registration.
+
+Future public readback after an explicitly approved deploy:
+
+1. Confirm cache-busted `style.css` reports `Version: 1.3.40`.
+2. Confirm every regression URL returns `200`, remains self-canonical, and retains one H1.
+3. Confirm each `<title>` exactly matches the approved value.
+4. Confirm standard, Open Graph, and Twitter descriptions retain one owner each.
+5. Confirm front page, Blog archive, taxonomy, search, and 404 title behavior is unchanged.
+
+## Deployment Gate
+
+This handoff does not package or deploy the theme. It does not modify the already-hashed Aurora 1.3.39 artifact from #351. Any 1.3.40 package requires a fresh checksum, a rollback package based on the then-live version, exact action-time approval, cache purge, and anonymous readback.
+
+After deployment and recrawl, compare query/page impressions, clicks, CTR, and average position after 14 and 28 full days. Do not claim causation before recrawl.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,7 @@
 	<file>inc</file>
 	<file>plugins/kk-sidebar-promos</file>
 	<file>theme/kk-aurora/functions.php</file>
+	<file>theme/kk-aurora/inc</file>
 	<file>theme/kk-aurora/patterns</file>
 
 	<exclude-pattern>*/vendor/*</exclude-pattern>

--- a/scripts/tests/test_issue_346_homepage_og_title.py
+++ b/scripts/tests/test_issue_346_homepage_og_title.py
@@ -18,6 +18,7 @@ class Issue346HomepageOpenGraphTitleTests(unittest.TestCase):
     @staticmethod
     def _run_php_harness(*, snippet_guard=False):
         functions_path = json.dumps(str(THEME_FUNCTIONS))
+        theme_path = json.dumps(str(THEME_FUNCTIONS.parent))
         guard = "define('KK_OG_SNIPPET_ACTIVE', true);" if snippet_guard else ""
         harness = f"""<?php
 define('ABSPATH', __DIR__);
@@ -33,6 +34,7 @@ $queried_post = new WP_Post();
 
 function add_action(...$args) {{}}
 function add_filter(...$args) {{}}
+function get_template_directory() {{ return {theme_path}; }}
 function is_front_page() {{ return true; }}
 function is_home() {{ return false; }}
 function is_page($page = '') {{ return false; }}

--- a/scripts/tests/test_issue_347_blog_canonical.py
+++ b/scripts/tests/test_issue_347_blog_canonical.py
@@ -12,6 +12,7 @@ FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
 
 def render_archive_identity(*, page: int, page_url: str, is_home: bool = True) -> dict:
     functions_path = json.dumps(str(FUNCTIONS))
+    theme_path = json.dumps(str(FUNCTIONS.parent))
     page_url_literal = json.dumps(page_url)
     is_home_literal = "true" if is_home else "false"
     php = textwrap.dedent(
@@ -28,6 +29,7 @@ def render_archive_identity(*, page: int, page_url: str, is_home: bool = True) -
             $GLOBALS['kk_test_hooks'][] = compact('hook', 'callback', 'priority', 'accepted_args');
         }}
         function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {{}}
+        function get_template_directory() {{ return {theme_path}; }}
         function is_home() {{ return $GLOBALS['kk_test_is_home']; }}
         function is_front_page() {{ return false; }}
         function get_query_var($name, $default = '') {{

--- a/scripts/tests/test_issue_351_aurora_release.py
+++ b/scripts/tests/test_issue_351_aurora_release.py
@@ -22,7 +22,8 @@ class Issue351AuroraReleaseTests(unittest.TestCase):
 
         self.assertIsNotNone(style_version)
         self.assertIsNotNone(cache_version)
-        self.assertEqual("1.3.39", style_version.group(1))
+        version_parts = tuple(int(part) for part in style_version.group(1).split("."))
+        self.assertGreaterEqual(version_parts, (1, 3, 39))
         self.assertEqual(style_version.group(1), cache_version.group(1))
 
     def test_changelog_names_both_metadata_repairs(self):

--- a/scripts/tests/test_swarm_ready_static_checks.py
+++ b/scripts/tests/test_swarm_ready_static_checks.py
@@ -50,6 +50,17 @@ class SwarmReadyStaticChecks(unittest.TestCase):
         self.assertIn("KK_OG_SNIPPET_ACTIVE", functions)
         self.assertIn("PHP_INT_MAX", functions)
 
+    def test_aurora_honors_approved_singular_search_titles(self):
+        functions = (ROOT / "theme/kk-aurora/functions.php").read_text()
+        title_module = (ROOT / "theme/kk-aurora/inc/seo-title.php").read_text()
+
+        self.assertIn("require_once get_template_directory() . '/inc/seo-title.php';", functions)
+        self.assertIn("function filter_pre_get_document_title", title_module)
+        self.assertIn("'jetpack_seo_html_title'", title_module)
+        self.assertIn("wp_strip_all_tags", title_module)
+        self.assertIn("'pre_get_document_title'", title_module)
+        self.assertIn("PHP_INT_MAX", title_module)
+
     def test_twitter_card_snippet_uses_current_site_handle(self):
         snippet = (ROOT / "fixes/issue-43-twitter-cards.php").read_text()
         note = (ROOT / "fixes/issue-43-twitter-cards.md").read_text()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,9 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.39');
+define('KK_AURORA_VERSION', '1.3.40');
+
+require_once get_template_directory() . '/inc/seo-title.php';
 
 /**
  * Theme setup

--- a/theme/kk-aurora/inc/seo-title.php
+++ b/theme/kk-aurora/inc/seo-title.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Approved singular search-title handling.
+ *
+ * @package KK_Aurora
+ */
+
+declare(strict_types=1);
+
+namespace KK_Aurora;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Normalize an approved search title stored in post meta.
+ */
+function approved_document_title(mixed $value): string {
+    if (!is_string($value)) {
+        return '';
+    }
+
+    return trim(wp_strip_all_tags($value));
+}
+
+/**
+ * Use the approved per-item search title without changing the public post title.
+ */
+function filter_pre_get_document_title(string $title): string {
+    if (!is_singular()) {
+        return $title;
+    }
+
+    $post = get_queried_object();
+    if (!$post instanceof \WP_Post) {
+        return $title;
+    }
+
+    $approved_title = approved_document_title(
+        get_post_meta($post->ID, 'jetpack_seo_html_title', true)
+    );
+
+    return $approved_title !== '' ? $approved_title : $title;
+}
+add_filter(
+    'pre_get_document_title',
+    __NAMESPACE__ . '\\filter_pre_get_document_title',
+    PHP_INT_MAX
+);

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.40 =
+* Render approved `jetpack_seo_html_title` values as exact singular document titles while preserving existing fallbacks (#357).
+
 = 1.3.39 =
 * Preserve the keynote-first homepage Open Graph title when the front-page object title is empty (#346).
 * Give every Blog archive page a clean self-canonical and matching Open Graph URL (#347).

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.39
+Version: 1.3.40
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/tests/seo-title-smoke.php
+++ b/theme/kk-aurora/tests/seo-title-smoke.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Behavior smoke for Aurora's approved singular search titles.
+ *
+ * @package KK_Aurora
+ */
+
+declare(strict_types=1);
+
+define('ABSPATH', __DIR__);
+
+final class WP_Post {
+    public function __construct(public int $ID) {
+    }
+}
+
+$GLOBALS['aurora_smoke_filters'] = [];
+$GLOBALS['aurora_smoke_is_singular'] = true;
+$GLOBALS['aurora_smoke_object'] = new WP_Post(5236);
+$GLOBALS['aurora_smoke_meta'] = [];
+
+function add_filter(
+    string $hook,
+    callable|string $callback,
+    int $priority = 10,
+    int $accepted_args = 1
+): bool {
+    $GLOBALS['aurora_smoke_filters'][] = compact(
+        'hook',
+        'callback',
+        'priority',
+        'accepted_args'
+    );
+    return true;
+}
+
+function is_singular(): bool {
+    return $GLOBALS['aurora_smoke_is_singular'];
+}
+
+function get_queried_object(): object|null {
+    return $GLOBALS['aurora_smoke_object'];
+}
+
+function get_post_meta(int $post_id, string $key, bool $single): mixed {
+    if ($post_id !== 5236 || $key !== 'jetpack_seo_html_title' || !$single) {
+        throw new RuntimeException('Unexpected post-meta lookup.');
+    }
+
+    return $GLOBALS['aurora_smoke_meta'][$key] ?? '';
+}
+
+function wp_strip_all_tags(string $value): string {
+    return strip_tags($value);
+}
+
+function expect_same(mixed $expected, mixed $actual, string $message): void {
+    if ($expected === $actual) {
+        return;
+    }
+
+    fwrite(
+        STDERR,
+        sprintf("FAIL: %s\nExpected: %s\nActual: %s\n", $message, var_export($expected, true), var_export($actual, true))
+    );
+    exit(1);
+}
+
+require dirname(__DIR__) . '/inc/seo-title.php';
+
+expect_same(
+    [
+        'hook'          => 'pre_get_document_title',
+        'callback'      => 'KK_Aurora\\filter_pre_get_document_title',
+        'priority'      => PHP_INT_MAX,
+        'accepted_args' => 1,
+    ],
+    $GLOBALS['aurora_smoke_filters'][0] ?? null,
+    'The title filter must be registered last.'
+);
+
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = '  <b>AI Skills for Storytellers: OpenAI\'s Souki Mansoor</b>  ';
+expect_same(
+    "AI Skills for Storytellers: OpenAI's Souki Mansoor",
+    KK_Aurora\filter_pre_get_document_title('Fallback title'),
+    'A populated approved title must be trimmed and tag-free.'
+);
+
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = "  Broetry, Content Farms, TL;DR \u{2014} Is the Internet OK?  ";
+expect_same(
+    "Broetry, Content Farms, TL;DR \u{2014} Is the Internet OK?",
+    KK_Aurora\filter_pre_get_document_title('Fallback title'),
+    'Unicode punctuation in approved titles must remain exact.'
+);
+
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = 'AI and Music: A Digital Renaissance';
+expect_same(
+    'AI and Music: A Digital Renaissance',
+    KK_Aurora\filter_pre_get_document_title('Fallback title'),
+    'Short approved titles must remain exact.'
+);
+
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = '';
+expect_same(
+    'Fallback title',
+    KK_Aurora\filter_pre_get_document_title('Fallback title'),
+    'Empty approved titles must preserve the existing fallback.'
+);
+
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = ['not', 'a', 'string'];
+expect_same(
+    'Fallback title',
+    KK_Aurora\filter_pre_get_document_title('Fallback title'),
+    'Invalid approved titles must preserve the existing fallback.'
+);
+
+$GLOBALS['aurora_smoke_is_singular'] = false;
+$GLOBALS['aurora_smoke_meta']['jetpack_seo_html_title'] = 'Must not render';
+expect_same(
+    'Archive fallback',
+    KK_Aurora\filter_pre_get_document_title('Archive fallback'),
+    'Non-singular routes must remain unchanged.'
+);
+
+$GLOBALS['aurora_smoke_is_singular'] = true;
+$GLOBALS['aurora_smoke_object'] = new stdClass();
+expect_same(
+    'Invalid object fallback',
+    KK_Aurora\filter_pre_get_document_title('Invalid object fallback'),
+    'Unexpected queried objects must remain unchanged.'
+);
+
+echo "Aurora SEO title smoke passed.\n";


### PR DESCRIPTION
## Summary

- honor non-empty `jetpack_seo_html_title` values as exact singular document titles
- preserve current front-page, archive, taxonomy, search, 404, empty-meta, and invalid-object fallbacks
- leave public H1s, post titles, canonicals, bodies, and Open Graph titles unchanged
- prepare Aurora 1.3.40 without modifying or replacing the hashed 1.3.39 package
- add a PHP behavior smoke, static registration coverage, release handoff, and PHPCS coverage for theme modules

## Evidence

The July 14 Growth Mirror window found post 5236 at 31 impressions, 0 clicks, 0.00% CTR, and average position 6.97 for `"creator community specialist" openai`. Its approved search title is already stored, but production still emits the longer public post title plus the site descriptor.

A deterministic public check of all 19 batch-4 posts with approved search titles found that none emitted its approved value as the exact document title. The theme source did not read `jetpack_seo_html_title`.

## Verification

- `make verify`
  - 54 publisher tests passed
  - 191 operational tests passed
  - 3 SEO inventory tests passed
  - 68 SEO/backfill/link tests passed
  - plugin smokes passed
  - Aurora SEO title behavior smoke passed
  - docs truth passed
  - PHPCS passed
- focused PHP syntax checks passed
- `git diff --check` passed

## Safety

This PR does not package or deploy Aurora, write WordPress content or metadata, submit Search Console indexing requests, change GA4, change DNS, or touch credentials. A future 1.3.40 deployment remains separately approval-gated with a fresh package checksum, rollback artifact, cache purge, and anonymous public readback.

Closes #357
