### PR TITLE
fix(#407): lighten hero scrim so the photo reads

### DIFF
--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -789,14 +789,17 @@ a {
 .aurora-hero-media img {
   height: 100%;
   object-fit: cover;
-  object-position: 54% 38%;
+  object-position: 50% 34%;
   width: 100%;
 }
 
+/* Scrim backs the left-aligned copy for legibility without burying the photo.
+   The prior 0.94/0.76 left stop rendered the subject as near-black (issue #407);
+   these lighter stops keep white text readable while surfacing the image. */
 .aurora-hero-scrim {
   background:
-    linear-gradient(90deg, rgba(3, 4, 5, 0.94) 0%, rgba(3, 4, 5, 0.76) 38%, rgba(3, 4, 5, 0.22) 100%),
-    linear-gradient(180deg, rgba(3, 4, 5, 0.2), rgba(3, 4, 5, 0.78));
+    linear-gradient(90deg, rgba(3, 4, 5, 0.82) 0%, rgba(3, 4, 5, 0.5) 42%, rgba(3, 4, 5, 0.05) 100%),
+    linear-gradient(180deg, rgba(3, 4, 5, 0.12), rgba(3, 4, 5, 0.5));
   z-index: -2;
 }
 


### PR DESCRIPTION
Addresses #407 (primary visible bug). Root cause written up in the issue thread.

## Root cause
The hero image loads fine (HTTP 200, single coherent photo). The `.aurora-hero-scrim` gradient (0.94/0.76 left) buried the subject in near-black, so it read as "doesn't load right."

## Fix
- Scrim lightened to `0.82/0.5/0.05` horizontal + `0.12/0.5` vertical.
- `object-position` re-framed to `50% 34%`.
- **Verified in live browser** at 1728 and 673 widths: photo visible, white copy legible, reveal settles to opacity 1.

## Not in this PR (follow-up on #407)
- Rehost the image from the `punkrockai.com` hotlink into the kriskrug.co media library (separate live-media task; acceptance criterion).
- Deploy: theme ships via manual wp-admin zip upload; production verification at 375/768/1440 happens post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv