### PR TITLE
Docs: interaction states gap inventory, audit half of #424

### DIFF
--- a/docs/current-state/INTERACTION-STATES-GAP-INVENTORY.md
+++ b/docs/current-state/INTERACTION-STATES-GAP-INVENTORY.md
@@ -1,0 +1,618 @@
+# Interaction states gap inventory — hover, focus, and keyboard (2026-07-25)
+
+**Issue:** [#424 — [QA] Site-wide hover, focus, and interactivity pass](https://github.com/WalksWithASwagger/kriskrug-wp/issues/424). This document delivers **only the first acceptance criterion**, the gap inventory.
+**Deliberately not done here:** the shared interaction styles. [`AURORA-STYLESHEET-REBUILD-PLAN.md`](AURORA-STYLESHEET-REBUILD-PLAN.md) §3.1 sequences #424's *implementation* behind step 4 (`04-primitives.css`), because the shared focus-ring and interactive-state layer #424 asks for **is** that primitives layer. Building it now means writing it twice. §3.1 says the audit half should start now; this is that half. See §10 for whether I still agree after doing the work.
+**Lane:** Track B measurement only. **Zero `.css`, `.php`, `.html`, or `theme.json` changed.** One new read-only script was added under `scripts/`.
+**Measured against:** **live** `https://kriskrug.co`, logged out, 2026-07-25, Aurora **1.4.3**. Not the repo — see §1.2.
+
+---
+
+## Bottom line
+
+The premise the issue was filed on — *"there's no hovers or interactivity on any of that shit"* — is **half right, and wrong in the half that matters most for accessibility.**
+
+- **Focus is in far better shape than the issue assumes.** Of **604** interactive elements rendered across the eight main-nav routes, **604 receive a visible `:focus-visible` ring**. A real keyboard tab-through of all eight routes produced **438 tab stops** and **every single one had a visible focus indicator** that matched `:focus-visible`. **Zero** elements have an outline suppressed without an equal-or-better replacement. **Zero** focus rings fall below WCAG 1.4.11's 3:1 (the weakest measured is 3.11:1). The theme's three competing `outline: none` declarations are all correctly re-covered downstream. **WCAG 2.4.7 passes on all eight routes.**
+- **Hover is where the gaps are, and they are concentrated, not site-wide.** **67 of 604 elements (11.1%)** have no hover affordance at all.
+- **The single most important finding is the shape of those gaps, not their count.** Only **5 of 67** are "nobody wrote a hover rule." The other **62 (92.5%)** have a hover rule that matches the element, declares a visibly different value, and **loses the cascade to an `!important` declaration on the element's own rest state.** These are not missing styles. They are styles that were silently switched off by later contrast patches. A primitives layer that only *adds* rules will not fix any of them.
+- **27 of the 98 interaction rules in the served CSS match nothing on any of the eight routes** — 27.6% of the authored interaction surface is dead.
+- **16 hover affordances are deleted outright for `prefers-reduced-motion` users**, because those affordances are motion-only and the reduced-motion block removes the motion without substituting anything.
+
+---
+
+## 1. Method — how every number here was produced
+
+A grep for `:hover` cannot answer this issue. The five front-end sheets contain **118 `:hover` occurrences** and **80 `:focus` / `:focus-visible` / `:focus-within` occurrences** (`grep -o ':hover' … | wc -l`), but the questions that matter are *does the rule apply to a rendered element*, *does it win*, and *does the pixel actually change*. All three need a browser. Of those 198 occurrences, the number that produce a measurable state change on a rendered element is what this document reports — and it is not the same number.
+
+### 1.1 The probe
+
+New reusable script: [`scripts/interaction_state_probe.js`](../../scripts/interaction_state_probe.js).
+
+```bash
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+  node scripts/interaction_state_probe.js --out /tmp/probe
+
+# reuse an existing mirror, no re-fetch
+node scripts/interaction_state_probe.js --out /tmp/probe --skip-mirror
+
+# the reduced-motion comparison run in §6
+node scripts/interaction_state_probe.js --out /tmp/probe-rm --skip-mirror --reduced-motion
+```
+
+It writes `probe.json` (full per-element data) and `summary.md`. It is read-only: no WordPress writes, no theme writes, and it **refuses to download a browser** — if `PLAYWRIGHT_BROWSERS_PATH` is unset it exits 2 rather than triggering `playwright install`, per rebuild-plan §4.6.
+
+What it does, in order:
+
+1. **Mirror.** Chromium in this sandbox cannot reach the public internet — the agent HTTPS proxy resets browser connections (`net::ERR_CONNECTION_RESET` on every proxy configuration tried; `curl` to the same URL returns `200`). So the script fetches each route's live HTML with `curl`, downloads every stylesheet and script it links, rewrites those URLs to local paths, and serves the result from `127.0.0.1`. Serving same-origin is not a workaround, it is a requirement: cross-origin stylesheets throw on `.cssRules`, and reading the rules is how the probe knows which rules *exist*.
+2. **Freeze timing.** A `transition-duration: 0s !important` sheet is injected before any measurement. **This is not cosmetic.** The theme transitions `color` over 0.15s; reading `getComputedStyle` immediately after a state change returns the *start* of the transition, i.e. the rest value. Before this fix the probe scored the entire primary nav as having no hover state. Verified both ways: without the freeze, `.aurora-primary-nav a` reads `rgba(23,19,16,0.78)` on hover (unchanged); with the freeze — or after a 700ms settle — it reads `rgb(181,60,24)`.
+3. **Force each state.** Per element, `:hover` and then `:focus`+`:focus-visible` are forced via CDP `CSS.forcePseudoState` — the mechanism behind DevTools' `:hov` panel. This is geometry-independent, so occluded, off-screen, and below-the-fold elements are measured exactly like visible ones. No mouse positioning, no scroll dependence.
+4. **Diff computed style.** ~40 visual properties on the element, plus 14 properties each on `::before` and `::after`, plus a fingerprint of the first 40 descendants. The pseudo-element and subtree passes exist because several Aurora components put their whole affordance somewhere other than the element (`.aurora-link:hover::after`, `.aurora-media-card:hover img`). Measuring only the element would have reported those as missing.
+5. **Attribute the cause.** For every state rule that matches the element, the declared value is resolved *on that element* by applying it inline for one frame. That separates three cases a grep collapses into one — see §1.3.
+6. **Tab through for real.** After the per-element pass, the script presses `Tab` up to 400 times per route and records `document.activeElement`, whether it matches `:focus-visible`, its computed outline and box-shadow, and the ring's contrast against the surface it is painted on.
+
+### 1.2 Live/repo parity — and why this audit is against live
+
+| Check | Result | Command |
+|---|---|---|
+| Live theme version | **1.4.3** | `curl -sS https://kriskrug.co/wp-content/themes/kk-aurora/style.css \| grep -m1 -i '^Version'` |
+| Repo `main` theme version | **1.4.4** | `theme/kk-aurora/style.css` header |
+| Live vs repo `style.css` | **differ** (13 changed lines) | `diff live-style.css theme/kk-aurora/style.css` |
+| Live vs repo `revive-port.css` | **differ** | `diff live-revive.css theme/kk-aurora/assets/css/revive-port.css` |
+
+This is a change since PR #468, which found them byte-identical. Repo `main` is now one undeployed version ahead. **The entire 1.4.3→1.4.4 delta is token *values*** — the #464/#465/#466 contrast work darkening `--aurora-signal`, `--revive-accent-text`, and the control fills. `diff` over both files returns **zero** changed lines containing `:hover`, `:focus`, or `outline`.
+
+Consequence, stated precisely: **every structural finding in this document holds for both 1.4.3 and 1.4.4** — the cascade conflicts, the missing rules, and the dead rules are all identical in the repo line. Only the focus-ring *contrast numbers* in §4 will shift when 1.4.4 deploys, and they shift **upward** (the ring colour darkens from `#b53c18` to `#9a2f14` against the same cream), so the "all rings clear 3:1" conclusion strengthens rather than weakens.
+
+Line references below cite **live** line numbers, with the repo equivalent where they differ.
+
+### 1.3 The distinction that matters: missing vs losing vs no-op
+
+The task of #424 is "fix gaps with shared styles, not per-element patches." Whether a shared style *can* fix a gap depends entirely on why the gap exists:
+
+| Cause | What was measured | What a fix has to do |
+|---|---|---|
+| `rule-missing` | No rule in any loaded sheet targets this element in this state. | **Add** a rule. A primitives layer fixes this for free. |
+| `rule-loses-cascade` | A rule targets it, and applying its declared value to the element *does* change the computed value — but under the forced state nothing changes. It is being outranked. | **Remove or re-scope the winning `!important`.** Adding another rule does nothing unless it also carries `!important` — which is the exact ratchet the rebuild is trying to stop. |
+| `rule-no-op` | A rule targets it, but its declared value resolves to the value the element already has. | **Change the value.** Specificity is irrelevant. |
+
+Zero `rule-no-op` cases survived into the final numbers; the split is 62 losing / 5 missing.
+
+### 1.4 Corpus and settings
+
+- Routes: `/`, `/about/`, `/speaking/`, `/services/`, `/work/`, `/blog/`, `/photography/`, `/contact/`. `/writing/` 301s to `/blog/` (`curl -sS -o /dev/null -w '%{url_effective}' -L https://kriskrug.co/writing/`), so it is one route, not two.
+- Viewport 1440×900, `colorScheme: light`, `prefers-reduced-motion: no-preference` for the primary run (see §6 for why that default matters), captured 2026-07-25T19:14Z.
+- CSS surface per route as loaded: 23 stylesheets on `/`, **all readable**, containing **98 distinct interaction rules** — 83 from the Jetpack Boost concatenated bundle (`78b2cf14fa.min.css`, 138,229 bytes, md5 `8dad4baf6c2e420e8cb83000247f75fd`, which carries all five front-end theme sheets), 6 from `global-styles-inline-css` generated from `theme.json`, and 9 from other WordPress inline block styles.
+- Images are fulfilled locally with a 1×1 PNG so layout is not distorted by broken-image boxes; fonts and media are aborted. Neither affects computed interaction states.
+
+### 1.5 Internal consistency check
+
+The per-element pass and the keyboard pass are independent code paths. They agree exactly:
+
+| | Value |
+|---|---|
+| Elements in the inventory with `tabIndex >= 0` | **438** |
+| Tab stops reached by pressing Tab | **438** |
+| Tab stops that could not be matched back to an inventory element | **0** |
+| Tab stops matching `:focus-visible` | **438 / 438** |
+
+### 1.6 Honest limits
+
+- **One viewport.** 1440×900 only. A mobile pass is not covered; note that the markup contains **zero** `<button>` elements (§3), so there is no nav toggle to miss, but a mobile run should still be done before #424 is closed.
+- **No JavaScript from the live origin executes.** Theme JS is mirrored and served locally, but anything fetched from a third-party origin does not run. `micro-interactions.js` attaches one `mousemove` handler for a card-tilt effect (`theme/kk-aurora/assets/js/micro-interactions.js:26`); that is a JS-driven affordance this CSS-focused probe does not score.
+- **Logged out only.** No admin bar, no editor canvas. The editor's divergent stylesheet set (rebuild plan §1.2) is out of scope here.
+- **`:hover` on touch devices** is not modelled. Every hover finding below should be read as "pointer users."
+- The **eight main-nav routes only**. Single posts, archives, and 404 are not covered; `/blog/` is the only archive sampled.
+
+---
+
+## 2. Summary — the inventory
+
+| Route | interactive elements | own `:hover` | hover on a descendant | hover inherited from a card | **no hover** | `:focus-visible` ring | **no focus** | tab stops | stops with no visible ring |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| `/` | 76 | 64 | 0 | 0 | **12** | 76 | 0 | 66 | 0 |
+| `/about/` | 55 | 45 | 4 | 0 | **6** | 55 | 0 | 44 | 0 |
+| `/speaking/` | 55 | 45 | 4 | 0 | **6** | 55 | 0 | 44 | 0 |
+| `/services/` | 48 | 42 | 0 | 0 | **6** | 48 | 0 | 42 | 0 |
+| `/work/` | 63 | 49 | 8 | 0 | **6** | 63 | 0 | 48 | 0 |
+| `/blog/` | 208 | 115 | 0 | 75 | **18** | 208 | 0 | 108 | 0 |
+| `/photography/` | 47 | 41 | 0 | 0 | **6** | 47 | 0 | 41 | 0 |
+| `/contact/` | 52 | 45 | 0 | 0 | **7** | 52 | 0 | 45 | 0 |
+| **All 8** | **604** | **446** | **16** | **75** | **67** | **604** | **0** | **438** | **0** |
+
+"hover inherited from a card" means the element has no hover rule of its own but sits inside a probed ancestor that does — hovering the card lights the card, and the title inside it is part of that affordance, so it is not a gap. All 75 are `.aurora-writing-card` internals on `/blog/`.
+
+Cause split for the 67 gaps: **62 `rule-loses-cascade`, 5 `rule-missing`, 0 `rule-no-op`.**
+
+Full per-route element tables are in §8.
+
+---
+
+## 3. What is actually on these pages
+
+Worth stating plainly, because it changes what "shared interaction styles cover links, buttons, cards, and pills" has to mean:
+
+```
+grep -c '<form\|<input\|<textarea\|<select\|<button' over all 8 mirrored routes  ->  0
+```
+
+**There are no form controls and no native `<button>` elements on any of the eight main-nav routes.** Every "button" on this site is an `<a>` carrying `.aurora-button`, `.kk-contact-button`, `.kk-services-button`, or `.kkx-btn`. The newsletter CTA is an outbound link to Beehiiv, not an embedded form. The contact page has no form; it offers a `mailto:` link and two link-buttons.
+
+Two consequences for step 4:
+
+1. The **form-field half of #424's scope is currently untestable and unshippable on these routes.** The theme's nine `.aurora-form-*` classes are among the dead code PR #468 identified, and `.aurora-search-form … button:hover` is on the dead-rule list in §5. Writing form-field interaction primitives now would be writing code with no consumer.
+2. The **button primitive must be authored for `<a>` first**, not for `<button>`. A primitives layer keyed on `button, input[type=submit]` would style nothing on this site.
+
+There are also no `[role="button"]`, `[role="link"]`, `[tabindex]`, or `[contenteditable]` elements. The interactive surface is: **anchors, and card/tile containers that wrap anchors.** That is a small, tractable vocabulary — which is good news for a shared layer.
+
+---
+
+## 4. Focus states (WCAG 2.4.7) — ranked first, as the issue requires
+
+### 4.1 The result
+
+**All eight routes pass a keyboard tab-through with a visible focus indicator on every stop.** 438 of 438 stops matched `:focus-visible` and rendered a solid 2px outline. Zero stops rendered `outline-style: none` with no `box-shadow` replacement. Zero stops were on hidden or zero-size elements.
+
+### 4.2 The three `outline: none` declarations, and why none of them is a defect
+
+The issue asks specifically for outlines suppressed without an equal-or-better replacement. The theme contains three suppressions. All three are covered:
+
+| # | Where | Declaration | Covered by | Verdict |
+|---|---|---|---|---|
+| 1 | `style.css:125` (live and repo) | `:focus-visible { outline: none; box-shadow: var(--focus-ring) }` | Declares its own replacement (`--focus-ring` = `0 0 0 2px #efe6d2, 0 0 0 4px #b53c18`), and its `outline: none` is in turn overridden by #2 and #3, both later in the cascade at equal or higher specificity | **Not a defect** — a replacement is declared *and* the suppression loses |
+| 2 | `bleeding-edge.css:416` | `:focus { outline: none }` | `bleeding-edge.css:420` `:focus-visible { outline: 2px solid var(--wp--preset--color--signal); outline-offset: 3px }` | **Not a defect** — this is the correct `:focus` / `:focus-visible` split; mouse clicks get no ring, keyboard does |
+| 3 | `revive-port.css:132–160` (repo `:138–166`) | R2 "cream-safe focus rings" block, `outline: 2px solid var(--revive-accent-text) !important; box-shadow: none !important` | Itself — it *is* the replacement, and it explicitly cancels #1's box-shadow | **Not a defect** |
+
+The comment on #3 reads *"must win over dark-theme outline:none"*, which is exactly what it does. This is the one place in the whole stylesheet where the `!important` war is being fought **for** accessibility rather than against it.
+
+`--focus-ring` itself is one of the 24 custom properties the rebuild plan §1.4 flags as declared twice: `style.css:56` sets it with `#d94a1f`, `revive-port.css:60` redeclares it with `--revive-accent-text`. The measured computed value is the second one. The ring people actually see is decided by which of two identical token declarations loads last.
+
+### 4.3 Which ring lands where
+
+Measured, not inferred:
+
+| Ring | Source | Elements | Contrast range vs the surface behind it |
+|---|---|--:|---|
+| `2px solid rgb(181,60,24)` @3px offset | `revive-port.css:132` R2 block, `--revive-accent-text` `#b53c18` | **400** | 3.19 – 4.67:1 |
+| `2px solid rgb(217,74,31)` @3px offset | `bleeding-edge.css:420` fallback, `--wp--preset--color--signal` `#d94a1f` | **196** | 3.11 – 4.76:1 |
+| `2px solid rgb(23,19,16)` @2px offset | `revive-port.css` skip-link block, `--revive-ink` | **8** | 14.88:1 |
+
+The split is structural and worth knowing before step 4 touches it: the R2 block's selector is `body.aurora-theme :where(a, button, input, select, textarea, summary, .aurora-button, .wp-block-button__link, .aurora-primary-nav a, .aurora-utility-link, .aurora-header-cta, .aurora-brand):focus-visible`. That is an **allowlist**. Anchors match it; card and tile *containers* (`article`, `section`, `nav`, `figure`, `div`, `h2`) do not, and fall through to the `bleeding-edge.css` catch-all.
+
+The consequence is measurable and nobody designed it. Because the R2 block also carries `box-shadow: none !important`, allowlisted elements get **a single 2px outline**, while the 196 non-allowlisted containers keep `style.css:127`'s `box-shadow` as well and get **a double indicator** — outline *plus* a 2px cream + 2px accent shadow ring:
+
+| | Allowlisted (anchors, 400) | Not allowlisted (containers, 196) |
+|---|---|---|
+| `outline` | `2px solid #b53c18` @3px | `2px solid #d94a1f` @3px |
+| `box-shadow` | `none` (forced) | `rgb(239,230,210) 0 0 0 2px, rgb(181,60,24) 0 0 0 4px` |
+
+Two rings, two colours, two thicknesses, one accidental boundary. Since every real tab stop today is an anchor (§1.5), the visible effect is nil — but the moment any container becomes focusable, it silently gets the other treatment. **One ring token, applied without an allowlist, is the step-4 deliverable this implies.**
+
+### 4.4 A contrast trap worth recording
+
+The primary CTA `a.aurora-button.aurora-button-primary` appears on all eight routes and first measured at **1.37:1** — which would have been the headline finding of this document. It is a false positive, and the reason is instructive.
+
+The ring is `#b53c18` and the button's fill is `#d94a1f`. Measuring the ring against the *element's own* background gives 1.37:1. But `outline-offset` is `3px`, so the ring is painted in the gap **outside** the border box, on the cream page (`#efe6d2`), which gives **4.67:1**. WCAG 1.4.11 asks about adjacent colours, and both of this ring's neighbours are cream.
+
+The probe now picks the baseline from `outline-offset`: positive offset measures against the ancestor background; zero or negative measures both and takes the worse. **After the fix, zero rings on the site fall below 3:1** (minimum 3.11:1). Anyone re-running this check by hand should be aware that measuring an offset ring against its own element manufactures failures.
+
+### 4.5 The one focus state that *is* broken
+
+`.aurora-footer-tile:hover, .aurora-footer-tile:focus-within` (live `style.css:2711`) is killed by `!important` — see §5.1. The `:hover` half is the visible symptom, but the `:focus-within` half is the accessibility one: **tabbing into a footer tile produces no container-level feedback on any of the eight routes.** The link inside still gets its own ring, so this does not fail 2.4.7 — but it is the only measured case where a keyboard-relevant state rule exists, matches, and is switched off. It belongs at the top of the step-4 list for that reason.
+
+---
+
+## 5. Hover gaps, ranked
+
+### 5.1 `.aurora-footer-tile` — 48 instances, all 8 routes, cascade loss
+
+The largest single gap on the site, and the cleanest example of the pattern.
+
+```css
+/* live style.css:2700 — base */
+.aurora-footer-tile { background: rgba(247,247,242,0.035); border: 1px solid var(--aurora-line); … }
+
+/* live style.css:2711 — the state */
+.aurora-footer-tile:hover,
+.aurora-footer-tile:focus-within { background: rgba(247,247,242,0.05); border-color: var(--aurora-line-strong); }
+
+/* live revive-port.css:900 — the killer */
+.aurora-footer-tile { border-color: var(--revive-line) !important; background: transparent !important; }
+```
+
+The Revive port pinned the tile's **rest** background and border with `!important`. Because the `:hover` / `:focus-within` rule is not `!important`, it can never win, no matter that it is more specific in intent. Measured: forced hover leaves `background-color` at `rgba(0,0,0,0)` and `border-top-color` at `rgba(23,19,16,0.14)` — identical to rest. The declared hover value resolves to `rgba(247,247,242,0.05)`, so the rule genuinely wants to change something.
+
+Worth noting for step 4: `rgba(247,247,242,0.05)` is a *dark-theme* hover — a near-white wash at 5% opacity, designed to sit on a dark panel. On cream it would be close to invisible even if it won. **The fix is not to restore this rule; it is to author a cream-native tile hover in the primitives layer and delete both sides of the fight.**
+
+### 5.2 `.aurora-feed-link-grid a` (×8) and `.aurora-writing-pagination a` (×4) on `/blog/` — cascade loss
+
+```css
+/* live style.css:1627 — the state, covering BOTH hover and focus */
+.aurora-feed-link-grid a:hover,
+.aurora-feed-link-grid a:focus-visible { background: rgba(200,255,61,0.08); border-color: rgba(200,255,61,0.35); }
+
+/* live style.css:1570 */
+.aurora-writing-pagination a:hover,
+.aurora-writing-pagination .page-numbers.current { background: rgba(247,247,242,0.06); }
+
+/* live style.css:4459 AND live style.css:4490 — the killer, declared twice */
+body.aurora-theme :where(.aurora-writing-pagination a, …, .aurora-feed-link-grid a) {
+  background-color: var(--aurora-panel-solid) !important;
+  border-color: var(--aurora-line-strong) !important;
+  color: var(--aurora-ink) !important;
+  -webkit-text-fill-color: currentColor !important;
+}
+```
+
+The "Aurora 1.4.0 cream contrast" block at the end of `style.css` pins background, border, **and colour** on the rest state with `!important`, twice, at two different specificities. It takes out the hover rule, the `:focus-visible` background rule, and WordPress's own `a:hover` (which would otherwise supply colour + underline from `global-styles-inline-css`). Measured: nothing changes on hover — colour, background, and border are all identical to rest.
+
+`rgba(200,255,61,0.08)` is acid green — another dark-theme leftover that should not be restored as-is.
+
+This is the mechanism the rebuild plan predicts in §2.4, caught in the act: **a contrast fix, applied late and with `!important`, silently deleted three interaction states as a side effect.** Nothing in the process noticed, because a contrast fix is not expected to change hover.
+
+### 5.3 `.aurora-section-head a` — 2 instances on `/`, cascade loss, *not* an `!important` fight
+
+The "Photography →" and "Full index →" section links.
+
+```css
+/* live revive-port.css:557 */
+.aurora-section-head a { color: var(--revive-ink); text-decoration: none; border-bottom: 1px solid var(--revive-accent); … }
+```
+
+There is no `:hover` rule for this component anywhere. The only matching hover rule is WordPress's own, from `theme.json`:
+
+```css
+:root :where(a:where(:not(.wp-element-button)):hover) { color: var(--wp--preset--color--signal); text-decoration: underline; }
+```
+
+That selector's specificity is `(0,1,0)` — `:root` plus a zero-weight `:where()`. The theme's base rule is `(0,1,1)`. **The base rule outranks the hover rule by one class, with no `!important` involved at all.** Measured: colour and border-bottom identical on hover.
+
+This is a distinct failure mode from §5.1/§5.2 and it matters for step 4's design: **not every lost state is an `!important` casualty.** Any component rule written as `.component a { color: … }` with no matching `.component a:hover` silently defeats WordPress's default link hover. A primitives layer must either supply the hover for every component that styles a link, or keep component link rules at a specificity WordPress's default can still beat.
+
+**Relation to #470:** that issue is fixing `.aurora-section-head a`'s *rest* contrast (~1.05:1). This is a different defect on the same selector — its *hover* state. They should be fixed together, and #470's fix should not be considered to have closed this. Flagging so the two are not double-counted or, worse, one assumed to cover the other.
+
+### 5.4 `.aurora-service-card` — 3 instances on `/`, rule missing
+
+Genuinely no `:hover` rule anywhere in any loaded sheet. `revive-port.css` styles `.aurora-service-card`, `::before`, `h3`, `p`, `.aurora-service-meta`, and `a` — six rules, no state. The card wraps a link, so the link inside responds; the card does not. Clean primitives-layer win.
+
+### 5.5 `.kk-contact-card` — 1 instance on `/contact/`, rule missing
+
+Same shape, but this is **Track A page-content CSS**, not theme CSS — it ships from inside the page's own `<style>` block, one of the six the rebuild plan's §3 step 7 retires. Its hover should be authored as part of that migration, not patched in the content block, or it will just be deleted twice.
+
+### 5.6 `div.aurora-writing-actions` — 1 instance on `/`, rule missing (low value)
+
+A `wp-block-buttons` layout wrapper the probe picked up because its class list contains "button". It contains buttons that do have hover states. **Not a real gap** — recorded for completeness and so a future re-run does not treat it as a regression.
+
+---
+
+## 6. Reduced motion deletes 16 hover affordances
+
+The primary run uses `prefers-reduced-motion: no-preference`, which is what most visitors get. Re-running with `--reduced-motion` and diffing element-for-element:
+
+| Component | Instances losing hover | Routes |
+|---|--:|---|
+| `article.aurora-media-card` | **16** | `/about/`, `/speaking/`, `/work/` |
+
+Mechanism, verified at source:
+
+```css
+/* live style.css:1194 — the only hover affordance this card has */
+.aurora-media-card:hover img { filter: saturate(1.12); transform: scale(1.035); }
+
+/* live style.css:4380, inside @media (prefers-reduced-motion: reduce) */
+.aurora-media-card:hover img, .aurora-writing-card:hover, … , .aurora-button:hover { transform: none; }
+```
+
+The card's affordance is a 3.5% image scale. The reduced-motion block cancels the transform — correctly, motion should be reduced. The companion `filter: saturate(1.12)` should have survived as a static fallback, but it does not land either: the image's computed `filter` reads `blur(0px)` in **both** rest and hover, so something later in the cascade is already overriding it. The net result for a reduced-motion user is **a card with no hover feedback at all**.
+
+Fourteen other selectors share that `transform: none` rule. Only the media card was measured losing its hover entirely — the rest either carry a non-motion affordance as well, or (per §7) render on none of these eight routes, so they were not exercised.
+
+This is the correct pattern stated wrongly: reduced motion should *substitute* a static affordance (border, background, underline), not subtract the only one. A primitives layer is exactly the right place to guarantee "every interactive component has at least one non-motion state change."
+
+**Methodological note for anyone re-running this:** the rebuild plan §4.3 recommends forcing `prefers-reduced-motion: reduce` for screenshot determinism. That is right for visual regression and **wrong for an interaction audit** — under `reduce` the media card scores as a hover gap for everyone. The probe therefore defaults to `no-preference` and takes reduced motion as an explicit second pass.
+
+---
+
+## 7. Dead interaction CSS
+
+Of **98** distinct interaction rules in the CSS actually served to these routes, **27 (27.6%) match zero elements** on any of the eight. Measured per route with `document.querySelectorAll()` on the state-stripped selector (pseudo-elements stripped before matching, so `.x:hover::after` is counted against `.x`), then unioned.
+
+These must not be inventoried as coverage, and they should not be migrated into the primitives layer — they should be deleted at rebuild step 6.
+
+| Dead interaction rule | Sheet |
+|---|---|
+| `.aurora-article-map a:hover` | Boost bundle |
+| `.aurora-article-map a:hover, .aurora-article-map a:focus-visible` | Boost bundle |
+| `.aurora-article-map:hover, .aurora-article-map:focus-within, .aurora-author-panel:hover, .aurora-author-panel:focus-within, …` | Boost bundle |
+| `.aurora-article-meta a:hover` | Boost bundle |
+| `.aurora-badge:hover` | Boost bundle |
+| `.aurora-button-press:active` | Boost bundle |
+| `.aurora-card-gradient:hover::before` | Boost bundle |
+| `.aurora-card-lift:hover` | Boost bundle |
+| `.aurora-featured-media:hover, .aurora-featured-media:focus-within` | Boost bundle |
+| `.aurora-featured-media:hover::after, .aurora-featured-media:focus-within::after, .aurora-article-map:hover::after, …` | Boost bundle |
+| `.aurora-footer-nav a:hover` | Boost bundle |
+| `.aurora-hero-headline:hover` | Boost bundle |
+| `.aurora-hired-grid article:hover, .aurora-hired-grid article:focus-within` | Boost bundle |
+| `.aurora-inline-link:hover` | Boost bundle |
+| `.aurora-link-slide:hover::after` | Boost bundle |
+| `.aurora-link:hover::after` | Boost bundle |
+| `.aurora-path-row a:hover` | Boost bundle |
+| `.aurora-photo-image img:focus-visible, .aurora-photo-tile:focus-within` | Boost bundle |
+| `.aurora-photo-tile:hover, .aurora-photo-tile:focus-within` | Boost bundle |
+| `.aurora-proof-row a:hover` | Boost bundle |
+| `.aurora-related-row:hover, .aurora-related-row:focus-within` | Boost bundle |
+| `.aurora-related-row:hover::before, .aurora-related-row:focus-within::before` | Boost bundle |
+| `.aurora-search-form .wp-block-search__button:hover, .aurora-theme .wp-block-search__button:hover, .aurora-form button:hover` | Boost bundle |
+| `.wp-block-button.is-style-aurora-primary .wp-block-button__link:hover` | Boost bundle |
+| `::-webkit-scrollbar-thumb:hover` | Boost bundle |
+| `.has-drop-cap:not(:focus)::first-letter` | WP `wp-block-paragraph-inline-css` |
+| `body.rtl .has-drop-cap:not(:focus)::first-letter` | WP `wp-block-paragraph-inline-css` |
+
+Two cross-checks against PR #468's findings:
+
+- `.aurora-photo-tile:hover` is dead **on `/photography/`** — the photography page renders `a.kkx-btn` and pack-authored markup, not `.aurora-photo-tile`. This is consistent with #468's dead-class list.
+- The `.aurora-writing-archive .aurora-writing-card:hover…` override layer that the rebuild plan §1.5 flags as a sixth duplicate definition **does match** on `/blog/` — the archive wrapper class is present. It is redundant, not dead. Worth correcting the expectation before step 5 deletes it as unused.
+
+`::-webkit-scrollbar-thumb:hover` and the two `has-drop-cap` rules are not defects; they are listed for completeness because the census counts them.
+
+---
+
+## 8. Per-route inventory
+
+Elements are grouped by tag + theme-authored classes and by verdict, so a row reading `× 17 yes` and a row reading `× 2 none` for the same selector means those two instances genuinely behave differently. WordPress-generated classes (`wp-*`, `post-1234`, `type-post`, `tag-*`, `has-*`, `is-*`) are stripped from signatures; wrappers whose entire class list is WordPress-generated are excluded as template artefacts rather than components.
+
+"ring contrast" is the lowest value measured in that group, against the surface the ring is painted on (§4.4).
+
+### `/` — 76 interactive elements, 66 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.aurora-service-card` | card | 3 | **none** | theme-ring | 4.35 | rule-missing |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a.aurora-work-card` | card-link | 3 | yes | theme-ring | 4.67 |  |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a` | link | 17 | yes | theme-ring | 3.19 |  |
+| `a` | link | 2 | **none** | theme-ring | 4.67 | rule-loses-cascade |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 4 | yes | theme-ring | 4.24 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 3 | yes | theme-ring | 4.24 |  |
+| `a` | link-button | 1 | yes | theme-ring | 4.67 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `div.aurora-writing-actions` | other | 1 | **none** | theme-ring | 3.42 | rule-missing |
+
+### `/about/` — 55 interactive elements, 44 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.aurora-media-card` | card | 4 | yes (on descendant) | theme-ring | 3.42 |  |
+| `div.aurora-card` | card | 1 | yes | theme-ring | 3.42 |  |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a` | link | 4 | yes | theme-ring | 3.11 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.aurora-button` | link-button | 1 | yes | theme-ring | 3.11 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/speaking/` — 55 interactive elements, 44 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.aurora-media-card` | card | 4 | yes (on descendant) | theme-ring | 3.42 |  |
+| `div.aurora-card` | card | 1 | yes | theme-ring | 3.42 |  |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a` | link | 4 | yes | theme-ring | 3.11 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.aurora-button` | link-button | 1 | yes | theme-ring | 3.11 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/services/` — 48 interactive elements, 42 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a.kk-services-proof-card` | card-link | 2 | yes | theme-ring | 3.42 |  |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.kk-services-button` | link-button | 1 | yes | theme-ring | 3.42 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/work/` — 63 interactive elements, 48 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.aurora-media-card` | card | 8 | yes (on descendant) | theme-ring | 3.42 |  |
+| `div.aurora-card` | card | 1 | yes | theme-ring | 3.42 |  |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a` | link | 8 | yes | theme-ring | 3.11 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.aurora-button` | link-button | 1 | yes | theme-ring | 3.11 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/blog/` — 208 interactive elements, 108 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.aurora-writing-card` | card | 19 | yes | theme-ring | 3.42 |  |
+| `div.aurora-writing-card-body` | card | 19 | inherited from card | theme-ring | 4.76 | via `article.aurora-writing-card` |
+| `div.taxonomy-category.aurora-writing-card-category` | card | 19 | inherited from card | theme-ring | 4.76 | via `article.aurora-writing-card` |
+| `h2.aurora-writing-card-title` | card | 19 | inherited from card | theme-ring | 4.76 | via `article.aurora-writing-card` |
+| `figure.aurora-writing-card-media` | card | 18 | inherited from card | theme-ring | 4.76 | via `article.aurora-writing-card` |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a` | link | 56 | yes | theme-ring | 3.48 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 2 | yes | theme-ring | 3.44 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 12 | **none** | theme-ring | 4.67 | rule-loses-cascade |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/photography/` — 47 interactive elements, 41 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a` | link | 1 | yes | theme-ring | 3.42 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.kkx-btn` | link-button | 1 | yes | theme-ring | 3.11 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+### `/contact/` — 52 interactive elements, 45 tab stops
+
+| Element | Category | n | `:hover` | `:focus-visible` | ring contrast | note |
+|---|---|--:|---|---|--:|---|
+| `article.kk-contact-card` | card | 1 | **none** | theme-ring | 3.42 | rule-missing |
+| `section.aurora-footer-tile.aurora-footer-tile-brand` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `section.aurora-footer-tile.aurora-footer-tile-newsletter` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-projects` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-site` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-utility` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `nav.aurora-footer-tile.aurora-footer-tile-social` | card | 1 | **none** | theme-ring | 3.11 | rule-loses-cascade |
+| `a` | footer-link | 2 | yes | theme-ring | 4.24 |  |
+| `a.skip-link` | link | 1 | yes | theme-ring | 14.88 |  |
+| `a` | link | 1 | yes | theme-ring | 3.11 |  |
+| `a.kk-contact-email` | link | 1 | yes | theme-ring | 3.11 |  |
+| `a.kk-contact-button` | link-button | 2 | yes | theme-ring | 3.11 |  |
+| `a.kk-contact-button.secondary` | link-button | 2 | yes | theme-ring | 3.11 |  |
+| `a.aurora-button.aurora-button-secondary` | link-button | 2 | yes | theme-ring | 4.24 |  |
+| `a.aurora-button.aurora-button-primary` | link-button | 1 | yes | theme-ring | 4.24 |  |
+| `a` | nav-link | 30 | yes | theme-ring | 4.24 |  |
+| `a.aurora-brand` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-utility-link` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+| `a.aurora-button.aurora-button-primary.aurora-header-cta` | nav-link | 1 | yes | theme-ring | 4.67 |  |
+
+---
+
+## 9. Prioritised gap list for step 4
+
+Ranked by user impact, keyboard-affecting first. Every row is a measured finding above.
+
+| # | Priority | Element / route | Gap | Cause | What step 4 has to do |
+|---|---|---|---|---|---|
+| 1 | **Keyboard** | `.aurora-footer-tile` `:focus-within` — 6 tiles × 8 routes | Tabbing into a footer tile gives no container feedback | cascade loss to `revive-port.css:900` `background: transparent !important` | Delete the `!important` rest pin; author one cream-native tile surface with `:hover` and `:focus-within` in the primitives layer |
+| 2 | **Keyboard** | `.aurora-feed-link-grid a` `:focus-visible` background — 8 links, `/blog/` | The focus *ring* lands, but the intended focus background never does | cascade loss to `style.css:4459` + `:4490` | Same block, same fix; the two duplicate `!important` blocks both have to go |
+| 3 | **Keyboard (structural)** | Ring allowlist — site-wide | Two different ring colours (`#b53c18` / `#d94a1f`) depending on whether the element is in `revive-port.css:132`'s `:where()` list | Design accident | One ring token, one rule, no allowlist. Any element that becomes focusable later must inherit it automatically |
+| 4 | Pointer | `.aurora-footer-tile` `:hover` — 48 instances, all 8 routes | Largest hover gap on the site | cascade loss | Covered by #1 |
+| 5 | Pointer | `.aurora-feed-link-grid a` + `.aurora-writing-pagination a` — 12 instances, `/blog/` | Pagination and category links are inert to the pointer | cascade loss | Covered by #2 |
+| 6 | Pointer | `.aurora-section-head a` — 2 instances, `/` | No hover; WordPress's default link hover is defeated by base-rule specificity, **no `!important` involved** | cascade loss (specificity) | Give the component an explicit hover; coordinate with #470, which is fixing the same selector's rest contrast |
+| 7 | Reduced motion | `.aurora-media-card` — 16 instances, 3 routes | Only affordance is a transform, and reduced motion removes it | motion-only affordance | Guarantee a non-motion state change per component; make the reduced-motion block *substitute*, not subtract |
+| 8 | Pointer | `.aurora-service-card` — 3 instances, `/` | No hover rule at all | rule missing | Card primitive |
+| 9 | Pointer | `.kk-contact-card` — 1 instance, `/contact/` | No hover rule at all | rule missing | Card primitive — but land it with rebuild step 7 (Track A page-content CSS), not before |
+| 10 | Hygiene | 27 dead interaction rules | 27.6% of the interaction surface matches nothing | dead code | Delete at step 6; do not migrate |
+| — | None | `div.aurora-writing-actions` | Probe artefact, not a gap | — | No action |
+
+**The one-line brief for step 4:** the interaction layer this site needs is not mostly new rules. It is **one ring token and one hover token applied to a vocabulary of roughly six components (link, link-button, card, tile, nav-link, pill), delivered together with the deletion of the four `!important` rest-state blocks that are currently switching the existing states off.** If step 4 adds primitives without removing those blocks, 62 of the 67 measured gaps will still be there afterwards.
+
+---
+
+## 10. Does the sequencing behind step 4 still hold?
+
+**Yes, and the evidence strengthens it.** Recorded here because the task asked me to say so if I disagreed.
+
+Three reasons from the measurements:
+
+1. **92.5% of the gaps cannot be fixed by adding CSS.** They are cascade losses to `!important` on rest states. Shipping #424 as a standalone patch today would mean either adding `!important` to the state rules — the exact ratchet §1.1 of the rebuild plan shows doubled the count between 2026-07-19 and 1.4.3 — or writing longer selectors. Both are debt the rebuild then has to unwind. The rules that need deleting live in the same two blocks step 4 is already rewriting.
+2. **The primitives vocabulary is now known and it is small.** Six component shapes, all anchors or anchor-wrapping containers, zero form controls (§3). That is a concrete, measured input to `04-primitives.css` that did not exist before this audit — which is exactly what the plan predicted the audit would produce.
+3. **The urgent half is already done.** The plan's implicit worry is that keyboard users are stranded. Measured: they are not. 438/438 tab stops have a visible ring, zero unreplaced outline suppressions, zero rings below 3:1. **There is no accessibility emergency forcing #424 ahead of the rebuild.** The one keyboard-relevant defect (`:focus-within` on footer tiles, §4.5) is a cascade loss in the same block as gap #1, so it is fixed by the same edit.
+
+One caveat that is **not** an argument for resequencing but should be tracked: gap #9 (`.kk-contact-card`) lives in Track A page-content CSS and is bound to step 7, not step 4. If #424 is closed on step 4 alone, that one instance stays open. It should be listed on step 7's checklist rather than held against step 4.
+
+---
+
+## 11. Reproducing this
+
+```bash
+# 1. full capture + audit (mirrors live, ~6 min)
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+  node scripts/interaction_state_probe.js --out /tmp/probe
+
+# 2. reduced-motion comparison run for section 6
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+  node scripts/interaction_state_probe.js --out /tmp/probe-rm --skip-mirror --reduced-motion
+
+# 3. dead-class cross-check against the same mirrored corpus (PR #468's script)
+python3 scripts/css_coverage_audit.py --live-corpus /tmp/probe/mirror --min-confidence high
+
+# 4. live/repo parity, section 1.2
+curl -sS https://kriskrug.co/wp-content/themes/kk-aurora/style.css | grep -m1 -i '^Version'
+```
+
+`probe.json` carries every measurement behind every number here: per element, the rest / hover / focus computed styles, every state rule that matched it with each declaration's resolved value, and the full ordered tab-stop list per route. It is ~15 MB per run and is **not committed** — regenerate it, do not archive it (#318).
+
+**Cross-check this document against the theme itself with:**
+
+```bash
+sed -n '2700,2716p' theme/kk-aurora/style.css              # footer tile base + state
+grep -n 'aurora-footer-tile' theme/kk-aurora/assets/css/revive-port.css   # the !important pin
+sed -n '4459,4470p' theme/kk-aurora/style.css              # the cream-contrast override block
+sed -n '416,424p'  theme/kk-aurora/assets/css/bleeding-edge.css           # focus / focus-visible split
+```
+
+(Repo is 1.4.4; live line numbers cited in §4–§5 differ by up to 6 lines in `revive-port.css`. §1.2 explains why the findings are identical in both.)

--- a/scripts/interaction_state_probe.js
+++ b/scripts/interaction_state_probe.js
@@ -1,0 +1,1118 @@
+#!/usr/bin/env node
+/**
+ * interaction_state_probe.js — measured hover / focus-visible audit for kriskrug.co
+ *
+ * Answers, per route, for every interactive element actually rendered:
+ *
+ *   1. Does :hover change any visual property?          (measured, not grepped)
+ *   2. Does :focus-visible change any visual property?  (measured)
+ *   3. If focus does change something, is it the theme's ring or the browser's
+ *      UA default ring (outline-style: auto)?
+ *   4. Is a focus outline suppressed (outline: none / 0) with no replacement?
+ *      -> WCAG 2.4.7 failure candidate.
+ *   5. Where a state rule EXISTS in CSS and matches the element but the computed
+ *      style does not change, the rule is losing the cascade. That is reported
+ *      separately from "no rule at all", because they are different fixes.
+ *   6. Real keyboard tab-through: order, reachability, and visible focus at each
+ *      stop, driven by actual Tab keypresses.
+ *
+ * HOW IT WORKS
+ * ------------
+ * Chromium in this sandbox cannot reach the public internet (the agent HTTPS
+ * proxy resets browser connections), but curl can. So the script:
+ *
+ *   a) mirrors each route's live HTML with curl, plus every stylesheet and
+ *      script it links, rewriting those URLs to local relative paths;
+ *   b) serves the mirror from 127.0.0.1 so document.styleSheets is same-origin
+ *      and cssRules are readable;
+ *   c) drives real Chromium against it.
+ *
+ * Ground truth is therefore the live rendered markup + the live Jetpack Boost
+ * CSS bundle + the live theme.json global styles, not the repo's CSS files.
+ * That matters: most of this site's markup lives in the WordPress database.
+ *
+ * State forcing uses CDP `CSS.forcePseudoState`, the same mechanism DevTools'
+ * ":hov" toggles use. It is geometry independent, so occluded or off-screen
+ * elements are measured exactly like visible ones. The keyboard pass is
+ * separate and uses genuine Tab keypresses.
+ *
+ * USAGE
+ * -----
+ *   PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers \
+ *     node scripts/interaction_state_probe.js --out /tmp/probe
+ *
+ *   # re-run analysis without re-fetching
+ *   node scripts/interaction_state_probe.js --out /tmp/probe --skip-mirror
+ *
+ *   # a subset of routes
+ *   node scripts/interaction_state_probe.js --out /tmp/probe --routes / /contact/
+ *
+ * Options:
+ *   --base <url>       origin to mirror                (default https://kriskrug.co)
+ *   --routes <r...>    routes to audit                 (default: the 8 main-nav routes)
+ *   --out <dir>        output directory                (required)
+ *   --skip-mirror      reuse an existing mirror in <out>/mirror
+ *   --port <n>         local server port               (default 8731)
+ *   --viewport <wxh>   viewport                        (default 1440x900)
+ *   --max-tabs <n>     Tab keypress budget per route   (default 400)
+ *   --reduced-motion   emulate prefers-reduced-motion: reduce (default: no-preference)
+ *   --json-only        skip the markdown summary
+ *
+ * Writes <out>/probe.json (full data) and <out>/summary.md (human summary).
+ * Read-only: it never writes to WordPress and never touches theme/.
+ *
+ * REQUIREMENTS
+ * ------------
+ * Playwright (global install at /opt/node22/lib/node_modules is auto-detected)
+ * and a preinstalled Chromium. The script REFUSES to download a browser: if
+ * PLAYWRIGHT_BROWSERS_PATH is unset or Chromium is missing it fails loudly,
+ * per AURORA-STYLESHEET-REBUILD-PLAN.md section 4.6.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const { execFileSync } = require('child_process');
+
+// --------------------------------------------------------------------------
+// Playwright resolution — never download, fail loudly (rebuild plan 4.1/4.6)
+// --------------------------------------------------------------------------
+
+function loadPlaywright() {
+  const candidates = [
+    'playwright',
+    '/opt/node22/lib/node_modules/playwright',
+    '/usr/lib/node_modules/playwright',
+    '/usr/local/lib/node_modules/playwright',
+  ];
+  for (const c of candidates) {
+    try {
+      return require(c);
+    } catch (_) {
+      /* next */
+    }
+  }
+  console.error(
+    'FATAL: playwright is not resolvable. Install it globally or set NODE_PATH.\n' +
+      'Do NOT run `playwright install` — Chromium is preinstalled at /opt/pw-browsers.'
+  );
+  process.exit(2);
+}
+
+function assertBrowsersPath() {
+  const p = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (!p) {
+    console.error(
+      'FATAL: PLAYWRIGHT_BROWSERS_PATH is unset. Re-run with\n' +
+        '  PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers node scripts/interaction_state_probe.js ...\n' +
+        'Refusing to trigger a browser download.'
+    );
+    process.exit(2);
+  }
+  if (!fs.existsSync(p)) {
+    console.error(`FATAL: PLAYWRIGHT_BROWSERS_PATH=${p} does not exist.`);
+    process.exit(2);
+  }
+}
+
+// --------------------------------------------------------------------------
+// CLI
+// --------------------------------------------------------------------------
+
+const DEFAULT_ROUTES = [
+  '/',
+  '/about/',
+  '/speaking/',
+  '/services/',
+  '/work/',
+  '/blog/',
+  '/photography/',
+  '/contact/',
+];
+
+function parseArgs(argv) {
+  const out = {
+    base: 'https://kriskrug.co',
+    routes: null,
+    out: null,
+    skipMirror: false,
+    port: 8731,
+    viewport: { width: 1440, height: 900 },
+    maxTabs: 400,
+    jsonOnly: false,
+    reducedMotion: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--base') out.base = argv[++i];
+    else if (a === '--out') out.out = argv[++i];
+    else if (a === '--skip-mirror') out.skipMirror = true;
+    else if (a === '--json-only') out.jsonOnly = true;
+    else if (a === '--reduced-motion') out.reducedMotion = true;
+    else if (a === '--port') out.port = Number(argv[++i]);
+    else if (a === '--max-tabs') out.maxTabs = Number(argv[++i]);
+    else if (a === '--viewport') {
+      const [w, h] = argv[++i].split('x').map(Number);
+      out.viewport = { width: w, height: h };
+    } else if (a === '--routes') {
+      out.routes = [];
+      while (i + 1 < argv.length && !argv[i + 1].startsWith('--')) out.routes.push(argv[++i]);
+    } else if (a === '--help' || a === '-h') {
+      console.log(fs.readFileSync(__filename, 'utf8').split('*/')[0]);
+      process.exit(0);
+    } else {
+      console.error(`unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  if (!out.routes) out.routes = DEFAULT_ROUTES.slice();
+  if (!out.out) {
+    console.error('FATAL: --out <dir> is required');
+    process.exit(2);
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------
+// Phase 1 — mirror with curl (the browser has no outbound network here)
+// --------------------------------------------------------------------------
+
+function curl(url, destFile) {
+  execFileSync('curl', ['-sS', '-L', '--fail', '--max-time', '60', '-o', destFile, url], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+}
+
+function routeSlug(route) {
+  const s = route.replace(/^\/|\/$/g, '').replace(/[^a-zA-Z0-9._-]/g, '_');
+  return s === '' ? 'home' : s;
+}
+
+function mirror(opts) {
+  const mdir = path.join(opts.out, 'mirror');
+  const adir = path.join(mdir, 'assets');
+  fs.mkdirSync(adir, { recursive: true });
+
+  const assetMap = new Map(); // absolute url -> local relative path
+  let assetIdx = 0;
+
+  const fetchAsset = (url, ext) => {
+    if (assetMap.has(url)) return assetMap.get(url);
+    const name = `a${String(assetIdx++).padStart(3, '0')}${ext}`;
+    const dest = path.join(adir, name);
+    try {
+      curl(url, dest);
+    } catch (e) {
+      process.stderr.write(`  ! asset failed ${url}\n`);
+      assetMap.set(url, null);
+      return null;
+    }
+    const rel = `assets/${name}`;
+    assetMap.set(url, rel);
+    return rel;
+  };
+
+  const pages = [];
+  for (const route of opts.routes) {
+    const slug = routeSlug(route);
+    const htmlPath = path.join(mdir, `${slug}.html`);
+    const url = opts.base.replace(/\/$/, '') + route;
+    process.stderr.write(`mirroring ${url}\n`);
+    curl(url, htmlPath);
+    let html = fs.readFileSync(htmlPath, 'utf8');
+
+    // Rewrite <link rel=stylesheet href="ABS"> and <script src="ABS">
+    html = html.replace(
+      /(<link\b[^>]*\brel=['"]?stylesheet['"]?[^>]*\bhref=)(['"])(https?:\/\/[^'"]+)\2/gi,
+      (m, pre, q, u) => {
+        const rel = fetchAsset(u, '.css');
+        return rel ? `${pre}${q}${rel}${q}` : m;
+      }
+    );
+    html = html.replace(/(<script\b[^>]*\bsrc=)(['"])(https?:\/\/[^'"]+)\2/gi, (m, pre, q, u) => {
+      const rel = fetchAsset(u, '.js');
+      return rel ? `${pre}${q}${rel}${q}` : m;
+    });
+
+    fs.writeFileSync(htmlPath, html);
+    pages.push({ route, slug, file: `${slug}.html`, bytes: Buffer.byteLength(html) });
+  }
+  fs.writeFileSync(
+    path.join(mdir, '_manifest.json'),
+    JSON.stringify({ base: opts.base, capturedAt: new Date().toISOString(), pages }, null, 2)
+  );
+  return { mdir, pages };
+}
+
+// --------------------------------------------------------------------------
+// Phase 2 — local static server
+// --------------------------------------------------------------------------
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json',
+};
+
+function serve(root, port) {
+  const srv = http.createServer((req, res) => {
+    const rel = decodeURIComponent(req.url.split('?')[0]);
+    const file = path.join(root, rel === '/' ? '/home.html' : rel);
+    if (!file.startsWith(root)) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
+    fs.readFile(file, (err, data) => {
+      if (err) {
+        res.writeHead(404, { 'content-type': 'text/plain' });
+        res.end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      res.end(data);
+    });
+  });
+  return new Promise((resolve) => srv.listen(port, '127.0.0.1', () => resolve(srv)));
+}
+
+// 1x1 transparent PNG, used to satisfy image requests so layout is not a wall
+// of broken-image icons. Dimensions come from attributes/CSS, not the bytes.
+const PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+// --------------------------------------------------------------------------
+// In-page collection code (runs inside the browser)
+// --------------------------------------------------------------------------
+
+const PAGE_LIB = `
+(() => {
+  const VISUAL_PROPS = [
+    'color','background-color','background-image','background-position','background-size',
+    'border-top-color','border-right-color','border-bottom-color','border-left-color',
+    'border-top-width','border-right-width','border-bottom-width','border-left-width',
+    'border-top-style','border-radius',
+    'outline-color','outline-style','outline-width','outline-offset',
+    'box-shadow','text-decoration-line','text-decoration-color','text-decoration-thickness',
+    'text-underline-offset','opacity','transform','translate','scale','rotate','filter',
+    'letter-spacing','font-weight','text-shadow','cursor','visibility'
+  ];
+  // cursor/visibility are collected for context but never counted as an
+  // affordance on their own.
+  const NON_AFFORDANCE = new Set(['cursor','visibility']);
+
+  const INTERACTIVE_SEL = [
+    'a[href]','button','input:not([type="hidden"])','select','textarea','summary',
+    '[tabindex]','[role="button"]','[role="link"]','[role="tab"]','[role="menuitem"]',
+    '[contenteditable=""]','[contenteditable="true"]'
+  ].join(',');
+
+  // Container shapes the issue names explicitly: cards and pills. Only counted
+  // when they actually contain or are an interactive element.
+  const CONTAINER_SEL = [
+    '[class*="card"]','[class*="pill"]','[class*="chip"]','[class*="tile"]',
+    '[class*="btn"]','[class*="button"]','[class*="-item"]','[class*="tag"]'
+  ].join(',');
+
+  // WordPress-generated class shapes. These are not design classes, so an
+  // element whose entire class list is noise is a template wrapper, not a
+  // component: it must not be reported as "a card missing a hover state".
+  const WP_NOISE = /^(wp-|has-|is-|alignwide|alignfull|aligncenter|screen-reader|post-\\d|type-|status-|format-|hentry|category-|tag-|entry-|menu-item|page-|postid-)/;
+
+  const WP_NOISE_EXACT = new Set(['post','page','blog','home','archive','search','single','hentry',
+    'sticky','attachment','error404','rtl','widget','sidebar','clearfix','group','row','col','container']);
+
+  function themeClasses(el) {
+    return Array.from(el.classList).filter(c => !WP_NOISE.test(c) && !WP_NOISE_EXACT.has(c));
+  }
+
+  function signature(el) {
+    const tc = themeClasses(el);
+    return el.tagName.toLowerCase() + (tc.length ? '.' + tc.join('.') : '');
+  }
+
+  function category(el) {
+    const tag = el.tagName.toLowerCase();
+    const cls = (el.className && el.className.baseVal !== undefined ? el.className.baseVal : el.className) || '';
+    if (['input','select','textarea'].includes(tag)) return 'field';
+    if (tag === 'button' || el.getAttribute('role') === 'button') return 'button';
+    if (tag === 'summary') return 'disclosure';
+    if (tag === 'a') {
+      if (el.closest('nav, header, .wp-block-navigation')) return 'nav-link';
+      if (/btn|button|cta/i.test(cls)) return 'link-button';
+      if (/pill|chip|tag|badge/i.test(cls)) return 'pill';
+      if (/card/i.test(cls)) return 'card-link';
+      if (el.closest('footer')) return 'footer-link';
+      return 'link';
+    }
+    if (/card|tile/i.test(cls)) return 'card';
+    if (/pill|chip|tag|badge/i.test(cls)) return 'pill';
+    return 'other';
+  }
+
+  function domPath(el) {
+    const parts = [];
+    let n = el;
+    while (n && n.nodeType === 1 && parts.length < 6) {
+      let s = n.tagName.toLowerCase();
+      if (n.id) { s += '#' + n.id; parts.unshift(s); break; }
+      const tc = themeClasses(n);
+      if (tc.length) s += '.' + tc.slice(0, 3).join('.');
+      const sibs = n.parentElement ? Array.from(n.parentElement.children).filter(c => c.tagName === n.tagName) : [];
+      if (sibs.length > 1) s += ':nth-of-type(' + (sibs.indexOf(n) + 1) + ')';
+      parts.unshift(s);
+      n = n.parentElement;
+    }
+    return parts.join(' > ');
+  }
+
+  // Several Aurora components put their whole hover affordance on a generated
+  // box (".aurora-link:hover::after", ".aurora-related-row:hover::before").
+  // Reading only the element would score those as "no hover state".
+  const PE_PROPS = ['content','background-color','background-image','transform','translate',
+    'scale','opacity','width','height','border-bottom-color','color','box-shadow','inset','filter'];
+
+  function snapshot(el) {
+    const s = getComputedStyle(el);
+    const o = {};
+    for (const p of VISUAL_PROPS) o[p] = s.getPropertyValue(p);
+    for (const pe of ['::before', '::after']) {
+      const ps = getComputedStyle(el, pe);
+      for (const p of PE_PROPS) o[pe + ' ' + p] = ps.getPropertyValue(p);
+    }
+    return o;
+  }
+
+  // A hover affordance often lands on a DESCENDANT (".card:hover .title").
+  // Fingerprint the first N descendants so those are not scored as "no hover".
+  const SUBTREE_PROPS = ['color','background-color','background-image','text-decoration-line',
+    'transform','opacity','box-shadow','border-bottom-color','outline-style','filter','translate','scale'];
+  function subtreeFingerprint(el, limit) {
+    const out = [];
+    const kids = el.querySelectorAll('*');
+    const n = Math.min(kids.length, limit || 40);
+    for (let i = 0; i < n; i++) {
+      const s = getComputedStyle(kids[i]);
+      out.push(SUBTREE_PROPS.map(p => s.getPropertyValue(p)).join('|'));
+    }
+    return out;
+  }
+  function subtreeDelta(a, b) {
+    if (!a || !b) return 0;
+    let n = 0;
+    for (let i = 0; i < Math.min(a.length, b.length); i++) if (a[i] !== b[i]) n++;
+    return n;
+  }
+
+  // Resolve what a declared value WOULD compute to on this element, by applying
+  // it inline for one frame. This is how we tell "the rule is a no-op because it
+  // declares the value the element already has" from "the rule declares a
+  // different value but loses the cascade".
+  function resolveDeclared(el, prop, value) {
+    const prev = el.style.getPropertyValue(prop);
+    const prevPrio = el.style.getPropertyPriority(prop);
+    let resolved = null;
+    try {
+      el.style.setProperty(prop, value, 'important');
+      resolved = getComputedStyle(el).getPropertyValue(prop);
+    } catch (e) {
+      resolved = null;
+    }
+    el.style.removeProperty(prop);
+    if (prev) el.style.setProperty(prop, prev, prevPrio);
+    return resolved;
+  }
+
+  function diff(a, b) {
+    const d = {};
+    for (const k of Object.keys(a)) if (a[k] !== b[k]) d[k] = [a[k], b[k]];
+    return d;
+  }
+
+  function affordanceProps(d) {
+    return Object.keys(d).filter(k => !NON_AFFORDANCE.has(k));
+  }
+
+  // ---- colour helpers, for WCAG contrast on focus rings -------------------
+  function parseRGB(v) {
+    const m = String(v).match(/rgba?\\(([^)]+)\\)/);
+    if (!m) return null;
+    const p = m[1].split(/[,\\s\\/]+/).filter(Boolean).map(Number);
+    return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 };
+  }
+  function lum(c) {
+    const f = v => { v /= 255; return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4); };
+    return 0.2126 * f(c.r) + 0.7152 * f(c.g) + 0.0722 * f(c.b);
+  }
+  function contrast(c1, c2) {
+    if (!c1 || !c2) return null;
+    const l1 = lum(c1), l2 = lum(c2);
+    return Math.round(((Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)) * 100) / 100;
+  }
+  function effectiveBg(el) {
+    let n = el;
+    while (n && n.nodeType === 1) {
+      const c = parseRGB(getComputedStyle(n).backgroundColor);
+      if (c && c.a > 0.5) return c;
+      n = n.parentElement;
+    }
+    return { r: 255, g: 255, b: 255, a: 1 };
+  }
+
+  /**
+   * WCAG 1.4.11 contrast for a focus ring, measured against the colour the ring
+   * is actually drawn on.
+   *
+   * An outline with a POSITIVE offset is painted in the gap outside the border
+   * box, i.e. over the ANCESTOR's background, not the element's own. Measuring
+   * a ring around a filled button against that button's own fill produces a
+   * false failure (measured: 1.37:1 against the CTA's orange fill vs 4.67:1
+   * against the cream page it is actually drawn on). With offset <= 0 the ring
+   * overlaps the element edge, so both neighbours count and the worse wins.
+   */
+  function ringContrast(el) {
+    const cs = getComputedStyle(el);
+    if (cs.outlineStyle === 'none' || parseFloat(cs.outlineWidth) === 0) return null;
+    const ring = parseRGB(cs.outlineColor);
+    if (!ring) return null;
+    const own = effectiveBg(el);
+    const outer = el.parentElement ? effectiveBg(el.parentElement) : own;
+    const offset = parseFloat(cs.outlineOffset) || 0;
+    const vsOuter = contrast(ring, outer);
+    const vsOwn = contrast(ring, own);
+    return {
+      value: offset > 0 ? vsOuter : Math.min(vsOuter, vsOwn),
+      vsOuter, vsOwn, offset,
+      outerHex: [outer.r, outer.g, outer.b], ringColor: cs.outlineColor
+    };
+  }
+
+  // ---- which state rules in the loaded CSS target this element? -----------
+  const STATE_RE = /:(hover|focus-visible|focus-within|focus|active)\\b/;
+
+  function collectStateRules() {
+    const out = [];
+    for (let i = 0; i < document.styleSheets.length; i++) {
+      const sheet = document.styleSheets[i];
+      let rules;
+      try { rules = sheet.cssRules; } catch (e) { out.push({ inaccessible: true, href: sheet.href }); continue; }
+      const walk = (list, cond) => {
+        for (const r of list) {
+          if (r.type === CSSRule.STYLE_RULE) {
+            if (!STATE_RE.test(r.selectorText || '')) continue;
+            const decls = {};
+            for (let j = 0; j < r.style.length; j++) {
+              const p = r.style[j];
+              decls[p] = { value: r.style.getPropertyValue(p), important: r.style.getPropertyPriority(p) === 'important' };
+            }
+            out.push({
+              sheet: sheet.href ? sheet.href.split('/').pop() : ('inline#' + (sheet.ownerNode && sheet.ownerNode.id || i)),
+              selector: r.selectorText,
+              condition: cond,
+              conditionApplies: cond ? matchMedia(cond).matches : true,
+              decls
+            });
+          } else if (r.cssRules) {
+            walk(r.cssRules, r.conditionText || cond);
+          }
+        }
+      };
+      walk(rules, null);
+    }
+    return out;
+  }
+
+  /**
+   * Split a selector list on TOP-LEVEL commas only. Naive String.split(',')
+   * shreds ":where(a, button, input):focus-visible" into invalid fragments --
+   * which silently reports the theme's own global focus-ring rule as matching
+   * nothing. Same for spaces when finding the subject compound.
+   */
+  function splitTop(sel, sep) {
+    const out = [];
+    let depth = 0, cur = '';
+    for (let i = 0; i < sel.length; i++) {
+      const c = sel[i];
+      if (c === '(' || c === '[') depth++;
+      else if (c === ')' || c === ']') depth--;
+      if (depth === 0 && sep.test(c)) { out.push(cur); cur = ''; continue; }
+      cur += c;
+    }
+    out.push(cur);
+    return out.map(s => s.trim()).filter(Boolean);
+  }
+
+  function stripState(sel, state) {
+    // "a.foo:hover .bar" -> { test: "a.foo .bar", subject: 'ancestor' }
+    const res = [];
+    for (const part of splitTop(sel, /,/)) {
+      if (!part.includes(':' + state)) continue;
+      const stripped = part.replace(new RegExp(':' + state + '\\\\b', 'g'), '');
+      // ":not(:hover)" collapses to ":not()", which is invalid -- skip those.
+      if (/\\(\\s*\\)/.test(stripped)) continue;
+      // subject = self when the state pseudo sits on the LAST compound
+      const compounds = splitTop(part.replace(/\\s*([>+~])\\s*/g, ' '), /\\s/);
+      const last = compounds[compounds.length - 1] || '';
+      res.push({
+        test: stripped.trim() || '*',
+        subject: last.includes(':' + state) ? 'self' : 'ancestor',
+        raw: part
+      });
+    }
+    return res;
+  }
+
+  window.__probe = {
+    VISUAL_PROPS, INTERACTIVE_SEL, CONTAINER_SEL, SUBTREE_PROPS,
+    themeClasses, signature, category, domPath, snapshot, diff, affordanceProps,
+    subtreeFingerprint, subtreeDelta, resolveDeclared, splitTop,
+    parseRGB, contrast, effectiveBg, ringContrast, collectStateRules, stripState, STATE_RE
+  };
+})();
+`;
+
+// --------------------------------------------------------------------------
+// Per-route probe
+// --------------------------------------------------------------------------
+
+async function probeRoute(ctx, page, cdp, route, url, opts) {
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForTimeout(1200); // let inline styles + any local JS settle
+
+  // CRITICAL: the theme transitions colour (0.15s) and transform. Reading
+  // getComputedStyle immediately after forcing :hover returns the START of the
+  // transition, i.e. the rest value -- which silently scores every transitioned
+  // hover as "no hover state". Freeze all timing so computed values snap.
+  // Verified: without this, .aurora-primary-nav a:hover reads as unchanged;
+  // with it (or after a 700ms settle) it reads rgb(181,60,24).
+  await page.addStyleTag({
+    content:
+      '*, *::before, *::after { transition-duration: 0s !important; transition-delay: 0s !important; ' +
+      'animation-duration: 0.001s !important; animation-delay: 0s !important; }',
+  });
+  await page.addScriptTag({ content: PAGE_LIB });
+  await page.waitForTimeout(120);
+
+  // 1. Inventory + rest snapshots + which state rules match each element.
+  const inventory = await page.evaluate(() => {
+    const P = window.__probe;
+    const stateRules = P.collectStateRules();
+    const accessible = stateRules.filter((r) => !r.inaccessible);
+    const inaccessible = stateRules.filter((r) => r.inaccessible);
+
+    const seen = new Set();
+    const els = [];
+    const push = (el) => {
+      if (seen.has(el)) return;
+      seen.add(el);
+      els.push(el);
+    };
+    document.querySelectorAll(P.INTERACTIVE_SEL).forEach(push);
+    document.querySelectorAll(P.CONTAINER_SEL).forEach((el) => {
+      if (el.matches(P.INTERACTIVE_SEL)) return; // already counted
+      // A wrapper whose whole class list is WordPress-generated (post-1234,
+      // type-post, tag-ai, …) is a template artefact, not a designed card.
+      if (P.themeClasses(el).length === 0) return;
+      if (el.querySelector(P.INTERACTIVE_SEL)) push(el);
+    });
+
+    const items = [];
+    els.forEach((el, i) => {
+      el.setAttribute('data-probe-id', String(i));
+      const cs = getComputedStyle(el);
+      const box = el.getBoundingClientRect();
+      const rendered =
+        cs.display !== 'none' && cs.visibility !== 'hidden' && (box.width > 0 || box.height > 0);
+
+      // Which authored state rules target this element?
+      const restCS = getComputedStyle(el);
+      const matched = { hover: [], 'focus-visible': [], focus: [], 'focus-within': [], active: [] };
+      for (const r of accessible) {
+        for (const state of Object.keys(matched)) {
+          if (!new RegExp(':' + state + '\\b').test(r.selector)) continue;
+          for (const cand of P.stripState(r.selector, state)) {
+            // A rule targeting the element's ::before/::after still styles the
+            // element visually, so match on the element and remember the fact.
+            const peMatch = cand.test.match(/::[a-zA-Z-]+/);
+            const testSel = cand.test.replace(/::[a-zA-Z-]+(\\([^)]*\\))?/g, '').trim();
+            let ok = false;
+            try {
+              ok = testSel ? el.matches(testSel) : false;
+            } catch (e) {
+              ok = false;
+            }
+            if (!ok) continue;
+            // For self-subject rules, work out whether each declaration would
+            // actually change anything if it won.
+            // Skip for pseudo-element rules: the declaration applies to the
+            // generated box, so testing it on the element proves nothing.
+            const declared = {};
+            if (cand.subject === 'self' && !peMatch) {
+              for (const [p, d] of Object.entries(r.decls)) {
+                const resolved = P.resolveDeclared(el, p, d.value);
+                declared[p] = {
+                  value: d.value,
+                  important: d.important,
+                  resolved,
+                  wouldChange: resolved !== null && resolved !== restCS.getPropertyValue(p),
+                };
+              }
+            }
+            matched[state].push({
+              sheet: r.sheet,
+              selector: cand.raw,
+              subject: cand.subject,
+              condition: r.condition,
+              conditionApplies: r.conditionApplies,
+              props: Object.keys(r.decls),
+              important: Object.values(r.decls).some((d) => d.important),
+              declared,
+              pseudoElement: peMatch ? peMatch[0] : null,
+              wouldChange: Object.values(declared).some((d) => d.wouldChange),
+            });
+          }
+        }
+      }
+
+      items.push({
+        idx: i,
+        tag: el.tagName.toLowerCase(),
+        category: P.category(el),
+        signature: P.signature(el),
+        classes: P.themeClasses(el),
+        path: P.domPath(el),
+        text: (el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 60),
+        href: el.getAttribute('href') || null,
+        type: el.getAttribute('type') || null,
+        rendered,
+        inHeader: !!el.closest('header, .wp-block-template-part'),
+        inFooter: !!el.closest('footer'),
+        tabbable: el.tabIndex >= 0,
+        rest: P.snapshot(el),
+        restSubtree: P.subtreeFingerprint(el, 40),
+        bg: P.effectiveBg(el),
+        matched,
+      });
+    });
+
+    // Second pass: which probed elements are ancestors of which? A card's hover
+    // state covers everything inside it, so an inner title with no hover rule of
+    // its own is NOT a gap.
+    els.forEach((el, i) => {
+      const anc = [];
+      let n = el.parentElement;
+      while (n) {
+        const id = n.getAttribute && n.getAttribute('data-probe-id');
+        if (id !== null && id !== undefined) anc.push(Number(id));
+        n = n.parentElement;
+      }
+      items[i].ancestorIds = anc;
+    });
+
+    // Exact dead-state-rule coverage: how many elements on THIS route does each
+    // authored state rule actually match? A ":hover" rule that matches nothing
+    // is not interaction coverage, and must not be inventoried as such.
+    const ruleCoverage = accessible.map((r) => {
+      let matches = 0;
+      const states = [];
+      for (const state of ['hover', 'focus-visible', 'focus-within', 'focus', 'active']) {
+        if (!new RegExp(':' + state + '\\b').test(r.selector)) continue;
+        states.push(state);
+        for (const cand of P.stripState(r.selector, state)) {
+          // querySelectorAll cannot select a pseudo-element; strip it so that
+          // ".x:hover::after" is counted against ".x", not reported as dead.
+          const test = cand.test.replace(/::[a-zA-Z-]+(\\([^)]*\\))?/g, '').trim();
+          if (!test) continue; // e.g. "::-webkit-scrollbar-thumb:hover"
+          try {
+            matches += document.querySelectorAll(test).length;
+          } catch (e) {
+            /* unsupported selector */
+          }
+        }
+      }
+      return {
+        sheet: r.sheet,
+        selector: r.selector,
+        states,
+        condition: r.condition,
+        conditionApplies: r.conditionApplies,
+        matches,
+        props: Object.keys(r.decls),
+        important: Object.values(r.decls).some((d) => d.important),
+      };
+    });
+
+    return {
+      items,
+      ruleCoverage,
+      stateRuleCount: accessible.length,
+      inaccessibleSheets: inaccessible.map((r) => r.href),
+      sheetCount: document.styleSheets.length,
+    };
+  });
+
+  // 2. Force :hover then :focus-visible per element via CDP, exactly as
+  //    DevTools' ":hov" panel does. Geometry independent.
+  const { root } = await cdp.send('DOM.getDocument', { depth: -1 });
+  const results = [];
+  for (const item of inventory.items) {
+    let nodeId = 0;
+    try {
+      ({ nodeId } = await cdp.send('DOM.querySelector', {
+        nodeId: root.nodeId,
+        selector: `[data-probe-id="${item.idx}"]`,
+      }));
+    } catch (e) {
+      nodeId = 0;
+    }
+    const out = {
+      ...item,
+      hoverState: null,
+      focusState: null,
+      forced: nodeId !== 0,
+    };
+    if (nodeId) {
+      const read = (id) =>
+        page.evaluate((i) => {
+          const P = window.__probe;
+          const el = document.querySelector(`[data-probe-id="${i}"]`);
+          const cs = getComputedStyle(el);
+          return {
+            style: P.snapshot(el),
+            subtree: P.subtreeFingerprint(el, 40),
+            ringContrast: P.ringContrast(el),
+          };
+        }, id);
+
+      await cdp.send('CSS.forcePseudoState', { nodeId, forcedPseudoClasses: ['hover'] });
+      await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r())));
+      out.hoverState = await read(item.idx);
+      await cdp.send('CSS.forcePseudoState', {
+        nodeId,
+        forcedPseudoClasses: ['focus', 'focus-visible'],
+      });
+      await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r())));
+      out.focusState = await read(item.idx);
+      await cdp.send('CSS.forcePseudoState', { nodeId, forcedPseudoClasses: [] });
+    }
+    results.push(out);
+  }
+
+  // 3. Genuine keyboard tab-through.
+  const tabStops = await (async () => {
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.evaluate(() => document.body.focus());
+    const stops = [];
+    const seenIdx = new Set();
+    for (let i = 0; i < opts.maxTabs; i++) {
+      await page.keyboard.press('Tab');
+      await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r())));
+      const stop = await page.evaluate(() => {
+        const a = document.activeElement;
+        if (!a || a === document.body || a === document.documentElement) return null;
+        const P = window.__probe;
+        const cs = getComputedStyle(a);
+        const ring = {
+          outlineStyle: cs.outlineStyle,
+          outlineWidth: cs.outlineWidth,
+          outlineColor: cs.outlineColor,
+          outlineOffset: cs.outlineOffset,
+          boxShadow: cs.boxShadow,
+        };
+        const box = a.getBoundingClientRect();
+        return {
+          probeId: a.getAttribute('data-probe-id'),
+          tag: a.tagName.toLowerCase(),
+          signature: P.signature(a),
+          text: (a.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 40),
+          focusVisible: a.matches(':focus-visible'),
+          ring,
+          ringContrast: P.ringContrast(a),
+          uaDefaultRing: cs.outlineStyle === 'auto',
+          offscreen: box.width === 0 && box.height === 0,
+          hidden: cs.visibility === 'hidden' || cs.display === 'none',
+        };
+      });
+      if (!stop) break;
+      const key = stop.probeId !== null ? 'p' + stop.probeId : stop.signature + '|' + stop.text;
+      if (seenIdx.has(key) && stops.length > 3) break; // wrapped around
+      seenIdx.add(key);
+      stops.push({ order: stops.length + 1, ...stop });
+    }
+    return stops;
+  })();
+
+  return { route, url, ...inventory, items: results, tabStops };
+}
+
+// --------------------------------------------------------------------------
+// Classification (runs in node, on the collected data)
+// --------------------------------------------------------------------------
+
+const NON_AFFORDANCE = new Set(['cursor', 'visibility']);
+
+/**
+ * Cause taxonomy for a missing state, which is the distinction #424's fix has
+ * to act on:
+ *
+ *   rule-missing        no authored rule targets this element in this state
+ *   rule-loses-cascade  a rule targets it and WOULD change something, but the
+ *                       computed style is unchanged -> it is being outranked
+ *   rule-no-op          a rule targets it but declares the value it already has
+ *                       (e.g. hover colour == rest colour). Cosmetically this is
+ *                       identical to having no rule, but the fix is different:
+ *                       change the value, not the specificity.
+ */
+function classify(item) {
+  const diffProps = (a, b) => {
+    if (!a || !b) return [];
+    return Object.keys(a).filter((k) => a[k] !== b[k] && !NON_AFFORDANCE.has(k));
+  };
+  const subtreeDelta = (a, b) => {
+    if (!a || !b) return 0;
+    let n = 0;
+    for (let i = 0; i < Math.min(a.length, b.length); i++) if (a[i] !== b[i]) n++;
+    return n;
+  };
+
+  const hoverStyle = item.hoverState && item.hoverState.style;
+  const focusStyle = item.focusState && item.focusState.style;
+  const hoverProps = diffProps(item.rest, hoverStyle);
+  const focusProps = diffProps(item.rest, focusStyle);
+  const hoverSubtree = subtreeDelta(item.restSubtree, item.hoverState && item.hoverState.subtree);
+  const focusSubtree = subtreeDelta(item.restSubtree, item.focusState && item.focusState.subtree);
+
+  const off = (s) => s && (s['outline-style'] === 'none' || parseFloat(s['outline-width']) === 0);
+  const restOutlineOff = off(item.rest);
+  const focusOutlineOff = off(focusStyle);
+  const uaRing = focusStyle && focusStyle['outline-style'] === 'auto';
+
+  // Did anything other than the outline change on focus? (an equal-or-better
+  // replacement, per WCAG 2.4.7 / the issue's explicit criterion)
+  const focusReplacement = focusProps.filter((p) => !p.startsWith('outline'));
+
+  let focusVerdict;
+  if (!focusStyle) focusVerdict = 'unmeasured';
+  else if (focusOutlineOff && focusReplacement.length === 0 && focusSubtree === 0)
+    focusVerdict = 'none';
+  else if (focusOutlineOff) focusVerdict = 'replacement-only';
+  else if (uaRing) focusVerdict = 'ua-default-ring';
+  else focusVerdict = 'theme-ring';
+
+  let hoverVerdict;
+  if (!hoverStyle) hoverVerdict = 'unmeasured';
+  else if (hoverProps.length) hoverVerdict = 'yes';
+  else if (hoverSubtree > 0) hoverVerdict = 'yes-descendant';
+  else hoverVerdict = 'no';
+
+  const applicable = (list) =>
+    (list || []).filter((r) => r.subject === 'self' && r.conditionApplies !== false);
+  const hoverRules = applicable(item.matched && item.matched.hover);
+  const fvRules = applicable(item.matched && item.matched['focus-visible']).concat(
+    applicable(item.matched && item.matched.focus)
+  );
+
+  const cause = (verdictMissing, rules) => {
+    if (!verdictMissing) return null;
+    if (!rules.length) return 'rule-missing';
+    // A pseudo-element rule's declared value cannot be resolved on the element,
+    // so it counts as "would change" for cause purposes — the measurement of
+    // ::before/::after computed style already proved nothing actually changed.
+    return rules.some((r) => r.wouldChange || r.pseudoElement)
+      ? 'rule-loses-cascade'
+      : 'rule-no-op';
+  };
+
+  return {
+    hoverVerdict,
+    hoverProps,
+    hoverSubtree,
+    hoverCause: cause(hoverVerdict === 'no', hoverRules),
+    hoverRuleCount: hoverRules.length,
+    focusVerdict,
+    focusProps,
+    focusSubtree,
+    focusCause: cause(focusVerdict === 'none', fvRules),
+    focusRuleCount: fvRules.length,
+    focusRing:
+      focusStyle && !focusOutlineOff
+        ? `${focusStyle['outline-width']} ${focusStyle['outline-style']} ${focusStyle['outline-color']} @${focusStyle['outline-offset']}`
+        : null,
+    focusRingContrast:
+      item.focusState && item.focusState.ringContrast
+        ? item.focusState.ringContrast.value
+        : null,
+    focusRingContrastDetail: item.focusState ? item.focusState.ringContrast : null,
+    restOutlineOff,
+    focusOutlineOff,
+    uaRing,
+  };
+}
+
+/**
+ * Second pass: an element with no hover state of its own is not a gap if a
+ * probed ANCESTOR has one — hovering the card lights the card, and the title
+ * inside it is part of that affordance. Same for focus-within.
+ */
+function applyAncestorCoverage(items) {
+  const byIdx = new Map(items.map((i) => [i.idx, i]));
+  for (const i of items) {
+    if (i.verdict.hoverVerdict !== 'no') continue;
+    const provider = (i.ancestorIds || [])
+      .map((id) => byIdx.get(id))
+      .find((a) => a && (a.verdict.hoverVerdict === 'yes' || a.verdict.hoverVerdict === 'yes-descendant'));
+    if (provider) {
+      i.verdict.hoverVerdict = 'covered-by-ancestor';
+      i.verdict.hoverCoveredBy = provider.signature;
+      i.verdict.hoverCause = null;
+    }
+  }
+  return items;
+}
+
+// --------------------------------------------------------------------------
+// Reporting
+// --------------------------------------------------------------------------
+
+function summarise(data) {
+  const L = [];
+  L.push('# Interaction state probe — measured results');
+  L.push('');
+  L.push(`Captured: ${data.capturedAt}  ·  base: ${data.base}`);
+  L.push('');
+  L.push('| Route | Interactive (rendered) | hover: no | focus: none | focus: UA ring only | tab stops | stops w/o visible focus |');
+  L.push('|---|---:|---:|---:|---:|---:|---:|');
+  for (const r of data.routes) {
+    const rendered = r.items.filter((i) => i.rendered);
+    const noHover = rendered.filter((i) => i.verdict.hoverVerdict === 'no').length;
+    const noFocus = rendered.filter((i) => i.verdict.focusVerdict === 'none').length;
+    const ua = rendered.filter((i) => i.verdict.focusVerdict === 'ua-default-ring').length;
+    const badStops = r.tabStops.filter(
+      (s) => s.ring.outlineStyle === 'none' && (!s.ring.boxShadow || s.ring.boxShadow === 'none')
+    ).length;
+    L.push(
+      `| \`${r.route}\` | ${rendered.length} | ${noHover} | ${noFocus} | ${ua} | ${r.tabStops.length} | ${badStops} |`
+    );
+  }
+  L.push('');
+  for (const r of data.routes) {
+    L.push(`## \`${r.route}\``);
+    L.push('');
+    L.push('| # | Element | Category | hover | focus | cause | focus ring |');
+    L.push('|---:|---|---|---|---|---|---|');
+    const rendered = r.items.filter((i) => i.rendered);
+    const bySig = new Map();
+    for (const i of rendered) {
+      if (!bySig.has(i.signature)) bySig.set(i.signature, []);
+      bySig.get(i.signature).push(i);
+    }
+    let n = 0;
+    for (const [sig, group] of bySig) {
+      const i = group[0];
+      const v = i.verdict;
+      L.push(
+        `| ${++n} | \`${sig}\` ×${group.length} | ${i.category} | ${v.hoverVerdict} | ${v.focusVerdict} | ${
+          v.focusCause || v.hoverCause || ''
+        } | ${v.focusRing || '—'}${v.focusRingContrast ? ' (' + v.focusRingContrast + ':1)' : ''} |`
+      );
+    }
+    L.push('');
+  }
+  return L.join('\n');
+}
+
+// --------------------------------------------------------------------------
+// main
+// --------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  assertBrowsersPath();
+  const { chromium } = loadPlaywright();
+
+  fs.mkdirSync(opts.out, { recursive: true });
+  const mdir = path.join(opts.out, 'mirror');
+  if (!opts.skipMirror) {
+    mirror(opts);
+  } else if (!fs.existsSync(mdir)) {
+    console.error(`FATAL: --skip-mirror given but ${mdir} does not exist`);
+    process.exit(2);
+  }
+
+  const srv = await serve(mdir, opts.port);
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  // Default to no-preference: that is what most visitors get, and the theme's
+  // prefers-reduced-motion block explicitly cancels transform-based hover
+  // affordances (style.css:4380 `.aurora-media-card:hover img { transform: none }`
+  // and 14 siblings). Auditing under `reduce` would score those as missing
+  // hover for everyone, which is wrong. Use --reduced-motion to measure the
+  // reduced-motion experience deliberately.
+  const ctx = await browser.newContext({
+    viewport: opts.viewport,
+    reducedMotion: opts.reducedMotion ? 'reduce' : 'no-preference',
+    colorScheme: 'light',
+  });
+  // Satisfy image/font requests locally so layout is not distorted by broken
+  // images; everything else 404s from the mirror, which is fine.
+  await ctx.route('**/*', (r) => {
+    const t = r.request().resourceType();
+    if (t === 'image') return r.fulfill({ status: 200, contentType: 'image/png', body: PIXEL });
+    if (t === 'font' || t === 'media') return r.abort();
+    return r.continue();
+  });
+
+  const page = await ctx.newPage();
+  const cdp = await ctx.newCDPSession(page);
+  await cdp.send('DOM.enable');
+  await cdp.send('CSS.enable');
+
+  const routes = [];
+  for (const route of opts.routes) {
+    const slug = routeSlug(route);
+    process.stderr.write(`probing ${route}\n`);
+    const r = await probeRoute(
+      ctx,
+      page,
+      cdp,
+      route,
+      `http://127.0.0.1:${opts.port}/${slug}.html`,
+      opts
+    );
+    r.items.forEach((i) => {
+      i.verdict = classify(i);
+    });
+    applyAncestorCoverage(r.items);
+    routes.push(r);
+    process.stderr.write(
+      `  ${r.items.filter((i) => i.rendered).length} rendered interactive elements, ` +
+        `${r.tabStops.length} tab stops\n`
+    );
+  }
+
+  await browser.close();
+  srv.close();
+
+  const data = {
+    capturedAt: new Date().toISOString(),
+    base: opts.base,
+    viewport: opts.viewport,
+    routes,
+  };
+  fs.writeFileSync(path.join(opts.out, 'probe.json'), JSON.stringify(data, null, 2));
+  if (!opts.jsonOnly) fs.writeFileSync(path.join(opts.out, 'summary.md'), summarise(data) + '\n');
+  process.stderr.write(`wrote ${path.join(opts.out, 'probe.json')}\n`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('FATAL:', e && e.stack ? e.stack : e);
+    process.exit(1);
+  });
+}
+
+module.exports = { classify, applyAncestorCoverage, routeSlug, PAGE_LIB };


### PR DESCRIPTION
## Summary

The gap-inventory half of #424 — its first acceptance criterion. **No CSS changed**; implementation is deliberately deferred to #476 (primitives layer) per the merged #423 plan, which sequences it there because #424's own premise ("shared styles, not per-element patches") *is* that layer.

Measured on **live 1.4.3, logged out**, 8 main-nav routes, with a real browser and real `Tab` keypresses.

## Related Issue

Relates to #424 (audit half — implementation stays open)
Relates to #423, #476, #486

## Changes

- `docs/current-state/INTERACTION-STATES-GAP-INVENTORY.md`
- `scripts/interaction_state_probe.js` — reusable; the scripted eval #424 asks for, using CDP `CSS.forcePseudoState`

## The headline is not what the teardown assumed

KK's teardown said *"There's no hovers or interactivity on any of that shit."* The hover half is real. **The focus half is not** — focus states are in good shape:

| | |
|---|---:|
| Interactive elements audited | **604** |
| Real tab stops | **438** |
| Missing `:hover` | **67** (11.1%) |
| Missing `:focus-visible` | **0** |
| Suppressed outlines with no replacement | **0** (all three `outline: none` correctly re-covered) |
| Focus rings below WCAG 1.4.11's 3:1 | **0** (minimum 3.11:1) |

**Keyboard users are fine today.** That removes the urgency argument for doing #424 before the rebuild.

## 🔑 The load-bearing finding: 92.5% of gaps cannot be fixed by adding CSS

**5 gaps are a missing rule. 62 are a rule that loses the cascade.**

They are hover rules defeated by `!important` pins on the element's own *rest* state — introduced by the 1.4.0 cream-contrast patches. **A contrast fix silently deleted three interaction states as a side effect.**

Independently confirmed by the reviewing session: `.aurora-footer-tile:hover, .aurora-footer-tile:focus-within` **exists** at `style.css:2714–2715`. The rule is there. It just never wins. Adding more CSS makes this worse, not better — the fix is deleting `!important` blocks, which is exactly what #476/#478 do.

## Worst 5, keyboard-impacting first

1. **`.aurora-footer-tile:focus-within`** — tabbing into a footer tile gives no container feedback, all 8 routes. Killed by a `background: transparent !important` pin.
2. **`.aurora-feed-link-grid a:focus-visible` background** — 8 links on `/blog/`; the ring lands, the intended focus background never does. Same `!important` block declared **twice**.
3. **Focus ring split across two colours/thicknesses** by an accidental `:where()` allowlist — anchors get a 2px outline, 196 container elements additionally keep a box-shadow ring. Invisible today because every tab stop is an anchor; **breaks the moment a container becomes focusable.**
4. **`.aurora-footer-tile:hover`** — 48 instances, all 8 routes. Largest hover gap on the site, same cause as #1.
5. **`.aurora-media-card` loses hover entirely under `prefers-reduced-motion`** — the only affordance is a transform, and the reduced-motion block subtracts it without substituting anything. Users who ask for less motion get no hover feedback at all.

## ⚠️ One finding that must not get lost

**`.aurora-section-head a` also has a hover gap** — a pure *specificity* loss with no `!important` involved: the component's base rule outranks WordPress's default `a:hover` by one class.

This is the same selector #470 named. **#470 has been closed as not planned** because its rest-state contrast claim was wrong (it renders at 14.88:1) — but this hover finding is real and distinct, and closing #470 must not bury it. Captured here and in the inventory doc; it belongs with #476.

## Incidental: #424's form-field scope has no live consumer

**Zero `<form>`, `<input>`, `<textarea>`, `<select>`, or `<button>` elements on any main-nav route** — every button is an `<a>`. Independently confirmed: no form controls in `theme/kk-aurora/templates/` or `parts/`.

So a button primitive keyed on `button, input[type=submit]` would style nothing, and #424's form-field acceptance criterion is currently vacuous. Worth knowing before #476 designs the primitives — and relevant to #277 (whether the lightweight contact CTA is enough).

## Method — and three methodology bugs caught mid-audit

Chromium cannot reach kriskrug.co through this environment's proxy (`ERR_CONNECTION_RESET`; curl gets 200). The script mirrors each route with curl, rewrites asset URLs, and serves from `127.0.0.1` — which is also required for `cssRules` to be readable.

The agent caught and fixed three of its own bugs, each of which had produced a wrong headline:
1. **CSS transitions masking state changes** — had scored the entire primary nav as hover-less
2. **Ring contrast measured against the element's own fill** instead of the surface an offset ring is painted on — had manufactured a 1.37:1 "failure" on the primary CTA, which is actually 4.67:1
3. **Non-paren-aware selector splitting** — had reported the theme's own global focus-ring rule as dead

Given that two issues this session were filed on unverified premises (#470, and my claim to the #369 agent), that self-correction is the reason I trust these numbers.

## What I verified independently vs. took on trust

**Verified:** the cascade-loss mechanism (footer-tile hover rule exists at `style.css:2714`), `!important` rest-state pins in the footer, zero form controls in theme markup.

**Not independently re-derived:** the 604/438/67 counts, individual ratios, and specific line references — those come from the live browser probe. The script is committed, so they're reproducible rather than asserted.

## Type of Change

- [x] Documentation update
- [x] Accessibility improvement (audit only — no behaviour change)

## Testing

- [x] `make python-test` — 0 failures. Only the doc and the new script changed; no test surface touched.

## Deployment Notes

- [x] No special deployment steps required

## Sequencing — the audit agrees with #423

62 of 67 gaps need `!important` blocks **deleted**, not primitives added, and those blocks live in the code #476 rewrites. The primitives vocabulary is now measured and small: **6 component shapes**, all anchors or anchor-wrapping containers. With no keyboard emergency, doing #424's implementation now would write the interaction layer twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_