### PR TITLE
fix(#404): remove Podcast from primary nav

### DIFF
--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -12,7 +12,6 @@
       <a href="/speaking/">Speaking</a>
       <a href="/services/">Services</a>
       <a href="/blog/">Writing</a>
-      <a href="/motleykrug-podcast/">Podcast</a>
       <a href="/contact/">Contact</a>
     </nav>
 


### PR DESCRIPTION
Closes #404 (code portion).

## What
Removes the `Podcast` link from the header primary navigation (`theme/kk-aurora/parts/header.html`). The footer already links to `/motleykrug-podcast/` (`footer.html:29`), so the "relocate to footer" requirement is already satisfied.

## Why
KK teardown 2026-07-17: "Podcasts should come out of the main nav... you can put it in the footer."

## Verification
- `aurora-primary-nav` is a single responsive markup block (mobile = horizontal scroll via `style.css` media queries), so this removes Podcast from **desktop and mobile** in one change.
- No other nav items reordered or removed.
- **Live eval pending deploy:** logged-out render at 375/768/1440 must be checked after the Aurora theme is deployed (manual wp-admin zip upload; SSH blocked). This PR is the code half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv