### PR TITLE
ci: validate every production PHP surface (#377)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test python-test javascript-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
+.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
 
 PYTHON ?= python3
 VARLOCK ?= varlock
@@ -52,6 +52,17 @@ javascript-syntax: ## Check committed JavaScript syntax
 	@command -v node >/dev/null 2>&1 || { echo "ERROR: node is required for JavaScript syntax checks."; exit 1; }
 	@for file in $(JAVASCRIPT_FILES); do node --check "$$file"; done
 
+php-syntax: ## Run php -l across all tracked PHP in inc/, plugins/, theme/, fixes/
+	@command -v php >/dev/null 2>&1 || { echo "ERROR: php is required for PHP syntax checks."; exit 1; }
+	@status=0; count=0; \
+	for file in $$(git ls-files 'inc/*.php' 'plugins/*.php' 'theme/*.php' 'fixes/*.php' | LC_ALL=C sort); do \
+		count=$$((count + 1)); \
+		out=$$(php -l "$$file" 2>&1) || { echo "$$out"; status=1; }; \
+	done; \
+	if [ "$$count" -eq 0 ]; then echo "ERROR: php-syntax found no tracked PHP files."; exit 1; fi; \
+	if [ "$$status" -ne 0 ]; then echo "php-syntax: FAILED ($$count files checked)"; exit 1; fi; \
+	echo "php-syntax: $$count files passed php -l"
+
 plugin-smoke: ## Run lightweight plugin smoke tests
 	@command -v php >/dev/null 2>&1 || { echo "ERROR: php is required for plugin smoke tests."; exit 1; }
 	@php plugins/kk-sidebar-promos/tests/smoke.php
@@ -66,7 +77,8 @@ verify: ## Run the standard local verification suite
 	@$(MAKE) docs-truth-check
 	@$(MAKE) validate
 
-validate: ## Run WordPress coding standards check
+validate: ## Run PHP syntax gate plus WordPress coding standards check
+	@$(MAKE) php-syntax
 	@echo "Validating WordPress coding standards..."
 	@bash skills/github-workflow-automation/scripts/validate_wordpress.sh
 

--- a/fixes/gsc-404-query-param-canonicalize.php
+++ b/fixes/gsc-404-query-param-canonicalize.php
@@ -24,11 +24,13 @@ function kk_gsc404_tracking_query_keys(): array {
  * Return true when the request carries legacy tracking params we should strip.
  */
 function kk_gsc404_has_tracking_query(): bool {
+    // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only key-presence check on public GET requests; no form data is processed.
     if (empty($_GET) || !is_array($_GET)) {
         return false;
     }
 
     foreach (kk_gsc404_tracking_query_keys() as $key) {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- key presence only; values are never read, and the redirect target is rebuilt from the sanitized path.
         if (array_key_exists($key, $_GET)) {
             return true;
         }

--- a/fixes/og-restore-snippet.php
+++ b/fixes/og-restore-snippet.php
@@ -83,6 +83,7 @@ add_action('wp_head', function (): void {
         $attribute = str_starts_with($name, 'twitter:') ? 'name' : 'property';
         printf(
             '<meta %s="%s" content="%s" />' . "\n",
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attribute is a hardcoded literal ('name' or 'property') selected by the ternary above.
             $attribute,
             esc_attr($name),
             esc_attr((string) $value)

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,9 @@
 	<arg name="parallel" value="8"/>
 	<arg value="p"/>
 
+	<file>fixes</file>
 	<file>inc</file>
+	<file>plugins/kk-marquee-board</file>
 	<file>plugins/kk-sidebar-promos</file>
 	<file>theme/kk-aurora/functions.php</file>
 	<file>theme/kk-aurora/inc</file>


### PR DESCRIPTION
Closes #377

Swarm lane (epic #379, wave 1B). Scope: `Makefile`, `phpcs.xml.dist`, and the two minimal annotations required to make the expanded high-signal gate pass. **No `.github/workflows/**` files touched** (lane #373 owns them this wave).

## What changed

- **`make php-syntax`** (new): deterministic `php -l` gate over all tracked PHP in `inc/`, `plugins/`, `theme/`, and `fixes/` via sorted `git ls-files` (38 files, tests and fixtures included). Fails loudly on parse errors or an empty file list.
- **`make validate`** now runs `php-syntax` first, then PHPCS. Because both `test-pr.yml` (php-validation job) and `reusable-wordpress-validation.yml` already invoke `make validate`, the syntax gate is in the PR CI path **with zero workflow edits** — no post-#373 wiring is required. If reviewers prefer a separate CI step later, the line to add after #373 merges is `run: make php-syntax` before the `make validate` step in `test-pr.yml`.
- **`phpcs.xml.dist`**: added `<file>fixes</file>` and `<file>plugins/kk-marquee-board</file>` to the existing high-signal security ruleset (EscapeOutput, NonceVerification, SafeRedirect, ValidatedSanitizedInput, Capabilities). PHPCS coverage went from 19 files to 35.
- **Test scaffolding**: `*/tests/smoke.php` stays PHPCS-excluded and `theme/kk-aurora/tests/` is not in the PHPCS file list (execution scaffolding), but all 3 test files are still covered by `php -l` (38 = 35 + 3).
- **PHP 8.2 CI target unchanged**; `testVersion 8.1-` untouched.

## Findings from the expanded gate (flagged, not silently fixed)

The expanded surface exposed 1 error + 3 warnings, all safe-by-construction false positives. Both files carry a "live Code Snippet must match this file" contract, so I used comment-only `phpcs:ignore` annotations with justifications instead of functional edits (zero runtime change; repo copy diverges from the live snippet by comments only until next sync):

1. `fixes/og-restore-snippet.php:86` — `WordPress.Security.EscapeOutput.OutputNotEscaped` on `$attribute`, which is a hardcoded ternary literal (`'name'`/`'property'`). Alternative real fix would be `esc_attr( $attribute )` (identity on these values) if KK prefers to re-sync the live snippet.
2. `fixes/gsc-404-query-param-canonicalize.php:27,32` — `WordPress.Security.NonceVerification.Recommended` (x3) on read-only `$_GET` key-presence checks in a public GET canonicalization redirect; no form data or values are consumed, and the redirect target is rebuilt from the sanitized path.

No genuine syntax errors or security violations were found in any production PHP file.

## PHP surface inventory (38 tracked PHP files)

| Surface | Files | php -l | PHPCS |
|---|---|---|---|
| `fixes/` | 12 | yes | yes (new) |
| `inc/` | 1 | yes | yes |
| `plugins/kk-marquee-board/` (incl. tests) | 4 | yes | 3 (new; smoke test excluded) |
| `plugins/kk-sidebar-promos/` (incl. tests) | 8 | yes | 7 (smoke test excluded) |
| `theme/kk-aurora/` functions + inc + patterns + tests | 13 | yes | 12 (test scaffold excluded) |

## Verification evidence (local, PHP 8.5.6; CI stays 8.2)

- `make php-syntax` → `php-syntax: 38 files passed php -l`
- PHPCS file-count proof: `vendor/bin/phpcs -q --standard=phpcs.xml.dist --report=json` → 35 files, 0 errors, 0 warnings
- `make validate` → php-syntax pass + `✓ No coding standard violations found`
- `make plugin-smoke` → `KK Sidebar Promos smoke tests passed.` / `KK Marquee Board smoke tests passed.`
- `make theme-smoke` → `Aurora SEO title smoke passed.`
- `make verify PYTHON=python3` → full pass (publisher/operational/SEO-inventory unittest suites, 68 pytest backfill/link-safety tests, JS syntax, smokes, docs-truth-check, validate)
- Negative test: staged a deliberately broken `fixes/tmp-invalid-fixture.php` (never committed) → `make php-syntax` failed with `Parse error ... php-syntax: FAILED (39 files checked)`, then removed it and re-verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tJ64xoJxsqNbVbyWBhDet
