### PR TITLE
Refactor: consolidate publisher block/media logic and de-hardcode WP IDs (#254)

### DIFF
--- a/scripts/notion-to-wp/README.md
+++ b/scripts/notion-to-wp/README.md
@@ -209,6 +209,48 @@ kk-aurora theme constraints baked into the defaults:
 
 Markup is locked by `tests/test_wp_blocks.py`.
 
+## Shared publisher orchestration (`publish_common.py`)
+
+`wp_blocks.py` owns the markup; `publish_common.py` owns everything the one-off
+`publish_*.py` scripts do *around* it — front matter, marker dispatch, media
+resolution, the slug guard, SEO meta, and declared IDs.
+
+- `strip_frontmatter(raw)` — drop a leading `---` YAML block.
+- `render_marker_blocks(body, handlers, *, paragraph=..., skip_first_h1=True)` —
+  split on blank lines, drop the first `# ` (the title lives in the WP title
+  field), then dispatch each block through ordered `(matcher, render)` handlers.
+  A matcher is a compiled regex or a callable (`exact("---")`, `prefix("## ")`);
+  a renderer returning `None` emits nothing. Unclaimed blocks fall through to
+  `paragraph`.
+- `standard_text_handlers(*, h3=True, pullquote_marker=False)` — the shared
+  `---` / `## ` / `### ` / `>>> ` set every script starts from.
+- `render_paragraph_from_markdown` (joins source lines with `<br>`) vs
+  `raw_paragraph` (keeps the newline). Both exist because both are already
+  shipped: `publish_dc_protest_draft.py` uses the latter, everything else the former.
+- `find_or_upload_media(...)` — idempotent resolve-by-filename-stem, then upload.
+  Dry-run returns `(0, "DRYRUN/<file>")` and never calls WordPress.
+- `find_existing_post_by_slug(wp, slug)` — the create/update guard. Confirm the
+  returned record is the intended target before any PATCH (2026-05-15 incident rule).
+
+### Declared IDs (`publisher-ids.json`)
+
+Production category and media IDs are declared once in `publisher-ids.json` —
+same shape as `content/source-packs/.../page-map.json` — instead of being typed
+into each script. Loaders: `category_id(key)`, `media_id(key)`,
+`media_group(key)`, `media_group_index(key)` (`{id: (url, alt)}` plus declared
+order) and `media_group_keys(key)` (`{name: id}`, so a script can say
+`SIGN["water-the-servers-last"]` instead of `11918`).
+
+Unknown keys and non-positive IDs abort with `[ABORT]`. Live existence is still
+proven separately at write time by `resolve_category_ids` / `validate_media_id`.
+Every script default stays overridable (`--category-id`, `--featured-media-id`)
+so a staging run never inherits a production ID.
+
+Locked by `tests/test_publish_common.py`, `tests/test_publisher_ids.py` and
+`tests/test_publisher_render_characterisation.py` (the last file keeps verbatim
+copies of the pre-consolidation loops and asserts the shared dispatcher still
+matches them byte for byte).
+
 ### Re-emitting an already-published post
 
 Rebuilding a live post's body from its source markdown is only safe when that source is still in sync with what's live. If the live post has drifted (manual edits, a newer source), a rebuild **drops** those blocks. To upgrade image markup on a drifted live post, transform the fetched live content **in place** (e.g. swap `"linkDestination":"none"` → `"lightbox":{"enabled":true}` and `wp-block-image__caption` → `wp-element-caption`), and diff the block structure before/after to confirm only the intended markup changed.

--- a/scripts/notion-to-wp/publish_common.py
+++ b/scripts/notion-to-wp/publish_common.py
@@ -1,22 +1,26 @@
 """Shared helpers for one-off publish_*.py scripts.
 
-Orchestration only: image manifests, text-post assembly, term/media ID
-validation, and SEO meta shaping. Gutenberg markup stays in wp_blocks.py.
+Orchestration only: front matter, marker -> block dispatch, image manifests,
+declared ID lookup, term/media ID validation, and SEO meta shaping. Gutenberg
+markup stays in wp_blocks.py.
 """
 from __future__ import annotations
 
+import functools
 import html
+import json
 import pathlib
 import re
 import sys
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable, Sequence
 
 from connector_payload import normalize_seo_meta
 from kk_notion_to_wp import slugify
 from wp_blocks import heading, inline, separator
 
 MARKDOWN_IMG_IMAGES_RE = re.compile(r"^!\[(.+?)\]\(images/(.+?)\)$")
+PUBLISHER_IDS_PATH = pathlib.Path(__file__).resolve().parent / "publisher-ids.json"
 
 
 @dataclass(frozen=True)
@@ -35,6 +39,18 @@ def parse_publish_argv(argv: list[str] | None = None) -> PublishFlags:
     return PublishFlags(execute="--execute" in args, update="--update" in args)
 
 
+def strip_frontmatter(raw: str) -> str:
+    """Return the post body with a leading `---` YAML front matter block removed.
+
+    Exactly the index-walk the one-off scripts each carried inline: find the
+    closing `\\n---` after the opening fence and slice past it. Raises ValueError
+    (as `str.index` always did) when the fences are missing, so a malformed
+    post.md still fails loudly rather than publishing its own front matter.
+    """
+    fm_end = raw.index("\n---", raw.index("---") + 3)
+    return raw[fm_end + 4:]
+
+
 def split_body_blocks(body: str) -> list[str]:
     """Split post body on blank lines; return stripped non-empty blocks."""
     return [x.strip() for x in re.split(r"\n\s*\n", body) if x.strip()]
@@ -51,23 +67,102 @@ def render_paragraph_from_markdown(block: str) -> str:
     return paragraph_block(para)
 
 
-def render_text_post(body: str) -> str:
-    """Text-only post assembler: skip first H1, map ---/##/###/else via wp_blocks."""
+def raw_paragraph(block: str) -> str:
+    """Single-line-ish paragraph: inline() the whole block, newlines preserved.
+
+    This is publish_dc_protest_draft.py's paragraph shape. It differs from
+    render_paragraph_from_markdown, which joins source lines with <br>. Both are
+    kept because the difference is visible in already-shipped post bodies.
+    """
+    return paragraph_block(inline(block))
+
+
+# ---------------------------------------------------------------------------
+# marker -> block dispatch
+# ---------------------------------------------------------------------------
+# A handler is (matcher, render).
+#   matcher: a compiled regex (matched against the block) or a callable
+#            returning truthy for blocks it claims.
+#   render:  callable(block, match) -> block markup, or None to emit nothing.
+BlockRender = Callable[[str, Any], "str | None"]
+BlockHandler = "tuple[Any, BlockRender]"
+
+
+def exact(literal: str) -> Callable[[str], bool]:
+    """Matcher for a block that equals `literal` (e.g. `---`, `[[GALLERY-AI]]`)."""
+    return lambda block: block == literal
+
+
+def prefix(literal: str) -> Callable[[str], bool]:
+    """Matcher for a block starting with `literal` (e.g. `## `, `>>> `)."""
+    return lambda block: block.startswith(literal)
+
+
+def render_marker_blocks(
+    body: str,
+    handlers: Sequence[Any] = (),
+    *,
+    paragraph: Callable[[str], str] = render_paragraph_from_markdown,
+    skip_first_h1: bool = True,
+) -> list[str]:
+    """Split `body` into blocks and dispatch each through `handlers`.
+
+    The first `# ` block is dropped when `skip_first_h1` (the post title lives in
+    the WP title field, not the body). Handlers are tried in order and the first
+    match wins; anything unclaimed falls through to `paragraph`. A handler may
+    return None to emit nothing for that block.
+    """
     out: list[str] = []
     seen_title = False
     for block in split_body_blocks(body):
-        if block.startswith("# ") and not seen_title:
+        if skip_first_h1 and block.startswith("# ") and not seen_title:
             seen_title = True
             continue
-        if block == "---":
-            out.append(separator())
-        elif block.startswith("## "):
-            out.append(heading(inline(block[3:].strip()), level=2))
-        elif block.startswith("### "):
-            out.append(heading(inline(block[4:].strip()), level=3))
-        else:
-            out.append(render_paragraph_from_markdown(block))
-    return "\n\n".join(out)
+        rendered: str | None = None
+        claimed = False
+        for matcher, render in handlers:
+            if hasattr(matcher, "match"):
+                match = matcher.match(block)
+                if match is None:
+                    continue
+            else:
+                if not matcher(block):
+                    continue
+                match = None
+            claimed = True
+            rendered = render(block, match)
+            break
+        if not claimed:
+            rendered = paragraph(block)
+        if rendered is not None:
+            out.append(rendered)
+    return out
+
+
+def standard_text_handlers(*, h3: bool = True, pullquote_marker: bool = False) -> list[Any]:
+    """The `---` / `## ` / `### ` / `>>> ` handlers every one-off script shares.
+
+    `### ` never collides with the `## ` prefix ("###"[0:3] != "## "), so callers
+    may reorder or extend this list freely.
+    """
+    from wp_blocks import pullquote as _pullquote
+
+    handlers: list[Any] = [
+        (exact("---"), lambda block, match: separator()),
+        (prefix("## "), lambda block, match: heading(inline(block[3:].strip()), level=2)),
+    ]
+    if h3:
+        handlers.append(
+            (prefix("### "), lambda block, match: heading(inline(block[4:].strip()), level=3))
+        )
+    if pullquote_marker:
+        handlers.append((prefix(">>> "), lambda block, match: _pullquote(inline(block[4:].strip()))))
+    return handlers
+
+
+def render_text_post(body: str) -> str:
+    """Text-only post assembler: skip first H1, map ---/##/###/else via wp_blocks."""
+    return "\n\n".join(render_marker_blocks(body, standard_text_handlers()))
 
 
 def parse_markdown_image_order(
@@ -124,6 +219,54 @@ def find_media_by_stem(
     return None
 
 
+def find_or_upload_media(
+    wp: Any,
+    path: pathlib.Path,
+    alt: str,
+    *,
+    mime: str,
+    write: bool,
+    label: str | None = None,
+    log: list[str] | None = None,
+    extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp"),
+) -> tuple[int, str]:
+    """Idempotent single-file media resolve: reuse by stem, else upload.
+
+    Returns (media_id, source_url). In dry-run (`write=False`) returns
+    (0, "DRYRUN/<filename>") without touching WordPress. `label` prefixes the log
+    line (scripts log either a bare filename or `subdir/filename`).
+    """
+    name = label or path.name
+    if not write:
+        return 0, f"DRYRUN/{path.name}"
+    found = find_media_by_stem(wp, path.stem, extensions=extensions)
+    if found:
+        media_id, url = found
+        if log is not None:
+            log.append(f"{name} -> REUSE id={media_id}")
+        return media_id, url
+    media = wp.upload_media(path, alt=alt, mime=mime)
+    media_id, url = int(media["id"]), media["source_url"]
+    if log is not None:
+        log.append(f"{name} -> NEW id={media_id} {url}")
+    return media_id, url
+
+
+def find_existing_post_by_slug(wp: Any, slug: str) -> dict[str, Any] | None:
+    """Return the first post record matching `slug` in any status, else None.
+
+    The create/update guard every one-off script runs before it writes. Keeping it
+    in one place keeps the 2026-05-15 slug-idempotency rule in one place too:
+    callers must confirm the returned record is the intended target before PATCH.
+    """
+    hits = wp.s.get(
+        f"{wp.base}/wp-json/wp/v2/posts",
+        params={"slug": slug, "status": "any", "context": "edit"},
+        timeout=30,
+    ).json()
+    return hits[0] if isinstance(hits, list) and hits else None
+
+
 def upload_image_manifest(
     wp: Any | None,
     items: list[tuple[str, str]],
@@ -171,18 +314,16 @@ def load_photos_from_dir(
             alt = re.sub(r"^\d+-", "", path.stem).replace("-", " ") + " protest sign"
         else:
             alt = caption or path.stem
-        if write:
-            found = find_media_by_stem(wp, path.stem)
-            if found:
-                media_id, url = found
-                log.append(f"{subdir}/{path.name} -> REUSE id={media_id}")
-            else:
-                media = wp.upload_media(path, alt=alt, mime="image/jpeg")
-                media_id, url = media["id"], media["source_url"]
-                log.append(f"{subdir}/{path.name} -> NEW id={media_id} {url}")
-            items.append((media_id, url, alt, caption, path.name))
-        else:
-            items.append((0, f"DRYRUN/{path.name}", alt, caption, path.name))
+        media_id, url = find_or_upload_media(
+            wp,
+            path,
+            alt,
+            mime="image/jpeg",
+            write=write,
+            label=f"{subdir}/{path.name}",
+            log=log,
+        )
+        items.append((media_id, url, alt, caption, path.name))
     return items
 
 
@@ -294,3 +435,79 @@ def parse_int_arg(argv: list[str], flag: str, default: int | None = None) -> int
             raise SystemExit(f"[ABORT] {flag} requires an integer value")
         return int(argv[idx + 1])
     return default
+
+
+# ---------------------------------------------------------------------------
+# declared WordPress IDs (publisher-ids.json)
+# ---------------------------------------------------------------------------
+@functools.lru_cache(maxsize=None)
+def load_publisher_ids(path: pathlib.Path | None = None) -> dict[str, Any]:
+    """Load and cache publisher-ids.json (same loader shape as page-map.json)."""
+    return json.loads((path or PUBLISHER_IDS_PATH).read_text(encoding="utf-8"))
+
+
+def _declared(section: str, key: str, ids: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = ids if ids is not None else load_publisher_ids()
+    entries = data.get(section) or {}
+    if key not in entries:
+        raise SystemExit(
+            f"[ABORT] unknown {section} key {key!r} in publisher-ids.json. "
+            f"Known keys: {sorted(entries)}"
+        )
+    return entries[key]
+
+
+def category_id(key: str, *, ids: dict[str, Any] | None = None) -> int:
+    """Declared category ID by logical key (e.g. 'ai-ethics-philosophy').
+
+    Structural validation only. Live existence is proven separately by
+    resolve_category_ids/validate_term_ids at write time.
+    """
+    entry = _declared("categories", key, ids)
+    value = entry.get("id")
+    if not isinstance(value, int) or value <= 0:
+        raise SystemExit(f"[ABORT] category {key!r} has a non-positive id: {value!r}")
+    return value
+
+
+def media_id(key: str, *, ids: dict[str, Any] | None = None) -> int:
+    """Declared media ID by logical key (e.g. 'you-cant-drink-data-featured')."""
+    entry = _declared("media", key, ids)
+    value = entry.get("id")
+    if not isinstance(value, int) or value <= 0:
+        raise SystemExit(f"[ABORT] media {key!r} has a non-positive id: {value!r}")
+    return value
+
+
+def media_group(key: str, *, ids: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Declared, ordered media set by logical key. Returns [{id, url, alt}, ...]."""
+    entry = _declared("media_groups", key, ids)
+    items = entry.get("items") or []
+    for item in items:
+        if not isinstance(item.get("id"), int) or item["id"] <= 0:
+            raise SystemExit(f"[ABORT] media group {key!r} has an entry with a bad id: {item!r}")
+        if not item.get("url") or not item.get("alt"):
+            raise SystemExit(f"[ABORT] media group {key!r} entry {item.get('id')} needs url + alt")
+    return list(items)
+
+
+def media_group_index(
+    key: str, *, ids: dict[str, Any] | None = None
+) -> tuple[dict[int, tuple[str, str]], list[int]]:
+    """media_group() as ({id: (url, alt)}, [id, ...]) in declared order."""
+    items = media_group(key, ids=ids)
+    return {it["id"]: (it["url"], it["alt"]) for it in items}, [it["id"] for it in items]
+
+
+def media_group_keys(key: str, *, ids: dict[str, Any] | None = None) -> dict[str, int]:
+    """media_group() as {declared key: media id}, so scripts can name a sign
+    instead of typing its production ID (e.g. SIGN["water-the-servers-last"])."""
+    keyed: dict[str, int] = {}
+    for item in media_group(key, ids=ids):
+        name = item.get("key")
+        if not name:
+            raise SystemExit(f"[ABORT] media group {key!r} entry {item['id']} has no 'key'")
+        if name in keyed:
+            raise SystemExit(f"[ABORT] media group {key!r} declares duplicate key {name!r}")
+        keyed[name] = item["id"]
+    return keyed

--- a/scripts/notion-to-wp/publish_context_creators.py
+++ b/scripts/notion-to-wp/publish_context_creators.py
@@ -17,14 +17,20 @@ Marker syntax in post.md:
 """
 import re, sys, json, pathlib
 from kk_notion_to_wp import WordPress, load_config
-from wp_blocks import inline, inline_image, hero_image, heading, separator, pullquote
+from wp_blocks import inline_image, hero_image
 from publish_common import (
     build_seo_meta,
-    find_media_by_stem,
+    find_existing_post_by_slug,
+    find_or_upload_media,
     parse_publish_argv,
-    render_paragraph_from_markdown,
-    split_body_blocks,
+    render_marker_blocks,
+    standard_text_handlers,
+    strip_frontmatter,
 )
+
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp")
+POSTER_RE = re.compile(r"^!\[(.*?)\]\(poster:(\d+)\)$")
+SCREENSHOT_RE = re.compile(r"^!\[(.*?)\]\(screenshot:([a-z-]+)\)$")
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parents[1]
@@ -83,47 +89,35 @@ POSTERS = {
 
 # ---------------------------------------------------------------------------
 raw = (STAGE / "post.md").read_text()
-fm_end = raw.index("\n---", raw.index("---") + 3)
-body = raw[fm_end + 4:]
+body = strip_frontmatter(raw)
 assert "—" not in body, "em-dash leaked into post.md body"
 
 cfg = load_config()
 wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
 
+
 media_log = []
+
+
+def stage_media(filename, alt, kind):
+    """Resolve a staged image to (id, url): reuse by filename stem, else upload."""
+    path = IMAGES / filename
+    assert path.exists(), f"missing staged {kind}: {path}"
+    return find_or_upload_media(
+        wp, path, alt, mime="image/png", write=WRITE, label=filename,
+        log=media_log, extensions=IMAGE_EXTENSIONS,
+    )
+
+
 poster_media = {}  # N -> (id, url, alt)
 for n, (fn, alt) in POSTERS.items():
-    p = IMAGES / fn
-    assert p.exists(), f"missing staged poster: {p}"
-    if WRITE:
-        found = find_media_by_stem(wp, p.stem, extensions=(".png", ".jpg", ".jpeg", ".webp"))
-        if found:
-            mid, url = found
-            media_log.append(f"{fn} -> REUSE id={mid}")
-        else:
-            m = wp.upload_media(p, alt=alt, mime="image/png")
-            mid, url = m["id"], m["source_url"]
-            media_log.append(f"{fn} -> NEW id={mid} {url}")
-        poster_media[n] = (mid, url, alt)
-    else:
-        poster_media[n] = (0, f"DRYRUN/{fn}", alt)
+    mid, url = stage_media(fn, alt, "poster")
+    poster_media[n] = (mid, url, alt)
 
 shot_media = {}  # key -> (id, url, alt, caption)
 for key, (fn, alt, caption) in SCREENSHOTS.items():
-    p = IMAGES / fn
-    assert p.exists(), f"missing staged screenshot: {p}"
-    if WRITE:
-        found = find_media_by_stem(wp, p.stem, extensions=(".png", ".jpg", ".jpeg", ".webp"))
-        if found:
-            mid, url = found
-            media_log.append(f"{fn} -> REUSE id={mid}")
-        else:
-            m = wp.upload_media(p, alt=alt, mime="image/png")
-            mid, url = m["id"], m["source_url"]
-            media_log.append(f"{fn} -> NEW id={mid} {url}")
-        shot_media[key] = (mid, url, alt, caption)
-    else:
-        shot_media[key] = (0, f"DRYRUN/{fn}", alt, caption)
+    mid, url = stage_media(fn, alt, "screenshot")
+    shot_media[key] = (mid, url, alt, caption)
 
 print(f"[media] {'wrote' if WRITE else 'DRY'} {len(poster_media)} posters + {len(shot_media)} screenshots")
 for l in media_log:
@@ -132,30 +126,23 @@ for l in media_log:
 FEATURED_ID = poster_media[1][0]
 
 # ---- build blocks ----
-out = []
-seen_title = False
-for b in split_body_blocks(body):
-    if b.startswith("# ") and not seen_title:
-        seen_title = True
-        continue
-    if b == "---":
-        out.append(separator())
-    elif b.startswith("## "):
-        out.append(heading(inline(b[3:].strip())))
-    elif b.startswith(">>> "):
-        out.append(pullquote(inline(b[4:].strip())))
-    else:
-        mp = re.match(r"^!\[(.*?)\]\(poster:(\d+)\)$", b)
-        ms = re.match(r"^!\[(.*?)\]\(screenshot:([a-z-]+)\)$", b)
-        if mp:
-            n = int(mp.group(2))
-            mid, url, alt = poster_media[n]
-            out.append(hero_image(mid, url, alt))
-        elif ms:
-            mid, url, alt, caption = shot_media[ms.group(2)]
-            out.append(inline_image(mid, url, alt, caption=caption))
-        else:
-            out.append(render_paragraph_from_markdown(b))
+def poster(block, match):
+    """`![alt](poster:N)` -> full-width section hero. alt comes from POSTERS."""
+    mid, url, alt = poster_media[int(match.group(2))]
+    return hero_image(mid, url, alt)
+
+
+def screenshot(block, match):
+    """`![alt](screenshot:KEY)` -> 460px captioned receipt. alt/caption from SCREENSHOTS."""
+    mid, url, alt, caption = shot_media[match.group(2)]
+    return inline_image(mid, url, alt, caption=caption)
+
+
+out = render_marker_blocks(
+    body,
+    standard_text_handlers(h3=False, pullquote_marker=True)
+    + [(POSTER_RE, poster), (SCREENSHOT_RE, screenshot)],
+)
 
 content = "\n\n".join(out)
 (STAGE / "post.html").write_text(content)
@@ -177,9 +164,7 @@ if not WRITE:
     sys.exit(0)
 
 # ---- find existing post by slug ----
-hits = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts",
-                params={"slug": SLUG, "status": "any", "context": "edit"}, timeout=30).json()
-existing = hits[0] if isinstance(hits, list) and hits else None
+existing = find_existing_post_by_slug(wp, SLUG)
 
 if UPDATE:
     if not existing:

--- a/scripts/notion-to-wp/publish_dc_protest_draft.py
+++ b/scripts/notion-to-wp/publish_dc_protest_draft.py
@@ -7,19 +7,24 @@ Dry-run by default (writes staged post.html + prints plan). --execute uploads
 the 14 images and creates the DRAFT post. NEVER publishes.
 """
 import os
-import re, sys, json, shutil, pathlib
+import sys, json, shutil, pathlib
 from kk_notion_to_wp import WordPress, load_config
 from text_polish import purge_em_dashes
-from wp_blocks import inline, image, heading, separator
+from wp_blocks import image
 from publish_common import (
     MARKDOWN_IMG_IMAGES_RE,
     build_seo_meta,
+    category_id,
+    find_existing_post_by_slug,
     parse_int_arg,
     parse_markdown_image_order,
     parse_publish_argv,
+    raw_paragraph,
+    render_marker_blocks,
     resolve_category_ids,
     resolve_featured_media,
-    split_body_blocks,
+    standard_text_handlers,
+    strip_frontmatter,
     upload_image_manifest,
 )
 
@@ -36,8 +41,8 @@ SRC = _CONTENT_ROOT / "content" / "articles" / "kris-krug-thought-leadership" / 
 STAGE = REPO_ROOT / "content" / "drafts" / "2026-05-23-data-center-protest-signs"
 FLAGS = parse_publish_argv()
 EXECUTE = FLAGS.execute
-# Default category: AI Ethics & Philosophy. Override with --category-id N.
-CATEGORY_ID = parse_int_arg(sys.argv[1:], "--category-id", 1678)
+# Default category declared in publisher-ids.json. Override with --category-id N.
+CATEGORY_ID = parse_int_arg(sys.argv[1:], "--category-id", category_id("ai-ethics-philosophy"))
 
 TITLE = "Both Hands Full at the Data Center: Protest Signs for People Who Refuse to Pick a Side"
 SLUG = "data-center-protest-signs"
@@ -56,14 +61,12 @@ META_DESC = purge_em_dashes("I made AI protest signs for a Vancouver data-center
 SEO_META = build_seo_meta(SEO_TITLE, META_DESC)
 
 raw = (SRC / "draft.md").read_text()
-fm_end = raw.index("\n---", raw.index("---") + 3)
-body = raw[fm_end + 4:]
+body = strip_frontmatter(raw)
 # fixes + house em-dash purge (site-wide)
 body = body.replace(LINK39_OLD, LINK39_NEW)
 assert LINK39_NEW in body, "line-39 link fix did not apply"
 body = purge_em_dashes(body)
 
-blocks_src = split_body_blocks(body)
 image_order = parse_markdown_image_order(body)
 assert len(image_order) == 14, f"expected 14 images, found {len(image_order)}"
 
@@ -86,22 +89,20 @@ print("[media] " + ("uploaded" if EXECUTE else "DRY-RUN") + f" {len(uploaded)} i
 for line in log: print("   " + line)
 
 # ---- build Gutenberg blocks ----
-out = []
-seen_title = False
-for b in blocks_src:
-    if b.startswith("# ") and not seen_title:
-        seen_title = True; continue  # drop duplicate H1 (post title field)
-    m = MARKDOWN_IMG_IMAGES_RE.match(b)
-    if m:
-        fn, alt = m.group(2), m.group(1)
-        u = uploaded[fn]
-        out.append(image(u["id"], u["url"], alt, caption=alt, width=None, align=None, lightbox=True))
-    elif b.startswith("## "):
-        out.append(heading(inline(b[3:].strip())))
-    elif b == "---":
-        out.append(separator())
-    else:
-        out.append(f"<!-- wp:paragraph -->\n<p>{inline(b)}</p>\n<!-- /wp:paragraph -->")
+# NOTE: this post's paragraphs are raw_paragraph (no <br> join between source
+# lines), unlike the other one-off publishers. That shape is already shipped.
+def staged_image(block, match):
+    """`![alt](images/FILE.png)` -> full-width, click-to-zoom, alt doubles as caption."""
+    alt, filename = match.group(1), match.group(2)
+    media = uploaded[filename]
+    return image(media["id"], media["url"], alt, caption=alt, width=None, align=None, lightbox=True)
+
+
+out = render_marker_blocks(
+    body,
+    [(MARKDOWN_IMG_IMAGES_RE, staged_image)] + standard_text_handlers(h3=False),
+    paragraph=raw_paragraph,
+)
 content = "\n\n".join(out)
 (STAGE / "post.html").write_text(content)
 
@@ -117,9 +118,9 @@ if not EXECUTE:
     sys.exit(0)
 
 # ---- create-only slug guard ----
-hits = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts", params={"slug": SLUG, "status": "any", "context": "edit"}, timeout=30).json()
-if isinstance(hits, list) and hits:
-    sys.exit(f"[ABORT] a post with slug {SLUG} already exists (id={hits[0]['id']}). Not creating a duplicate.")
+existing = find_existing_post_by_slug(wp, SLUG)
+if existing:
+    sys.exit(f"[ABORT] a post with slug {SLUG} already exists (id={existing['id']}). Not creating a duplicate.")
 
 # ---- terms ----
 category_ids = resolve_category_ids(wp, ids=[CATEGORY_ID])

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -36,9 +36,11 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from common import WPClient, load_env, wp_credentials  # noqa: E402
 from publish_common import (  # noqa: E402
     build_seo_meta,
+    category_id,
     parse_publish_argv,
     render_paragraph_from_markdown,
     split_body_blocks,
+    strip_frontmatter,
 )
 from wp_blocks import inline  # noqa: E402
 
@@ -52,7 +54,8 @@ WRITE = FLAGS.write
 TITLE = "Keep the Machine Strange: Technological Resistance in the Age of AI"
 SLUG = "keep-the-machine-strange"
 DATE = "2026-06-28T09:00:00"
-CATEGORY_IDS = [1678, 1754]  # AI Ethics & Philosophy; Responsible AI & Policy
+# AI Ethics & Philosophy; Responsible AI & Policy (declared in publisher-ids.json)
+CATEGORY_IDS = [category_id("ai-ethics-philosophy"), category_id("responsible-ai-policy")]
 TAGS = ["Neil Postman", "Marshall McLuhan", "Technopoly", "Media Ecology",
         "Responsible AI", "AI Governance", "AI for All", "Both Hands Full",
         "Technological Resistance"]
@@ -205,8 +208,7 @@ def ensure_term(c, taxonomy, name):
 
 # ---- load + verify post.md --------------------------------------------------
 raw = (STAGE / "post.md").read_text(encoding="utf-8")
-fm_end = raw.index("\n---", raw.index("---") + 3)
-body = raw[fm_end + 4:]
+body = strip_frontmatter(raw)
 assert "—" not in body, "em-dash leaked into post.md body"
 
 base, user, pw = wp_credentials(load_env(ENV_PATH))

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -20,16 +20,23 @@ refreshes the body of the existing draft. NEVER publishes.
 """
 import re, sys, json, pathlib
 from kk_notion_to_wp import WordPress, load_config
-from wp_blocks import inline, image, gallery, heading, separator, pullquote
+from wp_blocks import image, gallery
 from publish_common import (
     build_seo_meta,
+    category_id,
+    exact,
+    find_existing_post_by_slug,
     load_photos_from_dir,
+    media_group_index,
+    media_group_keys,
+    media_id,
     parse_int_arg,
     parse_publish_argv,
-    render_paragraph_from_markdown,
+    render_marker_blocks,
     resolve_category_ids,
     resolve_featured_media,
-    split_body_blocks,
+    standard_text_handlers,
+    strip_frontmatter,
 )
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
@@ -43,9 +50,12 @@ WRITE = FLAGS.write
 TITLE = "You Can't Drink Data"
 SLUG = "you-cant-drink-data"
 DATE = "2026-05-23T15:00:00"
-# Defaults match the live draft; override with --category-id / --featured-media-id.
-CATEGORY_ID = parse_int_arg(sys.argv[1:], "--category-id", 1678)
-FEATURED_ID = parse_int_arg(sys.argv[1:], "--featured-media-id", 11976)
+# Defaults are declared in publisher-ids.json and match the live draft;
+# override with --category-id / --featured-media-id.
+CATEGORY_ID = parse_int_arg(sys.argv[1:], "--category-id", category_id("ai-ethics-philosophy"))
+FEATURED_ID = parse_int_arg(
+    sys.argv[1:], "--featured-media-id", media_id("you-cant-drink-data-featured")
+)
 TAGS = ["ai-protest","data-centres","vancouver","clean-energy-ai",
         "indigenous-data-sovereignty","open-source-ai","both-hands-full"]
 SEO_TITLE = "You Can't Drink Data | Notes From My First AI Protest"
@@ -54,33 +64,22 @@ META_DESC = ("Kris Krug marches in Vancouver's first anti-AI, anti-data-centre p
              "dead end. A West Coast vision for building AI differently.")
 SEO_META = build_seo_meta(SEO_TITLE, META_DESC)
 
-# Already-uploaded AI protest signs (from the DC-signs draft): id -> (url, alt)
-AI_SIGNS = {
-    11915: ("https://kriskrug.co/wp-content/uploads/2026/05/02-both-hands-full.png", "BOTH HANDS FULL, neon block-stack lettering over two hands overflowing with shapes"),
-    11916: ("https://kriskrug.co/wp-content/uploads/2026/05/01-dumbest-timeline-the-keeper.png", "THIS IS THE DUMBEST TIMELINE & I WOULDN'T MISS IT, CMYK slab type"),
-    11917: ("https://kriskrug.co/wp-content/uploads/2026/05/01-ruthlessly-optimistic-absolutely-terrified.png", "RUTHLESSLY OPTIMISTIC & ABSOLUTELY TERRIFIED, acid riso, sunny yellow into blood red"),
-    11918: ("https://kriskrug.co/wp-content/uploads/2026/05/04-water-the-servers-last.png", "WATER THE SERVERS LAST, block-stack type with a watering can over a server rack"),
-    11919: ("https://kriskrug.co/wp-content/uploads/2026/05/06-who-s-a-thirsty-little-data-center.png", "WHO'S A THIRSTY LITTLE DATA CENTER?, a googly-eyed building with its tongue out"),
-    11920: ("https://kriskrug.co/wp-content/uploads/2026/05/02-we-are-the-training-data.jpg", "WE ARE THE TRAINING DATA, datamosh glitch type"),
-    11921: ("https://kriskrug.co/wp-content/uploads/2026/05/09-ai-wrote-a-better-sign.jpg", "AI WROTE A BETTER SIGN THAN THIS ONE, neon block panels"),
-    11922: ("https://kriskrug.co/wp-content/uploads/2026/05/03-my-position-yes-also-help.png", "MY POSITION: YES. ALSO: HELP., green YES over a panicked red HELP"),
-    11923: ("https://kriskrug.co/wp-content/uploads/2026/05/03-it-s-complicated.png", "IT'S COMPLICATED, CMYK halftone"),
-    11924: ("https://kriskrug.co/wp-content/uploads/2026/05/04-i-contain-multitudes.png", "I CONTAIN MULTITUDES, fractured tall glyphs in pink, teal, cream"),
-    11925: ("https://kriskrug.co/wp-content/uploads/2026/05/07-error-404-side-not-found.png", "ERROR 404: SIDE NOT FOUND, RGB-split datamosh"),
-    11926: ("https://kriskrug.co/wp-content/uploads/2026/05/09-stop-okay-go-no-stop.png", "STOP. okay GO. no, STOP., clashing panels with a strike-through"),
-    11927: ("https://kriskrug.co/wp-content/uploads/2026/05/07-hush-now-little-supercluster.png", "HUSH NOW, LITTLE SUPERCLUSTER, server racks tucked in under a quilt, crescent moon"),
-    11928: ("https://kriskrug.co/wp-content/uploads/2026/05/08-i-love-the-cloud-i-just-want-it-to-rain.png", "I LOVE THE CLOUD, I JUST WANT IT TO RAIN, riso clouds and rain"),
-}
-AI_GALLERY = [11915, 11919, 11920, 11918, 11922, 11923, 11924, 11916, 11917, 11925, 11926, 11921, 11927, 11928]
+# Already-uploaded AI protest signs (from the DC-signs draft), declared in
+# publisher-ids.json. AI_SIGNS is id -> (url, alt); AI_GALLERY is the declared
+# order used by the [[GALLERY-AI]] block.
+AI_SIGNS, AI_GALLERY = media_group_index("ai-protest-signs-2026-05")
 # short captions for the AI gallery (the slogan, lower-cased label)
 AI_CAP = {mid: AI_SIGNS[mid][1].split(",")[0] for mid in AI_GALLERY}
 
 # in-body AI signs: media id -> (caption, align, width). Small + floated so text wraps around them
 # (KK: "reduce the size and integrate them into the text"). Click to enlarge.
+# Signs are named via their declared key, so the production media IDs stay in
+# publisher-ids.json rather than being retyped here.
+SIGN = media_group_keys("ai-protest-signs-2026-05")
 INBODY_AI = {
-    11920: ("WE ARE THE TRAINING DATA. One of mine. The uncomfortable part is that it's just true.", "right", 300),
-    11918: ("WATER THE SERVERS LAST. Also mine. The watershed should outrank the GPU.", "left", 300),
-    11928: ("I LOVE THE CLOUD, I JUST WANT IT TO RAIN. Mine. Both-hands-full in eight words.", "right", 300),
+    SIGN["we-are-the-training-data"]: ("WE ARE THE TRAINING DATA. One of mine. The uncomfortable part is that it's just true.", "right", 300),
+    SIGN["water-the-servers-last"]: ("WATER THE SERVERS LAST. Also mine. The watershed should outrank the GPU.", "left", 300),
+    SIGN["i-love-the-cloud-i-just-want-it-to-rain"]: ("I LOVE THE CLOUD, I JUST WANT IT TO RAIN. Mine. Both-hands-full in eight words.", "right", 300),
 }
 # in-body documentary photos: key (leading IMG#) -> (align, width). Editorial = centered, larger.
 INBODY_PHOTO = {
@@ -91,13 +90,15 @@ INBODY_PHOTO = {
 PHOTOS_KEEP_PREFIX = {"05","07","10","13","14","15","16","17","18","21","23","24","25","26"}
 
 
-# in-body image / gallery / heading / separator / pullquote markup now lives in wp_blocks.py
+# in-body image / gallery / heading / separator / pullquote markup now lives in
+# wp_blocks.py; the marker -> block dispatch lives in publish_common.py.
+MEDIA_RE = re.compile(r"^!\[(.*?)\]\(media:(\d+)\)$")
+PHOTO_RE = re.compile(r"^!\[(.*?)\]\(photo:(\d+)\)$")
 
 
 # ---------------------------------------------------------------------------
 raw = (STAGE / "post.md").read_text()
-fm_end = raw.index("\n---", raw.index("---") + 3)
-body = raw[fm_end + 4:]
+body = strip_frontmatter(raw)
 assert "—" not in body, "em-dash leaked into post.md body"
 
 cfg = load_config()
@@ -123,43 +124,43 @@ print(f"[photos] {'wrote' if WRITE else 'DRY'} best={len(best_photos)} gallery_r
 for l in photo_log: print("   " + l)
 
 # ---- build blocks ----
-out = []
-seen_title = False
-blocks_src = split_body_blocks(body)
-for b in blocks_src:
-    b = b.strip()
-    if b.startswith("# ") and not seen_title:
-        seen_title = True
-        continue
-    if b == "---":
-        out.append(separator())
-    elif b.startswith("## "):
-        out.append(heading(inline(b[3:].strip())))
-    elif b.startswith(">>> "):
-        out.append(pullquote(inline(b[4:].strip())))
-    elif b == "[[GALLERY-BEST]]":
-        out.append(gallery([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3))
-    elif b == "[[GALLERY-AI]]":
-        out.append(gallery([(mid, AI_SIGNS[mid][0], AI_SIGNS[mid][1], AI_CAP[mid]) for mid in AI_GALLERY], columns=3))
-    elif b == "[[GALLERY-PHOTOS]]":
-        if photos_rest:
-            out.append(gallery([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3))
-    else:
-        m = re.match(r"^!\[(.*?)\]\(media:(\d+)\)$", b)
-        mp = re.match(r"^!\[(.*?)\]\(photo:(\d+)\)$", b)
-        if m:
-            mid = int(m.group(2))
-            url, alt = AI_SIGNS[mid]
-            cap, align, width = INBODY_AI.get(mid, (None, "center", 320))
-            out.append(image(mid, url, alt, caption=cap, width=width, align=align))
-        elif mp:
-            key = mp.group(2)
-            if key in inbody_photos:
-                mid, url, alt, cap = inbody_photos[key]
-                align, width = INBODY_PHOTO.get(key, ("center", 660))
-                out.append(image(mid, url, alt, caption=cap, width=width, align=align))
-        else:
-            out.append(render_paragraph_from_markdown(b))
+def ai_sign(block, match):
+    """`![alt](media:ID)` -> small floated sign reusing an already-uploaded media id."""
+    mid = int(match.group(2))
+    url, alt = AI_SIGNS[mid]
+    cap, align, width = INBODY_AI.get(mid, (None, "center", 320))
+    return image(mid, url, alt, caption=cap, width=width, align=align)
+
+
+def march_photo(block, match):
+    """`![alt](photo:NNNN)` -> in-body march photo. Unknown key emits nothing."""
+    key = match.group(2)
+    if key not in inbody_photos:
+        return None
+    mid, url, alt, cap = inbody_photos[key]
+    align, width = INBODY_PHOTO.get(key, ("center", 660))
+    return image(mid, url, alt, caption=cap, width=width, align=align)
+
+
+out = render_marker_blocks(
+    body,
+    standard_text_handlers(h3=False, pullquote_marker=True)
+    + [
+        (exact("[[GALLERY-BEST]]"),
+         lambda b, m: gallery([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3)),
+        (exact("[[GALLERY-AI]]"),
+         lambda b, m: gallery(
+             [(mid, AI_SIGNS[mid][0], AI_SIGNS[mid][1], AI_CAP[mid]) for mid in AI_GALLERY],
+             columns=3,
+         )),
+        # emits nothing when every gallery/ photo is already shown in BEST
+        (exact("[[GALLERY-PHOTOS]]"),
+         lambda b, m: gallery([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3)
+         if photos_rest else None),
+        (MEDIA_RE, ai_sign),
+        (PHOTO_RE, march_photo),
+    ],
+)
 
 content = "\n\n".join(out)
 (STAGE / "post.html").write_text(content)
@@ -178,9 +179,7 @@ if not WRITE:
     sys.exit(0)
 
 # ---- find existing post by slug ----
-hits = wp.s.get(f"{wp.base}/wp-json/wp/v2/posts",
-                params={"slug": SLUG, "status": "any", "context": "edit"}, timeout=30).json()
-existing = hits[0] if isinstance(hits, list) and hits else None
+existing = find_existing_post_by_slug(wp, SLUG)
 
 if UPDATE:
     if not existing:

--- a/scripts/notion-to-wp/publisher-ids.json
+++ b/scripts/notion-to-wp/publisher-ids.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "note": "Declared WordPress IDs for the one-off publish_*.py scripts (issue #254). Same shape as content/source-packs/.../page-map.json: a logical key -> a record carrying the live ID plus enough context to re-verify it. These are kriskrug.co PRODUCTION IDs. Scripts read them as defaults only; every one is overridable on the command line (--category-id / --featured-media-id) so a staging run never has to inherit a prod ID. Loaders live in publish_common.py (category_id / media_id / media_group).",
+  "wordpress_base_url": "https://kriskrug.co",
+  "categories": {
+    "ai-ethics-philosophy": {
+      "id": 1678,
+      "name": "AI Ethics & Philosophy",
+      "pillar_url": "https://kriskrug.co/ai-ethics/",
+      "note": "Default category for publish_dc_protest_draft.py and publish_you_cant_drink_data.py; first of the two on publish_keep_the_machine_strange.py. Cross-checked against scripts/seo-backfill/linkinject_lib.py."
+    },
+    "responsible-ai-policy": {
+      "id": 1754,
+      "name": "Responsible AI & Policy",
+      "pillar_url": "https://kriskrug.co/ai-ethics/",
+      "note": "Second category on publish_keep_the_machine_strange.py. Folded category: no dedicated pillar page, links to the AI Ethics pillar."
+    }
+  },
+  "media": {
+    "you-cant-drink-data-featured": {
+      "id": 11976,
+      "note": "March selfie used as the featured/OG image on the 'You Can't Drink Data' draft. Jetpack ties og:image to the featured image."
+    }
+  },
+  "media_groups": {
+    "ai-protest-signs-2026-05": {
+      "note": "The 14 AI protest signs uploaded by publish_dc_protest_draft.py on 2026-05-23 and reused (never re-uploaded) by publish_you_cant_drink_data.py. Listed in the order they appear in the [[GALLERY-AI]] block; publish_you_cant_drink_data.py also indexes them by id for the ![alt](media:ID) marker.",
+      "items": [
+        {
+          "key": "both-hands-full",
+          "id": 11915,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/02-both-hands-full.png",
+          "alt": "BOTH HANDS FULL, neon block-stack lettering over two hands overflowing with shapes"
+        },
+        {
+          "key": "who-s-a-thirsty-little-data-center",
+          "id": 11919,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/06-who-s-a-thirsty-little-data-center.png",
+          "alt": "WHO'S A THIRSTY LITTLE DATA CENTER?, a googly-eyed building with its tongue out"
+        },
+        {
+          "key": "we-are-the-training-data",
+          "id": 11920,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/02-we-are-the-training-data.jpg",
+          "alt": "WE ARE THE TRAINING DATA, datamosh glitch type"
+        },
+        {
+          "key": "water-the-servers-last",
+          "id": 11918,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/04-water-the-servers-last.png",
+          "alt": "WATER THE SERVERS LAST, block-stack type with a watering can over a server rack"
+        },
+        {
+          "key": "my-position-yes-also-help",
+          "id": 11922,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/03-my-position-yes-also-help.png",
+          "alt": "MY POSITION: YES. ALSO: HELP., green YES over a panicked red HELP"
+        },
+        {
+          "key": "it-s-complicated",
+          "id": 11923,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/03-it-s-complicated.png",
+          "alt": "IT'S COMPLICATED, CMYK halftone"
+        },
+        {
+          "key": "i-contain-multitudes",
+          "id": 11924,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/04-i-contain-multitudes.png",
+          "alt": "I CONTAIN MULTITUDES, fractured tall glyphs in pink, teal, cream"
+        },
+        {
+          "key": "dumbest-timeline-the-keeper",
+          "id": 11916,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/01-dumbest-timeline-the-keeper.png",
+          "alt": "THIS IS THE DUMBEST TIMELINE & I WOULDN'T MISS IT, CMYK slab type"
+        },
+        {
+          "key": "ruthlessly-optimistic-absolutely-terrified",
+          "id": 11917,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/01-ruthlessly-optimistic-absolutely-terrified.png",
+          "alt": "RUTHLESSLY OPTIMISTIC & ABSOLUTELY TERRIFIED, acid riso, sunny yellow into blood red"
+        },
+        {
+          "key": "error-404-side-not-found",
+          "id": 11925,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/07-error-404-side-not-found.png",
+          "alt": "ERROR 404: SIDE NOT FOUND, RGB-split datamosh"
+        },
+        {
+          "key": "stop-okay-go-no-stop",
+          "id": 11926,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/09-stop-okay-go-no-stop.png",
+          "alt": "STOP. okay GO. no, STOP., clashing panels with a strike-through"
+        },
+        {
+          "key": "ai-wrote-a-better-sign",
+          "id": 11921,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/09-ai-wrote-a-better-sign.jpg",
+          "alt": "AI WROTE A BETTER SIGN THAN THIS ONE, neon block panels"
+        },
+        {
+          "key": "hush-now-little-supercluster",
+          "id": 11927,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/07-hush-now-little-supercluster.png",
+          "alt": "HUSH NOW, LITTLE SUPERCLUSTER, server racks tucked in under a quilt, crescent moon"
+        },
+        {
+          "key": "i-love-the-cloud-i-just-want-it-to-rain",
+          "id": 11928,
+          "url": "https://kriskrug.co/wp-content/uploads/2026/05/08-i-love-the-cloud-i-just-want-it-to-rain.png",
+          "alt": "I LOVE THE CLOUD, I JUST WANT IT TO RAIN, riso clouds and rain"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/notion-to-wp/tests/test_publish_common.py
+++ b/scripts/notion-to-wp/tests/test_publish_common.py
@@ -90,5 +90,129 @@ class PublishCommonTests(unittest.TestCase):
         self.assertTrue(flags.update)
         self.assertTrue(flags.write)
 
+
+class FindOrUploadMediaTests(unittest.TestCase):
+    """Extracted from the copy-pasted resolve-or-upload loops (issue #254)."""
+
+    def test_dry_run_never_touches_wordpress(self):
+        wp = mock.Mock()
+        media_id, url = publish_common.find_or_upload_media(
+            wp, Path("/tmp/poster-1.png"), "alt", mime="image/png", write=False
+        )
+        self.assertEqual((media_id, url), (0, "DRYRUN/poster-1.png"))
+        wp.s.get.assert_not_called()
+        wp.upload_media.assert_not_called()
+
+    def test_reuse_logs_and_does_not_upload(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = [
+            {"id": 42, "source_url": "https://example.test/u/poster-1.png"}
+        ]
+        log: list[str] = []
+        media_id, url = publish_common.find_or_upload_media(
+            wp, Path("/tmp/poster-1.png"), "alt", mime="image/png", write=True, log=log
+        )
+        self.assertEqual((media_id, url), (42, "https://example.test/u/poster-1.png"))
+        self.assertEqual(log, ["poster-1.png -> REUSE id=42"])
+        wp.upload_media.assert_not_called()
+
+    def test_new_upload_logs_id_and_url(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = []
+        wp.upload_media.return_value = {"id": 43, "source_url": "https://example.test/u/new.png"}
+        log: list[str] = []
+        media_id, url = publish_common.find_or_upload_media(
+            wp, Path("/tmp/new.png"), "alt", mime="image/png", write=True, log=log
+        )
+        self.assertEqual((media_id, url), (43, "https://example.test/u/new.png"))
+        self.assertEqual(log, ["new.png -> NEW id=43 https://example.test/u/new.png"])
+
+    def test_label_prefixes_the_log_line(self):
+        """load_photos_from_dir logs `subdir/filename`; the shape must not change."""
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = [
+            {"id": 7, "source_url": "https://example.test/u/01-a.jpg"}
+        ]
+        log: list[str] = []
+        publish_common.find_or_upload_media(
+            wp, Path("/tmp/01-a.jpg"), "alt", mime="image/jpeg", write=True,
+            label="photos/best/01-a.jpg", log=log,
+        )
+        self.assertEqual(log, ["photos/best/01-a.jpg -> REUSE id=7"])
+
+
+class LoadPhotosFromDirTests(unittest.TestCase):
+    def test_dry_run_shape_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stage = Path(tmp)
+            directory = stage / "photos" / "best"
+            directory.mkdir(parents=True)
+            (directory / "01-water.jpg").write_bytes(b"x")
+            (directory / "_skipped.jpg").write_bytes(b"x")
+            (directory / "captions.txt").write_text("01-water.jpg|A caption\n")
+            items = publish_common.load_photos_from_dir(
+                mock.Mock(), stage, "photos/best", write=False
+            )
+        self.assertEqual(
+            items, [(0, "DRYRUN/01-water.jpg", "A caption", "A caption", "01-water.jpg")]
+        )
+
+    def test_alt_from_slug_appends_protest_sign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stage = Path(tmp)
+            directory = stage / "photos" / "best"
+            directory.mkdir(parents=True)
+            (directory / "01-water-the-servers.jpg").write_bytes(b"x")
+            items = publish_common.load_photos_from_dir(
+                mock.Mock(), stage, "photos/best", write=False, alt_from_slug=True
+            )
+        self.assertEqual(items[0][2], "water the servers protest sign")
+
+
+class FindExistingPostBySlugTests(unittest.TestCase):
+    def test_returns_first_hit(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = [{"id": 11}, {"id": 12}]
+        self.assertEqual(publish_common.find_existing_post_by_slug(wp, "a-slug"), {"id": 11})
+
+    def test_queries_any_status_in_edit_context(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = []
+        publish_common.find_existing_post_by_slug(wp, "a-slug")
+        _, kwargs = wp.s.get.call_args
+        self.assertEqual(
+            kwargs["params"], {"slug": "a-slug", "status": "any", "context": "edit"}
+        )
+
+    def test_returns_none_when_absent_or_malformed(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = []
+        self.assertIsNone(publish_common.find_existing_post_by_slug(wp, "a-slug"))
+        wp.s.get.return_value.json.return_value = {"code": "rest_no_route"}
+        self.assertIsNone(publish_common.find_existing_post_by_slug(wp, "a-slug"))
+
+
+class RawParagraphTests(unittest.TestCase):
+    def test_differs_from_br_joined_paragraph_on_multiline_blocks(self):
+        block = "line one\nline two"
+        self.assertIn("line one\nline two", publish_common.raw_paragraph(block))
+        self.assertIn(
+            "line one<br>line two", publish_common.render_paragraph_from_markdown(block)
+        )
+
+    def test_agrees_on_single_line_blocks(self):
+        block = "just one line with a [link](https://example.com)"
+        self.assertEqual(
+            publish_common.raw_paragraph(block),
+            publish_common.render_paragraph_from_markdown(block),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/notion-to-wp/tests/test_publisher_ids.py
+++ b/scripts/notion-to-wp/tests/test_publisher_ids.py
@@ -1,0 +1,204 @@
+"""Tests for the declared publisher ID map (issue #254).
+
+publisher-ids.json replaces the WordPress IDs that used to be typed straight into
+the one-off publish_*.py scripts. The equivalence tests below pin the manifest to
+the exact literals those scripts carried before the refactor, so "de-hardcoded"
+provably means "same numbers, one declaration" and not "new numbers".
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import publish_common  # noqa: E402
+
+MANIFEST_PATH = SCRIPT_DIR / "publisher-ids.json"
+
+# --- pre-#254 literals, transcribed verbatim from the scripts -----------------
+LEGACY_DC_PROTEST_CATEGORY_ID = 1678
+LEGACY_YOU_CANT_DRINK_CATEGORY_ID = 1678
+LEGACY_YOU_CANT_DRINK_FEATURED_ID = 11976
+LEGACY_KEEP_THE_MACHINE_CATEGORY_IDS = [1678, 1754]
+
+LEGACY_AI_SIGNS = {
+    11915: ("https://kriskrug.co/wp-content/uploads/2026/05/02-both-hands-full.png", "BOTH HANDS FULL, neon block-stack lettering over two hands overflowing with shapes"),
+    11916: ("https://kriskrug.co/wp-content/uploads/2026/05/01-dumbest-timeline-the-keeper.png", "THIS IS THE DUMBEST TIMELINE & I WOULDN'T MISS IT, CMYK slab type"),
+    11917: ("https://kriskrug.co/wp-content/uploads/2026/05/01-ruthlessly-optimistic-absolutely-terrified.png", "RUTHLESSLY OPTIMISTIC & ABSOLUTELY TERRIFIED, acid riso, sunny yellow into blood red"),
+    11918: ("https://kriskrug.co/wp-content/uploads/2026/05/04-water-the-servers-last.png", "WATER THE SERVERS LAST, block-stack type with a watering can over a server rack"),
+    11919: ("https://kriskrug.co/wp-content/uploads/2026/05/06-who-s-a-thirsty-little-data-center.png", "WHO'S A THIRSTY LITTLE DATA CENTER?, a googly-eyed building with its tongue out"),
+    11920: ("https://kriskrug.co/wp-content/uploads/2026/05/02-we-are-the-training-data.jpg", "WE ARE THE TRAINING DATA, datamosh glitch type"),
+    11921: ("https://kriskrug.co/wp-content/uploads/2026/05/09-ai-wrote-a-better-sign.jpg", "AI WROTE A BETTER SIGN THAN THIS ONE, neon block panels"),
+    11922: ("https://kriskrug.co/wp-content/uploads/2026/05/03-my-position-yes-also-help.png", "MY POSITION: YES. ALSO: HELP., green YES over a panicked red HELP"),
+    11923: ("https://kriskrug.co/wp-content/uploads/2026/05/03-it-s-complicated.png", "IT'S COMPLICATED, CMYK halftone"),
+    11924: ("https://kriskrug.co/wp-content/uploads/2026/05/04-i-contain-multitudes.png", "I CONTAIN MULTITUDES, fractured tall glyphs in pink, teal, cream"),
+    11925: ("https://kriskrug.co/wp-content/uploads/2026/05/07-error-404-side-not-found.png", "ERROR 404: SIDE NOT FOUND, RGB-split datamosh"),
+    11926: ("https://kriskrug.co/wp-content/uploads/2026/05/09-stop-okay-go-no-stop.png", "STOP. okay GO. no, STOP., clashing panels with a strike-through"),
+    11927: ("https://kriskrug.co/wp-content/uploads/2026/05/07-hush-now-little-supercluster.png", "HUSH NOW, LITTLE SUPERCLUSTER, server racks tucked in under a quilt, crescent moon"),
+    11928: ("https://kriskrug.co/wp-content/uploads/2026/05/08-i-love-the-cloud-i-just-want-it-to-rain.png", "I LOVE THE CLOUD, I JUST WANT IT TO RAIN, riso clouds and rain"),
+}
+LEGACY_AI_GALLERY = [11915, 11919, 11920, 11918, 11922, 11923, 11924, 11916, 11917, 11925, 11926, 11921, 11927, 11928]
+
+
+class ManifestShapeTests(unittest.TestCase):
+    def test_manifest_is_valid_json_with_a_schema_version(self):
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(data["schema_version"], 1)
+        self.assertEqual(data["wordpress_base_url"], "https://kriskrug.co")
+
+    def test_every_declared_id_is_a_positive_int(self):
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        for section in ("categories", "media"):
+            for key, entry in data[section].items():
+                with self.subTest(section=section, key=key):
+                    self.assertIsInstance(entry["id"], int)
+                    self.assertGreater(entry["id"], 0)
+        for key, group in data["media_groups"].items():
+            for item in group["items"]:
+                with self.subTest(group=key, item=item.get("id")):
+                    self.assertIsInstance(item["id"], int)
+                    self.assertGreater(item["id"], 0)
+                    self.assertTrue(item["url"].startswith("https://kriskrug.co/"))
+                    self.assertTrue(item["alt"].strip())
+
+    def test_media_group_ids_are_unique(self):
+        data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        for key, group in data["media_groups"].items():
+            ids = [item["id"] for item in group["items"]]
+            with self.subTest(group=key):
+                self.assertEqual(len(ids), len(set(ids)))
+
+
+class DeclaredIdEquivalenceTests(unittest.TestCase):
+    """The manifest must resolve to the exact pre-refactor literals."""
+
+    def test_category_ids_match_the_literals_they_replaced(self):
+        self.assertEqual(
+            publish_common.category_id("ai-ethics-philosophy"), LEGACY_DC_PROTEST_CATEGORY_ID
+        )
+        self.assertEqual(
+            publish_common.category_id("ai-ethics-philosophy"), LEGACY_YOU_CANT_DRINK_CATEGORY_ID
+        )
+        self.assertEqual(
+            [
+                publish_common.category_id("ai-ethics-philosophy"),
+                publish_common.category_id("responsible-ai-policy"),
+            ],
+            LEGACY_KEEP_THE_MACHINE_CATEGORY_IDS,
+        )
+
+    def test_featured_media_id_matches_the_literal_it_replaced(self):
+        self.assertEqual(
+            publish_common.media_id("you-cant-drink-data-featured"),
+            LEGACY_YOU_CANT_DRINK_FEATURED_ID,
+        )
+
+    def test_ai_protest_signs_group_reproduces_AI_SIGNS_and_AI_GALLERY(self):
+        signs, order = publish_common.media_group_index("ai-protest-signs-2026-05")
+        self.assertEqual(signs, LEGACY_AI_SIGNS)
+        self.assertEqual(order, LEGACY_AI_GALLERY)
+
+    def test_inbody_sign_keys_resolve_to_the_legacy_ids(self):
+        """publish_you_cant_drink_data.py's INBODY_AI used to key on these raw IDs."""
+        sign = publish_common.media_group_keys("ai-protest-signs-2026-05")
+        self.assertEqual(
+            [
+                sign["we-are-the-training-data"],
+                sign["water-the-servers-last"],
+                sign["i-love-the-cloud-i-just-want-it-to-rain"],
+            ],
+            [11920, 11918, 11928],
+        )
+
+    def test_every_declared_key_matches_its_upload_filename_stem(self):
+        """The key is the uploaded filename minus its ordering prefix; keep them in sync."""
+        for item in publish_common.media_group("ai-protest-signs-2026-05"):
+            stem = item["url"].rsplit("/", 1)[-1].rsplit(".", 1)[0]
+            with self.subTest(id=item["id"]):
+                self.assertEqual(item["key"], stem.split("-", 1)[1])
+
+    def test_derived_gallery_captions_are_unchanged(self):
+        """AI_CAP is built off the declared alt text; pin the derivation."""
+        signs, order = publish_common.media_group_index("ai-protest-signs-2026-05")
+        self.assertEqual(
+            {mid: signs[mid][1].split(",")[0] for mid in order},
+            {mid: LEGACY_AI_SIGNS[mid][1].split(",")[0] for mid in LEGACY_AI_GALLERY},
+        )
+
+
+class LookupValidationTests(unittest.TestCase):
+    def test_unknown_category_key_aborts_with_known_keys_listed(self):
+        with self.assertRaises(SystemExit) as ctx:
+            publish_common.category_id("no-such-category")
+        self.assertIn("ai-ethics-philosophy", str(ctx.exception))
+
+    def test_unknown_media_key_aborts(self):
+        with self.assertRaises(SystemExit):
+            publish_common.media_id("no-such-media")
+
+    def test_unknown_media_group_aborts(self):
+        with self.assertRaises(SystemExit):
+            publish_common.media_group("no-such-group")
+
+    def test_non_positive_id_aborts(self):
+        bad = {"categories": {"broken": {"id": 0}}}
+        with self.assertRaises(SystemExit):
+            publish_common.category_id("broken", ids=bad)
+
+    def test_media_group_entry_without_url_or_alt_aborts(self):
+        bad = {"media_groups": {"g": {"items": [{"id": 5, "url": "", "alt": "a"}]}}}
+        with self.assertRaises(SystemExit):
+            publish_common.media_group("g", ids=bad)
+
+    def test_media_group_keys_rejects_a_missing_or_duplicate_key(self):
+        missing = {"media_groups": {"g": {"items": [{"id": 5, "url": "u", "alt": "a"}]}}}
+        with self.assertRaises(SystemExit):
+            publish_common.media_group_keys("g", ids=missing)
+        dupe = {
+            "media_groups": {
+                "g": {
+                    "items": [
+                        {"key": "k", "id": 5, "url": "u", "alt": "a"},
+                        {"key": "k", "id": 6, "url": "u", "alt": "a"},
+                    ]
+                }
+            }
+        }
+        with self.assertRaises(SystemExit):
+            publish_common.media_group_keys("g", ids=dupe)
+
+    def test_loader_reads_an_explicit_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ids.json"
+            path.write_text(json.dumps({"categories": {"x": {"id": 7}}}), encoding="utf-8")
+            data = publish_common.load_publisher_ids(path)
+        self.assertEqual(publish_common.category_id("x", ids=data), 7)
+
+
+class ScriptsCarryNoBareIdsTests(unittest.TestCase):
+    """Acceptance criterion: the prod IDs no longer live in the script sources."""
+
+    SCRIPTS = (
+        "publish_dc_protest_draft.py",
+        "publish_you_cant_drink_data.py",
+        "publish_keep_the_machine_strange.py",
+        "publish_context_creators.py",
+        "publish_proximity_game.py",
+    )
+    RETIRED_LITERALS = ("1678", "1754", "11976") + tuple(str(i) for i in LEGACY_AI_GALLERY)
+
+    def test_no_publisher_script_hardcodes_a_declared_id(self):
+        for name in self.SCRIPTS:
+            source = (SCRIPT_DIR / name).read_text(encoding="utf-8")
+            for literal in self.RETIRED_LITERALS:
+                with self.subTest(script=name, literal=literal):
+                    self.assertNotIn(literal, source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
+++ b/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
@@ -1,0 +1,405 @@
+"""Characterisation tests for the one-off publish_*.py block loops (issue #254).
+
+These pin the CURRENT rendering behaviour of the marker -> Gutenberg loops that
+each `publish_*.py` script carries inline, so the #254 consolidation can be shown
+to be behaviour-preserving.
+
+The `legacy_*` functions below are transcribed verbatim from the scripts as they
+stood before the #254 refactor:
+
+  * `legacy_render_dc_protest`       <- publish_dc_protest_draft.py
+  * `legacy_render_you_cant_drink`   <- publish_you_cant_drink_data.py
+  * `legacy_render_context_creators` <- publish_context_creators.py
+  * `legacy_render_text_post`        <- publish_common.render_text_post (proximity)
+
+Do NOT "fix" a legacy function. They are the reference. If a shared helper stops
+matching one of them, the helper changed behaviour and that is the bug.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import publish_common  # noqa: E402
+from wp_blocks import (  # noqa: E402
+    gallery,
+    heading,
+    hero_image,
+    image,
+    inline,
+    inline_image,
+    pullquote,
+    separator,
+)
+
+MEDIA_RE = re.compile(r"^!\[(.*?)\]\(media:(\d+)\)$")
+PHOTO_RE = re.compile(r"^!\[(.*?)\]\(photo:(\d+)\)$")
+POSTER_RE = re.compile(r"^!\[(.*?)\]\(poster:(\d+)\)$")
+SCREENSHOT_RE = re.compile(r"^!\[(.*?)\]\(screenshot:([a-z-]+)\)$")
+
+
+# --------------------------------------------------------------------------
+# Legacy reference implementations (verbatim, pre-#254)
+# --------------------------------------------------------------------------
+def legacy_render_dc_protest(body: str, uploaded: dict) -> list[str]:
+    out = []
+    seen_title = False
+    for b in publish_common.split_body_blocks(body):
+        if b.startswith("# ") and not seen_title:
+            seen_title = True
+            continue
+        m = publish_common.MARKDOWN_IMG_IMAGES_RE.match(b)
+        if m:
+            fn, alt = m.group(2), m.group(1)
+            u = uploaded[fn]
+            out.append(image(u["id"], u["url"], alt, caption=alt, width=None, align=None, lightbox=True))
+        elif b.startswith("## "):
+            out.append(heading(inline(b[3:].strip())))
+        elif b == "---":
+            out.append(separator())
+        else:
+            out.append(f"<!-- wp:paragraph -->\n<p>{inline(b)}</p>\n<!-- /wp:paragraph -->")
+    return out
+
+
+def legacy_render_you_cant_drink(
+    body: str,
+    *,
+    ai_signs: dict,
+    ai_gallery: list,
+    ai_cap: dict,
+    inbody_ai: dict,
+    inbody_photo: dict,
+    best_photos: list,
+    photos_rest: list,
+    inbody_photos: dict,
+) -> list[str]:
+    out = []
+    seen_title = False
+    for b in publish_common.split_body_blocks(body):
+        b = b.strip()
+        if b.startswith("# ") and not seen_title:
+            seen_title = True
+            continue
+        if b == "---":
+            out.append(separator())
+        elif b.startswith("## "):
+            out.append(heading(inline(b[3:].strip())))
+        elif b.startswith(">>> "):
+            out.append(pullquote(inline(b[4:].strip())))
+        elif b == "[[GALLERY-BEST]]":
+            out.append(gallery([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3))
+        elif b == "[[GALLERY-AI]]":
+            out.append(
+                gallery(
+                    [(mid, ai_signs[mid][0], ai_signs[mid][1], ai_cap[mid]) for mid in ai_gallery],
+                    columns=3,
+                )
+            )
+        elif b == "[[GALLERY-PHOTOS]]":
+            if photos_rest:
+                out.append(gallery([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3))
+        else:
+            m = MEDIA_RE.match(b)
+            mp = PHOTO_RE.match(b)
+            if m:
+                mid = int(m.group(2))
+                url, alt = ai_signs[mid]
+                cap, align, width = inbody_ai.get(mid, (None, "center", 320))
+                out.append(image(mid, url, alt, caption=cap, width=width, align=align))
+            elif mp:
+                key = mp.group(2)
+                if key in inbody_photos:
+                    mid, url, alt, cap = inbody_photos[key]
+                    align, width = inbody_photo.get(key, ("center", 660))
+                    out.append(image(mid, url, alt, caption=cap, width=width, align=align))
+            else:
+                out.append(publish_common.render_paragraph_from_markdown(b))
+    return out
+
+
+def legacy_render_context_creators(body: str, *, poster_media: dict, shot_media: dict) -> list[str]:
+    out = []
+    seen_title = False
+    for b in publish_common.split_body_blocks(body):
+        if b.startswith("# ") and not seen_title:
+            seen_title = True
+            continue
+        if b == "---":
+            out.append(separator())
+        elif b.startswith("## "):
+            out.append(heading(inline(b[3:].strip())))
+        elif b.startswith(">>> "):
+            out.append(pullquote(inline(b[4:].strip())))
+        else:
+            mp = POSTER_RE.match(b)
+            ms = SCREENSHOT_RE.match(b)
+            if mp:
+                n = int(mp.group(2))
+                mid, url, alt = poster_media[n]
+                out.append(hero_image(mid, url, alt))
+            elif ms:
+                mid, url, alt, caption = shot_media[ms.group(2)]
+                out.append(inline_image(mid, url, alt, caption=caption))
+            else:
+                out.append(publish_common.render_paragraph_from_markdown(b))
+    return out
+
+
+def legacy_render_text_post(body: str) -> str:
+    out: list[str] = []
+    seen_title = False
+    for block in publish_common.split_body_blocks(body):
+        if block.startswith("# ") and not seen_title:
+            seen_title = True
+            continue
+        if block == "---":
+            out.append(separator())
+        elif block.startswith("## "):
+            out.append(heading(inline(block[3:].strip()), level=2))
+        elif block.startswith("### "):
+            out.append(heading(inline(block[4:].strip()), level=3))
+        else:
+            out.append(publish_common.render_paragraph_from_markdown(block))
+    return "\n\n".join(out)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+DC_BODY = """# Dropped Title
+
+Intro paragraph with an [internal link](https://kriskrug.co/x/) and **bold**.
+
+## A Heading
+
+![a sign that says water the servers last](images/04-water.png)
+
+---
+
+A multi-line paragraph
+that spans two source lines.
+
+![second sign](images/06-thirsty.png)
+"""
+
+DC_UPLOADED = {
+    "04-water.png": {"id": 11918, "url": "https://kriskrug.co/wp-content/uploads/2026/05/04-water.png"},
+    "06-thirsty.png": {"id": 11919, "url": "https://kriskrug.co/wp-content/uploads/2026/05/06-thirsty.png"},
+}
+
+YCDD_BODY = """# Dropped Title
+
+Opening paragraph.
+
+## Section One
+
+>>> A punchy pullquote line.
+
+---
+
+![we are the training data](media:11920)
+
+![march photo](photo:7674)
+
+![missing photo key](photo:9999)
+
+[[GALLERY-BEST]]
+
+[[GALLERY-AI]]
+
+[[GALLERY-PHOTOS]]
+
+Closing paragraph
+with a second line.
+"""
+
+YCDD_AI_SIGNS = {
+    11920: ("https://kriskrug.co/u/we-are-the-training-data.jpg", "WE ARE THE TRAINING DATA, datamosh glitch type"),
+    11918: ("https://kriskrug.co/u/water-the-servers-last.png", "WATER THE SERVERS LAST, block-stack type"),
+}
+YCDD_AI_GALLERY = [11918, 11920]
+YCDD_AI_CAP = {mid: YCDD_AI_SIGNS[mid][1].split(",")[0] for mid in YCDD_AI_GALLERY}
+YCDD_INBODY_AI = {11920: ("One of mine.", "right", 300)}
+YCDD_INBODY_PHOTO = {"7674": ("center", 680)}
+YCDD_BEST = [(1, "https://kriskrug.co/u/best-1.jpg", "best one", "cap one", "01-best.jpg")]
+YCDD_INBODY_PHOTOS = {"7674": (2, "https://kriskrug.co/u/7674.jpg", "alt 7674", "cap 7674")}
+
+CC_BODY = """# Dropped Title
+
+Lead paragraph.
+
+## What I Actually Did
+
+>>> A deck line.
+
+---
+
+![poster hero](poster:2)
+
+![the recipe slide](screenshot:persona)
+
+Trailing paragraph
+over two lines.
+"""
+
+CC_POSTER_MEDIA = {2: (900, "https://kriskrug.co/u/poster-2.png", "Both Hands Full poster")}
+CC_SHOT_MEDIA = {"persona": (901, "https://kriskrug.co/u/slide-persona.png", "Persona slide", "The recipe.")}
+
+TEXT_BODY = """# Dropped Title
+
+Opening with an [external link](https://example.com/a).
+
+## H2 Section
+
+### H3 Section
+
+---
+
+Two line
+paragraph here.
+"""
+
+
+def block_kinds(blocks: list[str]) -> list[str]:
+    """First-line block-comment name for each rendered block."""
+    return [b.split("\n", 1)[0].split(" ")[1].rstrip(">").strip() for b in blocks]
+
+
+class DcProtestCharacterisationTests(unittest.TestCase):
+    def test_block_sequence_is_stable(self):
+        out = legacy_render_dc_protest(DC_BODY, DC_UPLOADED)
+        self.assertEqual(
+            block_kinds(out),
+            ["wp:paragraph", "wp:heading", "wp:image", "wp:separator", "wp:paragraph", "wp:image"],
+        )
+
+    def test_first_h1_is_dropped(self):
+        out = legacy_render_dc_protest(DC_BODY, DC_UPLOADED)
+        self.assertNotIn("Dropped Title", "\n".join(out))
+
+    def test_image_block_uses_alt_as_caption_and_no_align(self):
+        out = legacy_render_dc_protest(DC_BODY, DC_UPLOADED)
+        img_block = out[2]
+        self.assertIn('"id":11918', img_block)
+        self.assertIn('"lightbox":{"enabled":true}', img_block)
+        self.assertNotIn('"align"', img_block)
+        self.assertIn(
+            '<figcaption class="wp-element-caption">a sign that says water the servers last</figcaption>',
+            img_block,
+        )
+
+    def test_multiline_paragraph_keeps_newline_and_does_not_insert_br(self):
+        """dc_protest is the ONLY script that does not <br>-join paragraph lines."""
+        out = legacy_render_dc_protest(DC_BODY, DC_UPLOADED)
+        para = out[4]
+        self.assertIn("A multi-line paragraph\nthat spans two source lines.", para)
+        self.assertNotIn("<br>", para)
+
+
+class YouCantDrinkDataCharacterisationTests(unittest.TestCase):
+    def render(self, *, photos_rest):
+        return legacy_render_you_cant_drink(
+            YCDD_BODY,
+            ai_signs=YCDD_AI_SIGNS,
+            ai_gallery=YCDD_AI_GALLERY,
+            ai_cap=YCDD_AI_CAP,
+            inbody_ai=YCDD_INBODY_AI,
+            inbody_photo=YCDD_INBODY_PHOTO,
+            best_photos=YCDD_BEST,
+            photos_rest=photos_rest,
+            inbody_photos=YCDD_INBODY_PHOTOS,
+        )
+
+    def test_block_sequence_is_stable(self):
+        out = self.render(photos_rest=[])
+        self.assertEqual(
+            block_kinds(out),
+            [
+                "wp:paragraph",
+                "wp:heading",
+                "wp:pullquote",
+                "wp:separator",
+                "wp:image",
+                "wp:image",
+                "wp:gallery",
+                "wp:gallery",
+                "wp:paragraph",
+            ],
+        )
+
+    def test_unknown_photo_key_emits_nothing(self):
+        """`![x](photo:9999)` with no matching upload is silently dropped."""
+        out = self.render(photos_rest=[])
+        self.assertNotIn("9999", "\n".join(out))
+
+    def test_empty_gallery_photos_emits_nothing(self):
+        without = self.render(photos_rest=[])
+        with_rest = self.render(
+            photos_rest=[(3, "https://kriskrug.co/u/rest.jpg", "rest alt", "rest cap", "05-rest.jpg")]
+        )
+        self.assertEqual(len(with_rest), len(without) + 1)
+
+    def test_inbody_ai_uses_declared_align_and_width(self):
+        out = self.render(photos_rest=[])
+        block = out[4]
+        self.assertIn('"width":"300px"', block)
+        self.assertIn('"align":"right"', block)
+        self.assertIn("One of mine.", block)
+
+    def test_multiline_paragraph_is_br_joined(self):
+        out = self.render(photos_rest=[])
+        self.assertIn("Closing paragraph<br>with a second line.", out[-1])
+
+
+class ContextCreatorsCharacterisationTests(unittest.TestCase):
+    def render(self):
+        return legacy_render_context_creators(
+            CC_BODY, poster_media=CC_POSTER_MEDIA, shot_media=CC_SHOT_MEDIA
+        )
+
+    def test_block_sequence_is_stable(self):
+        self.assertEqual(
+            block_kinds(self.render()),
+            [
+                "wp:paragraph",
+                "wp:heading",
+                "wp:pullquote",
+                "wp:separator",
+                "wp:image",
+                "wp:image",
+                "wp:paragraph",
+            ],
+        )
+
+    def test_poster_is_full_width_and_screenshot_is_460(self):
+        out = self.render()
+        self.assertNotIn('"width"', out[4])
+        self.assertIn('"width":"460px"', out[5])
+
+    def test_screenshot_caption_comes_from_declaration_not_markdown_alt(self):
+        out = self.render()
+        self.assertIn("The recipe.", out[5])
+        self.assertIn('alt="Persona slide"', out[5])
+
+
+class TextPostCharacterisationTests(unittest.TestCase):
+    def test_matches_shipped_render_text_post(self):
+        self.assertEqual(
+            publish_common.render_text_post(TEXT_BODY), legacy_render_text_post(TEXT_BODY)
+        )
+
+    def test_h3_level_attr_and_external_link_target(self):
+        out = publish_common.render_text_post(TEXT_BODY)
+        self.assertIn('{"level":3}', out)
+        self.assertIn('target="_blank" rel="noopener noreferrer"', out)
+        self.assertNotIn("<h1", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
+++ b/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
@@ -401,5 +401,229 @@ class TextPostCharacterisationTests(unittest.TestCase):
         self.assertNotIn("<h1", out)
 
 
+# --------------------------------------------------------------------------
+# Equivalence: the consolidated dispatcher must reproduce every legacy loop
+# byte for byte. These are the proof that #254 is behaviour-preserving.
+# --------------------------------------------------------------------------
+def shared_render_dc_protest(body: str, uploaded: dict) -> list[str]:
+    """publish_dc_protest_draft.py, post-#254."""
+    def staged_image(block, match):
+        alt, filename = match.group(1), match.group(2)
+        media = uploaded[filename]
+        return image(media["id"], media["url"], alt, caption=alt, width=None, align=None, lightbox=True)
+
+    return publish_common.render_marker_blocks(
+        body,
+        [(publish_common.MARKDOWN_IMG_IMAGES_RE, staged_image)]
+        + publish_common.standard_text_handlers(h3=False),
+        paragraph=publish_common.raw_paragraph,
+    )
+
+
+def shared_render_you_cant_drink(
+    body: str,
+    *,
+    ai_signs: dict,
+    ai_gallery: list,
+    ai_cap: dict,
+    inbody_ai: dict,
+    inbody_photo: dict,
+    best_photos: list,
+    photos_rest: list,
+    inbody_photos: dict,
+) -> list[str]:
+    """publish_you_cant_drink_data.py, post-#254."""
+    def ai_sign(block, match):
+        mid = int(match.group(2))
+        url, alt = ai_signs[mid]
+        cap, align, width = inbody_ai.get(mid, (None, "center", 320))
+        return image(mid, url, alt, caption=cap, width=width, align=align)
+
+    def march_photo(block, match):
+        key = match.group(2)
+        if key not in inbody_photos:
+            return None
+        mid, url, alt, cap = inbody_photos[key]
+        align, width = inbody_photo.get(key, ("center", 660))
+        return image(mid, url, alt, caption=cap, width=width, align=align)
+
+    return publish_common.render_marker_blocks(
+        body,
+        publish_common.standard_text_handlers(h3=False, pullquote_marker=True)
+        + [
+            (publish_common.exact("[[GALLERY-BEST]]"),
+             lambda b, m: gallery([(i, u, a, c) for i, u, a, c, _ in best_photos], columns=3)),
+            (publish_common.exact("[[GALLERY-AI]]"),
+             lambda b, m: gallery(
+                 [(mid, ai_signs[mid][0], ai_signs[mid][1], ai_cap[mid]) for mid in ai_gallery],
+                 columns=3,
+             )),
+            (publish_common.exact("[[GALLERY-PHOTOS]]"),
+             lambda b, m: gallery([(i, u, a, c) for i, u, a, c, _ in photos_rest], columns=3)
+             if photos_rest else None),
+            (MEDIA_RE, ai_sign),
+            (PHOTO_RE, march_photo),
+        ],
+    )
+
+
+def shared_render_context_creators(body: str, *, poster_media: dict, shot_media: dict) -> list[str]:
+    """publish_context_creators.py, post-#254."""
+    def poster(block, match):
+        mid, url, alt = poster_media[int(match.group(2))]
+        return hero_image(mid, url, alt)
+
+    def screenshot(block, match):
+        mid, url, alt, caption = shot_media[match.group(2)]
+        return inline_image(mid, url, alt, caption=caption)
+
+    return publish_common.render_marker_blocks(
+        body,
+        publish_common.standard_text_handlers(h3=False, pullquote_marker=True)
+        + [(POSTER_RE, poster), (SCREENSHOT_RE, screenshot)],
+    )
+
+
+class DispatcherEquivalenceTests(unittest.TestCase):
+    def test_dc_protest_identical(self):
+        self.assertEqual(
+            shared_render_dc_protest(DC_BODY, DC_UPLOADED),
+            legacy_render_dc_protest(DC_BODY, DC_UPLOADED),
+        )
+
+    def test_you_cant_drink_identical(self):
+        for photos_rest in ([], [(3, "https://kriskrug.co/u/r.jpg", "r alt", "r cap", "05-r.jpg")]):
+            kwargs = dict(
+                ai_signs=YCDD_AI_SIGNS,
+                ai_gallery=YCDD_AI_GALLERY,
+                ai_cap=YCDD_AI_CAP,
+                inbody_ai=YCDD_INBODY_AI,
+                inbody_photo=YCDD_INBODY_PHOTO,
+                best_photos=YCDD_BEST,
+                photos_rest=photos_rest,
+                inbody_photos=YCDD_INBODY_PHOTOS,
+            )
+            with self.subTest(photos_rest=bool(photos_rest)):
+                self.assertEqual(
+                    shared_render_you_cant_drink(YCDD_BODY, **kwargs),
+                    legacy_render_you_cant_drink(YCDD_BODY, **kwargs),
+                )
+
+    def test_context_creators_identical(self):
+        self.assertEqual(
+            shared_render_context_creators(
+                CC_BODY, poster_media=CC_POSTER_MEDIA, shot_media=CC_SHOT_MEDIA
+            ),
+            legacy_render_context_creators(
+                CC_BODY, poster_media=CC_POSTER_MEDIA, shot_media=CC_SHOT_MEDIA
+            ),
+        )
+
+    def test_text_post_identical(self):
+        self.assertEqual(
+            publish_common.render_text_post(TEXT_BODY), legacy_render_text_post(TEXT_BODY)
+        )
+
+    def test_cross_fed_bodies_stay_identical(self):
+        """Every corpus body through every renderer: legacy and shared must agree.
+
+        Cross-feeding catches marker-precedence drift that a script's own body
+        would never exercise (e.g. a `>>> ` line reaching the dc_protest loop).
+        """
+        bodies = {"dc": DC_BODY, "ycdd": YCDD_BODY, "cc": CC_BODY, "text": TEXT_BODY}
+        ycdd_kwargs = dict(
+            ai_signs=YCDD_AI_SIGNS,
+            ai_gallery=YCDD_AI_GALLERY,
+            ai_cap=YCDD_AI_CAP,
+            inbody_ai=YCDD_INBODY_AI,
+            inbody_photo=YCDD_INBODY_PHOTO,
+            best_photos=YCDD_BEST,
+            photos_rest=[],
+            inbody_photos=YCDD_INBODY_PHOTOS,
+        )
+        for name, body in bodies.items():
+            with self.subTest(body=name, loop="you_cant_drink"):
+                self.assertEqual(
+                    shared_render_you_cant_drink(body, **ycdd_kwargs),
+                    legacy_render_you_cant_drink(body, **ycdd_kwargs),
+                )
+            with self.subTest(body=name, loop="context_creators"):
+                self.assertEqual(
+                    shared_render_context_creators(
+                        body, poster_media=CC_POSTER_MEDIA, shot_media=CC_SHOT_MEDIA
+                    ),
+                    legacy_render_context_creators(
+                        body, poster_media=CC_POSTER_MEDIA, shot_media=CC_SHOT_MEDIA
+                    ),
+                )
+            with self.subTest(body=name, loop="text_post"):
+                self.assertEqual(
+                    "\n\n".join(
+                        publish_common.render_marker_blocks(
+                            body, publish_common.standard_text_handlers()
+                        )
+                    ),
+                    legacy_render_text_post(body),
+                )
+
+    def test_dc_protest_cross_fed_bodies_stay_identical(self):
+        """dc_protest's loop only resolves `images/` markers, so feed it safe bodies."""
+        for name, body in (("dc", DC_BODY), ("text", TEXT_BODY)):
+            with self.subTest(body=name):
+                self.assertEqual(
+                    shared_render_dc_protest(body, DC_UPLOADED),
+                    legacy_render_dc_protest(body, DC_UPLOADED),
+                )
+
+
+class RenderMarkerBlocksUnitTests(unittest.TestCase):
+    def test_first_matching_handler_wins(self):
+        handlers = [
+            (publish_common.prefix("## "), lambda b, m: "FIRST"),
+            (publish_common.prefix("## "), lambda b, m: "SECOND"),
+        ]
+        self.assertEqual(publish_common.render_marker_blocks("## x", handlers), ["FIRST"])
+
+    def test_handler_returning_none_emits_nothing(self):
+        handlers = [(publish_common.exact("SKIP"), lambda b, m: None)]
+        self.assertEqual(publish_common.render_marker_blocks("SKIP\n\nkeep", handlers)[0].count("keep"), 1)
+        self.assertEqual(len(publish_common.render_marker_blocks("SKIP\n\nkeep", handlers)), 1)
+
+    def test_regex_matcher_receives_the_match_object(self):
+        seen = []
+        handlers = [(re.compile(r"^X(\d+)$"), lambda b, m: seen.append(m.group(1)) or "ok")]
+        publish_common.render_marker_blocks("X42", handlers)
+        self.assertEqual(seen, ["42"])
+
+    def test_h3_never_collides_with_h2_prefix(self):
+        out = publish_common.render_marker_blocks("### Sub", publish_common.standard_text_handlers())
+        self.assertIn('{"level":3}', out[0])
+
+    def test_skip_first_h1_only_drops_the_first(self):
+        out = publish_common.render_marker_blocks("# One\n\n# Two", [])
+        self.assertEqual(len(out), 1)
+        self.assertIn("# Two", out[0])
+
+    def test_skip_first_h1_can_be_disabled(self):
+        out = publish_common.render_marker_blocks("# One", [], skip_first_h1=False)
+        self.assertEqual(len(out), 1)
+
+
+class StripFrontmatterTests(unittest.TestCase):
+    def test_matches_the_inline_index_walk_it_replaces(self):
+        raw = "---\ntitle: T\nslug: s\n---\n\nBody line.\n"
+        fm_end = raw.index("\n---", raw.index("---") + 3)
+        self.assertEqual(publish_common.strip_frontmatter(raw), raw[fm_end + 4:])
+
+    def test_body_survives_a_horizontal_rule(self):
+        raw = "---\ntitle: T\n---\n\nOne.\n\n---\n\nTwo.\n"
+        body = publish_common.strip_frontmatter(raw)
+        self.assertEqual(publish_common.split_body_blocks(body), ["One.", "---", "Two."])
+
+    def test_missing_fences_raise(self):
+        with self.assertRaises(ValueError):
+            publish_common.strip_frontmatter("no front matter here")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Consolidates duplicated orchestration across the one-off `publish_*.py` scripts and moves hardcoded WordPress IDs into a declared manifest.

**Behaviour-preserving.** No WordPress writes, no credential access, no dry-runs against production.

## Related Issue

Fixes #254
Relates to #483 (bug found here, reported not fixed)

## Changes

A previous pass had already created `publish_common.py` and `wp_blocks.py`, so image-block markup and SEO meta were shared. What remained duplicated was the *orchestration around* them:

| Helper extracted | Was duplicated in |
|---|---|
| `strip_frontmatter()` | dc_protest, you_cant_drink, context_creators, keep_the_machine |
| `render_marker_blocks()` + `exact()`/`prefix()`/`standard_text_handlers()` | dc_protest, you_cant_drink, context_creators, `render_text_post` |
| `find_or_upload_media()` | context_creators (twice, inline), `load_photos_from_dir` |
| `find_existing_post_by_slug()` | dc_protest, you_cant_drink, context_creators |

**Net across the five callers: −97 lines**, removing three inline block loops and five inline media/slug fragments. `publish_common.py` grows 296 → 567, of which ~120 is the new declared-ID layer.

### De-hardcoding

New `scripts/notion-to-wp/publisher-ids.json`, following the existing **`page-map.json`** pattern (logical key → record with the live ID plus context to re-verify it; `schema_version`, `wordpress_base_url`, plain `json.loads` loader). Moved out: category IDs `1678`/`1754` (3 scripts), featured media `11976`, and the 14-entry `AI_SIGNS`/`AI_GALLERY` table.

`INBODY_AI` now reads `SIGN["water-the-servers-last"]` instead of `11918`. Loaders abort on unknown keys and non-positive IDs; live existence validation stays where it was. All CLI overrides preserved.

Verified: `1678`, `1754`, `11976`, `11918` no longer appear in any `publish_*.py`.

## What I deliberately did NOT consolidate

**`publish_keep_the_machine_strange.py`'s local block helpers** (`b_image`, `b_heading`, `b_pullquote`, `b_quote`, `b_youtube`, `b_list`) look like duplicates of `wp_blocks.py` but **emit different markup**: anchor-wrapped images with `linkDestination:media` rather than the native lightbox, `wp-block-image__caption` rather than `wp-element-caption`, headings without `wp-block-heading`, and a pullquote supporting `<cite>`.

Folding them in would change what a re-run sends to an already-shipped post. **That's a frozen artifact, not redundancy.** Only its category IDs and front matter were touched.

`publish_proximity_game.py` was already fully on the shared helpers with no hardcoded IDs; its YAML front-matter parse is a genuinely better shape than the index-walk, so it wasn't forced onto `strip_frontmatter`.

## Type of Change

- [x] Code refactoring (no functional changes)

## Testing

**375 → 432 tests, 0 failures** (publisher suite 63 → 120). Independently re-run by the reviewing session: `Ran 120` / `Ran 241` / `Ran 3` / `68 passed`, all OK.

The new tests are equivalence proofs, not coverage padding:
- `test_publisher_render_characterisation.py` keeps **verbatim copies of each pre-refactor loop** and asserts the consolidated dispatcher matches them block-for-block — cross-feeding every corpus body through every renderer, so marker-precedence drift can't hide behind a script's own content
- `test_publisher_ids.py` asserts the manifest resolves to the exact literals it replaced (including the full 14-entry dict and gallery order), plus a static check that no `publish_*.py` still carries those numbers

Characterisation tests were committed **before** the refactor (`b3ae895`), then the equivalence proof after (`b942c83`) — the commit order is the argument.

## Behaviour differences introduced — three, all provably inert

No rendered markup or REST payload changes:

1. `find_or_upload_media` coerces `int(media["id"])` on the upload path where `load_photos_from_dir` passed it raw. WP REST returns an int; the reuse path already coerced.
2. dc_protest's `split_body_blocks(body)` now runs inside `render_marker_blocks` (after media upload) rather than before it. `body` is not mutated in between.
3. Marker regexes are module-level compiled patterns instead of per-block `re.match(pattern_string, ...)`. Same semantics.

Also removed an unused `import re` and a no-op `b = b.strip()`.

## ⚠️ Bug found, reported not fixed — see #483

`find_media_by_stem` at `publish_common.py:214` uses `base.startswith(stem)`, so uploading `hero.png` can **silently reuse `hero-2.png` or `hero-scaled.png`**. This is the idempotency guard for every publisher re-run, and it can attach the wrong image without erroring — the same class of defect as the 2026-05-15 incident. `publish_keep_the_machine_strange.py`'s local `find_media` has the identical flaw.

Not fixed here because this PR is behaviour-preserving and that's a behaviour change. Filed as **#483** with three lower-severity siblings.

## Deployment Notes

- [x] No special deployment steps required

Nothing deploys from this merge. The scripts are run manually with credentials, dry-run first.

## Remaining #254 scope

All four acceptance criteria are met. Scoped out, as concrete follow-ups:

1. Unify keep_the_machine's block layer — needs `quote()`, `youtube_embed()`, `list_block()` and a cite-bearing `pullquote()` in `wp_blocks.py`, **plus KK's call** on whether to re-emit that live post with different markup. Content change, not refactor.
2. Extract the verify/readback block — all five hand-roll `checks = {...}`, the `publish.log` writer, and the `PREVIEW:`/`EDIT:` print. ~25 lines each.
3. Extract create/update payload assembly, repeated in four scripts.
4. **Two WordPress clients coexist** — `WordPress` (kk_notion_to_wp) vs `WPClient` (scripts/common.py). keep_the_machine uses the latter, which is why its helpers couldn't share the others'. Own issue.
5. The issue's closing note about parameterised `kk_notion_to_wp.py` runs — untouched, but with marker dispatch now declarative, a manifest-driven single publisher is plausible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_