### PR TITLE
Fix: match WP media by exact filename and abort on ambiguity (#483)

### DIFF
--- a/scripts/notion-to-wp/publish_common.py
+++ b/scripts/notion-to-wp/publish_common.py
@@ -192,31 +192,101 @@ def load_captions(directory: pathlib.Path) -> dict[str, str]:
     return caps
 
 
+DEFAULT_MEDIA_EXTENSIONS: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp")
+
+
+def _split_basename(name: str) -> tuple[str, str]:
+    """('.../hero-scaled.PNG') -> ('hero-scaled', '.png'). No extension -> ('x', '')."""
+    base = name.rsplit("/", 1)[-1]
+    head, dot, ext = base.rpartition(".")
+    if not dot:
+        return base, ""
+    return head, f".{ext.lower()}"
+
+
+def select_media_match(
+    results: Any,
+    stem: str,
+    *,
+    extensions: tuple[str, ...] = DEFAULT_MEDIA_EXTENSIONS,
+) -> tuple[int, str] | None:
+    """Pick the one attachment in `results` whose filename is exactly `stem` + an
+    allowed extension. Returns (id, source_url), or None when nothing matches.
+
+    Matching rule (issue #483 — no prefix matching, ever):
+
+      * the `source_url` basename must split to (stem, ext) with ext in
+        `extensions` (case-insensitive on the extension only), OR
+      * `media_details.original_image` — WordPress's own record of the filename it
+        was handed before it produced a `-scaled` variant — must split the same way.
+
+    So `hero.png` matches an attachment served as `hero.png`, and matches a scaled
+    attachment whose `original_image` WordPress reports as `hero.png`. It does NOT
+    match `hero-2.png`, `hero-scaled.png`, `hero-thumbnail.png`, or
+    `hero-1024x768.png` — those are different files, and silently reusing one is
+    how the wrong image gets attached to a post.
+
+    Two or more DISTINCT attachment ids matching the same stem is an ambiguity the
+    caller cannot resolve safely, so it raises SystemExit rather than picking one.
+    That is the 2026-05-15 incident rule applied to media: never bind an operation
+    to a target you only half-identified.
+
+    Pure function over the REST payload so both WordPress clients in this repo can
+    share one matching rule without sharing a client.
+    """
+    allowed = tuple(ext.lower() for ext in extensions)
+    matches: dict[int, str] = {}
+    for media in results or []:
+        if not isinstance(media, dict):
+            continue
+        url = media.get("source_url") or ""
+        media_id = media.get("id")
+        if not url or media_id is None:
+            continue
+        original = (media.get("media_details") or {}).get("original_image") or ""
+        for name in (url, original):
+            if not name:
+                continue
+            head, ext = _split_basename(name)
+            if head == stem and ext in allowed:
+                matches[int(media_id)] = str(url)
+                break
+    if not matches:
+        return None
+    if len(matches) > 1:
+        listed = ", ".join(f"{mid} ({matches[mid]})" for mid in sorted(matches))
+        raise SystemExit(
+            f"[ABORT] ambiguous media match for {stem!r}: {len(matches)} attachments share "
+            f"that filename -> {listed}. Refusing to guess which one the post meant; "
+            f"delete or rename the duplicates in the media library, or pass an explicit id."
+        )
+    media_id, url = next(iter(matches.items()))
+    return media_id, url
+
+
 def find_media_by_stem(
     wp: Any,
     stem: str,
     *,
-    extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp"),
+    extensions: tuple[str, ...] = DEFAULT_MEDIA_EXTENSIONS,
 ) -> tuple[int, str] | None:
-    """Idempotent WP media lookup by basename stem (you_cant find_media logic)."""
+    """Idempotent WP media lookup by exact filename stem + extension allow-list.
+
+    Network failures return None (caller uploads instead — a duplicate upload is
+    recoverable, a wrong attachment is not). An ambiguous match raises SystemExit;
+    see select_media_match for the rule.
+    """
     try:
         result = wp.s.get(
             f"{wp.base}/wp-json/wp/v2/media",
-            params={"search": stem, "per_page": 10, "context": "edit"},
+            params={"search": stem, "per_page": 100, "context": "edit"},
             timeout=30,
         ).json()
     except Exception:
         return None
     if not isinstance(result, list):
         return None
-    for media in result:
-        base = media.get("source_url", "").rsplit("/", 1)[-1]
-        if base == f"{stem}.jpg" or base.startswith(stem):
-            return int(media["id"]), media["source_url"]
-        for ext in extensions:
-            if base == f"{stem}{ext}":
-                return int(media["id"]), media["source_url"]
-    return None
+    return select_media_match(result, stem, extensions=extensions)
 
 
 def find_or_upload_media(
@@ -228,7 +298,7 @@ def find_or_upload_media(
     write: bool,
     label: str | None = None,
     log: list[str] | None = None,
-    extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp"),
+    extensions: tuple[str, ...] = DEFAULT_MEDIA_EXTENSIONS,
 ) -> tuple[int, str]:
     """Idempotent single-file media resolve: reuse by stem, else upload.
 

--- a/scripts/notion-to-wp/publish_common.py
+++ b/scripts/notion-to-wp/publish_common.py
@@ -455,20 +455,18 @@ def resolve_category_ids(
     *,
     ids: list[int] | None = None,
     names: list[str] | None = None,
-    create_missing: bool = False,
 ) -> list[int]:
-    """Validate numeric IDs when provided; else resolve names via ensure_term_id."""
+    """Validate numeric IDs when provided; else resolve names via ensure_term_id.
+
+    Name resolution is always create-or-reuse (proximity's behaviour). There used to
+    be a `create_missing` flag whose two branches called ensure_term_id identically,
+    which read as an opt-in write guard that did not exist (issue #483). Dropped
+    rather than implemented: no caller passes names today, and a real read-only mode
+    needs a distinct resolver, not a flag on this one.
+    """
     if ids:
         return validate_term_ids(wp, "categories", ids)
-    resolved: list[int] = []
-    for name in names or []:
-        if create_missing:
-            resolved.append(ensure_term_id(wp, "categories", name))
-        else:
-            # Read-only resolve: ensure_term_id creates on miss; for names we still
-            # need create-or-reuse behavior matching proximity.
-            resolved.append(ensure_term_id(wp, "categories", name))
-    return resolved
+    return [ensure_term_id(wp, "categories", name) for name in names or []]
 
 
 def resolve_featured_media(

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -300,6 +300,11 @@ if not WRITE:
 # ---- create / update draft (idempotent by slug, never publishes) -------------
 hits = c.get("posts", params={"slug": SLUG, "status": "any", "context": "edit", "per_page": 5})
 existing = hits[0] if isinstance(hits, list) and hits else None
+# FLAG (issue #483, unresolved): this falls back to author 18 while
+# connector_config.WP_DEFAULT_AUTHOR_ID falls back to 1. One of them writes posts
+# under the wrong author whenever WP_DEFAULT_AUTHOR_ID is unset. NOT changed here --
+# which id is KK on the live site needs human confirmation against kriskrug.co, and
+# guessing would mis-attribute a post. Set WP_DEFAULT_AUTHOR_ID explicitly until then.
 author_id = int(load_env(ENV_PATH).get("WP_DEFAULT_AUTHOR_ID") or 18)
 
 if UPDATE:

--- a/scripts/notion-to-wp/publish_keep_the_machine_strange.py
+++ b/scripts/notion-to-wp/publish_keep_the_machine_strange.py
@@ -39,6 +39,7 @@ from publish_common import (  # noqa: E402
     category_id,
     parse_publish_argv,
     render_paragraph_from_markdown,
+    select_media_match,
     split_body_blocks,
     strip_frontmatter,
 )
@@ -165,15 +166,17 @@ def b_image(media_id, url, alt, caption=None, width=None, align="center"):
 
 # ---- media upload (idempotent) ----------------------------------------------
 def find_media(c, stem):
+    """Exact filename match only; ambiguity aborts. See publish_common.select_media_match.
+
+    This script talks to WPClient (scripts/common.py) rather than the connector's
+    WordPress client, so it cannot reuse find_media_by_stem — but it must not carry
+    its own matching rule, so the rule itself is shared (issue #483).
+    """
     try:
-        r = c.get("media", params={"search": stem, "per_page": 10, "context": "edit"})
+        r = c.get("media", params={"search": stem, "per_page": 100, "context": "edit"})
     except Exception:
         return None
-    for m in r or []:
-        base = m.get("source_url", "").rsplit("/", 1)[-1]
-        if base.startswith(stem):
-            return m["id"], m["source_url"]
-    return None
+    return select_media_match(r, stem)
 
 
 def upload_media(c, path, alt, mime):

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -220,7 +220,11 @@ else:
 v = wp.get_post(pid)
 vc = v["content"]["raw"]
 checks = {
-    "published": v["status"] == "publish",
+    # This script NEVER publishes (see the module docstring), so the safe outcome
+    # is status=draft. The check used to assert status=="publish", which printed
+    # "FAIL published" on every correct run and trained readers to skim past FAIL
+    # lines in a safety readback (issue #483).
+    "stays_draft": v["status"] == "draft",
     "featured_set": v.get("featured_media") == FEATURED_ID,
     "pullquotes_4": vc.count("wp:pullquote") == 8,
     "two_galleries": vc.count("wp:gallery") == 4,  # consolidated signs + AI (open+close each)

--- a/scripts/notion-to-wp/publish_you_cant_drink_data.py
+++ b/scripts/notion-to-wp/publish_you_cant_drink_data.py
@@ -133,10 +133,22 @@ def ai_sign(block, match):
 
 
 def march_photo(block, match):
-    """`![alt](photo:NNNN)` -> in-body march photo. Unknown key emits nothing."""
+    """`![alt](photo:NNNN)` -> in-body march photo. An unknown key aborts.
+
+    This used to emit nothing, which published a quietly shorter post than the one
+    in post.md: the author asked for a photo, the photo was missing from
+    photos/inbody/, and nothing said so (issue #483). Aborting surfaces it in the
+    dry-run, before any WordPress write, because the inbody/ directory is globbed
+    on both dry-run and execute.
+    """
     key = match.group(2)
     if key not in inbody_photos:
-        return None
+        raise SystemExit(
+            f"[ABORT] post.md references photo:{key} but no file in "
+            f"{STAGE / 'photos/inbody'} starts with '{key}-'. "
+            f"Known keys: {sorted(inbody_photos)}. "
+            f"Add the photo or remove the marker; do not publish a shorter post silently."
+        )
     mid, url, alt, cap = inbody_photos[key]
     align, width = INBODY_PHOTO.get(key, ("center", 660))
     return image(mid, url, alt, caption=cap, width=width, align=align)

--- a/scripts/notion-to-wp/tests/test_publish_common.py
+++ b/scripts/notion-to-wp/tests/test_publish_common.py
@@ -91,6 +91,146 @@ class PublishCommonTests(unittest.TestCase):
         self.assertTrue(flags.write)
 
 
+def _media(media_id: str | int, filename: str, *, original: str | None = None) -> dict:
+    """A media REST record as WordPress returns it."""
+    record: dict = {
+        "id": media_id,
+        "source_url": f"https://example.test/wp-content/uploads/2026/07/{filename}",
+    }
+    if original:
+        record["media_details"] = {"original_image": original}
+    return record
+
+
+class SelectMediaMatchTests(unittest.TestCase):
+    """Issue #483: prefix matching attached the wrong image and reported success."""
+
+    def test_exact_filename_matches(self):
+        self.assertEqual(
+            publish_common.select_media_match([_media(9, "hero.png")], "hero"),
+            (9, "https://example.test/wp-content/uploads/2026/07/hero.png"),
+        )
+
+    def test_scaled_variant_does_not_match_its_own_stem(self):
+        """The reported collision: uploading hero.png must not reuse hero-scaled.png."""
+        self.assertIsNone(
+            publish_common.select_media_match([_media(9, "hero-scaled.png")], "hero")
+        )
+
+    def test_dimension_variant_does_not_match(self):
+        """WordPress auto-generates -{width}x{height}; those are not the original."""
+        for variant in ("hero-1024x768.png", "hero-150x150.png", "hero-thumbnail.png"):
+            with self.subTest(variant=variant):
+                self.assertIsNone(
+                    publish_common.select_media_match([_media(9, variant)], "hero")
+                )
+
+    def test_re_export_suffix_does_not_match(self):
+        """hero-2.png is an editor's re-export, a different image entirely."""
+        self.assertIsNone(publish_common.select_media_match([_media(9, "hero-2.png")], "hero"))
+
+    def test_longer_stem_does_not_match_shorter_request(self):
+        self.assertIsNone(
+            publish_common.select_media_match([_media(9, "hero-at-city-hall.jpg")], "hero")
+        )
+
+    def test_scaled_attachment_matches_via_wordpress_original_image(self):
+        """A scaled attachment is still the same upload when WP says so itself."""
+        record = _media(9, "hero-scaled.png", original="hero.png")
+        self.assertEqual(
+            publish_common.select_media_match([record], "hero"),
+            (9, "https://example.test/wp-content/uploads/2026/07/hero-scaled.png"),
+        )
+
+    def test_original_image_still_requires_an_exact_stem(self):
+        record = _media(9, "hero-2-scaled.png", original="hero-2.png")
+        self.assertIsNone(publish_common.select_media_match([record], "hero"))
+
+    def test_extension_allow_list_is_enforced(self):
+        self.assertIsNone(
+            publish_common.select_media_match([_media(9, "hero.tiff")], "hero")
+        )
+        self.assertIsNone(
+            publish_common.select_media_match(
+                [_media(9, "hero.png")], "hero", extensions=(".jpg",)
+            )
+        )
+
+    def test_extension_match_is_case_insensitive(self):
+        self.assertEqual(
+            publish_common.select_media_match([_media(9, "hero.PNG")], "hero")[0], 9
+        )
+
+    def test_ambiguous_match_aborts_instead_of_picking_one(self):
+        records = [_media(9, "hero.png"), _media(10, "hero.png")]
+        with self.assertRaises(SystemExit) as ctx:
+            publish_common.select_media_match(records, "hero")
+        message = str(ctx.exception)
+        self.assertIn("ambiguous media match", message)
+        self.assertIn("9", message)
+        self.assertIn("10", message)
+
+    def test_ambiguity_counts_attachments_not_matching_names(self):
+        """One attachment matching by both source_url and original_image is not ambiguous."""
+        record = _media(9, "hero.png", original="hero.png")
+        self.assertEqual(publish_common.select_media_match([record], "hero")[0], 9)
+
+    def test_ambiguity_spans_the_extension_allow_list(self):
+        """hero.png and hero.jpg are different files; the publisher cannot pick."""
+        with self.assertRaises(SystemExit):
+            publish_common.select_media_match(
+                [_media(9, "hero.png"), _media(10, "hero.jpg")], "hero"
+            )
+
+    def test_malformed_records_are_skipped(self):
+        records = ["nonsense", {"id": 9}, {"source_url": "https://example.test/u/hero.png"}]
+        self.assertIsNone(publish_common.select_media_match(records, "hero"))
+
+    def test_empty_results(self):
+        self.assertIsNone(publish_common.select_media_match([], "hero"))
+        self.assertIsNone(publish_common.select_media_match(None, "hero"))
+
+
+class FindMediaByStemTests(unittest.TestCase):
+    def _wp(self, payload):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.return_value.json.return_value = payload
+        return wp
+
+    def test_scaled_collision_does_not_reuse(self):
+        wp = self._wp([_media(9, "hero-scaled.png")])
+        self.assertIsNone(publish_common.find_media_by_stem(wp, "hero"))
+
+    def test_ambiguity_propagates_out_of_the_lookup(self):
+        wp = self._wp([_media(9, "hero.png"), _media(10, "hero.png")])
+        with self.assertRaises(SystemExit):
+            publish_common.find_media_by_stem(wp, "hero")
+
+    def test_network_failure_returns_none(self):
+        wp = mock.Mock()
+        wp.base = "https://example.test"
+        wp.s.get.side_effect = RuntimeError("connection reset")
+        self.assertIsNone(publish_common.find_media_by_stem(wp, "hero"))
+
+    def test_non_list_payload_returns_none(self):
+        wp = self._wp({"code": "rest_forbidden"})
+        self.assertIsNone(publish_common.find_media_by_stem(wp, "hero"))
+
+
+class PrefixMatchRegressionGuardTests(unittest.TestCase):
+    """Both publishers must route media matching through the one shared rule (#483)."""
+
+    def test_keep_the_machine_strange_delegates_to_select_media_match(self):
+        source = (SCRIPT_DIR / "publish_keep_the_machine_strange.py").read_text()
+        self.assertIn("select_media_match", source)
+        self.assertNotIn("base.startswith(stem)", source)
+
+    def test_publish_common_has_no_stem_prefix_match(self):
+        source = (SCRIPT_DIR / "publish_common.py").read_text()
+        self.assertNotIn("startswith(stem)", source)
+
+
 class FindOrUploadMediaTests(unittest.TestCase):
     """Extracted from the copy-pasted resolve-or-upload loops (issue #254)."""
 

--- a/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
+++ b/scripts/notion-to-wp/tests/test_publisher_render_characterisation.py
@@ -334,7 +334,14 @@ class YouCantDrinkDataCharacterisationTests(unittest.TestCase):
         )
 
     def test_unknown_photo_key_emits_nothing(self):
-        """`![x](photo:9999)` with no matching upload is silently dropped."""
+        """`![x](photo:9999)` with no matching upload is silently dropped.
+
+        SUPERSEDED IN THE LIVE SCRIPT (issue #483): publish_you_cant_drink_data.py's
+        march_photo now raises SystemExit on an unknown key instead of returning
+        None. This test and the legacy/shared pair below are deliberately NOT
+        updated -- they are the frozen pre-#483 behaviour and the #254 equivalence
+        proof. Read them as history, not as the current publisher.
+        """
         out = self.render(photos_rest=[])
         self.assertNotIn("9999", "\n".join(out))
 
@@ -432,7 +439,13 @@ def shared_render_you_cant_drink(
     photos_rest: list,
     inbody_photos: dict,
 ) -> list[str]:
-    """publish_you_cant_drink_data.py, post-#254."""
+    """publish_you_cant_drink_data.py, post-#254 / pre-#483.
+
+    Frozen at the #254 shape so the equivalence proof below stays meaningful. The
+    live script's march_photo now aborts on an unknown photo key (#483) instead of
+    returning None; that one intentional divergence is covered by the script itself,
+    not here.
+    """
     def ai_sign(block, match):
         mid = int(match.group(2))
         url, alt = ai_signs[mid]


### PR DESCRIPTION
## Summary

`find_media_by_stem` used `base.startswith(stem)`, so uploading `hero.png` could silently reuse `hero-scaled.png` or `hero-2.png` — attaching the wrong image and reporting success. This is the idempotency guard for every publisher re-run, and it's the same shape as the 2026-05-15 incident: a matching heuristic that is *almost* right, silently binding an operation to a half-identified target.

## Related Issue

Fixes #483

## The subtlety that makes this more than a one-liner

**A naive exact-match fix would have broken idempotency.** WordPress serves any image large enough to trigger `-scaled` under a `source_url` of `hero-scaled.png`. Pure exact matching would never match it, so every re-run would upload again, forever.

The rule therefore has two clauses. An attachment matches stem `S` iff **either**:
1. its `source_url` basename splits to exactly `(S, ext)` with `ext` in an allow-list, **or**
2. `media_details.original_image` — *WordPress's own record of the filename it was handed* before producing the variant — splits the same way

Clause 2 restores reuse only where WP itself declares the original filename. Nothing is inferred from string shape.

| Input | Result |
|---|---|
| `hero.png`, `hero.PNG` | ✅ match (extension case-insensitive, stem exact) |
| scaled attachment, `original_image: hero.png` | ✅ match (via clause 2) |
| `hero-scaled.png` with no `original_image` | ❌ no match |
| `hero-2.png`, `hero-1024x768.png`, `hero-thumbnail.png` | ❌ no match |
| `hero-at-city-hall.jpg`, `hero.tiff` | ❌ no match |
| two distinct attachment ids matching | 🛑 **`SystemExit`**, listing every candidate id + URL |

One attachment matching via both `source_url` *and* `original_image` counts as one match, not an ambiguity.

**Returns `None` (→ caller uploads) on network failure or malformed payload.** A duplicate upload is recoverable; a wrong attachment is not. That asymmetry is the design principle throughout.

Also raised `per_page` 10 → 100 on both lookups — now that a miss costs a duplicate upload, an exact match shouldn't be lost past page one.

Implemented as a pure function `select_media_match(results, stem, *, extensions)` over the REST payload, so both WordPress clients share one rule without sharing a client. `publish_keep_the_machine_strange.py`'s local `find_media` delegates to it; the clients stay separate as scoped.

## Verified independently

The reviewing session exercised the function directly rather than trusting the report:

```
hero-scaled.png only              → None          ✓ (won't wrongly reuse)
hero.png exact                    → (2, …)        ✓
scaled w/ original_image=hero.png → (3, …)        ✓ (idempotency preserved)
hero-2.png                        → None          ✓
hero-1024x768.png                 → None          ✓
hero.png + hero.jpg               → SystemExit    ✓ (aborts, doesn't pick)
```

Also confirmed: **no `startswith(stem)` remains anywhere** in `scripts/notion-to-wp/`. The only textual references are in a source-level test asserting it can't come back.

## Attachment verification (hash/dimensions) — deliberately not added

- **Hash is impossible** — the REST API exposes no checksum, and WP re-encodes on upload, so bytes wouldn't match even for a correct reuse
- **Dimensions would be actively harmful** — the honest reuse case (clause 2, `-scaled`) has *different* dimensions from the local file by definition. A dimension check would reject exactly the matches it should accept
- **Cost** — reading local image dimensions needs Pillow; `publish_keep_the_machine_strange.py` is deliberately stdlib-only

Exact filename + `original_image` establishes provenance more directly than a lossy dimension comparison.

## Characterisation tests: no assertion changed

PR #484's equivalence proofs are intact. Two **docstrings** were updated to note they now describe pre-#483 behaviour. The `legacy_*` / `shared_*` renderers are self-contained transcriptions inside the test file, so the live script's change doesn't touch them and every equivalence test still passes untouched.

Rewriting `shared_render_you_cant_drink` to hard-fail would have destroyed #484's behaviour-preserving proof. Leaving them silently describing a script that had moved on was the real risk — so they're labelled, not relaxed.

## Also fixed (the three lower-severity items in #483)

1. **Silent block drop → hard failure.** `[alt](photo:NNNN)` with an unmatched key now raises `SystemExit` naming the missing key, the directory searched, and the known keys. Justification: the script *already* asserts `"photo:" not in content` after rendering, so "no unresolved markers" was always the intent — the silent-drop path just failed to enforce it. It costs nothing to fail loudly, since `photos/inbody/` is globbed identically on dry-run and execute, so this fires in the mandatory dry-run before any write. All six live `photo:` keys verified to still resolve.
2. **`"published"` FAIL line** → now `"stays_draft": v["status"] == "draft"`, matching a script whose docstring says it never publishes. Cosmetic, but it was training readers to ignore FAIL lines in a safety readback.
3. **Dead `create_missing`** parameter removed. Removed rather than implemented — a genuine read-only resolve needs its own resolver, not a flag on the create-or-reuse one.

## ⚠️ Flagged, not fixed — needs your confirmation

**`publish_keep_the_machine_strange.py` falls back to author ID 18 while `connector_config.WP_DEFAULT_AUTHOR_ID` is 1.** A `--execute` with the env unset writes under a different author depending on which script runs. That's a wrong-target bind of a different kind. Not changed — it needs a live readback, and guessing mis-attributes a post. A code comment now marks it and points at #483.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**439 → 459 tests, 0 failures** (publisher suite 120 → 140). Independently re-run: `Ran 140` / `Ran 248` / `Ran 3` / `68 passed`, all OK.

New coverage: the `hero.png`/`hero-scaled.png` collision specifically, `-{width}x{height}` and `-2` variants, the `original_image` alias path (and that it still requires an exact stem), extension allow-list, case-insensitive extensions, ambiguity-aborts at both the pure-function and lookup levels, malformed records, and a source-level guard asserting neither publisher regrows `startswith(stem)`.

No WordPress writes, no credential access.

## Deployment Notes

- [x] No special deployment steps required

Scripts are run manually with credentials, dry-run first. Nothing deploys from this merge.

## Residual risk, stated honestly

1. **Filename is still the only identity.** Replace the file at `hero.png` with a different image and re-run, and the publisher reuses the old attachment. Content hashing would close this; the REST API doesn't expose a checksum.
2. **Search-relevance miss → duplicate, not wrong.** `?search=` isn't a filename query; an exact match past 100 results is missed and re-uploaded. Safe direction, but re-runs aren't guaranteed idempotent on a large library.
3. **`media_details.original_image` is trusted as-is.** A plugin or migration that rewrote it would be inherited. Low likelihood, no cheap cross-check.
4. **Ambiguity aborts mid-render** — before any post write, but on `--execute` a prior image in the same run may already have uploaded. No wrong binding, just media to clean up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_