### PR TITLE
fix(#405): move marquee board to bottom of homepage

### DIFF
--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -3,8 +3,6 @@
 <!-- wp:group {"tagName":"main","className":"aurora-home-2026 aurora-keynote-first","layout":{"type":"default"}} -->
 <main id="aurora-main" class="wp-block-group aurora-home-2026 aurora-keynote-first">
 
-  <!-- wp:pattern {"slug":"kk-aurora/marquee-hero"} /-->
-
   <!-- wp:html -->
   <style>
     @media (max-width: 700px) {
@@ -376,6 +374,8 @@
     </div>
   </section>
   <!-- /wp:html -->
+
+  <!-- wp:pattern {"slug":"kk-aurora/marquee-hero"} /-->
 
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes #405 (code portion).

## What
Moves the `kk-aurora/marquee-hero` pattern from the top of `front-page.html` to the bottom, just before `</main>`. The `aurora-hero-2026` image section now leads the homepage.

## Why
KK teardown: the marquee board dominated the top of the homepage; the real hero should lead.

## Verification
- Pattern renders only the marquee board (`parts/marquee-current.html`), confirmed — the hero section is separate and untouched.
- Marquee now appears exactly once, at the bottom.
- **Live eval pending deploy:** marquee absent from top / present at bottom, no layout shift at 375/768/1440, checked after Aurora deploy (manual wp-admin zip upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv