### PR TITLE
fix(#408): stop card-label pills stretching (align-self)

### DIFF
--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1204,6 +1204,7 @@ a {
 }
 
 .aurora-card-label {
+  align-self: start;
   background: rgba(18, 20, 27, 0.76);
   border: 1px solid var(--aurora-line);
   border-radius: 999px;


### PR DESCRIPTION
Addresses #408. Root cause written up in the issue thread.

## Root cause
`.aurora-media-card > a` is a CSS grid; `.aurora-card-label` had `align-self` defaulting to **stretch**, inflating the pill to the full grid-row height (~92px vs ~35px intended). Shared markup = all three sections (Ecosystem, Festival, Creative Labs) broke identically.

## Fix
One shared-layer property: `align-self: start` on `.aurora-card-label`.
- No new `!important` (verified: `git diff | grep -c '!important'` = 0)
- No per-section patches
- Verified in-browser: sampled pills drop 92px -> 35px

## Deploy
Theme ships via manual wp-admin zip upload; before/after at 375/768/1440 to be captured on production post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv