### PR TITLE
Fix: restore WCAG AA contrast tokens and working header skip link (Aurora 1.4.4)

### DIFF
--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -11,9 +11,15 @@
   --revive-ink: #171310;
   --revive-ink-soft: rgba(23, 19, 16, 0.78);
   --revive-ink-muted: rgba(23, 19, 16, 0.55);
-  /* Fill/CTA orange stays bright; text-on-cream uses AA-safe darker orange */
+  /* Decorative-only orange (rules, ribbons, borders). Never put text on it. */
   --revive-accent: #d94a1f;
-  --revive-accent-text: #b53c18; /* ~4.67:1 on cream */
+  /* Text-on-cream accent: 6.06:1 on #efe6d2, 4.77:1 on the darkest cream (#d9cdb0).
+     The previous #b53c18 only reached 3.67:1 on #d9cdb0. */
+  --revive-accent-text: #9a2f14;
+  /* Solid control fill; label text is #fffaf6 (5.11:1). */
+  --revive-accent-control: #c03f18;
+  --revive-accent-control-hover: #a52918;
+  --revive-accent-control-label: #fffaf6;
   --revive-accent-soft: #e8b53a;
   --revive-line: rgba(23, 19, 16, 0.14);
   --revive-line-strong: rgba(181, 60, 24, 0.4);
@@ -32,11 +38,11 @@
   --aurora-ink-soft: rgba(23, 19, 16, 0.78);
   --aurora-ink-muted: rgba(23, 19, 16, 0.55);
   --aurora-paper: #efe6d2;
-  --aurora-signal: #d94a1f;
-  --aurora-readable-accent: #b53c18;
+  --aurora-signal: #9a2f14;
+  --aurora-readable-accent: #9a2f14;
   --aurora-signal-dark: #a52918;
-  --aurora-signal-control: #d94a1f;
-  --aurora-signal-control-hover: #c03f18;
+  --aurora-signal-control: #c03f18;
+  --aurora-signal-control-hover: #a52918;
   --aurora-wildcard: #e8b53a;
   --aurora-opal-void: #efe6d2;
   --aurora-opal-ink: #e6dcc2;
@@ -93,9 +99,9 @@ body.aurora-theme::before {
 
 .aurora-button-primary,
 .wp-block-button.is-style-aurora-primary .wp-block-button__link {
-  background: var(--revive-accent);
-  border-color: var(--revive-accent);
-  color: var(--revive-surface);
+  background: var(--revive-accent-control);
+  border-color: var(--revive-accent-control);
+  color: var(--revive-accent-control-label);
   box-shadow: none;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -156,8 +162,8 @@ body.aurora-theme #wp-skip-link:focus-visible {
   outline: 2px solid var(--revive-ink) !important;
   outline-offset: 2px !important;
   top: var(--wp--preset--spacing--40, 1rem);
-  background: var(--revive-accent) !important;
-  color: var(--revive-surface) !important;
+  background: var(--revive-accent-control) !important;
+  color: var(--revive-accent-control-label) !important;
 }
 
 /* ========== Header ========== */
@@ -285,9 +291,9 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
 }
 
 .aurora-header-cta:hover {
-  background: var(--revive-accent) !important;
-  border-color: var(--revive-accent) !important;
-  color: var(--revive-surface) !important;
+  background: var(--revive-accent-control) !important;
+  border-color: var(--revive-accent-control) !important;
+  color: var(--revive-accent-control-label) !important;
 }
 
 /* ========== Homepage Revive layout ========== */

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,9 +18,27 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.4.3');
+define('KK_AURORA_VERSION', '1.4.4');
 
 require_once get_template_directory() . '/inc/seo-title.php';
+
+/**
+ * Suppress the core block-template skip link.
+ *
+ * Core injects a generic `#wp-skip-link` that targets the first content
+ * container it can find. The theme ships its own `.skip-link` in
+ * `parts/header.html` pointing at the real `#aurora-main` landmark, so
+ * removing the core one avoids two competing "Skip to content" links.
+ *
+ * @since 1.4.4
+ */
+function remove_core_skip_link(): void {
+    // WordPress 6.4+.
+    remove_action('wp_enqueue_scripts', 'wp_enqueue_block_template_skip_link');
+    // WordPress 6.2–6.3.
+    remove_action('wp_footer', 'the_block_template_skip_link');
+}
+add_action('init', __NAMESPACE__ . '\\remove_core_skip_link');
 
 /**
  * Theme setup

--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -1,6 +1,8 @@
 <!-- wp:html -->
 <header class="aurora-header aurora-header-2026" role="banner">
-  <!-- Skip link: WordPress core renders #wp-skip-link before .wp-site-blocks -->
+  <!-- Skip link: theme-owned, targets the #aurora-main landmark every template renders.
+       Core's generic #wp-skip-link is suppressed in functions.php so there is only one. -->
+  <a class="skip-link" href="#aurora-main">Skip to content</a>
   <div class="aurora-scroll-progress" aria-hidden="true"></div>
   <div class="aurora-woven-marquee" aria-hidden="true">
     <div class="aurora-woven-marquee-track">

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.3 tightens Revive chrome (left-pinned header, rainbow/riso accents) on Pagely WordPress.
+KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.4 restores WCAG AA contrast for accent text, primary controls, and the skip link after the cream/ink restyle.
 
 Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
@@ -32,11 +32,19 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 * Cream surface: #efe6d2
 * Ink text: #171310
-* Burnt orange accent: #d94a1f
+* Burnt orange accent (text/AA): #9a2f14
+* Burnt orange control fill: #c03f18
+* Burnt orange decorative: #d94a1f
 * Riso yellow: #e8b53a
 * Rainbow accents: teal / cyan / cobalt / violet / magenta
 
 == Changelog ==
+
+= 1.4.4 =
+* a11y: darken the accent orange to #9a2f14 so accent text clears 4.5:1 on every cream surface (was 2.69:1 on #d9cdb0).
+* a11y: darken `Ink Muted` to #5c5044 (3.93:1 -> 4.96:1 on the darkest cream surface).
+* a11y: primary control fill #c03f18 / hover #a52918 with #fffaf6 labels (was 4.09:1, now 5.11:1 / 6.91:1).
+* a11y: restore the theme skip link to #aurora-main and suppress the duplicate core skip link.
 
 = 1.4.3 =
 * R5: full-bleed header shell so brand pins left of the viewport, not mid-column on ultrawide.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.4.3
+Version: 1.4.4
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -493,12 +493,15 @@ a {
   --aurora-ink: #171310;
   --aurora-ink-soft: rgba(23, 19, 16, 0.78);
   --aurora-ink-muted: rgba(23, 19, 16, 0.55);
-  --aurora-readable-accent: #b53c18;
+  /* Accent orange used as TEXT on cream must clear 4.5:1 against the darkest
+     cream surface (muted #d9cdb0). #d94a1f only reached 2.69:1 there. */
+  --aurora-readable-accent: #9a2f14;
   --aurora-paper: #efe6d2;
-  --aurora-signal: #d94a1f;
+  --aurora-signal: #9a2f14;
   --aurora-signal-dark: #a52918;
-  --aurora-signal-control: #d94a1f;
-  --aurora-signal-control-hover: #c03f18;
+  /* Control fills carry #fffaf6 label text — both states clear 4.5:1 on it. */
+  --aurora-signal-control: #c03f18;
+  --aurora-signal-control-hover: #a52918;
   --aurora-wildcard: #e8b53a;
   --aurora-opal-void: #efe6d2;
   --aurora-opal-ink: #e6dcc2;

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -54,7 +54,7 @@
         {
           "slug": "text-muted",
           "name": "Ink Muted",
-          "color": "#6b5f52"
+          "color": "#5c5044"
         },
         {
           "slug": "paper",
@@ -64,12 +64,12 @@
         {
           "slug": "signal",
           "name": "Burnt Orange",
-          "color": "#d94a1f"
+          "color": "#9a2f14"
         },
         {
           "slug": "signal-text",
           "name": "Burnt Orange Text",
-          "color": "#b53c18"
+          "color": "#9a2f14"
         },
         {
           "slug": "wildcard",


### PR DESCRIPTION
## Summary

`main` is currently red with 8 test failures. This PR fixes the accessibility half: WCAG AA contrast regressions and the removed header skip link, both introduced by the Aurora 1.4.x cream/ink restyle. Ships as **Aurora 1.4.4**.

Fixes the underlying defects — no test was loosened, skipped, or rewritten.

## Related Issue

Fixes #464
Relates to #46, #86, #424
Relates to #288 (the accessibility statement in PR #463 names both of these as known limitations)

## Changes

- **Contrast tokens** synced across all three declaration sites — `theme.json`, `style.css` `:root`, and `assets/css/revive-port.css` `:root`. The last of those is enqueued last and was silently re-declaring the same properties, so a `theme.json`-only fix would have been overridden.
  - `signal` `#d94a1f` → `#9a2f14`
  - `signal-text` / `--aurora-readable-accent` / `--revive-accent-text` `#b53c18` → `#9a2f14`
  - `text-muted` `#6b5f52` → `#5c5044`
  - `--aurora-signal-control` `#d94a1f` → `#c03f18`; hover `#c03f18` → `#a52918`
  - New `--revive-accent-control` / `--revive-accent-control-label` for `.aurora-button-primary`, `.skip-link:focus`, `.aurora-header-cta:hover`. `--revive-accent` stays `#d94a1f` for rules/ribbons/borders that never carry text — the decorative orange is preserved where it's safe.
- **Skip link** restored in `parts/header.html` targeting `#aurora-main`, plus `remove_core_skip_link()` in `functions.php` suppressing core's generic `#wp-skip-link` so there is exactly one, not two.
- Version bumped 1.4.3 → 1.4.4 in `style.css`, `KK_AURORA_VERSION`, and `readme.txt`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement

## Testing

### Test Results

- [x] `make python-test` — the 3 contrast/skip-link tests this PR owns now pass; no new failures introduced
- [x] `make php-syntax` — 39/39 pass
- [x] `make validate` — `theme/kk-aurora/functions.php` passes PHPCS clean. The only 3 errors are pre-existing unescaped-output warnings in `fixes/kk-news-sitemap-snippet.php`, verified identical on `main` and out of scope here.
- [x] Contrast ratios independently recomputed by the reviewing session, not taken on trust

| Change | Before | After | AA |
|---|---|---|---|
| `signal` on `muted` | 2.69:1 | **4.77:1** | ✅ |
| `signal` on `deep` | 3.42:1 | **6.06:1** | ✅ |
| `text-muted` on `muted` | 3.93:1 | **4.96:1** | ✅ |
| CTA label on control | 4.09:1 | **5.11:1** | ✅ |
| CTA label on hover | — | **6.91:1** | ✅ |

Verified separately: all 8 templates render `id="aurora-main"` (the parts correctly don't — they're fragments), and `add_action('init', __NAMESPACE__ . '\\remove_core_skip_link')` matches the file's existing `namespace KK_Aurora` convention.

## ⚠️ One test in #464 is NOT fixed here

`test_homepage_feature_band_contrast_floor_is_present` still fails. The CSS contrast-floor rule and its ratio assertions all pass — the only failing assertion is `assertIn("aurora-feature-band-contrast", front_page)`, which needs a `theme/kk-aurora/templates/front-page.html` edit. That file is owned by the sibling branch `swarm/main-green-payload-drift` in this same swarm, which is already rewriting it for `test_issue_415`. Handed off there to avoid a merge conflict.

**`main` does not go green until both PRs land.** This one is not independently sufficient.

## Accessibility Considerations

- [x] Improves accessibility
- [x] Restores WCAG 2.1 AA compliance for the affected tokens
- [x] Keyboard navigation — skip link restored and de-duplicated

Not done: screen-reader testing, and no live verification (see below).

## Deployment Notes

- [x] Requires cache clearing (after deploy)

Merging does **not** touch the live site. Aurora deploys by manual `make aurora-package` → wp-admin zip upload. Live was **1.3.37** at the last public readback while repo is on the 1.4.x line, so production may not currently exhibit these defects at all — confirm with a live `style.css` readback before assuming either way. Repo green is not proof of production.

## Additional Notes

The decorative orange `#d94a1f` is deliberately kept for non-text surfaces. The cream/ink design intent is preserved; only the text-bearing pairings moved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_