### PR TITLE
[BUG] Make startup truth fail closed and honor injected credentials

### DIFF
--- a/scripts/check_current_state_drift.py
+++ b/scripts/check_current_state_drift.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -75,14 +76,36 @@ def parse_declared_values(work_plan: Path) -> dict[str, Any]:
 
 def fetch_wp_queue_counts(repo_root: Path) -> tuple[dict[str, int] | None, str | None]:
     env_path = repo_root / "scripts/notion-to-wp/.env"
-    if not env_path.exists():
-        return None, f"missing env file: {env_path}"
+    has_env_file = env_path.exists()
+    has_process_creds = bool(os.environ.get("WP_USER") and os.environ.get("WP_APP_PASSWORD"))
+    if not has_env_file and not has_process_creds:
+        return None, (
+            f"WordPress credentials unavailable: missing env file: {env_path} "
+            "and WP_USER/WP_APP_PASSWORD not set in process env"
+        )
 
     try:
-        client = WPClient.from_env(env_path, timeout=30)
+        client = WPClient.from_env(env_path if has_env_file else None, timeout=30)
         return wp_queue_counts(client), None
     except Exception as exc:
         return None, f"failed to fetch live draft queue counts: {exc}"
+
+
+def build_observed(
+    prs_json: Any,
+    issues_json: Any,
+    wp_counts: dict[str, int] | None,
+    smoke_json: Any,
+) -> dict[str, Any]:
+    """Map raw check payloads to observed values; failed sources stay None, never 0."""
+    return {
+        "open_prs": len(prs_json) if isinstance(prs_json, list) else None,
+        "open_issues": len(issues_json) if isinstance(issues_json, list) else None,
+        "wp_version": smoke_json.get("observed_wordpress_version") if isinstance(smoke_json, dict) else None,
+        "future_posts": wp_counts["future_posts"] if wp_counts else None,
+        "draft_posts": wp_counts["draft_posts"] if wp_counts else None,
+        "draft_pages": wp_counts["draft_pages"] if wp_counts else None,
+    }
 
 
 def evaluate_drift(declared: dict[str, Any], observed: dict[str, Any]) -> list[dict[str, Any]]:
@@ -98,14 +121,23 @@ def evaluate_drift(declared: dict[str, Any], observed: dict[str, Any]) -> list[d
     for key, label in labels:
         declared_value = declared.get(key)
         observed_value = observed.get(key)
-        drift = declared_value is not None and observed_value is not None and declared_value != observed_value
+        evaluated = declared_value is not None and observed_value is not None
+        drift = evaluated and declared_value != observed_value
+        if drift:
+            status = "drift"
+        elif evaluated:
+            status = "no drift"
+        else:
+            status = "not evaluated"
         checks.append(
             {
                 "key": key,
                 "label": label,
                 "declared": declared_value,
                 "observed": observed_value,
+                "evaluated": evaluated,
                 "drift": drift,
+                "status": status,
             }
         )
     return checks
@@ -123,8 +155,11 @@ def render_human(report: dict[str, Any]) -> str:
     ]
     for check in report["checks"]:
         declared = check["declared"] if check["declared"] is not None else "(missing)"
-        observed = check["observed"] if check["observed"] is not None else "(missing)"
-        drift = "YES" if check["drift"] else "no"
+        observed = check["observed"] if check["observed"] is not None else "unavailable"
+        if not check.get("evaluated", True):
+            drift = "not evaluated"
+        else:
+            drift = "YES" if check["drift"] else "no"
         lines.append(f"| {check['label']} | {declared} | {observed} | {drift} |")
 
     errors = report.get("errors", [])
@@ -145,7 +180,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--base-url", default="https://kriskrug.co", help="Site URL for smoke checks.")
     parser.add_argument("--json", action="store_true", help="Print JSON report.")
-    parser.add_argument("--fail-on-drift", action="store_true", help="Exit non-zero if any drift is detected.")
+    parser.add_argument(
+        "--fail-on-drift",
+        action="store_true",
+        help="Exit non-zero if any drift or check error is detected (opt-in automation gate).",
+    )
     return parser.parse_args()
 
 
@@ -177,14 +216,7 @@ def main() -> int:
         if error:
             errors.append(error)
 
-    observed = {
-        "open_prs": len(prs_json or []),
-        "open_issues": len(issues_json or []),
-        "wp_version": (smoke_json or {}).get("observed_wordpress_version"),
-        "future_posts": None if not wp_counts else wp_counts["future_posts"],
-        "draft_posts": None if not wp_counts else wp_counts["draft_posts"],
-        "draft_pages": None if not wp_counts else wp_counts["draft_pages"],
-    }
+    observed = build_observed(prs_json, issues_json, wp_counts, smoke_json)
 
     checks = evaluate_drift(declared, observed)
     report = {

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -106,14 +107,65 @@ def build_label_counts(issues_json: list[dict[str, Any]]) -> dict[str, int]:
 
 def fetch_wp_queue_counts(repo_root: Path) -> tuple[dict[str, int] | None, str | None]:
     env_path = repo_root / "scripts/notion-to-wp/.env"
-    if not env_path.exists():
-        return None, f"missing env file: {env_path}"
+    has_env_file = env_path.exists()
+    has_process_creds = bool(os.environ.get("WP_USER") and os.environ.get("WP_APP_PASSWORD"))
+    if not has_env_file and not has_process_creds:
+        return None, (
+            f"WordPress credentials unavailable: missing env file: {env_path} "
+            "and WP_USER/WP_APP_PASSWORD not set in process env"
+        )
 
     try:
-        client = WPClient.from_env(env_path, timeout=30)
+        client = WPClient.from_env(env_path if has_env_file else None, timeout=30)
         return wp_queue_counts(client), None
     except Exception as exc:
         return None, f"failed to fetch live draft queue counts: {exc}"
+
+
+def format_json_count(payload: Any) -> str:
+    """Render a list length, or 'unavailable' when the source query failed."""
+    return str(len(payload)) if isinstance(payload, list) else "unavailable"
+
+
+def summarize_smoke(smoke_json: Any) -> dict[str, Any]:
+    """Summarize public smoke JSON; an unavailable result never reads as 0 failures."""
+    if not isinstance(smoke_json, dict):
+        return {"available": False, "failures": None, "warnings": None, "observed_version": None}
+    failures = 0
+    warnings = 0
+    for check in smoke_json.get("checks", []):
+        if check.get("status") == "fail":
+            failures += 1
+        elif check.get("status") == "warn":
+            warnings += 1
+    return {
+        "available": True,
+        "failures": failures,
+        "warnings": warnings,
+        "observed_version": smoke_json.get("observed_wordpress_version"),
+    }
+
+
+def collect_truth_errors(
+    prs_json: Any,
+    issues_json: Any,
+    queue_error: str | None,
+    smoke_available: bool,
+    drift_json: Any,
+) -> list[str]:
+    """List startup truth data sources that could not be evaluated."""
+    errors: list[str] = []
+    if not isinstance(prs_json, list):
+        errors.append("open PR list unavailable (gh pr list JSON failed or was unparsable)")
+    if not isinstance(issues_json, list):
+        errors.append("open issue list unavailable (gh issue list JSON failed or was unparsable)")
+    if queue_error:
+        errors.append(f"draft queue counts unavailable: {queue_error}")
+    if not smoke_available:
+        errors.append("public smoke result unavailable (missing or unparsable JSON); treat as degraded")
+    if not isinstance(drift_json, dict):
+        errors.append("current-state drift report unavailable (command or parsing failure)")
+    return errors
 
 
 def render_command_block(result: CommandResult) -> str:
@@ -144,6 +196,11 @@ def main() -> int:
     parser.add_argument("--out", help="Write report to this path.")
     parser.add_argument("--stdout", action="store_true", help="Print the report instead of writing a file.")
     parser.add_argument("--skip-fetch", action="store_true", help="Skip git fetch for strictly non-mutating runs.")
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help="Exit non-zero when any startup truth data source is unavailable (opt-in automation gate).",
+    )
     args = parser.parse_args()
     if args.stdout and args.out:
         parser.error("--stdout cannot be combined with --out")
@@ -271,7 +328,11 @@ def main() -> int:
             repo_root,
         )
 
-    label_counts = build_label_counts(issues_json or [])
+    if isinstance(issues_json, list):
+        label_counts = build_label_counts(issues_json)
+        label_lines = [f"- `{key}`: `{count}`" for key, count in label_counts.items()]
+    else:
+        label_lines = ["- Issue label counts: `unavailable` (open issue JSON query failed)"]
     draft_queue_summary = (
         f"future posts `{queue_counts['future_posts']}`, "
         f"draft posts `{queue_counts['draft_posts']}`, "
@@ -280,16 +341,11 @@ def main() -> int:
         else "`unavailable` (see Draft Queue Counts stderr)"
     )
 
-    smoke_failures = 0
-    smoke_warnings = 0
-    observed_wp_version = "(unknown)"
-    if smoke_json:
-        observed_wp_version = smoke_json.get("observed_wordpress_version") or "(unknown)"
-        for check in smoke_json.get("checks", []):
-            if check.get("status") == "fail":
-                smoke_failures += 1
-            elif check.get("status") == "warn":
-                smoke_warnings += 1
+    smoke = summarize_smoke(smoke_json)
+    if smoke["available"]:
+        observed_wp_version = smoke["observed_version"] or "(unknown)"
+    else:
+        observed_wp_version = "unavailable"
 
     projects_status = parse_status_line(projects_headers.stdout)
     work_og_image = parse_og_image(work_page_html.stdout)
@@ -303,8 +359,8 @@ def main() -> int:
         "",
         "## Snapshot Summary",
         "",
-        f"- Open PRs: `{len(prs_json or [])}`",
-        f"- Open issues: `{len(issues_json or [])}`",
+        f"- Open PRs: `{format_json_count(prs_json)}`",
+        f"- Open issues: `{format_json_count(issues_json)}`",
         f"- WordPress version (smoke): `{observed_wp_version}`",
         f"- Draft queue: {draft_queue_summary}",
         f"- `/projects/` status: `{projects_status}`",
@@ -314,13 +370,7 @@ def main() -> int:
         "",
         "## Issue Label Signals",
         "",
-        f"- `priority:high`: `{label_counts['priority:high']}`",
-        f"- `aurora-v2`: `{label_counts['aurora-v2']}`",
-        f"- `track-b`: `{label_counts['track-b']}`",
-        f"- `swarm-ready`: `{label_counts['swarm-ready']}`",
-        f"- `swarm-parked`: `{label_counts['swarm-parked']}`",
-        f"- `needs-human-review`: `{label_counts['needs-human-review']}`",
-        f"- `auto-implement`: `{label_counts['auto-implement']}`",
+        *label_lines,
         "",
         "## Drift Check",
         "",
@@ -336,10 +386,13 @@ def main() -> int:
         for check in drift_json["checks"]:
             declared = check.get("declared")
             observed = check.get("observed")
-            drift = "YES" if check.get("drift") else "no"
+            if not check.get("evaluated", True):
+                drift = "not evaluated"
+            else:
+                drift = "YES" if check.get("drift") else "no"
             lines.append(
                 f"| {check.get('label')} | {declared if declared is not None else '(missing)'} | "
-                f"{observed if observed is not None else '(missing)'} | {drift} |"
+                f"{observed if observed is not None else 'unavailable'} | {drift} |"
             )
         if drift_json.get("errors"):
             lines.extend(["", "Drift checker errors:"])
@@ -348,13 +401,32 @@ def main() -> int:
     else:
         lines.append("- Drift report unavailable (command/parsing failure).")
 
+    if smoke["available"]:
+        smoke_lines = [
+            f"- Failures: `{smoke['failures']}`",
+            f"- Warnings: `{smoke['warnings']}`",
+        ]
+    else:
+        smoke_lines = [
+            "- Result: `unavailable` (public smoke output missing or unparsable; treat as degraded, not passing)",
+        ]
+
+    truth_errors = collect_truth_errors(prs_json, issues_json, queue_error, smoke["available"], drift_json)
+    if truth_errors:
+        availability_lines = [f"- `unavailable`: {error}" for error in truth_errors]
+    else:
+        availability_lines = ["- All startup truth data sources resolved."]
+
     lines.extend(
         [
             "",
             "## WP Smoke Summary",
             "",
-            f"- Failures: `{smoke_failures}`",
-            f"- Warnings: `{smoke_warnings}`",
+            *smoke_lines,
+            "",
+            "## Data Availability",
+            "",
+            *availability_lines,
             "",
             "## Aurora Risk (Read-Only)",
             "",
@@ -399,6 +471,12 @@ def main() -> int:
     else:
         out_path.write_text(report, encoding="utf-8")
         print(out_path)
+    if args.fail_on_error and truth_errors:
+        print(
+            f"morning-truth: {len(truth_errors)} data source(s) unavailable (--fail-on-error)",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/scripts/tests/test_check_current_state_drift.py
+++ b/scripts/tests/test_check_current_state_drift.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 import tempfile
 import unittest
@@ -15,6 +16,15 @@ def _http_error(code: int) -> HTTPError:
     err = HTTPError("http://x", code, f"err{code}", hdrs=None, fp=io.BytesIO(b""))
     err.close()
     return err
+
+
+def _clear_wp_process_creds():
+    """Context manager that removes injected WP credentials for deterministic tests."""
+    patcher = mock.patch.dict(os.environ)
+    patcher.start()
+    os.environ.pop("WP_USER", None)
+    os.environ.pop("WP_APP_PASSWORD", None)
+    return patcher
 
 
 class CurrentStateDriftQueueCountsTests(unittest.TestCase):
@@ -50,6 +60,112 @@ class CurrentStateDriftQueueCountsTests(unittest.TestCase):
         self.assertIsNone(result)
         self.assertIn("failed to fetch live draft queue counts", error)
         self.assertIn("HTTP Error 400", error)
+
+    def test_process_env_credentials_work_without_env_file(self):
+        client = object()
+        counts = {"future_posts": 4, "draft_posts": 5, "draft_pages": 6}
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"WP_USER": "u", "WP_APP_PASSWORD": "p"}), \
+                 mock.patch.object(check_current_state_drift.WPClient, "from_env", return_value=client) as from_env, \
+                 mock.patch.object(check_current_state_drift, "wp_queue_counts", return_value=counts):
+                result, error = check_current_state_drift.fetch_wp_queue_counts(Path(tmp))
+
+        self.assertEqual(result, counts)
+        self.assertIsNone(error)
+        from_env.assert_called_once_with(None, timeout=30)
+
+    def test_missing_env_file_and_process_env_is_reported(self):
+        patcher = _clear_wp_process_creds()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                result, error = check_current_state_drift.fetch_wp_queue_counts(Path(tmp))
+        finally:
+            patcher.stop()
+
+        self.assertIsNone(result)
+        self.assertIn("missing env file", error)
+        self.assertIn("WP_USER/WP_APP_PASSWORD not set in process env", error)
+
+
+class CurrentStateDriftJsonSourceTests(unittest.TestCase):
+    def test_failed_gh_command_returns_none_with_error(self):
+        failed = check_current_state_drift.CommandResult(
+            command=["gh", "pr", "list"], returncode=1, stdout="", stderr="gh: auth required"
+        )
+        with mock.patch.object(check_current_state_drift, "run_command", return_value=failed):
+            payload, error = check_current_state_drift.load_json_result(["gh", "pr", "list"], Path("."))
+
+        self.assertIsNone(payload)
+        self.assertIn("command failed (1)", error)
+        self.assertIn("gh: auth required", error)
+
+    def test_invalid_json_returns_none_with_error(self):
+        garbled = check_current_state_drift.CommandResult(
+            command=["gh", "issue", "list"], returncode=0, stdout="not json at all", stderr=""
+        )
+        with mock.patch.object(check_current_state_drift, "run_command", return_value=garbled):
+            payload, error = check_current_state_drift.load_json_result(["gh", "issue", "list"], Path("."))
+
+        self.assertIsNone(payload)
+        self.assertIn("invalid JSON", error)
+
+    def test_build_observed_keeps_failed_sources_unavailable_not_zero(self):
+        observed = check_current_state_drift.build_observed(None, None, None, None)
+        self.assertIsNone(observed["open_prs"])
+        self.assertIsNone(observed["open_issues"])
+        self.assertIsNone(observed["wp_version"])
+        self.assertIsNone(observed["future_posts"])
+        self.assertIsNone(observed["draft_posts"])
+        self.assertIsNone(observed["draft_pages"])
+
+    def test_build_observed_counts_successful_sources(self):
+        observed = check_current_state_drift.build_observed(
+            [{"number": 1}],
+            [{"number": 2}, {"number": 3}],
+            {"future_posts": 7, "draft_posts": 8, "draft_pages": 9},
+            {"observed_wordpress_version": "7.0.1"},
+        )
+        self.assertEqual(observed["open_prs"], 1)
+        self.assertEqual(observed["open_issues"], 2)
+        self.assertEqual(observed["wp_version"], "7.0.1")
+        self.assertEqual(observed["future_posts"], 7)
+
+
+class CurrentStateDriftEvaluationTests(unittest.TestCase):
+    def test_evaluate_drift_distinguishes_no_drift_from_not_evaluated(self):
+        declared = {"open_prs": 3, "open_issues": 5}
+        observed = {"open_prs": 3, "open_issues": None}
+        checks = {check["key"]: check for check in check_current_state_drift.evaluate_drift(declared, observed)}
+
+        self.assertTrue(checks["open_prs"]["evaluated"])
+        self.assertFalse(checks["open_prs"]["drift"])
+        self.assertEqual(checks["open_prs"]["status"], "no drift")
+
+        self.assertFalse(checks["open_issues"]["evaluated"])
+        self.assertFalse(checks["open_issues"]["drift"])
+        self.assertEqual(checks["open_issues"]["status"], "not evaluated")
+
+    def test_evaluate_drift_flags_real_drift(self):
+        checks = {
+            check["key"]: check
+            for check in check_current_state_drift.evaluate_drift({"open_prs": 3}, {"open_prs": 4})
+        }
+        self.assertEqual(checks["open_prs"]["status"], "drift")
+        self.assertTrue(checks["open_prs"]["drift"])
+
+    def test_render_human_shows_unavailable_and_not_evaluated(self):
+        checks = check_current_state_drift.evaluate_drift({"open_prs": 3}, {"open_prs": None})
+        report = {
+            "work_plan": "docs/current-state/WORK-PLAN.md",
+            "base_url": "https://example.test",
+            "checks": checks,
+            "errors": ["command failed (1): gh pr list"],
+        }
+        rendered = check_current_state_drift.render_human(report)
+
+        self.assertIn("| Open PRs | 3 | unavailable | not evaluated |", rendered)
+        self.assertNotIn("| Open PRs | 3 | 0 |", rendered)
+        self.assertIn("command failed (1): gh pr list", rendered)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_morning_truth_report.py
+++ b/scripts/tests/test_morning_truth_report.py
@@ -1,4 +1,6 @@
 import io
+import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -15,6 +17,15 @@ def _http_error(code: int) -> HTTPError:
     err = HTTPError("http://x", code, f"err{code}", hdrs=None, fp=io.BytesIO(b""))
     err.close()
     return err
+
+
+def _clear_wp_process_creds():
+    """Started patcher that removes injected WP credentials for deterministic tests."""
+    patcher = mock.patch.dict(os.environ)
+    patcher.start()
+    os.environ.pop("WP_USER", None)
+    os.environ.pop("WP_APP_PASSWORD", None)
+    return patcher
 
 
 class MorningTruthQueueCountsTests(unittest.TestCase):
@@ -51,12 +62,108 @@ class MorningTruthQueueCountsTests(unittest.TestCase):
         self.assertIn("failed to fetch live draft queue counts", error)
         self.assertIn("HTTP Error 400", error)
 
-    def test_missing_env_file_is_reported(self):
+    def test_process_env_credentials_work_without_env_file(self):
+        client = object()
+        counts = {"future_posts": 4, "draft_posts": 5, "draft_pages": 6}
         with tempfile.TemporaryDirectory() as tmp:
-            result, error = morning_truth_report.fetch_wp_queue_counts(Path(tmp))
+            with mock.patch.dict(os.environ, {"WP_USER": "u", "WP_APP_PASSWORD": "p"}), \
+                 mock.patch.object(morning_truth_report.WPClient, "from_env", return_value=client) as from_env, \
+                 mock.patch.object(morning_truth_report, "wp_queue_counts", return_value=counts):
+                result, error = morning_truth_report.fetch_wp_queue_counts(Path(tmp))
+
+        self.assertEqual(result, counts)
+        self.assertIsNone(error)
+        from_env.assert_called_once_with(None, timeout=30)
+
+    def test_missing_env_file_and_process_env_is_reported(self):
+        patcher = _clear_wp_process_creds()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                result, error = morning_truth_report.fetch_wp_queue_counts(Path(tmp))
+        finally:
+            patcher.stop()
 
         self.assertIsNone(result)
         self.assertIn("missing env file", error)
+        self.assertIn("WP_USER/WP_APP_PASSWORD not set in process env", error)
+
+
+class MorningTruthAvailabilityTests(unittest.TestCase):
+    def test_format_json_count_never_renders_failed_query_as_zero(self):
+        self.assertEqual(morning_truth_report.format_json_count(None), "unavailable")
+        self.assertEqual(morning_truth_report.format_json_count("gh error text"), "unavailable")
+        self.assertEqual(morning_truth_report.format_json_count([]), "0")
+        self.assertEqual(morning_truth_report.format_json_count([{"number": 1}]), "1")
+
+    def test_summarize_smoke_unavailable_is_not_zero_failures(self):
+        summary = morning_truth_report.summarize_smoke(None)
+        self.assertFalse(summary["available"])
+        self.assertIsNone(summary["failures"])
+        self.assertIsNone(summary["warnings"])
+        self.assertIsNone(summary["observed_version"])
+
+    def test_summarize_smoke_counts_failures_and_warnings(self):
+        summary = morning_truth_report.summarize_smoke(
+            {
+                "observed_wordpress_version": "7.0.1",
+                "checks": [
+                    {"status": "fail"},
+                    {"status": "warn"},
+                    {"status": "pass"},
+                    {"status": "fail"},
+                ],
+            }
+        )
+        self.assertTrue(summary["available"])
+        self.assertEqual(summary["failures"], 2)
+        self.assertEqual(summary["warnings"], 1)
+        self.assertEqual(summary["observed_version"], "7.0.1")
+
+    def test_run_json_command_failure_yields_none_payload(self):
+        completed = subprocess.CompletedProcess(
+            args=["gh", "pr", "list"], returncode=1, stdout="", stderr="gh: auth required"
+        )
+        with mock.patch.object(morning_truth_report.subprocess, "run", return_value=completed):
+            result, payload = morning_truth_report.run_json_command("PR JSON", ["gh", "pr", "list"], Path("."))
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIsNone(payload)
+
+    def test_run_json_command_invalid_json_yields_none_payload(self):
+        completed = subprocess.CompletedProcess(
+            args=["gh", "issue", "list"], returncode=0, stdout="definitely not json", stderr=""
+        )
+        with mock.patch.object(morning_truth_report.subprocess, "run", return_value=completed):
+            result, payload = morning_truth_report.run_json_command("Issue JSON", ["gh", "issue", "list"], Path("."))
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(payload)
+
+    def test_collect_truth_errors_lists_every_unavailable_source(self):
+        errors = morning_truth_report.collect_truth_errors(
+            prs_json=None,
+            issues_json=None,
+            queue_error="missing env file",
+            smoke_available=False,
+            drift_json=None,
+        )
+        self.assertEqual(len(errors), 5)
+        joined = "\n".join(errors)
+        self.assertIn("open PR list unavailable", joined)
+        self.assertIn("open issue list unavailable", joined)
+        self.assertIn("draft queue counts unavailable", joined)
+        self.assertIn("public smoke result unavailable", joined)
+        self.assertIn("drift report unavailable", joined)
+
+    def test_collect_truth_errors_empty_when_all_sources_resolved(self):
+        errors = morning_truth_report.collect_truth_errors(
+            prs_json=[],
+            issues_json=[{"number": 1, "labels": []}],
+            queue_error=None,
+            smoke_available=True,
+            drift_json={"checks": []},
+        )
+        self.assertEqual(errors, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #376

## Summary

The startup truth tools could turn failed checks into healthy-looking zeros and required a plaintext `scripts/notion-to-wp/.env` file before credentials would work. This PR makes both truth scripts report unavailable data honestly and honor process-env credentials.

**`scripts/check_current_state_drift.py`**
- New `build_observed()` maps raw payloads to observed values; a failed or unparsable `gh pr list` / `gh issue list` / smoke query stays `None` instead of collapsing to `0` via `len(x or [])`.
- Drift rows now carry `evaluated` and `status` (`drift` / `no drift` / `not evaluated`) so a row that could not be checked is never presented as clean.
- Human render shows `unavailable` for missing observed values and `not evaluated` in the drift column; `--fail-on-drift` remains the opt-in nonzero gate (drift or check errors).

**`scripts/morning_truth_report.py`**
- Snapshot summary renders `unavailable` (never `0`) for failed PR/issue JSON queries via `format_json_count()`.
- `summarize_smoke()` distinguishes a real 0-failure run from a missing/unparsable smoke result; unavailable smoke renders as degraded, never `0 failures`.
- Issue label signals render `unavailable` when the issue JSON query failed instead of all-zero counts.
- New `## Data Availability` section lists every unresolved data source.
- New opt-in `--fail-on-error` flag exits non-zero for automation; default read-only operation still degrades gracefully with exit 0.

**Injected credentials (both scripts)**
- `fetch_wp_queue_counts()` now works when `WP_USER` / `WP_APP_PASSWORD` come from process env (Varlock `varlock run --inject vars`, Cursor Cloud secrets) and `scripts/notion-to-wp/.env` is absent, matching `docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md`.
- The gitignored `.env` compatibility path continues to work and stays the explicit source when present (process env still overlays it via `load_env`).
- When neither source exists, the error names both paths without printing any credential values.

## Tests

Extended `scripts/tests/test_check_current_state_drift.py` and `scripts/tests/test_morning_truth_report.py` (11 tests each) covering: gh command failure, invalid JSON, smoke unavailability, drift `no drift` vs `not evaluated`, human render never showing false `0`, process-env credentials without `.env`, `.env` fallback, and the missing-both error. All offline and deterministic via mocked `subprocess` and `WPClient`/`wp_queue_counts` boundaries; no live WordPress calls, no real credentials.

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_morning_truth_report.py' -v` — 11 tests, OK
- `python3 -m unittest discover -s scripts/tests -p 'test_check_current_state_drift.py' -v` — 11 tests, OK
- `make python-test PYTHON=python3` — all suites pass (publisher, operational 216 tests, SEO inventory, SEO backfill 68 passed); no pre-existing failures observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tJ64xoJxsqNbVbyWBhDet