### PR TITLE
Fix: convert the writing card to the cream system and repair ink-muted (Aurora 1.4.6)

### DIFF
--- a/scripts/tests/test_aurora_css_literal_contrast.py
+++ b/scripts/tests/test_aurora_css_literal_contrast.py
@@ -25,24 +25,32 @@ A rule can be correct here and still lose to a later rule of equal
 specificity. Confirming a *live* value needs the concatenated stylesheet the
 site actually serves, matched against real markup.
 
-Known open findings from the #470 sweep, deliberately not asserted here
-because fixing them is a design decision rather than a value correction:
+Closed by #485 (theme 1.4.6), and now asserted rather than merely noted:
 
-* `.aurora-writing-card` keeps a pre-cream near-black background (`#050708`)
-  while its text uses cream-palette tokens. On the live blog index that puts
-  `--revive-ink` titles at 1.01:1 and `--aurora-ink-muted` meta at 1.00:1.
-  revive-port.css already flips `.aurora-card`, `.aurora-media-card` and
-  `.aurora-proof-grid > article` to a cream surface; this component was missed.
-  Flipping it also needs its light-on-dark borders, gradients and `::after`
-  washes redone, so it is not a one-line change.
-* `.aurora-featured-media` keeps a dark panel (`rgba(21, 24, 33, 0.76)`) for
-  the same reason; its caption resolves to 2.06:1 (see the registry entry).
+* `.aurora-writing-card` kept a pre-cream near-black background (`#050708`)
+  while its text used cream-palette tokens, putting blog-index titles at
+  1.00–1.06:1 and meta at 1.00–1.03:1. All six declaration sites were converted
+  to `--aurora-panel-solid` together with the component's borders, gradients,
+  `::after` wash and `::before` placeholder tiles. Pinned by
+  `test_writing_card_is_a_cream_surface` and
+  `test_blog_index_card_text_meets_aa_on_the_cream_card`.
+* `.aurora-featured-media`'s dark panel (`rgba(21, 24, 33, 0.76)`) is cream, so
+  the caption declaration that actually wins the cascade (revive-port.css's
+  `--revive-ink-soft`) is 7.62:1 rather than 2.06:1. The losing pre-cream
+  literal was deleted rather than retuned. Pinned by
+  `test_featured_media_caption_winner_is_legible`.
+* `--aurora-ink-muted` was rgba(23, 19, 16, 0.55) — 3.84:1 on cream — while
+  theme.json's `text-muted` (#5c5044), the value it is supposed to mirror, is
+  6.30:1. Both `:root` blocks now carry #5c5044. Pinned by
+  `test_ink_muted_matches_the_palette_entry_it_aliases`.
+
+Known open finding, deliberately not asserted here because fixing it is a
+design decision rather than a value correction:
+
 * `.aurora-work-card-num` renders on bare photography with no scrim.
-* `--aurora-ink-muted` (rgba(23, 19, 16, 0.55)) is 3.84:1 on cream, while
-  theme.json's `text-muted` (#5c5044) — the value it is supposed to mirror —
-  is 6.30:1. The CSS alias diverges from the palette it aliases.
 """
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -274,10 +282,15 @@ SURFACES = {
     # grayscaled photo. Worst case is the scrim over a pure-white photo
     # region: 0.72*(23,19,16) + 0.28*(255,255,255).
     "work-card-scrim": (88, 85, 83),
-    # .aurora-featured-media — rgba(21,24,33,.76) + a ~0.06 cream wash, over cream.
-    "media-panel": (0x53, 0x52, 0x53),
-    # .aurora-writing-card — near-black card that survived the cream port.
-    "writing-card": (0x11, 0x13, 0x13),
+    # .aurora-writing-card / .aurora-featured-media after the #485 cream port:
+    # both are flat var(--aurora-panel-solid). The card's ::after wash sits
+    # under the card body (z-index 2 vs 3), so it is part of the backdrop; at
+    # its darkest (hover, opacity .26) the surface is (227, 215, 189), which is
+    # what "writing-card-hover" measures.
+    "writing-card": (0xE6, 0xDC, 0xC2),
+    "writing-card-hover": (227, 215, 189),
+    # .aurora-writing-card ::before placeholder tile, darkest cream + a tint.
+    "writing-card-placeholder": (0xD9, 0xCD, 0xB0),
 }
 
 # (file, selector, literal) -> (surface key, floor, note)
@@ -287,24 +300,6 @@ REGISTERED_LITERALS = {
         ".aurora-check-grid li::before",
         "#fff",
     ): ("signal", AA_TEXT, "checkmark glyph on the solid signal fill"),
-    (
-        "style.css",
-        ".aurora-featured-media :where(figcaption, .wp-element-caption)",
-        "rgba(207, 199, 187, 0.72)",
-    ): (
-        "media-panel",
-        OVERRIDDEN,
-        "loses to revive-port.css `.aurora-theme :where(p, li, figcaption)` "
-        "(equal specificity, later source order), which paints the caption "
-        "--revive-ink-soft — dark ink on this rule's own dark panel, 2.06:1 "
-        "live. Needs a design call on .aurora-featured-media's surface.",
-    ),
-    (
-        "style.css",
-        ".aurora-writing-archive .aurora-writing-card-excerpt, "
-        ".aurora-writing-archive .aurora-writing-card-excerpt p",
-        "rgba(247, 247, 242, 0.66)",
-    ): ("writing-card", AA_TEXT, "excerpt on the dark writing card"),
     (
         "style.css",
         ".aurora-writing-archive .aurora-writing-archive-dek",
@@ -411,6 +406,63 @@ RESOLVED_COMPONENT_COLORS = (
     (
         "style.css",
         ".aurora-single-2026 .aurora-article-dek",
+        ("cream", "cream-2"),
+        AA_TEXT,
+    ),
+    # #485: every foreground inside the ported writing card, measured against
+    # the card surface *and* the darkest point of its ::after wash.
+    (
+        "style.css",
+        ".aurora-writing-card-title a",
+        ("writing-card", "writing-card-hover"),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-writing-card-category, .aurora-writing-card-meta",
+        ("writing-card", "writing-card-hover"),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-writing-card-meta time, .aurora-writing-card-meta span",
+        ("writing-card", "writing-card-hover"),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-writing-archive .aurora-writing-card-excerpt, "
+        ".aurora-writing-archive .aurora-writing-card-excerpt p",
+        ("writing-card", "writing-card-hover"),
+        AA_TEXT,
+    ),
+    (
+        "style.css",
+        ".aurora-writing-card-excerpt, .aurora-writing-card-excerpt p",
+        ("writing-card", "writing-card-hover"),
+        AA_TEXT,
+    ),
+    # The category pill draws its own rgba(23,19,16,.05) fill on the card.
+    (
+        "style.css",
+        ".aurora-writing-card-category a, .aurora-article-category a, .aurora-post-tags a",
+        ("writing-card", "cream", "cream-muted"),
+        AA_TEXT,
+    ),
+    # Pagination and RSS chips on the same template.
+    (
+        "style.css",
+        ".aurora-writing-pagination a, "
+        ".aurora-writing-pagination .page-numbers, "
+        ".aurora-writing-pagination .wp-block-query-pagination-previous, "
+        ".aurora-writing-pagination .wp-block-query-pagination-next",
+        ("cream-2",),
+        AA_TEXT,
+    ),
+    ("style.css", ".aurora-feed-link-grid a", ("cream-2",), AA_TEXT),
+    (
+        "style.css",
+        ".aurora-writing-pagination",
         ("cream", "cream-2"),
         AA_TEXT,
     ),
@@ -550,6 +602,151 @@ class AuroraCssLiteralContrastTests(unittest.TestCase):
         self.assertIn("aurora-section-head", front_page)
         self.assertIn("Photography", front_page)
         self.assertIn("Full index", front_page)
+
+    # -- the specific #485 regression --------------------------------------
+
+    def test_ink_muted_matches_the_palette_entry_it_aliases(self):
+        """#485: the CSS alias had drifted from theme.json's `text-muted`.
+
+        rgba(23, 19, 16, 0.55) is not #5c5044 — it is a *different colour* that
+        happens to sit in the same family, and it was 3.84:1 on cream against
+        the palette value's 6.30:1, across ~30 foreground uses.
+        """
+        palette = json.loads((THEME_DIR / "theme.json").read_text(encoding="utf-8"))
+        text_muted = next(
+            entry["color"]
+            for entry in palette["settings"]["color"]["palette"]
+            if entry["slug"] == "text-muted"
+        )
+        for token in ("--aurora-ink-muted", "--revive-ink-muted"):
+            self.assertEqual(
+                self.properties[token].lower(),
+                text_muted.lower(),
+                f"{token} must mirror theme.json text-muted ({text_muted})",
+            )
+        # ...and it has to actually clear AA on every cream surface it lands on.
+        for surface_key in ("cream", "cream-2", "cream-muted"):
+            surface = SURFACES[surface_key]
+            ratio = contrast_ratio(
+                composite(parse_color(text_muted), surface), surface
+            )
+            self.assertGreaterEqual(
+                ratio, AA_TEXT, f"text-muted on {surface_key} is {ratio:.2f}:1"
+            )
+
+    def test_writing_card_is_a_cream_surface(self):
+        """#485: no `.aurora-writing-card` rule may repaint a dark surface.
+
+        The component is declared in six places. The archive override at
+        (0,2,0) is the one that wins on /blog/, so a fix applied only to the
+        base rule would have changed nothing live — this walks every rule whose
+        selector mentions the component and fails on any dark background,
+        whichever site it came from.
+        """
+        text = (THEME_DIR / "style.css").read_text(encoding="utf-8")
+        offenders = []
+        for context, selector, body, line in iter_rules(text):
+            if "print" in context or "aurora-writing-card" not in selector:
+                continue
+            for declaration in body.split(";"):
+                match = re.match(
+                    r"\s*(background|background-color)\s*:\s*(.+)",
+                    declaration,
+                    flags=re.S,
+                )
+                if not match:
+                    continue
+                value = " ".join(match.group(2).split())
+                for literal in re.findall(
+                    r"#[0-9a-fA-F]{3,6}\b|rgba?\([^)]*\)", value
+                ):
+                    parsed = parse_color(literal)
+                    if parsed[3] < 0.5:
+                        # A translucent tint reads as a wash over whatever is
+                        # beneath it, not as the surface itself.
+                        continue
+                    if relative_luminance(parsed[:3]) < 0.18:
+                        offenders.append(
+                            f"style.css:{line} {selector} -> {literal}"
+                        )
+        self.assertEqual(
+            offenders,
+            [],
+            "dark surface(s) still painted inside the cream writing card:\n"
+            + "\n".join(f"  {entry}" for entry in offenders),
+        )
+
+    def test_blog_index_card_text_meets_aa_on_the_cream_card(self):
+        """#485 as filed: titles and meta on the blog index.
+
+        Measured against the darkest backdrop the text can get — the card
+        surface with the hover ::after wash on top of it, since that wash
+        paints below `.aurora-writing-card-body` (z-index 2 vs 3).
+        """
+        surface = SURFACES["writing-card-hover"]
+        for selector in (
+            ".aurora-writing-card-title a",
+            ".aurora-writing-card-category, .aurora-writing-card-meta",
+        ):
+            declaration = declared_color("style.css", selector)
+            self.assertIsNotNone(declaration, f"no color declared for {selector}")
+            self.assertTrue(
+                declaration.startswith("var("),
+                f"{selector} must use a semantic token, got {declaration!r}",
+            )
+            literal = resolve(declaration, self.properties)
+            ratio = contrast_ratio(composite(parse_color(literal), surface), surface)
+            self.assertGreaterEqual(
+                ratio, AA_TEXT, f"{selector} ({literal}) is {ratio:.2f}:1 on the card"
+            )
+
+    def test_blog_index_template_still_renders_the_probed_classes(self):
+        """Guard the selectors — a renamed class would silence the tests above."""
+        home = (THEME_DIR / "templates/home.html").read_text(encoding="utf-8")
+        for class_name in (
+            "aurora-writing-archive",
+            "aurora-writing-card",
+            "aurora-writing-card-title",
+            "aurora-writing-card-meta",
+            "aurora-writing-pagination",
+        ):
+            self.assertIn(class_name, home)
+
+    def test_featured_media_caption_winner_is_legible(self):
+        """#485: fix the surface, not the declaration that never paints.
+
+        `.aurora-featured-media :where(figcaption, ...)` and revive-port.css's
+        `.aurora-theme :where(p, li, figcaption)` are both (0,1,0); the later
+        file wins. So the caption's real colour is --revive-ink-soft, and the
+        only thing that can move its ratio is the panel underneath.
+        """
+        panel_rule = None
+        for _context, selector, body, _line in iter_rules(
+            (THEME_DIR / "style.css").read_text(encoding="utf-8")
+        ):
+            if " ".join(selector.split()) == ".aurora-featured-media":
+                for declaration in body.split(";"):
+                    match = re.match(r"\s*background\s*:\s*(.+)", declaration, flags=re.S)
+                    if match:
+                        panel_rule = " ".join(match.group(1).split())
+        self.assertIsNotNone(panel_rule, "no background declared for .aurora-featured-media")
+        panel = parse_color(resolve(panel_rule, self.properties))
+        self.assertEqual(panel[3], 1.0, "the featured-media panel must be opaque")
+
+        # The losing pre-cream literal must be gone, not retuned in place.
+        self.assertIsNone(
+            declared_color(
+                "style.css",
+                ".aurora-featured-media :where(figcaption, .wp-element-caption)",
+            ),
+            "this rule's color never paints; it must not declare one",
+        )
+
+        winner = resolve(self.properties["--revive-ink-soft"], self.properties)
+        ratio = contrast_ratio(composite(parse_color(winner), panel[:3]), panel[:3])
+        self.assertGreaterEqual(
+            ratio, AA_TEXT, f"featured-media caption is {ratio:.2f}:1 on its panel"
+        )
 
     # -- sanity check on the maths ----------------------------------------
 

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -10,7 +10,10 @@
   --revive-surface-2: #e6dcc2;
   --revive-ink: #171310;
   --revive-ink-soft: rgba(23, 19, 16, 0.78);
-  --revive-ink-muted: rgba(23, 19, 16, 0.55);
+  /* theme.json `text-muted`. The old rgba(23, 19, 16, 0.55) was 3.84:1 on
+     --revive-surface and 3.75:1 on --revive-surface-2; this is 6.30 / 5.73:1.
+     All uses are foregrounds (see issue #485). */
+  --revive-ink-muted: #5c5044;
   /* Decorative-only orange (rules, ribbons, borders). Never put text on it. */
   --revive-accent: #d94a1f;
   /* Text-on-cream accent: 6.06:1 on #efe6d2, 4.77:1 on the darkest cream (#d9cdb0).
@@ -40,7 +43,7 @@
   /* Remap Aurora 2026 tokens onto Revive paper */
   --aurora-ink: #171310;
   --aurora-ink-soft: rgba(23, 19, 16, 0.78);
-  --aurora-ink-muted: rgba(23, 19, 16, 0.55);
+  --aurora-ink-muted: #5c5044;
   --aurora-paper: #efe6d2;
   --aurora-signal: #9a2f14;
   --aurora-readable-accent: #9a2f14;

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.4.5');
+define('KK_AURORA_VERSION', '1.4.6');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -8,7 +8,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.5 clears the remaining pre-cream foreground colour literals and adds a regression test that requires every hardcoded foreground colour to declare the surface it renders on.
+KK Aurora is a WordPress FSE theme for Kris Krug. Version 1.4.6 finishes the 1.4.0 cream port for the blog index: the writing card, its pagination and the featured-media panel were still painting pre-cream dark surfaces under cream-era ink.
 
 Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
@@ -39,6 +39,16 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 * Rainbow accents: teal / cyan / cobalt / violet / magenta
 
 == Changelog ==
+
+= 1.4.6 =
+* a11y (#485): `.aurora-writing-card` — the blog index card — still painted the pre-cream `#050708` under cream-era ink. Titles measured 1.00–1.06:1 and meta 1.00–1.03:1, i.e. the archive listing for every post on the site was effectively blank. The card is declared in six places; all six are reconciled to `--aurora-panel-solid`. Titles are now 12.95–13.53:1 and meta 5.48–5.73:1.
+* a11y (#485): converted the card's chrome with the surface, not just its background — borders and the meta rule moved from white tints to `--aurora-line`, the `::after` wash from a white sheen to an ink wash (it paints below the card body, so it is part of the measured backdrop), the four `::before` placeholder tiles from near-black textures to darkest-cream ones, and the shadows from black to ink.
+* a11y (#485): the archive excerpt was the one rule the dark card was still serving (near-white at 7.91:1). It has specificity (0,3,1) and does not inherit revive-port's cream fix, so it was converted with the surface rather than left to invert; now 7.40–7.62:1.
+* a11y (#485): `--aurora-ink-muted` was `rgba(23, 19, 16, 0.55)` (3.84:1 on cream) while theme.json's `text-muted`, the palette entry it aliases, was raised to `#5c5044` (6.30:1) back in 1.4.4. The CSS alias never followed. Both `:root` blocks now carry `#5c5044`, which lifts roughly 30 foreground declarations across ~15 components in one change.
+* a11y (#485): `.aurora-featured-media` kept a dark panel, which put its caption at 2.06:1 — and the caption's own colour declaration always lost the cascade to revive-port.css, so retuning it could never have helped. The panel is cream and the losing literal is deleted; the declaration that actually paints is 7.62:1.
+* a11y (#485): the card's `:focus-within` outline was `rgba(229, 70, 46, 0.7)` — 2.35:1 on cream, under the 3:1 floor for a focus indicator. Now `--aurora-readable-accent` (6.06:1).
+* a11y (#485): the blog index's pagination chips, RSS category chips and dispatch band were pre-cream dark surfaces on the same template; all three are cream, and the category pill's invisible white fill and border are ink tints.
+* test: `test_aurora_css_literal_contrast.py` gains five #485 regressions — every `.aurora-writing-card` rule is walked for dark surfaces so a fix to one declaration site cannot mask the other five, the token alias is pinned to theme.json, and the featured-media caption is measured on the declaration that wins rather than the one that is written.
 
 = 1.4.5 =
 * a11y: `.aurora-inline-link:hover` was #ff735d — 2.15:1 on cream, i.e. hovering made the link less legible than its 6.06:1 resting state. Now ink (14.88:1).

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.4.5
+Version: 1.4.6
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -492,7 +492,13 @@ a {
   /* Revive 1.4.0 cream/ink baseline (see assets/css/revive-port.css) */
   --aurora-ink: #171310;
   --aurora-ink-soft: rgba(23, 19, 16, 0.78);
-  --aurora-ink-muted: rgba(23, 19, 16, 0.55);
+  /* Mirrors theme.json `text-muted` exactly. It previously aliased the palette
+     entry as rgba(23, 19, 16, 0.55), which is a *different colour*: 3.84:1 on
+     --aurora-paper, 3.75:1 on --aurora-panel-solid, 3.55:1 on the darkest cream
+     (#d9cdb0) — all below AA, across ~30 foreground uses. #5c5044 is 6.30 /
+     5.73 / 4.96:1 on those same three surfaces. Every use of this token is a
+     `color:` declaration, so the opaque value is safe. See issue #485. */
+  --aurora-ink-muted: #5c5044;
   /* Accent orange used as TEXT on cream must clear 4.5:1 against the darkest
      cream surface (muted #d9cdb0). #d94a1f only reached 2.69:1 there. */
   --aurora-readable-accent: #9a2f14;
@@ -1420,10 +1426,14 @@ a {
   width: auto !important;
 }
 
+/* Cream card. Declaration site 1 of 6 for this component — the 1.4.0 port
+   flipped .aurora-card / .aurora-media-card / .aurora-proof-grid > article and
+   missed this one, so the archive kept a #050708 surface under cream-era ink
+   (titles 1.00–1.06:1). Sites 2–6 are the .aurora-writing-archive overrides
+   below, the two breakpoint blocks, the shared category-pill rule, and the
+   reduced-motion block; all are reconciled to this surface. Issue #485. */
 .aurora-writing-card {
-  background:
-    linear-gradient(145deg, rgba(247, 247, 242, 0.055), rgba(247, 247, 242, 0.025)),
-    #050708;
+  background: var(--aurora-panel-solid);
   border: 1px solid var(--aurora-line);
   border-radius: var(--aurora-radius-card);
   display: grid;
@@ -1434,10 +1444,11 @@ a {
   transition: background-color 180ms ease, border-color 180ms ease, transform 180ms ease;
 }
 
+/* On the dark card the hover state was a lighten. On cream a lighten walks the
+   card into the page paper (--revive-surface, only 1.10:1 away), so the state
+   is carried by the accent border and the lift instead. */
 .aurora-writing-card:hover {
-  background:
-    linear-gradient(145deg, rgba(247, 247, 242, 0.075), rgba(247, 247, 242, 0.035)),
-    #050708;
+  background: var(--aurora-panel-solid);
   border-color: var(--aurora-line-strong);
   transform: translateY(-2px);
 }
@@ -1445,7 +1456,7 @@ a {
 .aurora-writing-card-media {
   aspect-ratio: 16 / 10 !important;
   background: var(--aurora-panel-solid);
-  border-bottom: 1px solid rgba(247, 247, 242, 0.08);
+  border-bottom: 1px solid var(--aurora-line);
   margin: 0;
   max-width: 100%;
   min-width: 0;
@@ -1469,9 +1480,9 @@ a {
   align-items: center;
   aspect-ratio: 16 / 10;
   background:
-    linear-gradient(135deg, rgba(229, 70, 46, 0.16), rgba(229, 70, 46, 0.16)),
+    linear-gradient(135deg, rgba(217, 74, 31, 0.18), rgba(217, 74, 31, 0.18)),
     var(--aurora-panel-solid);
-  border-bottom: 1px solid rgba(247, 247, 242, 0.08);
+  border-bottom: 1px solid var(--aurora-line);
   color: var(--aurora-ink-muted);
   content: "";
   display: flex;
@@ -1568,7 +1579,10 @@ a {
 .aurora-writing-pagination .wp-block-query-pagination-previous,
 .aurora-writing-pagination .wp-block-query-pagination-next {
   align-items: center;
-  background: rgba(9, 12, 17, 0.52);
+  /* Was rgba(9, 12, 17, 0.52) — a pre-cream dark chip. Over cream it flattens
+     to #77756e and put --aurora-ink at 4.01:1; on the card surface it is
+     13.53:1. Same blog index, same missed-port cause as the card. */
+  background: var(--aurora-panel-solid);
   border: 1px solid var(--aurora-line);
   border-radius: var(--aurora-radius-control);
   color: var(--aurora-ink);
@@ -1583,7 +1597,7 @@ a {
 
 .aurora-writing-pagination a:hover,
 .aurora-writing-pagination .page-numbers.current {
-  background: rgba(247, 247, 242, 0.06);
+  background: rgba(217, 74, 31, 0.12);
   border-color: var(--aurora-line-strong);
   color: var(--aurora-ink);
 }
@@ -1625,7 +1639,9 @@ a {
 
 .aurora-feed-link-grid a {
   align-items: center;
-  background: rgba(9, 12, 17, 0.52);
+  /* Same pre-cream dark chip as the pagination above; both live on
+     templates/home.html alongside the writing cards. */
+  background: var(--aurora-panel-solid);
   border: 1px solid var(--aurora-line);
   border-radius: var(--aurora-radius-control);
   color: var(--aurora-ink);
@@ -1640,16 +1656,19 @@ a {
 
 .aurora-feed-link-grid a:hover,
 .aurora-feed-link-grid a:focus-visible {
-  background: rgba(200, 255, 61, 0.08);
-  border-color: rgba(200, 255, 61, 0.35);
+  background: rgba(217, 74, 31, 0.12);
+  border-color: var(--aurora-line-strong);
   color: var(--aurora-ink);
 }
 
+/* The blog index's own dispatch band; it overrides the shared
+   .aurora-dispatch-band background, so converting it here is enough for
+   templates/home.html. The shared band is still pre-cream — separate issue. */
 .aurora-writing-dispatch {
   align-items: center;
   background:
-    linear-gradient(135deg, rgba(229, 70, 46, 0.04), rgba(229, 70, 46, 0.08)),
-    #07090b;
+    linear-gradient(135deg, rgba(217, 74, 31, 0.08), rgba(217, 74, 31, 0.14)),
+    var(--aurora-panel-solid);
   border: 1px solid var(--aurora-line);
   border-radius: var(--aurora-radius-card);
   display: grid;
@@ -3037,7 +3056,7 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   }
 
   .aurora-writing-archive-list.wp-block-post-template > li:first-child .aurora-writing-card-media {
-    border-bottom: 1px solid rgba(247, 247, 242, 0.08);
+    border-bottom: 1px solid var(--aurora-line);
     border-right: 0;
     height: auto;
   }
@@ -3214,7 +3233,7 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   }
 
   .aurora-writing-archive-list.wp-block-post-template > li:first-child .aurora-writing-card-media {
-    border-bottom: 1px solid rgba(247, 247, 242, 0.08);
+    border-bottom: 1px solid var(--aurora-line);
     border-right: 0;
     height: auto;
   }
@@ -3365,9 +3384,12 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   --aurora-lux-ease: cubic-bezier(0.22, 1, 0.36, 1);
   --aurora-lux-quick: 220ms var(--aurora-lux-ease);
   --aurora-lux-slow: 560ms var(--aurora-lux-ease);
-  --aurora-composition-border: rgba(232, 224, 209, 0.14);
-  --aurora-composition-border-strong: rgba(242, 180, 207, 0.28);
-  --aurora-composition-shadow: 0 18px 48px rgba(0, 0, 0, 0.2);
+  /* Consumed only by .aurora-featured-media (3 declarations). Ported to ink on
+     cream with the panel itself — the old light-on-dark values were 1.05:1
+     against the new surface. */
+  --aurora-composition-border: rgba(23, 19, 16, 0.14);
+  --aurora-composition-border-strong: rgba(217, 74, 31, 0.35);
+  --aurora-composition-shadow: 0 18px 48px rgba(23, 19, 16, 0.12);
 }
 
 .aurora-single-2026 {
@@ -3477,11 +3499,15 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   padding-left: 0.85rem;
 }
 
+/* Declaration site 6: the category pill, shared with the single-post header.
+   The white fill/border were sized for a dark card; on cream they vanish into
+   the surface (fill 1.02:1, border 1.03:1 against the card). Ink tints of the
+   same weight read correctly on cream and keep the pill's text at 12.28:1. */
 .aurora-writing-card-category a,
 .aurora-article-category a,
 .aurora-post-tags a {
-  background: rgba(247, 247, 242, 0.045);
-  border: 1px solid rgba(247, 247, 242, 0.105);
+  background: rgba(23, 19, 16, 0.05);
+  border: 1px solid var(--aurora-line);
   border-radius: 999px;
   color: var(--aurora-ink);
   display: inline-flex;
@@ -3500,8 +3526,8 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 .aurora-article-category a:focus-visible,
 .aurora-post-tags a:hover,
 .aurora-post-tags a:focus-visible {
-  background: rgba(229, 70, 46, 0.075);
-  border-color: rgba(229, 70, 46, 0.34);
+  background: rgba(217, 74, 31, 0.1);
+  border-color: var(--aurora-line-strong);
   color: var(--wp--preset--color--signal);
 }
 
@@ -3519,10 +3545,15 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   outline-offset: 3px !important;
 }
 
+/* Was rgba(21, 24, 33, 0.76) over cream — flattens to ~#535253. That is the
+   surface the caption below renders on, and revive-port.css wins the caption
+   with --revive-ink-soft, giving 2.06:1. Retuning the caption cannot fix that
+   (the losing declaration is never painted); deciding this surface can. Cream
+   here matches every other ported panel (.aurora-card, .aurora-media-card,
+   .aurora-proof-grid > article, .aurora-writing-card) and puts the winning
+   caption declaration at 7.62:1. Issue #485. */
 .aurora-featured-media {
-  background:
-    linear-gradient(180deg, rgba(232, 224, 209, 0.06), rgba(232, 224, 209, 0.018)),
-    rgba(21, 24, 33, 0.76);
+  background: var(--aurora-panel-solid);
   border: 1px solid var(--aurora-composition-border);
   border-radius: var(--aurora-radius-card);
   box-shadow: var(--aurora-composition-shadow);
@@ -3545,14 +3576,12 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   width: 100%;
 }
 
+/* The pre-cream `color: rgba(207, 199, 187, 0.72)` is gone rather than retuned.
+   It never painted: revive-port.css's `.aurora-theme :where(p, li, figcaption)`
+   has equal specificity (0,1,0) and loads later, so it always won. With the
+   panel above now cream, the declaration that does win (--revive-ink-soft) is
+   7.62:1 instead of 2.06:1, and this rule keeps only its typography. */
 .aurora-featured-media :where(figcaption, .wp-element-caption) {
-  /* DEAD DECLARATION — do not "fix" this value in place. revive-port.css's
-     `.aurora-theme :where(p, li, figcaption)` has equal specificity (0,1,0)
-     and loads later, so it wins and paints this caption --revive-ink-soft:
-     dark ink on this rule's own dark panel, 2.06:1 live. The fix is to decide
-     .aurora-featured-media's surface (it is a pre-cream literal), not to
-     retune the caption. See the #470 sweep notes. */
-  color: rgba(207, 199, 187, 0.72);
   font-size: 0.86rem;
   line-height: 1.45;
   margin: 0.6rem auto 0;
@@ -3567,7 +3596,7 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 }
 
 .aurora-writing-archive .aurora-writing-archive-header {
-  border-bottom: 1px solid rgba(247, 247, 242, 0.09);
+  border-bottom: 1px solid var(--aurora-line);
   gap: 1rem 1.4rem;
   margin-bottom: 1.05rem;
   padding-bottom: 1.2rem;
@@ -3589,12 +3618,13 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   gap: 14px;
 }
 
+/* Declaration site 2: the archive override. This is the rule that actually
+   wins on templates/home.html (0,2,0 beats the base 0,1,0), so fixing only the
+   base rule would have changed nothing on the live blog index. */
 .aurora-writing-archive .aurora-writing-card {
-  background:
-    linear-gradient(150deg, rgba(247, 247, 242, 0.048), rgba(247, 247, 242, 0.018)),
-    #050708;
-  border-color: rgba(247, 247, 242, 0.095);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  background: var(--aurora-panel-solid);
+  border-color: var(--aurora-line);
+  box-shadow: 0 10px 30px rgba(23, 19, 16, 0.1);
   isolation: isolate;
   position: relative;
   transition:
@@ -3604,10 +3634,15 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
     transform var(--aurora-lux-quick);
 }
 
+/* The wash sits at z-index 2 under the body (z-index 3), so it is part of the
+   backdrop the title and meta are measured against — it is not decoration that
+   can be ignored. On the dark card it was a white sheen (a lift); on cream the
+   equivalent depth cue is an ink wash. Measured with the wash included:
+   title 12.95:1, meta 5.48:1, excerpt 7.40:1 at the hover opacity of 0.26. */
 .aurora-writing-archive .aurora-writing-card::after {
   background:
-    radial-gradient(circle at 18% 0%, rgba(229, 70, 46, 0.035), transparent 34%),
-    linear-gradient(118deg, rgba(247, 247, 242, 0.045), transparent 34%);
+    radial-gradient(circle at 18% 0%, rgba(217, 74, 31, 0.06), transparent 34%),
+    linear-gradient(118deg, rgba(23, 19, 16, 0.05), transparent 34%);
   content: "";
   inset: 0;
   opacity: 0.14;
@@ -3619,8 +3654,8 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
 
 .aurora-writing-archive .aurora-writing-card:hover,
 .aurora-writing-archive .aurora-writing-card:focus-within {
-  border-color: rgba(247, 247, 242, 0.18);
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.24);
+  border-color: var(--aurora-line-strong);
+  box-shadow: 0 16px 38px rgba(23, 19, 16, 0.16);
   transform: translateY(-1px);
 }
 
@@ -3629,8 +3664,11 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   opacity: 0.26;
 }
 
+/* rgba(229, 70, 46, 0.7) flattened to 2.35:1 on cream — below the 3:1 SC 1.4.11
+   floor for a focus indicator. --aurora-readable-accent is 6.06:1 on the page
+   paper and 5.51:1 on the card, and matches the theme's other focus rings. */
 .aurora-writing-card:focus-within {
-  outline: 2px solid rgba(229, 70, 46, 0.7);
+  outline: 2px solid var(--aurora-readable-accent);
   outline-offset: 3px;
 }
 
@@ -3646,15 +3684,20 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   line-height: 1.14;
 }
 
+/* The one rule on this card that the dark surface was still serving: near-white
+   at 7.91:1 on #050708. It has specificity (0,3,1) and so beats revive-port's
+   `.aurora-theme :where(p, li, figcaption)` at (0,1,0) — it does not inherit
+   the cream fix, it has to be converted with the surface or it inverts from
+   legible to invisible. --aurora-ink-soft is 7.40–7.62:1 on the cream card. */
 .aurora-writing-archive .aurora-writing-card-excerpt,
 .aurora-writing-archive .aurora-writing-card-excerpt p {
-  color: rgba(247, 247, 242, 0.66);
+  color: var(--aurora-ink-soft);
   font-size: var(--aurora-card-body-size);
   line-height: 1.6;
 }
 
 .aurora-writing-archive .aurora-writing-card-meta {
-  border-top: 1px solid rgba(247, 247, 242, 0.07);
+  border-top: 1px solid var(--aurora-line);
   padding-top: 0.62rem;
 }
 
@@ -3691,43 +3734,48 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   transform: scale(1.018);
 }
 
+/* Placeholder tile for posts with no featured image. Purely decorative
+   (content: ""), but it is a 16:10 block at the top of every such card, so it
+   has to be cream or the card reads as half-ported. Base moves from near-black
+   to the palette's darkest cream (theme.json `muted` #d9cdb0) so the tile still
+   separates from the #e6dcc2 card, and the white hairline grid flips to ink. */
 .aurora-writing-archive .aurora-writing-card:not(:has(.aurora-writing-card-media))::before {
   aspect-ratio: 16 / 10;
   background:
-    radial-gradient(circle at 18% 20%, rgba(229, 70, 46, 0.18), transparent 18%),
-    radial-gradient(circle at 78% 78%, rgba(229, 70, 46, 0.04), transparent 22%),
-    linear-gradient(135deg, rgba(247, 247, 242, 0.12) 0 1px, transparent 1px 18px),
-    linear-gradient(145deg, rgba(14, 21, 22, 0.98), rgba(5, 7, 8, 0.98) 58%, rgba(20, 14, 11, 0.96));
+    radial-gradient(circle at 18% 20%, rgba(217, 74, 31, 0.2), transparent 18%),
+    radial-gradient(circle at 78% 78%, rgba(217, 74, 31, 0.06), transparent 22%),
+    linear-gradient(135deg, rgba(23, 19, 16, 0.1) 0 1px, transparent 1px 18px),
+    linear-gradient(145deg, #ded2b8, #d9cdb0 58%, #d8c9ae);
   background-size: auto, auto, 18px 18px, auto;
-  border-bottom-color: rgba(247, 247, 242, 0.075);
+  border-bottom-color: var(--aurora-line);
   content: "";
   display: block;
 }
 
 .aurora-writing-archive-list.wp-block-post-template > li:nth-child(3n + 2) .aurora-writing-card:not(:has(.aurora-writing-card-media))::before {
   background:
-    radial-gradient(circle at 72% 22%, rgba(200, 255, 61, 0.13), transparent 18%),
-    radial-gradient(circle at 20% 82%, rgba(229, 70, 46, 0.04), transparent 22%),
-    linear-gradient(0deg, rgba(247, 247, 242, 0.085) 0 1px, transparent 1px 17px),
-    linear-gradient(150deg, rgba(12, 19, 15, 0.98), rgba(5, 7, 8, 0.98) 62%, rgba(8, 17, 18, 0.96));
+    radial-gradient(circle at 72% 22%, rgba(232, 181, 58, 0.26), transparent 18%),
+    radial-gradient(circle at 20% 82%, rgba(217, 74, 31, 0.06), transparent 22%),
+    linear-gradient(0deg, rgba(23, 19, 16, 0.09) 0 1px, transparent 1px 17px),
+    linear-gradient(150deg, #dcd3b4, #d9cdb0 62%, #d5ceb4);
   background-size: auto, auto, 17px 17px, auto;
 }
 
 .aurora-writing-archive-list.wp-block-post-template > li:nth-child(3n + 3) .aurora-writing-card:not(:has(.aurora-writing-card-media))::before {
   background:
-    radial-gradient(circle at 24% 74%, rgba(240, 179, 90, 0.17), transparent 20%),
-    radial-gradient(circle at 82% 26%, rgba(229, 70, 46, 0.04), transparent 22%),
-    linear-gradient(35deg, rgba(247, 247, 242, 0.1) 0 1px, transparent 1px 20px),
-    linear-gradient(140deg, rgba(19, 14, 12, 0.98), rgba(5, 7, 8, 0.98) 58%, rgba(12, 13, 21, 0.96));
+    radial-gradient(circle at 24% 74%, rgba(214, 51, 122, 0.16), transparent 20%),
+    radial-gradient(circle at 82% 26%, rgba(217, 74, 31, 0.06), transparent 22%),
+    linear-gradient(35deg, rgba(23, 19, 16, 0.1) 0 1px, transparent 1px 20px),
+    linear-gradient(140deg, #ded0ae, #d9cdb0 58%, #d5cdb8);
   background-size: auto, auto, 20px 20px, auto;
 }
 
 .aurora-writing-archive-list.wp-block-post-template > li:nth-child(4n) .aurora-writing-card:not(:has(.aurora-writing-card-media))::before {
   background:
-    radial-gradient(circle at 70% 72%, rgba(154, 163, 165, 0.17), transparent 20%),
-    radial-gradient(circle at 24% 20%, rgba(0, 191, 165, 0.14), transparent 22%),
-    linear-gradient(90deg, rgba(247, 247, 242, 0.08) 0 1px, transparent 1px 16px),
-    linear-gradient(145deg, rgba(13, 16, 17, 0.98), rgba(5, 7, 8, 0.98) 58%, rgba(10, 18, 16, 0.96));
+    radial-gradient(circle at 70% 72%, rgba(57, 168, 216, 0.2), transparent 20%),
+    radial-gradient(circle at 24% 20%, rgba(31, 138, 134, 0.16), transparent 22%),
+    linear-gradient(90deg, rgba(23, 19, 16, 0.08) 0 1px, transparent 1px 16px),
+    linear-gradient(145deg, #d9d0b6, #d9cdb0 58%, #d3cfb6);
   background-size: auto, auto, 16px 16px, auto;
 }
 


### PR DESCRIPTION
## Summary

Blog index post titles were rendering at **1.00–1.06:1** — invisible. `.aurora-writing-card` kept its pre-cream `#050708` surface while its text moved to cream-era tokens. Fixed across all six declaration sites, plus the token drift that was the shared root cause.

Ships as Aurora **1.4.6**.

## Related Issue

Fixes #485
Relates to #464, #470, #423

## 🔑 The root cause was a token that never followed its own fix

**`--aurora-ink-muted` was `rgba(23, 19, 16, 0.55)`, not `#5c5044`.** Those are different colours.

Traced: the rgba arrived with `819f182` (the 1.4.0 cream port). `theme.json`'s `text-muted` was raised to `#5c5044` in `a14446e` — the 1.4.4 a11y fix — **and the CSS alias never followed.** So `theme.json` said one thing and every component read another.

Verified independently:

```
main:  style.css:495 + revive-port.css:43   --aurora-ink-muted: rgba(23,19,16,0.55)
       theme.json  text-muted: #5c5044
after: both files                            --aurora-ink-muted: #5c5044

rgba(23,19,16,.55) composited over cream #efe6d2 → #727267 = 3.84:1   ❌
#5c5044 on cream                                            = 6.30:1   ✅
```

All 30 uses are `color:` declarations — zero borders or backgrounds — so the opaque value is safe. The identical `--revive-ink-muted` (5 uses, all foregrounds) is fixed too. **This one change lifts ~15 components**, which is why it was worth finding before patching individual rules.

## All six declaration sites reconciled

The issue's line numbers were stale. Actual sites in `style.css`:

| # | Lines | Declares | Action |
|---|---|---|---|
| 1 | 1423–1559 | base: bg, hover, media, `::before`, body, category/meta, title, excerpt | bg + hover → `--aurora-panel-solid`; 2 white borders → `--aurora-line` |
| 2 | 3592–3732 | `.aurora-writing-archive` overrides | **full conversion — this is the site that wins live** |
| 3 | 3030–3045 | `min-width` breakpoint | white border → `--aurora-line` |
| 4 | 3211–3232 | `max-width` breakpoint | white border → `--aurora-line` |
| 5 | 2012–2022 | `a:focus-visible` / `a:active` | already resolves to `#9a2f14`, 5.51:1 on the new card |
| 6 | 3480–3514 | shared category pill | white fill + border → ink tint + `--aurora-line` |

**Site 2 at `(0,2,0)` beats site 1 at `(0,1,0)`**, and `templates/home.html` carries the `.aurora-writing-archive` wrapper — so a fix applied only to the first site would have changed **nothing** on the live blog index. That's the trap this issue was built around, and it was avoided by resolving the cascade rather than reading declarations.

`revive-port.css` contains **zero** `.aurora-writing-card` rules, confirming the premise. Cross-checked against `INTERACTION-STATES-GAP-INVENTORY.md` (PR #487), which independently recorded the archive override as *"does match on /blog/ — redundant, not dead."*

## Before → after

Backdrop is the card background **plus its `::after` wash** — the wash sits at `z-index: 2` and the body at `z-index: 3`, so it paints *under* the text and is part of the measured surface. Ratios use its darkest point (hover, opacity `.26`).

| | Before | After |
|---|---|---|
| Title `--aurora-ink` | **1.00–1.06:1** | **12.95–13.53:1** |
| Meta `--aurora-ink-muted` | **1.00–1.03:1** | **5.48–5.73:1** |
| Excerpt | 7.91:1 *(near-white on dark)* | **7.40–7.62:1** |
| Card border | 1.28:1 | `--aurora-line` |
| Hover border | 1.69:1 | `--aurora-line-strong` |
| `focus-within` outline | **2.35:1** (under SC 1.4.11's 3:1) | **6.06:1** |

**The excerpt was the second trap.** At `(0,3,1)` it beats revive-port's `.aurora-theme :where(p,li,figcaption)` at `(0,1,0)`, so it does *not* inherit the cream fix. It was the one rule the dark surface was still serving correctly — converting the background alone would have flipped it from 7.91:1 to invisible.

Final numbers are read back out of the committed CSS by the test module, not transcribed from notes.

## Also fixed on the same template

Same missed-port cause: pagination chips (4.01:1 → 13.53:1), RSS category chips, the dispatch band, the archive header rule, and the category pill's white fill/border (1.02:1 and 1.03:1 against the card — invisible chrome). Shipping a cream card between three black bands would have been a half-fix of the page.

**`.aurora-featured-media` caption, 2.06:1 → 7.62:1.** A previous attempt retuned the caption and correctly reverted when it lost the cascade. The file's own comment said *"the fix is to decide `.aurora-featured-media`'s surface."* Decided: cream, matching every other ported panel. The dead literal was deleted rather than retuned.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement

## Testing

- [x] `make python-test` — **439 → 444 tests, 0 failures**, independently re-run
- [x] `make php-syntax` — 39/39
- [x] `docs_truth_check` — passes
- [x] The literal-contrast suite from #486 was **added to, not weakened**

**Mutation-verified, not just green.** The reviewing session restored `#050708` at a single site and confirmed the suite fails. `test_writing_card_is_a_cream_surface` walks *every* rule mentioning the component rather than checking one selector — precisely the shape that let the original port miss five of six sites.

Also verified: the only `#050708` strings left in `style.css` are inside explanatory comments and two unrelated dark bands (`.aurora-stage-strip`, `.aurora-feature-band-dark`).

## ⚠️ For KK before deploy

1. **`.aurora-featured-media` is the one visible change beyond the blog index.** It's the mat around the featured image on **every single post** — previously a dark frame, now cream. Correct for a11y and consistent with every other ported panel, but it changes the article header sitewide. Worth an eyeball.
2. **Card borders are 1.33:1** (`--aurora-line`). Below SC 1.4.11's 3:1, but identical to the shipped `.aurora-card` / `.aurora-media-card` hairline. Matched the system rather than inventing a stronger border for one component — if that's wrong it's a system-wide decision, not a #485 one.
3. **`.aurora-work-card-num` left unfixed, deliberately.** It renders on user-supplied photography with no scrim, so no colour value fixes it — it needs a scrim, an opaque chip, or `aria-hidden`. A design call, not a value correction. Registered under the `NOT_STATIC` sentinel.
4. **`.aurora-dispatch-band` (`#07090b`) is still pre-cream** on other templates. `/blog/` is clean because the archive override shadows it. Worth its own issue.

## Deployment Notes

- [x] Requires cache clearing (after deploy)

Repo is now **1.4.6**; live is **1.4.3**. Three versions of a11y fixes pending the same manual `make aurora-package` upload. Per AGENTS.md, read back rather than assume the gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_