### PR TITLE
docs: repair front-door project identity and setup drift (#372)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to the [kriskrug.co](https://kriskru
 
 ## Code of Conduct
 
-By participating in this project, you agree to maintain a respectful, inclusive, and collaborative environment that aligns with Kris Krug's mission of building a responsible and inclusive AI future.
+By participating in this project, you agree to keep this a respectful, inclusive, and collaborative place to work. This is the operations repo for Kris Krug's personal site; treat it and the people around it with care.
 
 ### Our Standards
 
@@ -54,7 +54,7 @@ Do **not** commit plaintext secrets. Canonical store is your vault (1Password `k
 ### Code Contributions
 
 1. **Fork the repository**
-2. **Create a branch**: `feature/issue-123-short-description` or `fix/issue-456-bug-name`
+2. **Create a lane-scoped branch from `main`**: `fix/issue-456-bug-name`, `docs/issue-101-update-readme`, or an agent-lane branch like `codex/...` or `cursor/...` (see [Branch Naming](#branch-naming))
 3. **Make your changes** following our coding standards
 4. **Test thoroughly** - all tests must pass
 5. **Submit a pull request** using our PR template
@@ -199,15 +199,25 @@ See [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL
 
 ### Local Setup
 
+There is no local app server to boot. The live site runs on Pagely and is not file-synced here. Local work means running the CLI tools and the validation gates below.
+
+CI runs the gates on PHP 8.2, Python 3.12, and Node 20 (pinned in [`.github/workflows/test-pr.yml`](.github/workflows/test-pr.yml)). The Aurora theme declares a minimum of PHP 8.0 in [`theme/kk-aurora/style.css`](theme/kk-aurora/style.css). You don't need exact version matches locally, but if a gate behaves differently than CI, check your runtime versions first.
+
 ```bash
 # Clone repository
 git clone https://github.com/WalksWithASwagger/kriskrug-wp.git
 cd kriskrug-wp
 
-# Notion → WP publisher (Python)
+# Full Python test gate (repo root)
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements-test.txt
+make python-test PYTHON=python
+
+# Notion → WP publisher (its own venv; several Makefile targets call it directly)
 cd scripts/notion-to-wp
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
+cd ../..
 # Then see scripts/notion-to-wp/README.md for env vars + dry-run usage
 
 # WordPress PHP validation
@@ -219,10 +229,14 @@ make verify
 
 ### Branch Naming
 
-- Feature: `feature/issue-123-description`
-- Bug Fix: `fix/issue-456-bug-name`
-- Enhancement: `enhancement/issue-789-improvement`
+All work branches from current `main`, one lane per branch. Agent sessions use their lane prefix so it is obvious which tool owns the branch:
+
+- Agent lanes: `codex/short-description`, `cursor/short-description`, `claude/issue-123-short-description`
+- Bug fix: `fix/issue-456-bug-name`
 - Documentation: `docs/issue-101-update-readme`
+- Feature: `feature/issue-123-description`
+
+Keep one issue per branch and don't mix Track A content changes with Track B theme changes in the same branch.
 
 ### Commit Messages
 
@@ -270,9 +284,8 @@ If broader automated coverage is added (for example PHPUnit, Playwright, or end-
 Contributors will be:
 - Listed in release notes
 - Credited in PR descriptions
-- Recognized in the Kris Krug community
 
-Thank you for helping build a better AI future for British Columbia!
+Thanks for helping keep kriskrug.co healthy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kriskrug-wp — Operations Hub for kriskrug.co
 
-> Building a Responsible & Inclusive AI Future for British Columbia
+> The personal site of Kris Krug: photographer, AI community builder, keynote speaker.
 
 **Live site:** [kriskrug.co](https://kriskrug.co/) (Pagely-hosted WordPress, Aurora `kk-aurora` theme)
 **Repo:** [WalksWithASwagger/kriskrug-wp](https://github.com/WalksWithASwagger/kriskrug-wp)
@@ -12,21 +12,9 @@ This repository is the **operations + content hub** for [kriskrug.co](https://kr
 
 ## About Kris Krug
 
-Kris Krug is a grassroots AI ecosystem initiative focused on building a responsible and inclusive AI future for British Columbia. Our community brings together:
+Kris Krug is a person, not an organization: a Vancouver-based photographer, AI community builder, and keynote speaker. [kriskrug.co](https://kriskrug.co/) is his personal site, covering his photography, writing, speaking, and community work.
 
-- AI enthusiasts and professionals
-- Policy makers and educators
-- Artists and creative technologists
-- Local community organizers
-- Technology innovators
-
-### Key Initiatives
-
-- **Regional Hubs** - Hyperlocal AI community building
-- **AI Film Club** - Exploring AI through cinema
-- **Mind/AI/Consciousness** - Philosophical discussions
-- **Events & Workshops** - Community learning opportunities
-- **Resource Directory** - Funding, hackathons, and tools
+Kris also convenes the BC + AI ecosystem community, but that project lives at [bc-ai.ca](https://bc-ai.ca/) and in its own repos. This repo is only about keeping his personal site healthy: publishing posts, maintaining the Aurora theme, and keeping SEO and schema in shape.
 
 ## Repository Purpose
 
@@ -96,8 +84,8 @@ skills/                          # Claude Code skills used in this repo
 ### Where to start
 
 - **Reading the site state:** `docs/current-state/README.md`
-- **Planning next work:** `docs/current-state/HANDOFF-2026-06-17.md` and `docs/current-state/CURRENT-STATE-2026-06-23.md`
-- **Latest startup truth:** `docs/current-state/reports/morning-truth-20260624-175842Z.md` (or run `make morning-truth` for a fresh read)
+- **Planning next work:** the newest dated `docs/current-state/CURRENT-STATE-*.md` and `docs/current-state/WORK-PLAN-*.md` (the index in `docs/current-state/README.md` names the current ones)
+- **Latest startup truth:** the newest `docs/current-state/reports/morning-truth-*.md` (run `make morning-truth` for a fresh one; dated links go stale fast, so always take the newest)
 - **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
 - **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
@@ -141,6 +129,24 @@ If you're editing a post, page, schema, redirect, or category → Track A. If yo
 
 ## Getting Started
 
+### What runs here
+
+There is no local app server. The live WordPress site runs on Pagely and is not file-synced with this repo. "Running" this repo means the CLI and validation surfaces:
+
+- `make status-readonly` or `make morning-truth` for startup truth
+- `make test` for the local test suite (Python, JavaScript syntax, plugin and theme smoke)
+- `make validate` for the WordPress PHP security ruleset (run `composer install` first)
+- `make verify` for the standard local gate (test + docs-truth-check + validate)
+- The Notion publisher CLI in [`scripts/notion-to-wp/`](scripts/notion-to-wp/)
+
+The full Python gate needs the packages in [`requirements-test.txt`](requirements-test.txt) at the repo root:
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements-test.txt
+make python-test PYTHON=python
+```
+
 ### For agents
 Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](docs/current-state/README.md).
 
@@ -160,6 +166,7 @@ Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](do
 - **Custom code:** PHP snippets (Code Snippets plugin on prod), `inc/digital-composting.php`, and packaged helper plugins such as `plugins/kk-sidebar-promos/`
 - **CLI Tools:** GitHub CLI (`gh`), Claude Code / Cursor agents
 - **Languages:** PHP, JavaScript, Python, Bash
+- **CI runtimes:** PHP 8.2, Python 3.12, Node 20 (pinned in [`.github/workflows/test-pr.yml`](.github/workflows/test-pr.yml)); the Aurora theme itself declares a minimum of PHP 8.0 in [`theme/kk-aurora/style.css`](theme/kk-aurora/style.css)
 
 ## Issue Labels
 
@@ -186,8 +193,11 @@ For questions about this repository or Kris Krug:
 
 - Create an issue in this repository
 - Visit [kriskrug.co](https://kriskrug.co/) for general inquiries
-- Join our community events
 
 ## License
 
-This repository is for project management, content publishing, and theme development. WordPress core and third-party plugins/themes maintain their respective licenses.
+Licensing is mixed on purpose:
+
+- The repo's own tooling, scripts, and docs are declared `proprietary` in [`composer.json`](composer.json). This is Kris's personal operations tooling, not a redistributable package.
+- The Aurora theme ([`theme/kk-aurora/`](theme/kk-aurora/)) is GPL-2.0-or-later, as declared in its `style.css`. WordPress themes are GPL derivatives, so the theme carries the GPL even though the surrounding repo does not.
+- WordPress core and third-party plugins/themes keep their own licenses.


### PR DESCRIPTION
Closes #372

## Summary

Repairs front-door identity and setup drift in `README.md` and `CONTRIBUTING.md` per the acceptance criteria in #372 (swarm epic #379, wave 1A). No code, workflow, Makefile, or script changes.

- **Identity:** README no longer describes Kris Krug as "a grassroots AI ecosystem initiative" with BC+AI community bullets. It now says plainly that Kris is a person (Vancouver-based photographer, AI community builder, keynote speaker), that kriskrug.co is his personal site, and that BC + AI work lives at bc-ai.ca in its own repos. Same fix for the tagline, Contact, CONTRIBUTING code-of-conduct wording, and the closing line.
- **Startup guidance:** README "Where to start" now points at the newest `docs/current-state/reports/morning-truth-*.md` and the newest dated `CURRENT-STATE-*` / `WORK-PLAN-*` via the `docs/current-state/README.md` index, instead of hard-coded dated links (the old link was to a 2026-06-24 report even though 2026-07-16 exists).
- **No local app server:** README "What runs here" and CONTRIBUTING "Local Setup" now state there is nothing to boot; the supported surfaces are `make status-readonly` / `make morning-truth`, `make test`, `make validate`, `make verify`, and the Notion publisher CLI.
- **CI runtime contract:** PHP 8.2, Python 3.12, Node 20 (pinned in `.github/workflows/test-pr.yml`) plus the theme minimum of PHP 8.0 (`theme/kk-aurora/style.css`), documented in both files.
- **Python test environment:** full gate setup via root `requirements-test.txt` + `make python-test PYTHON=python`, documented in both files.
- **Branch guidance:** CONTRIBUTING now leads with lane-scoped branches from `main` (`codex/...`, `cursor/...`, `claude/...`) while retaining readable `fix/` and `docs/` examples.
- **Licensing boundary:** README License section now explains the `proprietary` declaration in `composer.json` for repo tooling vs the GPL-2.0-or-later Aurora theme vs third-party licenses.
- **Historical docs:** untouched. No dated evidence rewritten, nothing deleted.

## Verification

- `make docs-truth-check` — passed ("docs truth check passed")
- `rg -n 'Python 3\.12|Node 20|PHP 8\.2|requirements-test\.txt' README.md CONTRIBUTING.md` — all four values present in both files
- `git diff --check` — clean
- All relative links in both edited files resolve (scripted check: none missing)
- Every documented make target exists on this branch: `status-readonly`, `morning-truth`, `test`, `validate`, `verify`, `python-test`, `docs-truth-check` (all pass `make -n`)
- Facts verified against this branch: `requirements-test.txt` at repo root; `composer.json` line 5 `"license": "proprietary"`; `theme/kk-aurora/style.css` `Requires PHP: 8.0` + GPL v2 or later; `test-pr.yml` pins PHP `8.2`, Python `3.12`, Node `20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tJ64xoJxsqNbVbyWBhDet
