### PR TITLE
chore: track notion-to-wp Varlock env schema

### DIFF
--- a/scripts/notion-to-wp/.env.schema
+++ b/scripts/notion-to-wp/.env.schema
@@ -1,0 +1,12 @@
+# @defaultRequired=false @defaultSensitive=false
+# ---
+
+WP_BASE_URL=
+
+WP_USER=
+
+# @sensitive
+WP_APP_PASSWORD=
+
+WP_AUTH_MODE=
+


### PR DESCRIPTION
## What
Track the per-directory `scripts/notion-to-wp/.env.schema` alongside the already-tracked root `.env.schema`, completing the Varlock rollout contract.

## Why
The root schema is tracked; this sibling was left untracked in the working tree. `.gitignore:23` explicitly whitelists `.env.schema`, so it is meant to be committed.

## Safety
Schema only — keys plus `@sensitive` markers, no real values. Surfaced during the consolidation audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv