### PR TITLE
Fix: clear pre-cream foreground literals and guard hardcoded colours (Aurora 1.4.5)

### DIFF
--- a/scripts/tests/test_aurora_css_literal_contrast.py
+++ b/scripts/tests/test_aurora_css_literal_contrast.py
@@ -1,0 +1,574 @@
+"""Contrast coverage for colours that live *inside component rules*.
+
+`test_aurora_contrast_tokens.py` checks named tokens in `theme.json`. That is
+necessary but not sufficient: issue #470 was filed against a foreground colour
+hardcoded in a component rule, and #464 before it hit rules whose foreground
+token was fine but whose *surface* had flipped from dark to cream in the 1.4.0
+port. Neither class is visible to a palette-only test.
+
+This module closes that gap with two mechanisms:
+
+1. `REGISTERED_LITERALS` — every literal `color:` declaration in the theme's
+   front-end CSS must be registered here together with the surface it actually
+   renders against, and must clear its floor. A literal added anywhere in the
+   theme with no registry entry fails `test_no_unregistered_foreground_literals`
+   until somebody states, in this file, what it sits on and measures it. That
+   is the check that would have caught #470 as filed.
+
+2. `RESOLVED_COMPONENT_COLORS` — component rules whose foreground is a *token*
+   are resolved through the `:root` blocks and measured against their real
+   surface, so a token that is fine in the abstract but wrong in context (the
+   #464 failure mode) is still caught.
+
+A caveat this module cannot remove: it reads declarations, not the cascade.
+A rule can be correct here and still lose to a later rule of equal
+specificity. Confirming a *live* value needs the concatenated stylesheet the
+site actually serves, matched against real markup.
+
+Known open findings from the #470 sweep, deliberately not asserted here
+because fixing them is a design decision rather than a value correction:
+
+* `.aurora-writing-card` keeps a pre-cream near-black background (`#050708`)
+  while its text uses cream-palette tokens. On the live blog index that puts
+  `--revive-ink` titles at 1.01:1 and `--aurora-ink-muted` meta at 1.00:1.
+  revive-port.css already flips `.aurora-card`, `.aurora-media-card` and
+  `.aurora-proof-grid > article` to a cream surface; this component was missed.
+  Flipping it also needs its light-on-dark borders, gradients and `::after`
+  washes redone, so it is not a one-line change.
+* `.aurora-featured-media` keeps a dark panel (`rgba(21, 24, 33, 0.76)`) for
+  the same reason; its caption resolves to 2.06:1 (see the registry entry).
+* `.aurora-work-card-num` renders on bare photography with no scrim.
+* `--aurora-ink-muted` (rgba(23, 19, 16, 0.55)) is 3.84:1 on cream, while
+  theme.json's `text-muted` (#5c5044) — the value it is supposed to mirror —
+  is 6.30:1. The CSS alias diverges from the palette it aliases.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME_DIR = ROOT / "theme/kk-aurora"
+
+# Front-end sheets only. editor.css is not served to visitors.
+CSS_FILES = (
+    "style.css",
+    "assets/css/revive-port.css",
+    "assets/css/typography-refined.css",
+    "assets/css/bleeding-edge.css",
+    "assets/css/animations.css",
+)
+
+AA_TEXT = 4.5
+# SC 1.4.11: graphical objects / decorative separators.
+AA_NON_TEXT = 3.0
+# Sentinel floors for declarations that cannot be given an honest ratio.
+# Both are exempt from the ratio assertion but must still carry a note, so they
+# stay visible in the registry instead of silently reading as "fine".
+#
+#   NOT_STATIC — renders over user-supplied photography with no scrim
+#                guaranteeing a surface.
+#   OVERRIDDEN — loses the cascade to a later rule, so measuring this value
+#                would describe something the browser never paints. The note
+#                must record the winning rule and its real ratio.
+NOT_STATIC = "not-statically-determinable"
+OVERRIDDEN = "overridden-in-the-cascade"
+EXEMPT_FLOORS = {NOT_STATIC, OVERRIDDEN}
+
+
+# --------------------------------------------------------------------------
+# colour maths
+# --------------------------------------------------------------------------
+
+
+def _linearize(channel):
+    channel = channel / 255
+    if channel <= 0.03928:
+        return channel / 12.92
+    return ((channel + 0.055) / 1.055) ** 2.4
+
+
+def relative_luminance(rgb):
+    red, green, blue = (_linearize(channel) for channel in rgb)
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+def contrast_ratio(foreground, background):
+    first = relative_luminance(foreground)
+    second = relative_luminance(background)
+    lighter, darker = max(first, second), min(first, second)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def parse_color(value):
+    """Parse `#rgb`, `#rrggbb`, `rgb()`, `rgba()` into (r, g, b, alpha)."""
+    value = value.replace("!important", "").strip()
+
+    hex_match = re.fullmatch(r"#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})", value)
+    if hex_match:
+        digits = hex_match.group(1)
+        if len(digits) == 3:
+            digits = "".join(channel * 2 for channel in digits)
+        return (
+            int(digits[0:2], 16),
+            int(digits[2:4], 16),
+            int(digits[4:6], 16),
+            1.0,
+        )
+
+    func_match = re.fullmatch(r"rgba?\(([^)]*)\)", value)
+    if func_match:
+        parts = [part for part in re.split(r"[,\s/]+", func_match.group(1)) if part]
+        red, green, blue = (int(float(part)) for part in parts[:3])
+        alpha = float(parts[3]) if len(parts) > 3 else 1.0
+        return (red, green, blue, alpha)
+
+    raise ValueError(f"unparseable colour: {value!r}")
+
+
+def composite(foreground, background):
+    """Flatten a possibly-translucent foreground onto an opaque background."""
+    red, green, blue, alpha = foreground
+    if alpha >= 1.0:
+        return (red, green, blue)
+    return tuple(
+        round(alpha * channel + (1 - alpha) * base)
+        for channel, base in zip((red, green, blue), background)
+    )
+
+
+# --------------------------------------------------------------------------
+# a very small CSS reader (selector + declaration pairs, at-rule aware)
+# --------------------------------------------------------------------------
+
+
+def iter_rules(css_text):
+    """Yield (at_rule_context, selector, declarations, line_number)."""
+    css_text = re.sub(r"/\*.*?\*/", "", css_text, flags=re.S)
+    stack = []
+    buffer = ""
+    index = 0
+    line = 1
+    while index < len(css_text):
+        char = css_text[index]
+        if char == "{":
+            prelude = " ".join(buffer.split())
+            if prelude.startswith("@"):
+                stack.append((prelude, None))
+                buffer = ""
+                index += 1
+                continue
+            # find the matching close brace for this declaration block
+            depth = 1
+            end = index + 1
+            while end < len(css_text) and depth:
+                if css_text[end] == "{":
+                    depth += 1
+                elif css_text[end] == "}":
+                    depth -= 1
+                end += 1
+            body = css_text[index + 1 : end - 1]
+            context = " ".join(entry[0] for entry in stack)
+            yield context, prelude, body, line
+            line += css_text[index:end].count("\n")
+            index = end
+            buffer = ""
+            continue
+        if char == "}":
+            if stack:
+                stack.pop()
+            buffer = ""
+        else:
+            buffer += char
+        if char == "\n":
+            line += 1
+        index += 1
+
+
+def root_custom_properties():
+    """Collect `--*` declarations from every `:root` block, later files winning."""
+    properties = {}
+    for name in CSS_FILES:
+        for _context, selector, body, _line in iter_rules(
+            (THEME_DIR / name).read_text(encoding="utf-8")
+        ):
+            if selector != ":root":
+                continue
+            for declaration in body.split(";"):
+                match = re.match(r"\s*(--[\w-]+)\s*:\s*(.+)", declaration, flags=re.S)
+                if match:
+                    properties[match.group(1)] = " ".join(match.group(2).split())
+    return properties
+
+
+def resolve(value, properties, _depth=0):
+    """Resolve `var(--token, fallback)` chains down to a literal colour string."""
+    value = value.strip()
+    if _depth > 10:
+        raise ValueError(f"var() cycle resolving {value!r}")
+    match = re.fullmatch(r"var\(\s*(--[\w-]+)\s*(?:,\s*(.+?)\s*)?\)", value)
+    if not match:
+        return value
+    token, fallback = match.group(1), match.group(2)
+    if token in properties:
+        return resolve(properties[token], properties, _depth + 1)
+    if fallback is not None:
+        return resolve(fallback, properties, _depth + 1)
+    raise ValueError(f"unresolvable token: {token}")
+
+
+def literal_color_declarations():
+    """Every literal (non-`var()`) `color:` declaration in front-end CSS.
+
+    Returns {(file, selector, value)} — print-only rules are excluded because
+    they never render against a screen surface.
+    """
+    found = set()
+    for name in CSS_FILES:
+        text = (THEME_DIR / name).read_text(encoding="utf-8")
+        for context, selector, body, _line in iter_rules(text):
+            if "print" in context:
+                continue
+            for declaration in body.split(";"):
+                match = re.match(
+                    r"\s*(?:-webkit-text-fill-)?color\s*:\s*(.+)",
+                    declaration,
+                    flags=re.S,
+                )
+                if not match:
+                    continue
+                value = " ".join(match.group(1).split())
+                bare = value.replace("!important", "").strip()
+                if bare.startswith("var(") or bare in {
+                    "inherit",
+                    "currentColor",
+                    "transparent",
+                    "unset",
+                    "initial",
+                    "revert",
+                }:
+                    continue
+                found.add((name, " ".join(selector.split()), bare))
+    return found
+
+
+# --------------------------------------------------------------------------
+# the registry
+# --------------------------------------------------------------------------
+
+# Opaque surfaces these rules actually render against, all measured from the
+# CSS rather than assumed. Keys are referenced by the tables below.
+SURFACES = {
+    # body.aurora-theme background: var(--revive-surface)
+    "cream": (0xEF, 0xE6, 0xD2),
+    # --revive-surface-2 / --aurora-panel-solid
+    "cream-2": (0xE6, 0xDC, 0xC2),
+    # theme.json `muted`, the darkest cream in the palette
+    "cream-muted": (0xD9, 0xCD, 0xB0),
+    # .aurora-services-band background: var(--revive-ink)
+    "ink": (0x17, 0x13, 0x10),
+    # .aurora-signal / --wp--preset--color--signal solid fill
+    "signal": (0x9A, 0x2F, 0x14),
+    # .aurora-signal-control solid fill
+    "signal-control": (0xC0, 0x3F, 0x18),
+    # .aurora-work-card-media::after — rgba(23,19,16,.72) scrim over a
+    # grayscaled photo. Worst case is the scrim over a pure-white photo
+    # region: 0.72*(23,19,16) + 0.28*(255,255,255).
+    "work-card-scrim": (88, 85, 83),
+    # .aurora-featured-media — rgba(21,24,33,.76) + a ~0.06 cream wash, over cream.
+    "media-panel": (0x53, 0x52, 0x53),
+    # .aurora-writing-card — near-black card that survived the cream port.
+    "writing-card": (0x11, 0x13, 0x13),
+}
+
+# (file, selector, literal) -> (surface key, floor, note)
+REGISTERED_LITERALS = {
+    (
+        "style.css",
+        ".aurora-check-grid li::before",
+        "#fff",
+    ): ("signal", AA_TEXT, "checkmark glyph on the solid signal fill"),
+    (
+        "style.css",
+        ".aurora-featured-media :where(figcaption, .wp-element-caption)",
+        "rgba(207, 199, 187, 0.72)",
+    ): (
+        "media-panel",
+        OVERRIDDEN,
+        "loses to revive-port.css `.aurora-theme :where(p, li, figcaption)` "
+        "(equal specificity, later source order), which paints the caption "
+        "--revive-ink-soft — dark ink on this rule's own dark panel, 2.06:1 "
+        "live. Needs a design call on .aurora-featured-media's surface.",
+    ),
+    (
+        "style.css",
+        ".aurora-writing-archive .aurora-writing-card-excerpt, "
+        ".aurora-writing-archive .aurora-writing-card-excerpt p",
+        "rgba(247, 247, 242, 0.66)",
+    ): ("writing-card", AA_TEXT, "excerpt on the dark writing card"),
+    (
+        "style.css",
+        ".aurora-writing-archive .aurora-writing-archive-dek",
+        "rgba(247, 247, 242, 0.72)",
+    ): (
+        "cream",
+        OVERRIDDEN,
+        "revive-port.css sets this dek to --revive-ink-soft !important, and it "
+        "renders in the archive header on cream, not on a card: 8.11:1 live. "
+        "The literal here is dead pre-cream residue.",
+    ),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-proof-outlets span",
+        "rgba(23, 19, 16, 0.62)",
+    ): ("cream", AA_TEXT, "outlet names on cream"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-work-card-num",
+        "rgba(217, 74, 31, 0.45)",
+    ): (
+        "work-card-scrim",
+        NOT_STATIC,
+        "decorative index numeral pinned to the card's top-left, where the "
+        "::after scrim is fully transparent — it renders straight onto the "
+        "photo (measured 1.11:1 over mid-grey, 1.88:1 over white). Needs a "
+        "design call: scrim it, make it opaque, or mark it aria-hidden.",
+    ),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-work-card-body",
+        "#efe6d2",
+    ): ("work-card-scrim", AA_TEXT, "card body text over the ink scrim"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-work-card-body h3",
+        "#efe6d2",
+    ): ("work-card-scrim", AA_TEXT, "card heading over the ink scrim"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-work-card-body p",
+        "rgba(239, 230, 210, 0.84)",
+    ): ("work-card-scrim", AA_TEXT, "card copy over the ink scrim"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-services-band .aurora-kicker",
+        "rgba(239, 230, 210, 0.55)",
+    ): ("ink", AA_TEXT, "kicker on the ink services band"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-services-band .aurora-section-lede",
+        "rgba(239, 230, 210, 0.72)",
+    ): ("ink", AA_TEXT, "lede on the ink services band"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-service-card p",
+        "rgba(239, 230, 210, 0.75)",
+    ): ("ink", AA_TEXT, "service copy on the ink services band"),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-service-card .aurora-service-meta",
+        "rgba(239, 230, 210, 0.55)",
+    ): ("ink", AA_TEXT, "service meta on the ink services band"),
+}
+
+# Component rules whose foreground is a token. (file, selector) -> declaration
+# is read from the CSS, resolved through :root, and measured against every
+# listed surface. This is the #464 failure mode: right token, wrong surface.
+RESOLVED_COMPONENT_COLORS = (
+    # The #470 defect as filed: the two homepage band links.
+    (
+        "assets/css/revive-port.css",
+        ".aurora-section-head a",
+        ("cream", "cream-2"),
+        AA_TEXT,
+    ),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-section-head h2",
+        ("cream", "cream-2"),
+        AA_TEXT,
+    ),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-section-head h2 .accent",
+        ("cream", "cream-2", "cream-muted"),
+        AA_TEXT,
+    ),
+    (
+        "assets/css/revive-port.css",
+        ".aurora-service-card a",
+        ("ink",),
+        AA_TEXT,
+    ),
+    ("style.css", ".aurora-inline-link", ("cream", "cream-2"), AA_TEXT),
+    ("style.css", ".aurora-inline-link:hover", ("cream", "cream-2"), AA_TEXT),
+    (
+        "style.css",
+        ".aurora-form-error, "
+        ".aurora-theme :where(.gform_validation_errors, .jetpack-field-error)",
+        ("cream", "cream-2"),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-single-2026 .aurora-article-dek",
+        ("cream", "cream-2"),
+        AA_TEXT,
+    ),
+    ("style.css", ".aurora-meta-divider", ("cream", "cream-2"), AA_NON_TEXT),
+    (
+        "style.css",
+        ".aurora-search-form .wp-block-search__button, "
+        ".aurora-theme .wp-block-search__button, "
+        ".aurora-form button, "
+        ".aurora-theme :where(.gform_wrapper, .wp-block-jetpack-contact-form) button",
+        ("signal",),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-button-primary, "
+        ".wp-block-button.is-style-aurora-primary .wp-block-button__link",
+        ("signal-control",),
+        AA_TEXT,
+    ),
+)
+
+
+def declared_color(css_name, selector):
+    """The last `color:` declared for an exact selector in one file."""
+    text = (THEME_DIR / css_name).read_text(encoding="utf-8")
+    wanted = " ".join(selector.split())
+    value = None
+    for context, found_selector, body, _line in iter_rules(text):
+        if "print" in context or " ".join(found_selector.split()) != wanted:
+            continue
+        for declaration in body.split(";"):
+            match = re.match(r"\s*color\s*:\s*(.+)", declaration, flags=re.S)
+            if match:
+                value = " ".join(match.group(1).split()).replace("!important", "").strip()
+    return value
+
+
+class AuroraCssLiteralContrastTests(unittest.TestCase):
+    def setUp(self):
+        self.properties = root_custom_properties()
+
+    # -- mechanism 1: no unjustified literals ------------------------------
+
+    def test_no_unregistered_foreground_literals(self):
+        """A new hardcoded foreground colour must declare what it sits on.
+
+        This is the check that was missing when #470 was filed: nothing forced
+        a literal `color:` inside a component rule to be measured at all.
+        """
+        found = literal_color_declarations()
+        unregistered = sorted(entry for entry in found if entry not in REGISTERED_LITERALS)
+        self.assertEqual(
+            unregistered,
+            [],
+            "Hardcoded foreground colour(s) with no registered surface. Either use "
+            "a semantic token, or add an entry to REGISTERED_LITERALS naming the "
+            "surface it renders against:\n"
+            + "\n".join(f"  {name}  {selector}  ->  {value}" for name, selector, value in unregistered),
+        )
+
+    def test_registry_has_no_stale_entries(self):
+        """Registry entries must still exist in the CSS, so it cannot rot."""
+        found = literal_color_declarations()
+        stale = sorted(entry for entry in REGISTERED_LITERALS if entry not in found)
+        self.assertEqual(stale, [], f"REGISTERED_LITERALS entries no longer in the CSS: {stale}")
+
+    def test_registered_literals_meet_their_floor(self):
+        failures = []
+        for (name, selector, value), (surface_key, floor, note) in sorted(
+            REGISTERED_LITERALS.items()
+        ):
+            if floor in EXEMPT_FLOORS:
+                self.assertTrue(note, f"{name} {selector} needs a note explaining the exemption")
+                continue
+            surface = SURFACES[surface_key]
+            ratio = contrast_ratio(composite(parse_color(value), surface), surface)
+            if ratio < floor:
+                failures.append(
+                    f"{name} {selector}: {value} on {surface_key} = {ratio:.2f}:1 "
+                    f"(needs {floor}:1) — {note}"
+                )
+        self.assertEqual(failures, [])
+
+    # -- mechanism 2: tokens measured in context ---------------------------
+
+    def test_component_token_colors_meet_aa_on_their_real_surfaces(self):
+        """Right token, wrong surface — the #464/#470 root-cause family."""
+        failures = []
+        for name, selector, surface_keys, floor in RESOLVED_COMPONENT_COLORS:
+            declaration = declared_color(name, selector)
+            self.assertIsNotNone(
+                declaration,
+                f"expected a color declaration for {selector!r} in {name}",
+            )
+            literal = resolve(declaration, self.properties)
+            for surface_key in surface_keys:
+                surface = SURFACES[surface_key]
+                ratio = contrast_ratio(composite(parse_color(literal), surface), surface)
+                if ratio < floor:
+                    failures.append(
+                        f"{name} {selector} -> {declaration} ({literal}) "
+                        f"on {surface_key} = {ratio:.2f}:1 (needs {floor}:1)"
+                    )
+        self.assertEqual(failures, [])
+
+    # -- the specific #470 regression --------------------------------------
+
+    def test_section_head_links_are_legible_on_cream(self):
+        """#470: 'Photography →' and 'Full index →' on the homepage.
+
+        The archive and work bands inherit the cream body surface, so a
+        cream-family foreground here is invisible. Pinned explicitly because
+        this rule is the one the issue was filed against.
+        """
+        declaration = declared_color(
+            "assets/css/revive-port.css", ".aurora-section-head a"
+        )
+        self.assertIsNotNone(declaration)
+        self.assertTrue(
+            declaration.startswith("var("),
+            f"section-head links must use a semantic token, got {declaration!r}",
+        )
+        literal = resolve(declaration, self.properties)
+        for surface_key in ("cream", "cream-2"):
+            surface = SURFACES[surface_key]
+            ratio = contrast_ratio(composite(parse_color(literal), surface), surface)
+            self.assertGreaterEqual(
+                ratio,
+                AA_TEXT,
+                f".aurora-section-head a ({literal}) on {surface_key} is {ratio:.2f}:1",
+            )
+
+    def test_front_page_still_renders_the_section_head_links(self):
+        """Guard the selector itself — a renamed class would silence the test."""
+        front_page = (THEME_DIR / "templates/front-page.html").read_text(encoding="utf-8")
+        self.assertIn("aurora-section-head", front_page)
+        self.assertIn("Photography", front_page)
+        self.assertIn("Full index", front_page)
+
+    # -- sanity check on the maths ----------------------------------------
+
+    def test_contrast_maths_matches_known_values(self):
+        self.assertAlmostEqual(contrast_ratio((0, 0, 0), (255, 255, 255)), 21.0, places=2)
+        self.assertAlmostEqual(contrast_ratio((255, 255, 255), (255, 255, 255)), 1.0, places=2)
+        # #9a2f14 on cream #efe6d2, the accent-text value from #465.
+        self.assertAlmostEqual(
+            contrast_ratio((0x9A, 0x2F, 0x14), (0xEF, 0xE6, 0xD2)), 6.06, places=2
+        )
+        # A translucent cream on cream is the #470 failure shape.
+        self.assertLess(
+            contrast_ratio(
+                composite(parse_color("rgba(239, 230, 210, 0.78)"), SURFACES["cream"]),
+                SURFACES["cream"],
+            ),
+            1.1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -19,7 +19,11 @@
   /* Solid control fill; label text is #fffaf6 (5.11:1). */
   --revive-accent-control: #c03f18;
   --revive-accent-control-hover: #a52918;
-  --revive-accent-control-label: #fffaf6;
+  /* Alias, not a redefinition: style.css:--aurora-signal-control-label is the
+     sole definition site for this value (PR #467 Path A direction). The
+     fallback only covers a partial deploy where style.css is still the
+     previous version; this token feeds the skip-link focus state. */
+  --revive-accent-control-label: var(--aurora-signal-control-label, #fffaf6);
   --revive-accent-soft: #e8b53a;
   --revive-line: rgba(23, 19, 16, 0.14);
   --revive-line-strong: rgba(181, 60, 24, 0.4);
@@ -693,7 +697,9 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.45;
-  color: rgba(239, 230, 210, 0.78);
+  /* Sits on the ::after ink scrim (rgba(23,19,16,.72)). 0.78 was 4.36:1 over
+     the worst case (scrim over a white photo region); 0.84 is 4.78:1. */
+  color: rgba(239, 230, 210, 0.84);
 }
 
 .aurora-services-band {

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.4.4');
+define('KK_AURORA_VERSION', '1.4.5');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.4 restores WCAG AA contrast for accent text, primary controls, and the skip link after the cream/ink restyle.
+KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.5 clears the remaining pre-cream foreground colour literals and adds a regression test that requires every hardcoded foreground colour to declare the surface it renders on.
 
 Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
@@ -39,6 +39,16 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 * Rainbow accents: teal / cyan / cobalt / violet / magenta
 
 == Changelog ==
+
+= 1.4.5 =
+* a11y: `.aurora-inline-link:hover` was #ff735d — 2.15:1 on cream, i.e. hovering made the link less legible than its 6.06:1 resting state. Now ink (14.88:1).
+* a11y: form validation errors were #ffb4b4 (1.36:1 on cream) and are now a new `--aurora-error-text` token, #8a1f1f (7.37:1).
+* a11y: search and form submit labels were #041013 on the signal fill (2.56:1) and now use the control-label token (7.29:1).
+* a11y: homepage work-card copy raised from 78% to 84% cream, so it clears 4.5:1 over the worst-case scrim (4.36:1 -> 4.78:1).
+* tokens: `--aurora-signal-control-label` is now the single definition site for control label text; revive-port.css aliases it instead of repeating #fffaf6.
+* cleanup: dropped dead pre-cream literals from `.aurora-meta-divider` and `.aurora-single-2026 .aurora-article-dek` (both lost the cascade, so neither was rendering).
+* test: `scripts/tests/test_aurora_css_literal_contrast.py` now requires every hardcoded foreground colour in the front-end CSS to be registered with the surface it renders against and to clear its contrast floor.
+* Note: section-head links ("Photography →", "Full index →") were already ink at 14.88:1 — see #470 for the corrected diagnosis.
 
 = 1.4.4 =
 * a11y: darken the accent orange to #9a2f14 so accent text clears 4.5:1 on every cream surface (was 2.69:1 on #d9cdb0).

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.4.4
+Version: 1.4.5
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -499,9 +499,17 @@ a {
   --aurora-paper: #efe6d2;
   --aurora-signal: #9a2f14;
   --aurora-signal-dark: #a52918;
-  /* Control fills carry #fffaf6 label text — both states clear 4.5:1 on it. */
+  /* Control fills carry the label token below — both states clear 4.5:1 on it. */
   --aurora-signal-control: #c03f18;
   --aurora-signal-control-hover: #a52918;
+  /* Sole definition site for solid-control label text. 5.11:1 on
+     --aurora-signal-control, 7.29:1 on --aurora-signal. revive-port.css
+     aliases --revive-accent-control-label to this rather than repeating it. */
+  --aurora-signal-control-label: #fffaf6;
+  /* Error text on cream. theme.json's `error` (#d94a1f) is a decorative fill
+     and only reaches 2.69:1 on cream, so it must never carry error copy.
+     7.37:1 on --aurora-paper, 6.70:1 on the darker cream --aurora-panel-solid. */
+  --aurora-error-text: #8a1f1f;
   --aurora-wildcard: #e8b53a;
   --aurora-opal-void: #efe6d2;
   --aurora-opal-ink: #e6dcc2;
@@ -582,7 +590,7 @@ a {
 .wp-block-button.is-style-aurora-primary .wp-block-button__link {
   background: var(--aurora-signal-control);
   border: 1px solid var(--aurora-signal-control);
-  color: #fffaf6;
+  color: var(--aurora-signal-control-label);
   box-shadow: 0 0 28px rgba(229, 70, 46, 0.22);
 }
 
@@ -1053,7 +1061,10 @@ a {
 }
 
 .aurora-inline-link:hover {
-  color: #ff735d;
+  /* #ff735d was a dark-palette value: 2.15:1 on cream, i.e. hovering made the
+     link *less* legible than its 6.06:1 resting state. Ink matches the
+     established cream hover pattern (revive-port.css: page-content links). */
+  color: var(--aurora-ink);
 }
 
 .aurora-testimonial-band {
@@ -2406,7 +2417,12 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 }
 
 .aurora-meta-divider {
-  color: rgba(232, 224, 209, 0.28);
+  /* Pre-cream residue: rgba(232, 224, 209, 0.28) is cream-on-cream (1.02:1).
+     It never rendered — `.aurora-article-meta span` (0,1,1) out-specifies this
+     rule and already supplies ink-muted — so this is a dead-literal cleanup
+     that makes the losing rule agree with the winner rather than a live fix.
+     3.84:1 on cream, clearing the 3:1 floor for this aria-hidden separator. */
+  color: var(--aurora-ink-muted);
 }
 
 .aurora-article-dek {
@@ -2905,7 +2921,9 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   background: var(--wp--preset--color--signal);
   border: 1px solid var(--wp--preset--color--signal);
   border-radius: var(--aurora-radius-control);
-  color: #041013;
+  /* #041013 was a label for the old bright signal. Against today's
+     signal (#9a2f14) it is 2.56:1; the control label token is 7.29:1. */
+  color: var(--aurora-signal-control-label);
   cursor: pointer;
   display: inline-flex;
   font-weight: 800;
@@ -2934,7 +2952,9 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 
 .aurora-form-error,
 .aurora-theme :where(.gform_validation_errors, .jetpack-field-error) {
-  color: #ffb4b4;
+  /* #ffb4b4 was a dark-palette pink: 1.36:1 on cream, so validation errors
+     were invisible on the surface they render against. */
+  color: var(--aurora-error-text);
 }
 
 .aurora-form-success,
@@ -3437,7 +3457,13 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 
 .aurora-single-2026 .aurora-article-dek {
   border-left: 2px solid rgba(242, 180, 207, 0.32);
-  color: rgba(232, 224, 209, 0.72);
+  /* Pre-cream residue: rgba(232, 224, 209, 0.72) is cream-on-cream (1.04:1).
+     The dek's visible text lives in an inner <p> that revive-port.css paints
+     --revive-ink-soft (8.11:1), so the old value only ever applied to direct
+     text in this <div> — of which the post-excerpt block renders none. A
+     dead-literal cleanup that also makes the rule correct if that markup ever
+     changes, not a live fix. */
+  color: var(--aurora-ink-soft);
   font-style: normal;
   line-height: 1.6;
   max-width: 64ch;
@@ -3520,6 +3546,12 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 }
 
 .aurora-featured-media :where(figcaption, .wp-element-caption) {
+  /* DEAD DECLARATION — do not "fix" this value in place. revive-port.css's
+     `.aurora-theme :where(p, li, figcaption)` has equal specificity (0,1,0)
+     and loads later, so it wins and paints this caption --revive-ink-soft:
+     dark ink on this rule's own dark panel, 2.06:1 live. The fix is to decide
+     .aurora-featured-media's surface (it is a pre-cream literal), not to
+     retune the caption. See the #470 sweep notes. */
   color: rgba(207, 199, 187, 0.72);
   font-size: 0.86rem;
   line-height: 1.45;


### PR DESCRIPTION
## Summary

Fixes four real contrast defects left behind by the 1.4.0 cream/ink port, and adds a test that closes the *class* of gap rather than the instances.

## Related Issue

Relates to #470 (**closed as not planned — its premise was wrong, see below**)
Relates to #485 (the real defect this sweep found)
Relates to #464, #423

## ⚠️ #470's premise did not reproduce — correcting my own filing

I filed #470 claiming `.aurora-section-head a` renders at ~1.05:1. **It does not.** The rule has used `color: var(--revive-ink)` since `819f182`:

```
revive-port.css:563-572   color: var(--revive-ink);   /* #171310 on cream #efe6d2 = 14.88:1 */
```

The `rgba(239,230,210,0.78)` literal is real but sits at **line 696** on `.aurora-work-card-body p`, over a dark scrim. The original report conflated a selector line with a colour declaration 140 lines away, and I filed it without checking. Verified three ways: the rule, `git log -L`, and live readback.

The sweep was still worth doing.

## Method — why the first pass was thrown away

The initial findings were wrong because they read *declarations* instead of resolving the *cascade*. Redone with `jsdom` against live markup plus the concatenated stylesheet Jetpack Boost actually serves. **Every ratio below is post-cascade.** Two findings were retracted mid-work when they turned out to lose the cascade and never render.

## Fixed

| Rule | Old → new | Ratio |
|---|---|---|
| `.aurora-inline-link:hover` | `#ff735d` → `var(--aurora-ink)` | **2.15 → 14.88:1** — hover was *less* legible than its 6.06:1 rest state |
| `.aurora-form-error` + Gravity/Jetpack | `#ffb4b4` → `--aurora-error-text` `#8a1f1f` | **1.36 → 7.37:1** |
| search/form submit label | `#041013` → control-label token | **2.56 → 7.29:1** |
| `.aurora-work-card-body p` | alpha `0.78` → `0.84` | 4.36 → **4.78:1** worst-case scrim |

Only the work-card change moves live pixels; the other three are latent (not on the 8 sampled routes) but correct.

**Tokens, not literals** — following #467's direction:
- `--aurora-signal-control-label` added as the **sole** definition site; `revive-port.css` now *aliases* `--revive-accent-control-label` to it instead of repeating `#fffaf6`
- `--aurora-error-text` is new because `theme.json`'s `error` `#d94a1f` is a decorative fill at 2.69:1 and must never carry copy

**Dead-literal cleanup:** `.aurora-meta-divider` and `.aurora-single-2026 .aurora-article-dek` — both lose the cascade and never rendered. Earlier "live defect" claims about these were corrected in the code comments rather than left standing.

## The test — `scripts/tests/test_aurora_css_literal_contrast.py`

Every literal `color:` in the front-end CSS must be **registered with the surface it renders on** and clear its floor. A new hardcoded literal anywhere fails the suite until someone states what it sits on.

That is the gap that let all of this through: the existing `test_aurora_contrast_tokens.py` checks `theme.json` slugs, so a literal inside a component rule was invisible to it. #464 and this sweep were both that shape.

- Sentinels `NOT_STATIC` / `OVERRIDDEN` keep unmeasurable cases honest instead of forcing fake numbers
- A second mechanism resolves token-valued rules against their real surfaces (the #464 shape)
- **Mutation-verified:** reintroducing #470-as-filed fails 3 tests; a new literal elsewhere fails the registry; `--aurora-paper` on cream fails the resolved check

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement

## Testing

- [x] `make python-test` — **439 tests, 0 failures** (432 baseline + 7), independently re-run by the reviewing session
- [x] `make php-syntax` — 39/39
- [x] Ratios recomputed independently, not taken on trust
- [x] Version bumped 1.4.4 → **1.4.5** in `style.css`, `KK_AURORA_VERSION`, `readme.txt`

## 🚨 Needs a human call — one worse than anything fixed here

**Blog index post titles render at ~1.01–1.09:1** — `.aurora-writing-card` kept a pre-cream `#050708` background while its text uses cream tokens. Filed as **#485**. Not fixed here: its borders, gradients and `::after` washes are all light-on-dark and need redoing together, and the component is duplicated across **6 locations**. Guessing at it would have been worse than reporting it.

Also open, in #485: `.aurora-featured-media` caption 2.06:1 · `.aurora-work-card-num` 1.11–1.88:1 on bare photography · **`--aurora-ink-muted` is 3.84:1 on cream while `theme.json`'s `text-muted` `#5c5044` that it aliases is 6.30:1** — the CSS has diverged from the palette, ~15 components affected. That last one may resolve several findings at once.

**Passing, no action needed:** proof outlets 4.79:1, all four services-band literals 5.19–8.68:1, work-card h3 5.96:1, check-grid ✓ 7.52:1, writing-card excerpt 7.91:1, archive dek 8.11:1.

## Deployment Notes

- [x] Requires cache clearing (after deploy)

Merging does not deploy. Repo goes to 1.4.5; live is 1.4.3 and now two versions behind, both pending the same manual `make aurora-package` upload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_