### PR TITLE
feat(#422): Work with me CTA → /services/

### DIFF
--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.3.40');
+define('KK_AURORA_VERSION', '1.3.41');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -6,7 +6,7 @@
       <h2>Authored judgment, human agency, and the camera-trained habit of paying attention.</h2>
       <p>AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
       <div class="aurora-footer-actions">
-        <a class="aurora-button aurora-button-primary" href="/speaking/">Book a keynote</a>
+        <a class="aurora-button aurora-button-primary" href="/services/">Work with me</a>
         <a class="aurora-button aurora-button-secondary" href="/contact/">Get in touch</a>
       </div>
     </section>

--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -17,7 +17,7 @@
 
     <div class="aurora-header-actions">
       <a class="aurora-utility-link" href="https://kriskrug.beehiiv.com/">Newsletter</a>
-      <a class="aurora-button aurora-button-primary aurora-header-cta" href="/speaking/">Book a keynote</a>
+      <a class="aurora-button aurora-button-primary aurora-header-cta" href="/services/">Work with me</a>
     </div>
   </div>
 </header>

--- a/theme/kk-aurora/patterns/component-utility-system.php
+++ b/theme/kk-aurora/patterns/component-utility-system.php
@@ -36,7 +36,7 @@
     <div class="aurora-form-row">
       <label for="aurora-component-intent">What should we talk about?</label>
       <select id="aurora-component-intent" name="topic">
-        <option value="keynote">Book a keynote</option>
+        <option value="work">Work with me</option>
         <option value="workshop">Plan a workshop</option>
         <option value="training">Build a training program</option>
         <option value="media">Media or podcast appearance</option>

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -39,6 +39,10 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.3.41 =
+* Primary CTA becomes "Work with me" → `/services/` (#422).
+* Includes footer bento (#417/#449) and Wave 1 homepage theme fixes already on main.
+
 = 1.3.40 =
 * Render approved `jetpack_seo_html_title` values as exact singular document titles while preserving existing fallbacks (#357).
 

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.3.40
+Version: 1.3.41
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -140,7 +140,7 @@
         <a href="/work/">Culture, code, community</a>
       </div>
       <div class="aurora-action-row">
-        <a class="aurora-button aurora-button-primary" href="/speaking/">Book a keynote</a>
+        <a class="aurora-button aurora-button-primary" href="/services/">Work with me</a>
         <a class="aurora-button aurora-button-secondary" href="/work/">See current work</a>
       </div>
     </div>
@@ -197,7 +197,7 @@
         <span class="aurora-card-label">Keynotes</span>
         <h3>Keynotes</h3>
         <p>Plain-English talks on AI, taste, and human agency. No hype, no doom sermon. You leave with a frame you can use Monday morning.</p>
-        <a class="aurora-inline-link" href="/speaking/">Book a keynote</a>
+        <a class="aurora-inline-link" href="/services/">Work with me</a>
       </article>
       <article>
         <span class="aurora-card-label">Workshops</span>


### PR DESCRIPTION
## Summary
- Implements KK decision on #422: primary CTA label **Work with me**, destination **/services/**
- Updates header, footer, homepage primary + inline CTAs, and utility-form option
- Bumps Aurora `1.3.40` → `1.3.41` so the zip also carries merged footer bento (#449) and Wave 1 theme fixes

## Test plan
- [ ] `rg -n 'Book a keynote' theme` → empty (or only non-CTA leftovers)
- [ ] Logged-out check after deploy: header/footer/home primary CTA label + href
- [ ] `/services/` returns 200
- [ ] Keyboard focus visible on new CTA

Closes #422.

Made with [Cursor](https://cursor.com)