### PR TITLE
Add The Tyee AI adoption coverage to Publications

### DIFF
--- a/content/source-packs/keynotes-2026/wp-payloads/publications.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/publications.html
@@ -53,6 +53,11 @@
     <p class="kk-publications-section-intro">A cleaned-up entry point to the publication and citation history that used to live as one giant undifferentiated list.</p>
     <div class="kk-publications-grid">
       <article class="kk-publications-card">
+        <span class="kk-publications-tag">AI + public infrastructure</span>
+        <h3><a href="https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/">The Tyee: ‘We Want a Role’: Who Gets a Say in AI Adoption?</a></h3>
+        <p>Isaac Phan Nay quotes Kris on AI data centres as heavy industry, public bargaining, and consultation that can change outcomes. Read the argument behind the interview in <a href="https://bc-ai.ca/news/both-hands-on-the-grid">Both Hands on the Grid</a>.</p>
+      </article>
+      <article class="kk-publications-card">
         <span class="kk-publications-tag">Science + crowds</span>
         <h3><a href="http://www.popsci.com/space-industry-needs-to-blast-its-doors-open">Popular Science: NASA Needs to Harness the Genius of Crowds</a></h3>
         <p>A legacy Publications-page link that still explains a lot about the early open-web, crowd-intelligence thread in the work.</p>


### PR DESCRIPTION
## Summary
- add The Tyee article as the lead card in the Publications featured trail
- link the original BC + AI position paper for context and internal referral value
- keep the existing page structure and ordering intact after the new card

## Production status
- updated live WordPress page 1895 after an authenticated no-write diff
- captured a pre-write rollback snapshot
- verified authenticated raw readback and cache-busted public HTML
- checked the rendered grid on desktop and mobile

## Verification
- `git diff --check`
- both new destination URLs return HTTP 200
- each new URL appears exactly once in the payload
- payload contains no em dashes