### PR TITLE
seo: replace homepage placeholders and align identity

### DIFF
--- a/scripts/tests/test_issue_345_og_site_name.py
+++ b/scripts/tests/test_issue_345_og_site_name.py
@@ -68,11 +68,14 @@ class Issue345OpenGraphSiteNameTests(unittest.TestCase):
         self.assertFalse(change["repo_rendering_code_change_required"])
         self.assertFalse(self.data["live_wordpress_write_performed"])
 
-    def test_repo_owners_derive_site_name_and_preserve_title_positioning(self):
+    def test_theme_uses_reviewed_site_name_and_preserves_title_positioning(self):
         self.assertRegex(
             self.theme,
-            re.compile(r"'og:site_name'\s*=>\s*get_bloginfo\('name'\)"),
+            re.compile(r"'og:site_name'\s*=>\s*public_site_name\(\)"),
         )
+        self.assertIn("return 'Kris Krug';", self.theme)
+        self.assertIn("add_filter('get_bloginfo_rss'", self.theme)
+        self.assertIn("add_filter('get_wp_title_rss'", self.theme)
         self.assertRegex(
             self.bridge,
             re.compile(r"\$site\s*=\s*get_bloginfo\('name'\)"),

--- a/scripts/tests/test_issue_415_homepage_trust_identity.py
+++ b/scripts/tests/test_issue_415_homepage_trust_identity.py
@@ -1,0 +1,123 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME_FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
+FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
+SCHEMA_SOURCE = ROOT / "fixes/schema-snippets-deployed.php"
+SITE_NAME = "Kris Krug"
+STALE_IDENTITY = "Generative AI Tools & Techniques"
+HOME_DESCRIPTION = (
+    "Kris Krug is a Vancouver AI keynote speaker, creative technologist, and "
+    "community builder leading BC + AI and curating Futureproof Festival."
+)
+
+
+class Issue415HomepageTrustIdentityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.theme = THEME_FUNCTIONS.read_text(encoding="utf-8")
+        cls.schema = SCHEMA_SOURCE.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _function_block(source: str, name: str, next_name: str) -> str:
+        pattern = rf"function {re.escape(name)}\(.*?(?=function {re.escape(next_name)}\()"
+        match = re.search(pattern, source, re.DOTALL)
+        if match is None:
+            raise AssertionError(f"missing function block: {name}")
+        return match.group(0)
+
+    @staticmethod
+    def _scalar_constant(source: str, key: str) -> str:
+        match = re.search(rf"'{re.escape(key)}'\s*=>\s*'([^']*)'", source)
+        if match is None:
+            raise AssertionError(f"missing schema constant: {key}")
+        return match.group(1)
+
+    def test_homepage_metadata_uses_a_useful_fallback(self):
+        public_description = self._function_block(
+            self.theme,
+            "public_meta_description",
+            "writing_archive_canonical_url",
+        )
+
+        self.assertIn(f"return '{HOME_DESCRIPTION}';", self.theme)
+        self.assertIn("homepage_meta_description()", public_description)
+        self.assertRegex(
+            public_description,
+            re.compile(
+                r"advanced_seo_front_page_description.*?trim\(\$description\).*?homepage_meta_description\(\)",
+                re.DOTALL,
+            ),
+        )
+        self.assertGreaterEqual(len(HOME_DESCRIPTION), 120)
+        self.assertLessEqual(len(HOME_DESCRIPTION), 160)
+
+    def test_social_and_feed_metadata_use_the_current_site_identity(self):
+        social = self._function_block(
+            self.theme,
+            "social_meta_tags",
+            "render_social_meta_tags",
+        )
+
+        self.assertIn(f"return '{SITE_NAME}';", self.theme)
+        self.assertIn("'og:site_name'   => public_site_name()", social)
+        self.assertNotIn("get_bloginfo('name')", social)
+        self.assertIn("function filter_feed_bloginfo", self.theme)
+        self.assertIn("function filter_feed_title", self.theme)
+        self.assertIn("add_filter('get_bloginfo_rss'", self.theme)
+        self.assertIn("add_filter('get_wp_title_rss'", self.theme)
+        self.assertNotIn(STALE_IDENTITY, social)
+
+    def test_homepage_removes_unverified_quotes_and_routes_to_real_work(self):
+        source = FRONT_PAGE.read_text(encoding="utf-8")
+
+        for placeholder in (
+            "Fresh proof belongs here before launch",
+            "replace with verified",
+            "Event organizer quote",
+            "Workshop host quote",
+            "Leadership audience quote",
+        ):
+            self.assertNotIn(placeholder, source)
+        self.assertNotIn("<blockquote", source)
+        self.assertNotIn("aurora-testimonial-band", source)
+        self.assertIn('id="aurora-relationships-title"', source)
+        self.assertIn('href="/work/"', source)
+        self.assertIn('href="https://bc-ai.ca/"', source)
+        self.assertIn('href="https://www.futureproof.website/"', source)
+        self.assertNotIn('href="https://futureproof.website/"', source)
+
+    def test_rendered_schema_source_names_kris_and_his_current_projects(self):
+        self.assertEqual(SITE_NAME, self._scalar_constant(self.schema, "site_name"))
+        alternate_names = re.search(
+            r"'site_alternate_names'\s*=>\s*array\((.*?)\),",
+            self.schema,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(alternate_names)
+        self.assertEqual(
+            ["Kris Krüg", "kriskrug.co"],
+            re.findall(r"'([^']*)'", alternate_names.group(1)),
+        )
+        relationships = dict(
+            re.findall(
+                r"array\('name'\s*=>\s*'([^']+)',\s*'url'\s*=>\s*'([^']+)'\)",
+                self.schema,
+            )
+        )
+        self.assertEqual(
+            {
+                "BC + AI Ecosystem Industry Association": "https://bc-ai.ca/",
+                "Vancouver AI": "https://vancouver.ai/",
+                "Futureproof Festival": "https://futureproof.website/",
+            },
+            relationships,
+        )
+        self.assertNotIn(STALE_IDENTITY, self.schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -511,6 +511,44 @@ function exclude_current_post_from_related_query(array $query, \WP_Block $block)
 }
 add_filter('query_loop_block_query_vars', __NAMESPACE__ . '\\exclude_current_post_from_related_query', 10, 2);
 
+function public_site_name(): string {
+    return 'Kris Krug';
+}
+
+function homepage_meta_description(): string {
+    return 'Kris Krug is a Vancouver AI keynote speaker, creative technologist, and community builder leading BC + AI and curating Futureproof Festival.';
+}
+
+function filter_feed_bloginfo(string $value, string $show): string {
+    if ($show === 'name') {
+        return public_site_name();
+    }
+
+    if ($show === 'description') {
+        return homepage_meta_description();
+    }
+
+    return $value;
+}
+add_filter('get_bloginfo_rss', __NAMESPACE__ . '\\filter_feed_bloginfo', 10, 2);
+
+function filter_feed_title(string $title): string {
+    if (is_home()) {
+        return public_site_name();
+    }
+
+    $stored_site_name = get_option('blogname', '');
+    if (!is_string($stored_site_name) || trim($stored_site_name) === '') {
+        return $title;
+    }
+
+    $decoded_title = html_entity_decode($title, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $decoded_site_name = html_entity_decode($stored_site_name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    return str_replace($decoded_site_name, public_site_name(), $decoded_title);
+}
+add_filter('get_wp_title_rss', __NAMESPACE__ . '\\filter_feed_title');
+
 /**
  * Resolve the standard search description from the site's existing SEO fields.
  */
@@ -519,6 +557,9 @@ function public_meta_description(): string {
 
     if (is_front_page()) {
         $description = get_option('advanced_seo_front_page_description', '');
+        if (!is_string($description) || trim($description) === '') {
+            $description = homepage_meta_description();
+        }
     } elseif (is_home()) {
         $description = writing_archive_meta_description();
     } elseif (is_singular()) {
@@ -584,7 +625,7 @@ function social_meta_tags(): array {
     $description = public_meta_description();
 
     $tags = [
-        'og:site_name'   => get_bloginfo('name'),
+        'og:site_name'   => public_site_name(),
         'og:title'       => wp_get_document_title(),
         'og:type'        => 'website',
         'og:url'         => home_url('/'),

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -24,7 +24,6 @@
       .aurora-offer-band,
       .aurora-featured-strip,
       .aurora-stage-strip,
-      .aurora-testimonial-band,
       .aurora-writing-band {
         box-sizing: border-box;
         max-width: 100%;
@@ -136,7 +135,7 @@
       <p class="aurora-hero-dek">Building the trust layer and the public room for responsible AI in British Columbia through BC + AI's year-round ecosystem and Futureproof Festival's flagship gathering.</p>
       <div class="aurora-proof-row" aria-label="Current proof">
         <a href="https://bc-ai.ca/">Executive Director, BC + AI</a>
-        <a href="https://futureproof.website/">Founder / Lead Curator, Futureproof Festival</a>
+        <a href="https://www.futureproof.website/">Founder / Lead Curator, Futureproof Festival</a>
         <a href="/speaking/">AI keynote speaker</a>
         <a href="/work/">Culture, code, community</a>
       </div>
@@ -171,7 +170,7 @@
       </article>
 
       <article class="aurora-media-card aurora-media-card-large">
-        <a href="https://futureproof.website/" aria-label="Explore Futureproof Festival">
+        <a href="https://www.futureproof.website/" aria-label="Explore Futureproof Festival">
           <img src="https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260527.jpg" alt="Futureproof Festival 2026 key art" width="1200" height="630" loading="lazy" decoding="async">
           <span class="aurora-card-label">Festival</span>
           <div>
@@ -305,25 +304,16 @@
     </div>
   </section>
 
-  <section class="aurora-testimonial-band" aria-labelledby="aurora-testimonials-title" data-reveal>
-    <div class="aurora-section-heading">
-      <p class="aurora-kicker">What people say</p>
-      <h2 id="aurora-testimonials-title">Fresh proof belongs here before launch.</h2>
-      <p>The Stewart Butterfield quote can stay as an anchor. This slot is designed for two or three current organizer quotes from 2024-2026 work.</p>
+  <section class="aurora-featured-strip" aria-labelledby="aurora-relationships-title" data-reveal>
+    <div class="aurora-section-heading aurora-section-heading-compact">
+      <p class="aurora-kicker">Follow the work</p>
+      <h2 id="aurora-relationships-title">One practice, three useful front doors.</h2>
+      <p>Start with Kris's work archive, then follow the year-round BC + AI ecosystem and its Futureproof Festival gathering.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three">
-      <blockquote class="aurora-quote-card">
-        <p>"Kris brought a rare mix of clarity, cultural fluency, and practical next steps. The room left with language they could actually use."</p>
-        <cite>Event organizer quote - replace with verified 2024-2026 attribution</cite>
-      </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>"He made the AI conversation feel less abstract, less performative, and much more human."</p>
-        <cite>Workshop host quote - replace with verified attribution</cite>
-      </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>"The value was not just inspiration. People left with a working frame for what to do next."</p>
-        <cite>Leadership audience quote - replace with verified attribution</cite>
-      </blockquote>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="/work/">Explore Kris's work</a>
+      <a class="aurora-button aurora-button-secondary" href="https://bc-ai.ca/">Visit BC + AI</a>
+      <a class="aurora-button aurora-button-secondary" href="https://www.futureproof.website/">Explore Futureproof Festival</a>
     </div>
   </section>
   <!-- /wp:html -->


### PR DESCRIPTION
## Summary

- add a 141-character homepage description fallback when the existing SEO option is empty
- render the reviewed Kris Krug identity in Open Graph and RSS metadata without changing the stored WordPress option
- remove the homepage's three unverified quote placeholders and replace that publishable surface with factual links to Kris's Work archive, BC + AI, and Futureproof Festival
- normalize homepage Futureproof links to the verified canonical www URL
- add focused regression coverage for placeholder removal, homepage metadata, feed/social identity, and the already-reviewed schema identity source

## Verification

- make python-test with Homebrew Python 3 — 363 tests passed
- focused #415/#316/#345 suite — 19 tests passed
- Local PHP 8.2 syntax check for theme/kk-aurora/functions.php — passed
- Local PHP 8.2 Aurora SEO title smoke — passed
- git diff --check — passed
- make validate completed PHP syntax across 38 files; local PHPCS was unavailable because Composer dependencies are not installed, so CI remains the PHPCS authority

## Live baseline and gates

Read-only production verification before this PR found:

- no standard homepage meta description
- one Fresh proof belongs here before launch heading and three replacement-attribution placeholders
- stale Open Graph and WebSite schema identity
- Site Kit analytics markers present

No WordPress write, credential access, theme upload, merge, or deployment was performed. Analytics code and ownership are untouched.

The live homepage is a Site Editor override. After review/merge, removing the live placeholders still requires a separately approved snapshot-first template sync and public readback. The canonical #316 schema source is already reviewed in-repo; updating its live Code Snippet remains separately gated.

Refs #383
Refs #415
Refs #316
Refs #345
Refs #425
