### PR TITLE
Chore: stop new backup/ visual-capture spill from re-bloating the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ docs/current-state/reports/screenshots/
 docs/current-state/reports/**/*.png
 docs/current-state/reports/**/*.html
 docs/current-state/reports/**/*.csv
+
+# QA / deploy visual captures under backup/ — same policy as reports/ above (#318, #369).
+# Keep the .md handoffs and .json metrics that carry the audit trail; ignore the raw PNGs.
+# Visual-regression evidence belongs in a hash manifest, not committed screenshots.
+# Existing tracked copies stay until an approved cleanup — this only stops NEW spill.
+backup/**/*.png
+backup/**/*.jpg
+backup/**/*.jpeg


### PR DESCRIPTION
## Summary

**Deletes nothing.** Adds `backup/**/*.png|jpg|jpeg` to `.gitignore`, mirroring the policy already applied to `docs/current-state/reports/` (lines 68–74). `backup/` was the one bloat surface with no ignore rule.

A new ignore rule does not affect already-tracked files, so this is recurrence prevention only and needs no approval gate.

## Related Issue

Relates to #369, #318

## ⚠️ The reclaim list is NOT approved — correcting the record

I dispatched this work believing #369's list was KK-approved, because its **title** says "Execute KK-approved #318 reclaim list." That was my error. The actual state:

- #369 body: *"Do **not** delete without an exact approved path list."*
- Acceptance box "KK approves exact paths": **unchecked**
- Only comment (2026-07-24, KK): *"Ranked reclaim list committed for approval… **No deletes yet.** Reply with exact Tier 1 allow-list and I will open a delete-only PR."* — **no reply exists**
- `RECLAIM-LIST-2026-07-24.md` line 3: *"ranked proposal for KK path-by-path approval. No deletes in this commit."*
- #318 has zero comments; Phase B is "deferred, publish-gated."

**The approved set is empty.** No deletions were made.

## The proposed Tier 1 list doesn't survive verification anyway

A full reference analysis (every tracked image's basename and path grepped against the entire tracked text corpus — 347 images, 317.6 MB) found **295 referenced (308.2 MB), 52 orphaned (9.3 MB)**:

| Proposed Tier 1 pattern | Verdict |
|---|---|
| `content/drafts/**/screenshots/**/*.png` | **Matches zero files** — no such directory exists |
| `content/drafts/**/*.png` where post is live | **Gate unsatisfiable** (no credentials for published-status readback). Also 170 of 171 are referenced by `post.md`/`alt-text.md`, by `scripts/notion-to-wp/publish_you_cant_drink_data.py`, and by deployed payloads under `backup/20260624-181106Z-issue233-companions/` — load-bearing for the publish pipeline |
| `docs/current-state/reports/**/screenshots/**/*.png` | **All 80 files (23.7 MB) are cited evidence** — referenced by four 2026-07-01 audits and by `PERFORMANCE-RECOVERY-2026-07-01.md`. Deleting breaks the audit trail |

The single draft orphan is the featured/OG asset of an **unpublished, in-flight** draft carrying a `publish-gate.md`. Phase B's own rule: *"Leave unpublished / in-flight drafts untouched."*

## #318's headline number needs reframing

Measured: `.git` **303 MB**, working tree **332 MB**, total **635 MB**. 347 tracked images ✓, 48 `backup/` screenshots ✓.

- **Phase C (~295–303 MB — the bulk) is unreachable** without `git filter-repo` + force-push, which #369 puts explicitly out of scope
- **Phase B's "up to ~238 MB"** doesn't survive the reference data — those images are publisher inputs, not dead weight
- **Achievable by working-tree deletion right now: 5.56 MiB (~0.9%)**

The honest framing: **#318's headline is a git-history number, and the working-tree lane cannot deliver it.** Worth deciding whether the history rewrite is worth its cost, or whether #318 should be rescoped.

## Type of Change

- [x] Code refactoring (no functional changes)

## Testing

- [x] `make python-test` — 0 failures (241 + 3 + 68). Only `.gitignore` changed, so nothing could regress.

## Deployment Notes

- [x] No special deployment steps required

## Tradeoff worth noticing

Future deploy-QA screenshots under `backup/` won't be committed, so future handoffs citing them need hash manifests instead. That's the direction PR #467 established for visual-regression baselines — but it's a workflow change someone should notice deliberately rather than discover later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_