### PR TITLE
ci: pin all GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/agent-pr-generator.yml
+++ b/.github/workflows/agent-pr-generator.yml
@@ -12,7 +12,7 @@ jobs:
   diagnostic:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Report parked automation status
         run: |

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label based on title and body
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -109,7 +109,7 @@ jobs:
     needs: auto-label
     steps:
       - name: Suggest next routing
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/backlog-reconcile.yml
+++ b/.github/workflows/backlog-reconcile.yml
@@ -19,7 +19,7 @@ jobs:
   reconcile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0   # full history so branch ancestry checks work
       - name: Run backlog reconcile (report-only)
@@ -28,7 +28,7 @@ jobs:
         run: |
           python3 scripts/reconcile_backlog.py --stale-days 90 --write --timestamp "$(date -u +%Y%m%d-%H%M%SZ)" | tee "$GITHUB_STEP_SUMMARY"
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backlog-reconcile-report
           path: docs/current-state/reports/backlog-reconcile-*.md

--- a/.github/workflows/marquee-weekly.yml
+++ b/.github/workflows/marquee-weekly.yml
@@ -23,9 +23,9 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -63,7 +63,7 @@ jobs:
           PY
 
       - name: Open draft PR with proposals
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           branch: marquee/weekly-proposals
           base: main

--- a/.github/workflows/reusable-wordpress-validation.yml
+++ b/.github/workflows/reusable-wordpress-validation.yml
@@ -13,10 +13,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ inputs.php-version }}
           tools: composer
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload PHPCS report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: phpcs-report
           path: phpcs-report.*

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -20,11 +20,11 @@ jobs:
       has_php: ${{ steps.changed-files.outputs.has_php }}
       has_docs: ${{ steps.changed-files.outputs.has_docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Detect changed file types
         id: changed-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -46,7 +46,7 @@ jobs:
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
 
       - name: Check PR title format
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -60,7 +60,7 @@ jobs:
             }
 
       - name: Check PR links to issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.validate.outputs.has_php == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
           tools: composer
@@ -107,10 +107,10 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -125,10 +125,10 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.validate.outputs.has_docs == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check docs for stale current-state claims
         run: python3 scripts/docs_truth_check.py
@@ -150,10 +150,10 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -161,7 +161,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all validations passed
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;


### PR DESCRIPTION
Closes #373

Mechanical supply-chain hardening: every `uses:` reference under `.github/workflows/` is now pinned to the immutable commit SHA that its tag currently resolves to, with the human-readable tag preserved as a trailing comment. The one `@master` reference (`aquasecurity/trivy-action`) had no release in use, so it is pinned to the latest official release (v0.36.0). No version upgrades otherwise, no changes to action inputs, triggers, permissions, job conditions, or workflow enablement (agent-pr-generator.yml stays a parked manual stub).

## Pin table

| Action | Old ref | Pinned SHA | Release tag at SHA |
|---|---|---|---|
| actions/checkout | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| actions/upload-artifact | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| actions/github-script | v7 | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | v7.1.0 |
| shivammathur/setup-php | v2 | `f3e473d116dcccaddc5834248c87452386958240` | 2.37.2 |
| actions/setup-python | v5 | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| actions/setup-node | v4 | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| aquasecurity/trivy-action | master | `ed142fd0673e97e23eac54620cfb913e5ce36c25` | v0.36.0 |
| github/codeql-action/upload-sarif | v3 | `b7351df727350dca84cb9d725d57dcf5bc82ba26` | v3.37.1 |
| peter-evans/create-pull-request | v6 | `c5a7806660adbe173f04e3e038b0ccdcd758773c` | v6.1.0 |

## SHA verification method

Each tag was resolved via the GitHub API against the official upstream repo: `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereferencing annotated tags through `git/tags/<sha>` to the underlying commit. Every resulting commit SHA was then cross-checked against the repo's tag list to confirm it carries the release tag shown above. Trivy source release: https://github.com/aquasecurity/trivy-action/releases/tag/v0.36.0

## Verification

- `! rg -n 'uses:\s+[^./][^@\s]*@(master|main|v[0-9]+)' .github/workflows` — PASS (no matches)
- `make docs-truth-check` — "docs truth check passed"
- `make python-test PYTHON=python3` — all suites pass (3 + 68 tests OK)
- `python3 -c "import yaml,...; yaml.safe_load(...)"` over all 7 workflow files — YAML OK
- `actionlint` — not installed locally; GitHub's workflow parser on this PR is the integration check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tJ64xoJxsqNbVbyWBhDet