### PR TITLE
fix(#411): rewrite offer-band copy (kill "rooms") + card hovers

### DIFF
--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -1033,6 +1033,17 @@ a {
   margin: 0;
 }
 
+.aurora-hired-grid article {
+  transition: background-color 180ms ease, border-color 180ms ease, transform 180ms ease;
+}
+
+.aurora-hired-grid article:hover,
+.aurora-hired-grid article:focus-within {
+  background: rgba(247, 247, 242, 0.06);
+  border-color: var(--aurora-line-strong);
+  transform: translateY(-2px);
+}
+
 .aurora-inline-link {
   color: var(--aurora-signal);
   font-weight: 800;

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -191,25 +191,25 @@
   <section class="aurora-offer-band" aria-labelledby="aurora-hired-title" data-reveal>
     <div class="aurora-section-heading">
       <p class="aurora-kicker">What I get hired for</p>
-      <h2 id="aurora-hired-title">Rooms that need clarity, courage, and a useful next step.</h2>
+      <h2 id="aurora-hired-title">I get hired when the AI talk needs to become something you can use.</h2>
     </div>
     <div class="aurora-hired-grid">
       <article>
         <span class="aurora-card-label">Keynotes</span>
-        <h3>Keynotes that move rooms</h3>
-        <p>Plain-English talks on AI, taste, ethics, creativity, and human agency. No hype. No doom sermon. A better frame for the room.</p>
+        <h3>Keynotes</h3>
+        <p>Plain-English talks on AI, taste, and human agency. No hype, no doom sermon. You leave with a frame you can use Monday morning.</p>
         <a class="aurora-inline-link" href="/speaking/">Book a keynote</a>
       </article>
       <article>
         <span class="aurora-card-label">Workshops</span>
-        <h3>Workshops that change teams</h3>
-        <p>Practical AI learning for creative teams, leadership offsites, associations, and organizations that need shared language fast.</p>
+        <h3>Workshops</h3>
+        <p>Hands-on sessions for creative teams and leadership offsites. Everyone walks out having actually built something.</p>
         <a class="aurora-inline-link" href="/services/">Work with me</a>
       </article>
       <article>
         <span class="aurora-card-label">Networks</span>
-        <h3>Ecosystem work that builds durable networks</h3>
-        <p>Community strategy, salons, partner rooms, and public-interest infrastructure for people trying to build with the future, not just talk about it.</p>
+        <h3>Ecosystem work</h3>
+        <p>I build the places where BC's AI community meets in person. 250+ members, 94+ events, 3,000+ people through the door. Receipts, not a mailing list.</p>
         <a class="aurora-inline-link" href="/work/">See current work</a>
       </article>
     </div>


### PR DESCRIPTION
Addresses #411 (homepage "What I get hired for" section). Draft-first — merges to main but the theme only goes live on the manual Aurora upload, so copy is still redline-able.

## Copy (my drafted picks — swap freely before deploy)
- Heading → "I get hired when the AI talk needs to become something you can use." (kills "rooms" + the triad; one line)
- Card bodies rewritten in KK voice; Ecosystem card carries the confirmed BC+AI receipts (250+/94+/3,000+)
- **Gate met:** "rooms" count in the section = 0; em dashes = 0

## Structural
- Hover + `focus-within` states on the three cards (lift + border), matching the media-card pattern
- Cards were already grid-aligned at desktop; no `::first-letter` drop-cap rule exists on this heading (the large first glyph was heading size, fixed by the shorter heading)

## Still open on #411 (needs KK)
- Which heading option (posted A/B/C on the issue) — I used A
- Final blessing on card copy before the Aurora deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv