### PR TITLE
ci: add Dependabot coverage for Composer, pip, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+# Dependabot version-update configuration (issue #375).
+#
+# Scope: version updates only. Enabling Dependabot ALERTS and SECURITY
+# updates is a separate, human-gated repository-settings change
+# (Settings -> Advanced Security) tracked under issue #374 — this file
+# cannot and does not toggle those.
+#
+# Update PRs are never auto-merged: repo allow_auto_merge is false and
+# the manual review/deploy model is preserved. Patch/minor updates are
+# grouped per ecosystem to keep noise down; major updates arrive as
+# individual PRs so each one is reviewable on its own.
+#
+# Labels below are limited to labels that already exist in this repo
+# (`ci`, `tech-debt`); there is no `dependencies` label as of 2026-07-16.
+
+version: 2
+
+updates:
+  # Composer dev toolchain (phpcs / wpcs) — composer.json + composer.lock at repo root
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+      - "tech-debt"
+    groups:
+      composer-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Root Python test requirements (requirements-test.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+      - "tech-debt"
+    groups:
+      pip-root-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Notion -> WP connector requirements (scripts/notion-to-wp/requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/scripts/notion-to-wp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+      - "tech-debt"
+    groups:
+      pip-connector-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by .github/workflows/
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+      - "tech-debt"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Closes #375

## Summary

Adds `.github/dependabot.yml` (version 2 syntax) — a new file, nothing else touched. Weekly version-update coverage for every dependency surface found in `origin/main`:

| Ecosystem | Directory | Manifest verified |
|---|---|---|
| composer | `/` | `composer.json` + `composer.lock` |
| pip | `/` | `requirements-test.txt` |
| pip | `/scripts/notion-to-wp` | `requirements.txt` |
| github-actions | `/` | `.github/workflows/` |

Design choices per the acceptance criteria:

- `open-pull-requests-limit: 3` per ecosystem so automation cannot flood the backlog.
- Patch/minor updates grouped per ecosystem; major updates stay as individual, reviewable PRs.
- Labels limited to ones that actually exist in this repo (`ci`, `tech-debt`); `dependencies` does not exist here (checked `gh label list` 2026-07-16), so it is not referenced.
- Header comment in the file documents that enabling Dependabot alerts/security updates is a separate human repository-settings gate (tracked in #374) — this config covers version updates only.
- Manual deployment model preserved: no auto-merge, no workflow changes, no dependency bumps in this PR.

## Verification

```
$ ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot yaml ok"'
dependabot yaml ok

$ python3 -c "import yaml; d=yaml.safe_load(open('.github/dependabot.yml')); assert d['version']==2; assert len(d['updates'])==4; print([(u['package-ecosystem'], u['directory']) for u in d['updates']])"
[('composer', '/'), ('pip', '/'), ('pip', '/scripts/notion-to-wp'), ('github-actions', '/')]

$ test -f composer.lock && test -f requirements-test.txt && test -f scripts/notion-to-wp/requirements.txt && echo manifests ok
manifests ok
```

## Out of scope (per issue)

- Enabling repository security settings (human gate, #374)
- Auto-merging dependency PRs
- Updating any dependencies
- Renovate or other bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tJ64xoJxsqNbVbyWBhDet