### PR TITLE
feat(#425): publisher/schema smoke check + article-type rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
+.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke seo-publisher-smoke wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
 
 PYTHON ?= python3
 VARLOCK ?= varlock
@@ -246,6 +246,9 @@ jetpack-feedback-audit: ## Run PII-safe read-only Jetpack Forms feedback counts/
 
 wp7-smoke: ## Run read-only public WP rollout smoke checks (BASE_URL=https://kriskrug.co EXPECT_VERSION=7.0.2)
 	@python3 scripts/wp7-public-smoke.py --base-url "$${BASE_URL:-https://kriskrug.co}" --timeout "$${REQUEST_TIMEOUT:-20}" $${EXPECT_VERSION:+--expect-version "$$EXPECT_VERSION"}
+
+seo-publisher-smoke: ## Run read-only publisher/schema smoke checks (#425) (BASE_URL=https://kriskrug.co)
+	@python3 scripts/seo_publisher_smoke.py --base "$${BASE_URL:-https://kriskrug.co}" --posts "$${POSTS:-3}"
 
 wp7-admin-readiness: ## Run authenticated read-only WP 7 readiness snapshot (ENV_FILE=scripts/notion-to-wp/.env)
 	@python3 scripts/wp7-admin-readiness.py --env-file "$${ENV_FILE:-scripts/notion-to-wp/.env}"

--- a/docs/current-state/SEO-PUBLISHER-SCHEMA-2026-07-19.md
+++ b/docs/current-state/SEO-PUBLISHER-SCHEMA-2026-07-19.md
@@ -1,0 +1,71 @@
+# Publisher / News Discovery + Article Schema Rules — 2026-07-19
+
+Owner issue: #425. Read-only audit + the rule going forward. No live WordPress
+change is authorized by this doc; deploying a news sitemap or changing schema
+types is a separate, KK-gated step.
+
+## Audit (2026-07-19, public read-only)
+
+| Surface | State |
+|---|---|
+| Sitemap | WordPress core `wp-sitemap.xml` only: posts, pages, category, tag, users. Healthy (200). |
+| News sitemap | **Absent.** `/news-sitemap.xml`, `/sitemap-news.xml`, `/wp-sitemap-news.xml` all 404. |
+| Feed | `/feed/` healthy (200, valid RSS). |
+| Post schema | Every post emits generic **`Article`** (from `fixes/schema-snippets-deployed.php:146`) plus `Person`, `Organization`/`WebSite`, `BreadcrumbList`, `ImageObject`. |
+| Required fields | Present on sampled posts: `headline`, `datePublished`, `dateModified`, `author` (@id `#person`), `publisher` (@id `#person`), `image`, `mainEntityOfPage`. |
+
+Takeaway: the plumbing is solid (canonical author/publisher identity, dates,
+image), but every post is a generic `Article`. There is no publisher/news
+discovery surface for timely posts.
+
+## Schema-type rule (going forward)
+
+Encode this in the schema snippet when the change is deployed. Decide by post
+character, not blindly by post type:
+
+- **`BlogPosting`** — evergreen essays, field notes, opinion, how-to. This is
+  the default for most KrisKrug.co writing. It is the honest type for durable
+  personal writing and keeps the existing author/publisher identity graph.
+- **`NewsArticle`** — timely, dated, event-or-announcement posts (festival
+  recaps, launches, "this happened this week"). Only these are news-sitemap
+  eligible. Do not blanket-apply `NewsArticle`; Google penalizes non-news posts
+  in a news sitemap.
+- **`Article`** — fallback only when a post fits neither cleanly.
+
+Keep the existing required fields on every type (they already validate). Add a
+`section` / `articleSection` from the primary category when the type is
+`NewsArticle` or `BlogPosting`.
+
+## News sitemap recommendation
+
+WordPress core does not emit a Google-News sitemap. Options, in order of
+preference:
+
+1. **Custom snippet** (fits the existing Code Snippets pattern): emit
+   `<url>` entries with `news:news` for `NewsArticle`-classified posts from the
+   last 48 hours only, at `/news-sitemap.xml`. Lowest plugin footprint.
+2. **Yoast News SEO** add-on: turnkey, but adds a paid plugin dependency.
+
+Either is a **live change** and therefore KK-gated. Ship behind the same
+snapshot-first flow as other live SEO snippets; do not auto-deploy.
+
+## Regression check
+
+`scripts/seo_publisher_smoke.py` (read-only) verifies sitemap + feed health and
+that recent posts still carry an Article-family node with all required fields.
+The missing news sitemap is reported as a NOTE, not a failure, so the check
+stays green until the news sitemap is deliberately shipped (flip it to required
+in the same PR).
+
+```
+python3 scripts/seo_publisher_smoke.py            # live
+python3 scripts/seo_publisher_smoke.py --base URL --posts 5
+make seo-publisher-smoke
+```
+
+## Boundary vs existing SEO issues
+
+This issue owns publisher/news discovery + article schema *type*. It does not
+touch taxonomy sitemap bloat, canonical rules, or per-post metadata handoffs
+owned by the existing SEO issues (#274 / #331 / #347). The schema snippet edit,
+when made, must not add taxonomy entries to any sitemap.

--- a/scripts/seo_publisher_smoke.py
+++ b/scripts/seo_publisher_smoke.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Read-only publisher/schema smoke checks for KrisKrug.co (issue #425).
+
+Verifies the discovery surfaces stay healthy and that recent posts emit an
+Article-family JSON-LD block with the fields Google needs for a publisher
+pattern. Read-only: it makes GET requests only and never writes to WordPress.
+
+Usage:
+    python3 scripts/seo_publisher_smoke.py                 # check live site
+    python3 scripts/seo_publisher_smoke.py --base URL      # check another host
+    python3 scripts/seo_publisher_smoke.py --posts 5       # sample N recent posts
+
+Exit code is non-zero if a required surface is broken or a sampled post is
+missing a required schema field. The absent Google-News sitemap is reported as
+a known gap (see docs/current-state/SEO-PUBLISHER-SCHEMA-2026-07-19.md), not a
+failure, so this stays green until that work is deliberately shipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+DEFAULT_BASE = "https://kriskrug.co"
+
+# Fields every publisher-grade Article-family node should carry.
+REQUIRED_SCHEMA_FIELDS = (
+    "headline",
+    "datePublished",
+    "dateModified",
+    "author",
+    "publisher",
+    "image",
+    "mainEntityOfPage",
+)
+ARTICLE_TYPES = {"Article", "NewsArticle", "BlogPosting"}
+
+JSONLD_RE = re.compile(
+    r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def fetch(url: str, timeout: int = 20) -> tuple[int, str]:
+    req = Request(url, headers={"User-Agent": "kk-seo-smoke/1.0"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except HTTPError as exc:
+        return exc.code, ""
+    except (URLError, TimeoutError) as exc:
+        return 0, str(exc)
+
+
+def iter_jsonld_nodes(html: str):
+    """Yield every JSON-LD node, flattening @graph containers."""
+    for block in JSONLD_RE.findall(html):
+        try:
+            data = json.loads(block.strip())
+        except json.JSONDecodeError:
+            continue
+        graph = data.get("@graph") if isinstance(data, dict) else None
+        for node in (graph if isinstance(graph, list) else [data]):
+            if isinstance(node, dict):
+                yield node
+
+
+def article_node(html: str) -> dict | None:
+    for node in iter_jsonld_nodes(html):
+        node_type = node.get("@type")
+        types = node_type if isinstance(node_type, list) else [node_type]
+        if any(t in ARTICLE_TYPES for t in types):
+            return node
+    return None
+
+
+def check_surface(base: str, path: str, must_contain: str = "") -> tuple[bool, str]:
+    status, body = fetch(base + path)
+    if status != 200:
+        return False, f"{path} -> HTTP {status}"
+    if must_contain and must_contain not in body:
+        return False, f"{path} -> 200 but missing '{must_contain}'"
+    return True, f"{path} -> 200"
+
+
+def recent_post_links(base: str, count: int) -> list[str]:
+    status, body = fetch(f"{base}/wp-json/wp/v2/posts?per_page={count}&_fields=link")
+    if status != 200:
+        return []
+    try:
+        return [item["link"] for item in json.loads(body)]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=DEFAULT_BASE, help="site base URL")
+    parser.add_argument("--posts", type=int, default=3, help="recent posts to sample")
+    args = parser.parse_args()
+    base = args.base.rstrip("/")
+
+    failures: list[str] = []
+    notes: list[str] = []
+
+    # 1. Discovery surfaces that must stay healthy.
+    for path, needle in (
+        ("/wp-sitemap.xml", "wp-sitemap-posts-post"),
+        ("/feed/", "<rss"),
+    ):
+        ok, msg = check_surface(base, path, needle)
+        print(("PASS " if ok else "FAIL ") + msg)
+        if not ok:
+            failures.append(msg)
+
+    # 2. Google-News style sitemap: known gap, reported not enforced.
+    news_found = False
+    for path in ("/news-sitemap.xml", "/sitemap-news.xml", "/wp-sitemap-news.xml"):
+        status, _ = fetch(base + path)
+        if status == 200:
+            news_found = True
+            print(f"PASS news sitemap present: {path}")
+            break
+    if not news_found:
+        notes.append("No Google-News sitemap (known gap; see #425 doc).")
+        print("NOTE no news sitemap yet (known gap, not a failure)")
+
+    # 3. Recent posts must emit an Article-family node with required fields.
+    links = recent_post_links(base, args.posts)
+    if not links:
+        failures.append("could not list recent posts via wp-json")
+        print("FAIL could not list recent posts")
+    for link in links:
+        status, html = fetch(link)
+        if status != 200:
+            failures.append(f"{link} -> HTTP {status}")
+            print(f"FAIL {link} -> HTTP {status}")
+            continue
+        node = article_node(html)
+        if node is None:
+            failures.append(f"{link} -> no Article-family JSON-LD")
+            print(f"FAIL {link} -> no Article-family schema")
+            continue
+        missing = [f for f in REQUIRED_SCHEMA_FIELDS if not node.get(f)]
+        node_type = node.get("@type")
+        if missing:
+            failures.append(f"{link} -> {node_type} missing {missing}")
+            print(f"FAIL {link} -> {node_type} missing {missing}")
+        else:
+            print(f"PASS {link} -> {node_type} with all required fields")
+
+    print()
+    for note in notes:
+        print(f"NOTE: {note}")
+    if failures:
+        print(f"\n{len(failures)} failure(s).")
+        return 1
+    print("\nAll publisher/schema smoke checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_seo_publisher_smoke.py
+++ b/scripts/tests/test_seo_publisher_smoke.py
@@ -1,0 +1,70 @@
+"""CI-safe unit tests for the #425 publisher/schema smoke parser.
+
+These exercise the JSON-LD extraction logic with fixtures only; the live
+network checks in seo_publisher_smoke.main() are not invoked here.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import seo_publisher_smoke as sps  # noqa: E402
+
+GRAPH_HTML = """
+<html><head>
+<script type="application/ld+json">
+{"@graph":[
+  {"@type":"WebPage","@id":"https://x/"},
+  {"@type":"Article","headline":"H","datePublished":"2026-01-01",
+   "dateModified":"2026-01-02","author":{"@id":"#person"},
+   "publisher":{"@id":"#person"},"image":{"@type":"ImageObject"},
+   "mainEntityOfPage":"https://x/"}
+]}
+</script>
+</head><body></body></html>
+"""
+
+MISSING_HTML = """
+<script type="application/ld+json">
+{"@type":"BlogPosting","headline":"H","datePublished":"2026-01-01"}
+</script>
+"""
+
+NO_ARTICLE_HTML = """
+<script type="application/ld+json">
+{"@type":"WebSite","name":"x"}
+</script>
+"""
+
+
+class ArticleNodeTests(unittest.TestCase):
+    def test_finds_article_inside_graph(self):
+        node = sps.article_node(GRAPH_HTML)
+        self.assertIsNotNone(node)
+        self.assertEqual(node["@type"], "Article")
+
+    def test_all_required_fields_present(self):
+        node = sps.article_node(GRAPH_HTML)
+        missing = [f for f in sps.REQUIRED_SCHEMA_FIELDS if not node.get(f)]
+        self.assertEqual(missing, [])
+
+    def test_detects_missing_fields(self):
+        node = sps.article_node(MISSING_HTML)
+        self.assertIsNotNone(node)
+        missing = [f for f in sps.REQUIRED_SCHEMA_FIELDS if not node.get(f)]
+        self.assertIn("author", missing)
+        self.assertIn("image", missing)
+
+    def test_no_article_family_node(self):
+        self.assertIsNone(sps.article_node(NO_ARTICLE_HTML))
+
+    def test_type_list_is_matched(self):
+        html = '<script type="application/ld+json">{"@type":["NewsArticle","Thing"],"headline":"h"}</script>'
+        node = sps.article_node(html)
+        self.assertIsNotNone(node)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #425. Read-only audit + repo-only deliverables; no live WordPress change (news sitemap / schema-type deploy stays KK-gated).

## Audit (2026-07-19)
- Sitemap + feed healthy; every post emits generic **`Article`** with all required fields.
- **No Google-News sitemap** (all candidate URLs 404).

## Delivered
- `scripts/seo_publisher_smoke.py` — read-only sitemap/feed/schema check. **Passes live today.** Missing news sitemap is a NOTE, not a failure.
- `scripts/tests/test_seo_publisher_smoke.py` — **5 CI-safe unit tests** for the JSON-LD parser.
- `make seo-publisher-smoke` target.
- `docs/current-state/SEO-PUBLISHER-SCHEMA-2026-07-19.md` — schema-type rule (BlogPosting / NewsArticle / Article), news-sitemap recommendation, boundary vs #274/#331/#347.

## Verification
```
make seo-publisher-smoke              # exit 0 against live
python3 -m unittest scripts.tests.test_seo_publisher_smoke   # 5 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163ceEYKJxXVVCGZfw8j6Bv