### PR TITLE
docs: clear open-PR count after #433 merge

### DIFF
--- a/docs/current-state/CURRENT-STATE-2026-07-16.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-16.md
@@ -9,7 +9,7 @@ This file is the declared snapshot for `make current-state-drift-check` / `make 
 ## Verified State
 
 - `origin/main` includes merges through deps cleanup (#429/#392/#393/#395/#399–#401/#432) and content packet #431.
-- Open PRs: `1` (this truth-sync PR #433).
+- Open PRs: `0`.
 - Open issues: `77`.
 - Production still publicly reports WordPress `7.0.2`.
 - Live Aurora theme (`style.css` Version header): `1.3.37`.
@@ -40,7 +40,7 @@ This file is the declared snapshot for `make current-state-drift-check` / `make 
 - July agent ops stack merged: `publish_common` (#312/#315), content packets (#311), Cloud AGENTS notes (#310).
 - Front-door docs + day runbook merged via PR #359; Monday GitHub queue filed as #360–#366; long-run ops #368–#369.
 - Orchestra/hygiene stack merged via PR #367; Varlock vault/schema/Cloud secrets rollout merged via PR #370.
-- Open issues moved ~33 → **42** after Monday + long-run queue filing; open PRs are **1** during truth-sync PR #433; open issues about **77**.
+- Open issues moved ~33 → **42** after Monday + long-run queue filing; open PRs are **0** after truth-sync #433; open issues about **77**.
 - Declared draft-page count normalized to `4` (was `5` in the June snapshot).
 
 ## Stash / secrets notes

--- a/docs/current-state/CURRENT-STATE-2026-07-16.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-16.md
@@ -9,7 +9,7 @@ This file is the declared snapshot for `make current-state-drift-check` / `make 
 ## Verified State
 
 - `origin/main` includes merges through deps cleanup (#429/#392/#393/#395/#399–#401/#432) and content packet #431.
-- Open PRs: `0`.
+- Open PRs: `1` (PR clearing post-#433 open-PR count).
 - Open issues: `77`.
 - Production still publicly reports WordPress `7.0.2`.
 - Live Aurora theme (`style.css` Version header): `1.3.37`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tiny declared-state sync after #433. Declares open PRs correctly while this PR is open; after merge, follow with `0` if needed (or accept one-commit lag).

Also asks KK to keep/kill leftover remotes from #368: `marquee/weekly-proposals`, `fix/jetpack-open-graph-enable`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224f625e-7f8d-4d3b-9e9b-6b7425802853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

