### PR TITLE
fix: align WordPress tooling with Varlock

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -1,36 +1,14 @@
 # kriskrug-wp environment contract for agents and local operators.
-#
-# Real values belong in (priority order):
-#   1. Vault (1Password `kk-dev` item) resolved via `op(...)` in gitignored `.env.local`
-#   2. Cursor Cloud / process env injection
-#   3. Temporary gitignored `scripts/notion-to-wp/.env` cache (compat only — not SoT)
-#
-# Never commit plaintext secrets. Agents may read THIS file freely.
-#
-# This file uses @env-spec — see https://varlock.dev/env-spec
-# Rollout guide: docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md
-#
-# Optional 1Password plugin (enable locally when using op() resolvers):
-#   varlock install-plugin @varlock/1password-plugin@latest
-#   then uncomment:
-#     # @plugin(@varlock/1password-plugin@latest)
-#     # @initOp(token=$OP_TOKEN, allowAppAuth=forEnv(dev))
-#   and in gitignored `.env.local`:
-#     WP_USER=op(op://kk-dev/kriskrug-wp/username)
-#     WP_APP_PASSWORD=op(op://kk-dev/kriskrug-wp/credential)
-#     NOTION_TOKEN=op(op://kk-dev/notion/credential)
-#
+# Real values belong in the user-managed shared file or repo override below.
+# Agents may inspect this schema, but must not read local value files.
+# @import(~/.agents/env/values/.env.shared.local, pick=[WP_USER, WP_APP_PASSWORD, NOTION_TOKEN], allowMissing=true)
+# @import(~/.agents/env/values/.env.kriskrug-wp.local, pick=[WP_USER, WP_APP_PASSWORD, NOTION_TOKEN, WP_BASE_URL, WP_DEFAULT_AUTHOR_ID, WP_AUTH_MODE], allowMissing=true)
 # @defaultRequired=false @defaultSensitive=false
 # ---
 
-# 1Password service-account token for Cloud / CI. Desktop `op` app auth is
-# enough for local allowAppAuth — leave empty on laptops using the 1Password app.
-# @type=string @sensitive @optional
-OP_TOKEN=
-
 # WordPress application-password auth for kriskrug.co REST scripts.
-# Functionally required for live WP work. Soft @required so `make env-check`
-# succeeds in Cloud without secrets. Wire via `.env.local` / process env / vault.
+# Functionally required for live WP work. Optional here so schema validation
+# still succeeds for public and cloud-safe tasks.
 # Generate at https://kriskrug.co/wp-admin/profile.php → Application Passwords
 # @sensitive @docs(https://kriskrug.co/wp-admin/profile.php)
 WP_USER=
@@ -50,9 +28,8 @@ WP_AUTH_MODE=
 # @sensitive @optional
 NOTION_TOKEN=
 
-# Optional path overrides for sibling-repo env / content roots.
-# DEPRECATED as secret source-of-truth — prefer vault + `varlock run`.
-# Kept so existing loaders keep working during the migration.
+# Optional path overrides for legacy sibling env and content roots.
+# Prefer the shared Varlock imports above. These remain for compatibility.
 # @optional
 KKAI_ENV_PATH=
 # @optional

--- a/Makefile
+++ b/Makefile
@@ -267,8 +267,8 @@ env-check: ## Validate .env.schema via Varlock (soft-OK when secrets are absent)
 			echo "env-check: schema is readable; one or more values are missing/unresolved."; \
 			echo "This is expected in Cursor Cloud without secrets, or before local vault wiring."; \
 			echo "Wire WP_USER / WP_APP_PASSWORD (and optional NOTION_TOKEN) via:"; \
-			echo "  - gitignored .env.local with op(op://kk-dev/...) after enabling the 1Password plugin"; \
-			echo "  - Cursor Cloud secrets / process env"; \
+			echo "  - ~/.agents/env/values/.env.shared.local or .env.kriskrug-wp.local"; \
+			echo "  - cloud-agent secrets / process env"; \
 			echo "  - temporary scripts/notion-to-wp/.env cache (compat only)"; \
 			echo "Then: $(VARLOCK) run --inject vars -- make status-readonly"; \
 			exit 0; \

--- a/docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md
+++ b/docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md
@@ -1,104 +1,75 @@
-# Varlock rollout — kriskrug-wp (2026-07-16)
+# Varlock rollout: kriskrug-wp
 
-**Status:** implemented for this repo’s Phase 0 / ops secrets path.  
-**Does not authorize** live WordPress writes.  
-**Does not** make Cursor Cloud pick up laptop 1Password automatically.
+**Status:** the repository contract and process-injection path are implemented.
+This does not authorize live WordPress writes or copy laptop values into cloud
+environments.
 
-## Verdict (locked)
+## Contract
 
 | Layer | Role |
 |---|---|
-| **Vault** (1Password / Infisical / Bitwarden) | Canonical secret store |
-| **Varlock** (per repo `.env.schema`) | Schema + validation + AI-safe docs + `varlock run` injection |
-| **Cursor Cloud secrets** | Separate injection path for remote agents |
+| `~/.agents/env/values/.env.shared.local` | Human-managed reusable local values |
+| `~/.agents/env/values/.env.kriskrug-wp.local` | Optional repo-specific local overrides |
+| `.env.schema` | Committed variable names, sensitivity, defaults, and imports |
+| `varlock run --inject vars -- ...` | Validated process injection |
+| Cloud platform secret settings | Separate development or deployment copies |
 
-Do **not** invent one global auto-loader. Cross-directory personal use is only via explicit `varlock run -p ~/.env.cursor -- …`.
+Varlock is the repository contract and loader. The gitignored values directory
+is the canonical source for this Mac. Cloud platforms retain only the values
+their runtime needs.
 
-## 1. Human inventory → 1Password (no paste into chat/git)
+## Local setup
 
-Create vault item group **`kk-dev`** with fields matching env names:
-
-| Field / item path (suggested) | Env name | Used by |
-|---|---|---|
-| `op://kk-dev/kriskrug-wp/username` | `WP_USER` | REST / publisher / morning-truth auth |
-| `op://kk-dev/kriskrug-wp/credential` | `WP_APP_PASSWORD` | same |
-| `op://kk-dev/notion/credential` | `NOTION_TOKEN` | Notion → WP connector |
-| (optional) service account | `OP_TOKEN` | Cloud/CI `op()` without desktop app |
-
-Revoke any historically leaked WP application passwords still active.
-
-**Agent cannot complete this step** — values never leave the vault into the repo.
-
-## 2. This repo (done)
-
-- Committed [`.env.schema`](../../.env.schema) — names, sensitivity, defaults; no plaintext secrets
-- `!.env.schema` kept un-ignored in `.gitignore`
-- `make env-check` — soft-OK when secrets absent (Cloud-safe)
-- `make varlock-run CMD='…'` — wraps `varlock run --inject vars -- …`
-- Compat loaders in `scripts/common.py` / `connector_config.py` still honor process env first
-
-### Local operator loop
+Only the human operator should create or edit value files. Agents may inspect
+`.env.schema`, but must not read `.env*` value files.
 
 ```bash
-# once
-curl -sSfL https://varlock.dev/install.sh | sh -s
-export PATH="${XDG_CONFIG_HOME:-$HOME/.config}/varlock/bin:$PATH"
+mkdir -p ~/.agents/env/values
+chmod 700 ~/.agents/env/values
+cp docs/current-state/templates/varlock.env.local.example \
+  ~/.agents/env/values/.env.kriskrug-wp.local
+chmod 600 ~/.agents/env/values/.env.kriskrug-wp.local
+```
 
-# optional 1Password plugin
-varlock install-plugin @varlock/1password-plugin@latest
-# uncomment @plugin / @initOp lines in .env.schema (see file header)
+Store shared `WP_USER`, `WP_APP_PASSWORD`, and `NOTION_TOKEN` in
+`.env.shared.local` when other repositories use the same value. Use the
+repo-specific file only for overrides.
 
-# gitignored local resolvers (never commit)
-cp docs/current-state/templates/varlock.env.local.example .env.local
-# edit op:// paths to match your vault
-
+```bash
 make env-check
 make varlock-run CMD='make status-readonly'
 ```
 
-Preferred: **`varlock run`** so process env is injected; existing `load_env()` keeps working.  
-Bridge (temporary): write gitignored `scripts/notion-to-wp/.env` only for tools that cannot use process env (treat as cache).
+Legacy `scripts/notion-to-wp/.env` and sibling-file fallbacks remain supported,
+but process variables injected by Varlock take precedence.
 
-## 3. Cursor Cloud (separate channel)
+## Cloud agents
 
-Same vault values, different delivery:
+Laptop value files are not copied to cloud agents automatically. Give each
+remote environment only its required development values, then validate with:
 
-1. Cursor dashboard → Cloud Agent secrets / environment
-2. Set `WP_USER`, `WP_APP_PASSWORD`, optional `NOTION_TOKEN` (and `OP_TOKEN` only if using service-account `op()` in Cloud)
-3. Re-run `make status-readonly` — draft counts should stop being false zeros when auth works
+```bash
+varlock load --agent --show-all
+varlock run --inject vars -- make status-readonly
+```
 
-Laptop Varlock ≠ Cloud injection.
+Production values and live WordPress writes remain separately approved.
 
-## 4. Mirror into sibling repos
+## Sibling repositories
 
-Copy the pattern (not the secrets):
+Copy the contract pattern, not the values:
 
-1. Commit a `.env.schema` (start from [`templates/sibling.env.schema.example`](templates/sibling.env.schema.example))
-2. Un-ignore it (`!.env.schema`)
-3. Point `op://` paths at the **same** `kk-dev` vault items where names match
-4. Keep repo-specific renames documented (e.g. sibling `NOTION_API_KEY` vs this repo’s `NOTION_TOKEN`)
+1. Commit a small `.env.schema` based on
+   [`templates/sibling.env.schema.example`](templates/sibling.env.schema.example).
+2. Import matching shared names from `.env.shared.local`.
+3. Add a repo-specific override import only when needed.
+4. Run secret-dependent commands through Varlock.
 
-Template file is the checklist; do not assume `kk-ai-ecosystem` is present in this workspace.
+Do not add Varlock machinery to a repository with no secret consumers.
 
-## 5. Retire plaintext `.env` as source of truth
+## Verification
 
-| Keep | Deprecate as SoT |
-|---|---|
-| Process env / `varlock run` | Committing or sharing plaintext `.env` |
-| Vault `op://` in `.env.local` | `~/Code/notion-local/kk-ai-ecosystem/.env` sibling fallback as primary |
-| Cursor Cloud secrets | Pasting secrets into chat / PR / docs |
-
-Loaders still accept `scripts/notion-to-wp/.env` and `KKAI_ENV_PATH` so nothing breaks mid-migration. Remove those fallbacks only after morning-truth, connector, and MCP are proven under `varlock run` / Cloud secrets.
-
-## What not to do
-
-- Global silent Varlock export into every shell
-- Real secrets in `.env.schema`
-- Assuming Varlock replaces Cursor Cloud secrets
-- Mixing “collect secrets” with live WP content writes in the same session
-
-## Proof this session
-
-- Varlock **1.11.0** installed under `~/.config/varlock/bin`
-- `make env-check` exits 0 with schema readable when WP secrets are absent
-- Schema documents vault field map + plugin enable steps
+- `make env-check` validates the committed schema when values are absent.
+- Primary Notion and WordPress loaders prefer process-injected values.
+- Legacy local files remain compatibility fallbacks.
+- No secret values are committed in the contract or templates.

--- a/docs/current-state/WORK-PLAN-2026-07-16.md
+++ b/docs/current-state/WORK-PLAN-2026-07-16.md
@@ -23,7 +23,7 @@ Follow docs/current-state/WORK-PLAN-2026-07-16.md as the day runbook.
 If Cloud secrets exist (`WP_USER` / `WP_APP_PASSWORD`): also run authenticated draft-queue audit and proceed through Phases 1–3 as approved.  
 If secrets are **absent**: do only public/read-only + docs work; do **not** block the day asking for credentials.
 
-**Varlock note:** local Varlock/1Password does **not** inject into Cursor Cloud. Cloud needs the same values as Cursor secrets (or an explicit `OP_TOKEN` service-account path). Do not stall the session on that.
+**Varlock note:** local Varlock value files do **not** inject into Cursor Cloud. Cloud needs separately approved development values in its own secret settings. Do not stall the session on that.
 
 ---
 

--- a/docs/current-state/reports/varlock-proof-20260716.md
+++ b/docs/current-state/reports/varlock-proof-20260716.md
@@ -11,4 +11,6 @@
 | `common.load_env()` process overlay | prefers OS env over file |
 | Cursor Cloud secrets | **not** set in this VM (expected) — documented as separate channel |
 
-Human follow-ups: fill 1Password `kk-dev`; enable plugin + `.env.local`; add same values to Cursor Cloud secrets.
+Superseded follow-up: the current contract uses the human-managed
+`~/.agents/env/values/` directory, not an external vault plugin. Cloud values
+remain separate and require explicit approval.

--- a/docs/current-state/templates/sibling.env.schema.example
+++ b/docs/current-state/templates/sibling.env.schema.example
@@ -1,13 +1,14 @@
 # Sibling-repo Varlock schema starter (e.g. kk-ai-ecosystem).
 # Copy to that repo as `.env.schema`, adjust names, commit, and add `!.env.schema`
-# to its .gitignore. Point op:// paths at the SAME 1Password kk-dev vault items
-# when the secret is shared. Do not commit plaintext values.
-#
+# to its .gitignore. Import the same shared value names where appropriate.
+# Do not commit plaintext values.
+# @import(~/.agents/env/values/.env.shared.local, pick=[NOTION_TOKEN, WP_USER, WP_APP_PASSWORD], allowMissing=true)
+# @import(~/.agents/env/values/.env.REPO-SLUG.local, pick=[NOTION_TOKEN, WP_USER, WP_APP_PASSWORD, WP_BASE_URL], allowMissing=true)
 # @defaultRequired=false @defaultSensitive=false
 # ---
 
 # @sensitive
-# Shared with kriskrug-wp — prefer identical vault field when possible.
+# Shared with kriskrug-wp. Prefer the identical shared variable name.
 # If this repo historically used NOTION_API_KEY, keep that name here and
 # document the mapping in the sibling README (kriskrug-wp uses NOTION_TOKEN).
 NOTION_TOKEN=

--- a/docs/current-state/templates/varlock.env.local.example
+++ b/docs/current-state/templates/varlock.env.local.example
@@ -1,14 +1,9 @@
-# Copy to repo-root `.env.local` (gitignored). Never commit.
-# Requires: varlock + optional @varlock/1password-plugin (see .env.schema header).
-#
-# Replace vault/item/field paths to match your 1Password `kk-dev` items.
+# Human-only template. Copy manually to
+# ~/.agents/env/values/.env.kriskrug-wp.local and set mode 0600. Never commit.
 
-WP_USER=op(op://kk-dev/kriskrug-wp/username)
-WP_APP_PASSWORD=op(op://kk-dev/kriskrug-wp/credential)
-NOTION_TOKEN=op(op://kk-dev/notion/credential)
-
-# Optional Cloud/CI service account (leave empty when using 1Password desktop app auth):
-# OP_TOKEN=
+WP_USER=
+WP_APP_PASSWORD=
+NOTION_TOKEN=
 
 # Optional overrides:
 # WP_BASE_URL=https://kriskrug.co

--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -17,7 +17,7 @@ It does NOT inject schema. The `kk-schema` mu-plugin handles that sitewide. The 
 
 ### 1. Notion token
 
-Preferred: set `NOTION_TOKEN` via Varlock / process env / Cursor Cloud secrets (see repo-root [`.env.schema`](../../.env.schema) and [`docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md`](../../docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md)).
+Preferred: set `NOTION_TOKEN` in the user-managed Varlock values directory and run the command through Varlock (see repo-root [`.env.schema`](../../.env.schema) and [`docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md`](../../docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md)).
 
 Compat: put it in `scripts/notion-to-wp/.env`, or point `NOTION_ENV_PATH` / `KKAI_ENV_PATH` at a sibling env file. The optional local fallback `~/Code/notion-local/kk-ai-ecosystem/.env` still works if present but is **deprecated as secret source-of-truth**.
 
@@ -29,8 +29,8 @@ Generate one **once**:
 2. Scroll to **Application Passwords** (near the bottom of the page).
 3. Application Name: `kk-notion-to-wp`
 4. Click **Add New Application Password**.
-5. WordPress shows the password ONCE — copy it into the vault (1Password `kk-dev`) or a gitignored local file. Do not paste it into docs, issues, commits, or chat.
-6. Preferred: wire vault → `.env.local` with `op(...)` and run `make varlock-run CMD='…'`. Compat cache:
+5. WordPress shows the password once. Put it in the user-managed Varlock values file. Do not paste it into docs, issues, commits, or chat.
+6. Preferred: run the connector through `make varlock-run CMD='<command>'`. Compat cache:
 
 ```bash
 cp scripts/notion-to-wp/.env.example scripts/notion-to-wp/.env

--- a/scripts/notion-to-wp/connector_config.py
+++ b/scripts/notion-to-wp/connector_config.py
@@ -53,11 +53,11 @@ def load_config() -> Config:
     fallback = dotenv_values(KKAI_ENV_PATH) if KKAI_ENV_PATH.exists() else {}
 
     def get(key: str, default: str | None = None) -> str | None:
-        return local.get(key) or fallback.get(key) or os.environ.get(key) or default
+        return os.environ.get(key) or local.get(key) or fallback.get(key) or default
 
     notion_token = get("NOTION_TOKEN")
     if not notion_token:
-        sys.exit(f"NOTION_TOKEN not found. Add to {LOCAL_ENV_PATH} or {KKAI_ENV_PATH}.")
+        sys.exit("NOTION_TOKEN not found. Run through Varlock or configure a legacy local env file.")
     return Config(
         notion_token=notion_token,
         wp_base_url=get("WP_BASE_URL", WP_BASE_URL_DEFAULT) or WP_BASE_URL_DEFAULT,

--- a/scripts/notion-to-wp/create_local_wp_draft.py
+++ b/scripts/notion-to-wp/create_local_wp_draft.py
@@ -73,7 +73,7 @@ def load_wp_config() -> WPConfig:
     fallback = dotenv_values(KKAI_ENV_PATH) if KKAI_ENV_PATH.exists() else {}
 
     def get(key: str, default: str | None = None) -> str | None:
-        return local.get(key) or fallback.get(key) or os.environ.get(key) or default
+        return os.environ.get(key) or local.get(key) or fallback.get(key) or default
 
     user = get("WP_USER")
     app_password = (get("WP_APP_PASSWORD") or "").replace(" ", "")

--- a/scripts/notion-to-wp/publish_proximity_game.py
+++ b/scripts/notion-to-wp/publish_proximity_game.py
@@ -16,7 +16,7 @@ Dry-run by default. --execute creates the draft (status=draft, NEVER publishes,
 aborts if the slug already exists). --update refreshes the body of the existing
 draft found by slug.
 """
-import re, sys, json, pathlib
+import os, re, sys, json, pathlib
 import yaml
 from dotenv import dotenv_values
 from kk_notion_to_wp import WordPress, WP_BASE_URL_DEFAULT, WP_DEFAULT_AUTHOR_ID
@@ -57,9 +57,9 @@ if not WRITE:
 
 # ---- WP client (WP-only creds; no NOTION_TOKEN needed) ----
 env = dotenv_values(ENV)
-user = env.get("WP_USER")
-pw = (env.get("WP_APP_PASSWORD") or "").replace(" ", "")
-author_id = int(env.get("WP_DEFAULT_AUTHOR_ID", WP_DEFAULT_AUTHOR_ID))
+user = os.environ.get("WP_USER") or env.get("WP_USER")
+pw = (os.environ.get("WP_APP_PASSWORD") or env.get("WP_APP_PASSWORD") or "").replace(" ", "")
+author_id = int(os.environ.get("WP_DEFAULT_AUTHOR_ID") or env.get("WP_DEFAULT_AUTHOR_ID", WP_DEFAULT_AUTHOR_ID))
 if not (user and pw):
     sys.exit(f"[ABORT] WP_USER / WP_APP_PASSWORD missing from {ENV}")
 wp = WordPress(WP_BASE_URL_DEFAULT, user, pw)

--- a/scripts/notion-to-wp/tests/test_varlock_precedence.py
+++ b/scripts/notion-to-wp/tests/test_varlock_precedence.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import connector_config  # noqa: E402
+import create_local_wp_draft  # noqa: E402
+
+
+class VarlockPrecedenceTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        root = Path(self.tempdir.name)
+        self.local_env = root / ".env"
+        self.fallback_env = root / "fallback.env"
+        self.local_env.write_text(
+            "NOTION_TOKEN=file-notion\n"
+            "WP_USER=file-user\n"
+            "WP_APP_PASSWORD=file-password\n"
+            "WP_DEFAULT_AUTHOR_ID=1\n",
+            encoding="utf-8",
+        )
+        self.fallback_env.write_text("WP_BASE_URL=https://fallback.example\n", encoding="utf-8")
+
+    def test_connector_config_prefers_injected_process_values(self):
+        injected = {
+            "NOTION_TOKEN": "injected-notion",
+            "WP_USER": "injected-user",
+            "WP_APP_PASSWORD": "injected-password",
+            "WP_DEFAULT_AUTHOR_ID": "18",
+        }
+        with mock.patch.object(connector_config, "LOCAL_ENV_PATH", self.local_env), \
+                mock.patch.object(connector_config, "KKAI_ENV_PATH", self.fallback_env), \
+                mock.patch.dict(os.environ, injected, clear=True):
+            config = connector_config.load_config()
+
+        self.assertEqual(config.notion_token, "injected-notion")
+        self.assertEqual(config.wp_user, "injected-user")
+        self.assertEqual(config.wp_app_password, "injected-password")
+        self.assertEqual(config.wp_author_id, 18)
+
+    def test_local_draft_config_prefers_injected_process_values(self):
+        injected = {
+            "WP_USER": "injected-user",
+            "WP_APP_PASSWORD": "injected-password",
+            "WP_DEFAULT_AUTHOR_ID": "18",
+        }
+        with mock.patch.object(create_local_wp_draft, "LOCAL_ENV_PATH", self.local_env), \
+                mock.patch.object(create_local_wp_draft, "KKAI_ENV_PATH", self.fallback_env), \
+                mock.patch.dict(os.environ, injected, clear=True):
+            config = create_local_wp_draft.load_wp_config()
+
+        self.assertEqual(config.user, "injected-user")
+        self.assertEqual(config.app_password, "injected-password")
+        self.assertEqual(config.author_id, 18)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wp_post_ia_rollout.py
+++ b/scripts/wp_post_ia_rollout.py
@@ -133,10 +133,12 @@ def load_config() -> Config:
     sources.extend(load_env(path) for path in _fallback_env_paths())
 
     def value(key: str, default: str | None = None) -> str | None:
+        if os.environ.get(key):
+            return os.environ[key]
         for source in sources:
             if source.get(key):
                 return source.get(key)
-        return os.environ.get(key) or default
+        return default
 
     base_url = value("WP_BASE_URL", DEFAULT_BASE_URL) or DEFAULT_BASE_URL
     wp_user = value("WP_USER")


### PR DESCRIPTION
Removes the stale 1Password-specific contract, imports local values from the canonical Varlock values directory, and makes process-injected values win over legacy env-file fallbacks in the primary Notion/WordPress loaders. Legacy files remain compatible.\n\nVerification:\n- python3 -m unittest scripts/notion-to-wp/tests/test_varlock_precedence.py scripts/notion-to-wp/tests/test_create_local_wp_draft.py\n- varlock load --agent --show-all with core secrets unset\n- varlock run --inject vars -- /usr/bin/true with core secrets unset\n- make env-check\n- varlock scan --staged\n- git diff --check