### PR TITLE
fix(#416): kill "dispatch"/"field notes" on homepage newsletter

### DIFF
--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -16,7 +16,7 @@
     </nav>
 
     <div class="aurora-header-actions">
-      <a class="aurora-utility-link" href="https://kriskrug.beehiiv.com/">Dispatch</a>
+      <a class="aurora-utility-link" href="https://kriskrug.beehiiv.com/">Newsletter</a>
       <a class="aurora-button aurora-button-primary aurora-header-cta" href="/speaking/">Book a keynote</a>
     </div>
   </div>

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -365,12 +365,12 @@
 
   <!-- wp:html -->
   <section class="aurora-dispatch-band" aria-labelledby="aurora-dispatch-title" data-reveal>
-    <p class="aurora-kicker">Get the dispatch</p>
-    <h2 id="aurora-dispatch-title">The dispatch from the edge.</h2>
-    <p>Weekly field notes on AI, creativity, and what's still ours to make. Sharp, useful, and short enough to actually read. Free.</p>
+    <p class="aurora-kicker">The newsletter</p>
+    <h2 id="aurora-dispatch-title">AI and creativity, once a week, no hype.</h2>
+    <p>The stuff I'd tell you over coffee. Named people, real work, no vaporware. Free.</p>
     <div class="aurora-action-row">
-      <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Join the dispatch</a>
-      <a class="aurora-button aurora-button-secondary" href="/blog/">Read the field notes</a>
+      <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Subscribe free</a>
+      <a class="aurora-button aurora-button-secondary" href="/blog/">Read the writing</a>
     </div>
   </section>
   <!-- /wp:html -->


### PR DESCRIPTION
Addresses #416 (homepage newsletter section). Draft-first; copy is redline-able before the Aurora deploy.

## Copy (my pick — option B swagger)
- "Get the dispatch" → "The newsletter"
- "The dispatch from the edge." → "AI and creativity, once a week, no hype."
- Body → "The stuff I'd tell you over coffee. Named people, real work, no vaporware. Free."
- Buttons → "Subscribe free" / "Read the writing"
- Header "Dispatch" utility link → "Newsletter" (consistency)

**Gate met:** 0 visible "dispatch"/"field notes" in the section; 0 em dashes.

## Notes
- Internal class/id (`aurora-dispatch-band`/`-title`) unchanged (not user-visible).
- The **footer** newsletter block still says "dispatch/field notes" — left for #417 (footer redesign).
- Name direction (More Receipts / The Feed / nameless) still open on the issue if you want a real name over "Newsletter."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv