### PR TITLE
Feat: visual-regression baseline harness for logged-out key routes (#473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,19 @@ docs/current-state/reports/**/*.png
 docs/current-state/reports/**/*.html
 docs/current-state/reports/**/*.csv
 
+# Visual-regression harness artifacts (#473, storage rule from #318).
+# Deny-by-default: the whole artifact root is ignored one level down, so git
+# never descends into a run directory and its PNGs, curl cache and generated
+# drivers cannot be added even by `git add -A`. Only the hash manifests, diff
+# results and markdown reports at the top level are re-included by name — those
+# are the committed evidence. `scripts/visual_baseline.py guard` re-asserts this
+# against the index after every capture and diff.
+docs/current-state/reports/visual-baseline/*
+!docs/current-state/reports/visual-baseline/manifest-*.json
+!docs/current-state/reports/visual-baseline/diff-*.json
+!docs/current-state/reports/visual-baseline/report-*.md
+!docs/current-state/reports/visual-baseline/README.md
+
 # QA / deploy visual captures under backup/ — same policy as reports/ above (#318, #369).
 # Keep the .md handoffs and .json metrics that carry the audit trail; ignore the raw PNGs.
 # Visual-regression evidence belongs in a hash manifest, not committed screenshots.

--- a/Makefile
+++ b/Makefile
@@ -348,3 +348,55 @@ css-inventory-freeze: ## Re-record .css-budget.json. Raising a number needs WAIV
 
 css-coverage: ## Live-route CSS coverage (read-only GETs against kriskrug.co). RECORD=1 saves it
 	@$(PYTHON) scripts/css_inventory.py --coverage $(if $(LIVE_CORPUS),--live-corpus $(LIVE_CORPUS),--fetch-routes) $(if $(RECORD),--record,)
+
+# --- #473 visual regression ---
+# Visual-regression baseline harness (AURORA-STYLESHEET-REBUILD-PLAN.md §4).
+# This is the gate for the Aurora stylesheet rebuild (#423): no rebuild step
+# lands without a green `make visual-diff` against a frozen baseline.
+#
+# Chromium is preinstalled; the harness refuses to download one. Override
+# PLAYWRIGHT_BROWSERS_PATH if your install lives elsewhere — do NOT run
+# `playwright install`.
+#
+# PNGs are NEVER committed. `docs/current-state/reports/visual-baseline/*` is
+# git-ignored; only the manifest/diff JSON and markdown reports are tracked.
+# Every target below ends by re-asserting that against the git index.
+#
+# A second .PHONY declaration keeps this block self-contained so it can be
+# appended or removed without touching the list at the top of the file.
+.PHONY: visual-preflight visual-baseline visual-diff visual-diff-report visual-guard visual-list visual-prune
+
+PLAYWRIGHT_BROWSERS_PATH ?= /opt/pw-browsers
+export PLAYWRIGHT_BROWSERS_PATH
+VISUAL := python3 scripts/visual_baseline.py
+
+visual-preflight: ## Check Chromium, the 11 routes and the no-PNG storage guard
+	@$(VISUAL) preflight $(if $(ROUTES),--routes $(ROUTES),)
+
+visual-baseline: ## Freeze a visual baseline (11 routes x 3 viewports); writes a hash manifest, never PNGs
+	@$(VISUAL) capture \
+		$(if $(ROUTES),--routes $(ROUTES),) \
+		$(if $(VIEWPORTS),--viewports $(VIEWPORTS),) \
+		$(if $(SCALE),--scale $(SCALE),) \
+		$(if $(EXPECT_THEME),--expect-theme-version $(EXPECT_THEME),) \
+		$(if $(BASE_URL),--base $(BASE_URL),)
+
+visual-diff: ## Capture a candidate and compare against a baseline. Usage: make visual-diff BASE=<run-id>
+	@$(VISUAL) diff \
+		$(if $(BASE),--base-run $(BASE),) \
+		$(if $(ROUTES),--routes $(ROUTES),) \
+		$(if $(VIEWPORTS),--viewports $(VIEWPORTS),) \
+		$(if $(STRICT),--strict,) \
+		$(if $(BASE_URL),--base $(BASE_URL),)
+
+visual-diff-report: ## Markdown summary of a diff for the PR body. Usage: make visual-diff-report DIFF=<run-id>
+	@$(VISUAL) report $(if $(DIFF),--diff-run $(DIFF),) $(if $(OUT),--out $(OUT),)
+
+visual-guard: ## Fail if any visual-regression binary is tracked or staged (#318)
+	@$(VISUAL) guard
+
+visual-list: ## List baseline manifests and which still have images on disk
+	@$(VISUAL) list
+
+visual-prune: ## Delete old capture directories, keeping the newest KEEP (default 2)
+	@$(VISUAL) prune $(if $(KEEP),--keep $(KEEP),)

--- a/docs/current-state/AURORA-VISUAL-BASELINE-RUNBOOK.md
+++ b/docs/current-state/AURORA-VISUAL-BASELINE-RUNBOOK.md
@@ -1,0 +1,218 @@
+# Aurora visual-regression baseline — runbook (#473)
+
+**Status:** Active. Implements step 1 / §4 of
+[`AURORA-STYLESHEET-REBUILD-PLAN.md`](AURORA-STYLESHEET-REBUILD-PLAN.md).
+
+This harness is the gate for the Aurora stylesheet rebuild ([#423](https://github.com/WalksWithASwagger/kriskrug-wp/issues/423)).
+Nothing in rebuild steps 2–8 (#474–#481) lands without a green `make visual-diff`
+against a frozen baseline.
+
+Implementation: [`scripts/visual_baseline.py`](../../scripts/visual_baseline.py).
+
+---
+
+## The three commands
+
+```bash
+make visual-baseline                 # freeze a baseline; prints its run id
+make visual-diff BASE=<run-id>       # capture a candidate and compare
+make visual-diff-report DIFF=<run-id># markdown table for the PR body
+```
+
+Support commands:
+
+```bash
+make visual-preflight                # Chromium + routes + storage guard, captures nothing
+make visual-guard                    # re-assert "no capture binary is tracked or staged"
+make visual-list                     # which manifests exist and which still have PNGs on disk
+make visual-prune KEEP=2             # delete old capture dirs; manifests are kept
+```
+
+All targets accept `ROUTES="home blog"` and `VIEWPORTS="desktop"` to narrow a run,
+and `BASE_URL=` to point at a different origin.
+
+## The deploy-step loop
+
+1. **Before** the deploy: `make visual-baseline`. Note the run id and commit the
+   manifest. Record the Boost bundle hash it prints.
+2. Deploy the step. Purge Pagely + Jetpack Boost.
+3. **After** the deploy: `make visual-diff BASE=<run-id>`.
+4. `make visual-diff-report` and paste the table into the PR.
+5. Every `warn` needs a sentence in the PR saying why it is expected. Every
+   `fail` blocks the step until it is either fixed or explicitly approved by KK
+   and the baseline re-frozen **in the same PR, called out in the PR body**.
+   Never re-freeze silently (§4.4).
+
+If the Boost CSS bundle hash is **unchanged** after a deploy, the deploy did not
+reach the edge — that is risk R-2, not "the change had no visual effect". The
+diff report says so explicitly.
+
+## What it captures
+
+11 logged-out routes × 3 viewports (375 / 768 / 1440), full-page, device scale 2.
+
+| Route | Template | Expected status |
+|---|---|---|
+| `/` | `front-page.html` | 200 |
+| `/about/` | `page.html` | 200 |
+| `/generative-ai-services/` | `page.html` | 200 |
+| `/speaking/` | `page.html` | 200 |
+| `/work/` | `page.html` | 200 |
+| `/photography/` | `page.html` | 200 |
+| `/blog/` | `index.html` | 200 |
+| `/contact/` | `page.html` | 200 |
+| `/2026/07/18/i-am-nomad-ai-film/` | `single.html` | 200 |
+| `/definitely-not-a-page-404-probe/` | `404.html` | **404** |
+| `/category/vancouver-ai-ecosystem/` | `archive.html` | 200 |
+
+Two deliberate departures from §4.2's list, both verified against live on
+2026-07-25:
+
+- **`/services/` → `/generative-ai-services/`.** `/services/` 301s. Capturing the
+  canonical target captures a page rather than a redirect.
+- **Marquee board post → category archive.** §4.2 wants the marquee board post
+  because `parts/marquee-current.html` is the theme's only inline `<style>`.
+  `kk-marquee-board` is repo-side only and `/marquee/` returns 404 on live, so
+  there is no board post to capture. `archive.html` is otherwise uncovered by the
+  other ten routes, so it takes the slot. The marquee route is still declared in
+  `ROUTES`' sibling `MARQUEE_ROUTE` with `enabled: False` — flip it on and drop
+  the archive route once the plugin is deployed. **Until then, inline marquee CSS
+  is not covered by this gate.**
+
+The route list is asserted before every capture: a route whose HTTP status stops
+matching aborts the run. A baseline of the wrong page is worse than no baseline.
+
+## Tolerance (§4.4)
+
+| Verdict | Condition |
+|---|---|
+| **pass** | ≤ 0.1% of pixels differ |
+| **warn** | 0.1% – 1.0% — human review required |
+| **fail** | > 1.0%, **or** full-page height changed by > 2% |
+
+Per-pixel comparison uses pixelmatch's YIQ delta at threshold 0.2. When the two
+PNGs are byte-identical the comparison short-circuits to 0% — which is the path a
+stable site takes for most pairs.
+
+## Determinism controls
+
+Risk R-8 is that the harness produces false diffs, the team stops trusting it,
+and the gate becomes theatre. These are the controls, each added in response to a
+measured false positive between two back-to-back runs against unchanged
+production:
+
+| Control | What it fixes | Measured before it existed |
+|---|---|---|
+| `reducedMotion: reduce`, `colorScheme: light`, frozen animations/transitions | 11 `@keyframes`, 6 reduced-motion blocks, 1 dark-scheme block | — |
+| Force `loading=eager` + `decode()` on every image | Lazy images below the fold captured blank in full-page shots | **2.65%** of homepage pixels |
+| Strip `srcset`/`sizes` at parse time (MutationObserver init script) | Which srcset candidate wins is a layout-timing race; with `object-fit: cover` a different candidate crops differently | **0.089%** of `/blog/` pixels |
+| Drive reveal classes to their end state | `.aurora-fade-up`, `.aurora-scale-in`, `.is-aurora-lux-reveal` start at `opacity: 0` and only reveal when JS fires; content that never intersected is captured invisible | reveal-gated cards captured faded |
+| Selector masks for marquee / dates / Beehiiv | Genuinely non-deterministic content | — |
+| Scroll-settle, `document.fonts.ready`, `networkidle`, settle delay | Late webfont swap, IntersectionObserver reveals | — |
+| Third-party hosts fulfilled with an empty 200 | GTM, social embeds, widgets | — |
+
+Reveal end-states are driven by adding the **theme's own** `is-visible` /
+`is-revealed` class, not by overriding `opacity` in CSS — so a real regression in
+those rules still shows up in the pixels. A blanket `opacity: 1 !important` would
+hide it.
+
+Masks and reveals are **declared in the manifest, not hardcoded into the
+comparison** (§4.3). Per-capture match counts are recorded, so a class rename
+surfaces as a count of `0` rather than as a diff nobody can explain. Override
+both with `--masks <file.json>` (`{"masks": {...}, "reveals": [...]}`).
+
+Every run also records, in the manifest:
+
+- live-vs-repo **md5 per theme CSS file** and both `style.css` `Version:` strings;
+- the **Jetpack Boost** CSS and JS bundle hashes;
+- per-capture image counts (`painted/total`) and mask/reveal match counts.
+
+## Verification of the gate itself (2026-07-25)
+
+Two consecutive full runs against unchanged production, `BASE1` → `BASE2`,
+33 route/viewport pairs:
+
+**33 pass · 0 warn · 0 fail · 0 error.** 31 pairs byte-identical by SHA-256; the
+other two (`/photography/` tablet and desktop) differed in PNG bytes but had
+**0 differing pixels** above threshold. No full-page height changed at all.
+
+Committed evidence: `reports/visual-baseline/manifest-BASE1.json`,
+`diff-BASE2.json`, `report-BASE2.md`. The ~500 MB of PNGs those two runs produced
+are not in git and never were.
+
+Also observed and worth knowing:
+
+- The `beehiiv` mask matched **0 elements on all 33 captures**. The Beehiiv
+  presence on these routes is a link, not an embed. The mask is declared anyway,
+  and its per-capture match count is recorded — so if an embed is added later it
+  is masked automatically and visibly.
+- The `marquee` mask matches 4 elements on every route including the 404, i.e.
+  the site-wide woven marquee, not the (undeployed) board.
+- `.is-aurora-lux-reveal` matched 20 elements on `/blog/` and 76 on the single
+  post, and 0 elsewhere — those two routes are why the reveal control exists.
+
+## Storage — never commit a PNG (#318)
+
+`.git` is already ~303 MB with 347 tracked images. A naive screenshot harness
+would add tens of MB per rebuild step. The rule is enforced by three independent
+mechanisms, not by intention:
+
+1. **`.gitignore` denies by default.** `docs/current-state/reports/visual-baseline/*`
+   is ignored one level down, so git never descends into a run directory — its
+   PNGs, curl cache and generated drivers cannot be added even by `git add -A`.
+   Only `manifest-*.json`, `diff-*.json`, `report-*.md` and `README.md` at the top
+   level are re-included by name.
+2. **The script refuses to write into a tracked path.** Before any capture it runs
+   `git check-ignore` on the run directory and aborts if the directory is not
+   ignored — so a broken `.gitignore` stops the harness rather than filling the
+   repo.
+3. **`visual_baseline.py guard` re-asserts it against the index** after every
+   capture and every diff, and is exposed as `make visual-guard`. It fails if any
+   tracked file under the artifact root is not an allowed manifest, if any binary
+   is staged anywhere, or if the ignore rule has stopped working.
+
+Diff images are written only for pairs that **warn or fail**; passing pairs have
+their diff PNG deleted at the end of the run. Attach failing diffs to the PR
+comment or as CI artifacts — GitHub-hosted, not repo-hosted (§4.5.4).
+
+Losing a baseline costs one `make visual-baseline`, so prune freely.
+
+## Chromium
+
+Chromium is preinstalled at `/opt/pw-browsers`. **Never run `playwright install`.**
+The harness fails loudly and exits 2 if `PLAYWRIGHT_BROWSERS_PATH` is unset, does
+not exist, contains no `chromium*` directory, or resolves to a missing executable.
+Every Node child is spawned with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`.
+
+The Python `playwright` package is **not** installed and is not required: the
+capture and comparison drivers are Node programs, written into the (ignored) run
+directory at runtime and driven by `scripts/visual_baseline.py`. The only Python
+dependency is the standard library.
+
+### Why the browser never talks to kriskrug.co directly
+
+Chromium cannot reach the public internet through this environment's agent proxy
+(`ERR_CONNECTION_RESET`), while `curl` gets 200. So every request the browser
+makes is intercepted by Playwright and fulfilled from a curl fetch, cached on
+disk for the run. The page keeps its real origin (`https://kriskrug.co/...`), so
+no URL rewriting is needed. `scripts/interaction_state_probe.js` (#424) solves the
+same constraint with a rewritten local mirror; this harness uses interception
+because screenshots need asset URLs and layout left exactly as production serves
+them.
+
+Hosts outside the allowlist (`kriskrug.co`, `s5102.pcdn.co`, `i*.wp.com`) are
+fulfilled with an empty 200 rather than fetched.
+
+## Honest limits (§4.7)
+
+- **There is no staging.** Every step compares *post-deploy live* against
+  *pre-deploy live*, so a regression is caught minutes after it ships, not
+  before. That is why every step's rollback is a pre-built zip (R-1).
+- Screenshots cannot see focus, hover or keyboard behaviour. #424's manual
+  tab-through remains a separate required gate.
+- It cannot see the editor canvas. Step 4 adds a manual editor screenshot pair.
+- Inline marquee CSS is not covered while `/marquee/` is 404 on live (above).
+- Stripping `srcset` means captures use each image's `src` rather than the 2x
+  candidate a real retina visitor gets. Layout is identical; only bitmap
+  resolution differs, and it differs identically in baseline and candidate. Pass
+  `--keep-srcset` for higher fidelity at the cost of run-to-run stability.

--- a/docs/current-state/RECLAIM-LIST-2026-07-24.md
+++ b/docs/current-state/RECLAIM-LIST-2026-07-24.md
@@ -31,6 +31,17 @@ Source inventory: `docs/current-state/reports/repo-hygiene-prune-triage-20260716
 |---|---|
 | `backup/` snapshots older than active rollback windows | Confirm no open Pagely/theme rollback references them |
 
+## Untracked-by-design (no reclaim needed, but budget for the disk)
+
+| Path | Why it is here |
+|---|---|
+| `docs/current-state/reports/visual-baseline/<run-id>/` | Visual-regression captures (#473). **Never tracked** — the whole artifact root is git-ignored one level down and `make visual-guard` re-asserts that against the index after every run. Only `manifest-*.json`, `diff-*.json` and `report-*.md` at the top level are committed. |
+
+These directories cost nothing in `.git`, but a full 11-route × 3-viewport run at
+device scale 2 is roughly 250–450 MB of PNG **on disk**. Baselines regenerate in
+one command, so there is no archival argument for keeping old ones: run
+`make visual-prune KEEP=2` (or `KEEP=1`) after a rebuild step lands.
+
 ## Explicit keep
 
 - Newest `docs/current-state/reports/morning-truth-*.md`

--- a/docs/current-state/reports/visual-baseline/diff-BASE2.json
+++ b/docs/current-state/reports/visual-baseline/diff-BASE2.json
@@ -1,0 +1,863 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "kind": "diff",
+  "issue": 473,
+  "created_at": "2026-07-25T21:05:13+00:00",
+  "baseline_run": "BASE1",
+  "candidate_run": "BASE2",
+  "base_url": "https://kriskrug.co",
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "verdict": "pass",
+  "counts": {
+    "pass": 33,
+    "warn": 0,
+    "fail": 0,
+    "error": 0
+  },
+  "css_identity": {
+    "baseline": {
+      "live_theme_version": "1.4.3",
+      "all_identical": false
+    },
+    "candidate": {
+      "live_theme_version": "1.4.3",
+      "repo_theme_version": "1.4.5",
+      "all_identical": false,
+      "files": [
+        {
+          "file": "style.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+          "live_status": 200,
+          "live_md5": "28a523c46532dc0fcebf58df32f63cf5",
+          "live_bytes": 111255,
+          "repo_md5": "0ab1fadf9e64d0c2444d25d6a90e9fb7",
+          "repo_bytes": 113860,
+          "identical": false
+        },
+        {
+          "file": "assets/css/animations.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+          "live_status": 200,
+          "live_md5": "7645e93ae4fd628b59893794c70a8432",
+          "live_bytes": 7540,
+          "repo_md5": "7645e93ae4fd628b59893794c70a8432",
+          "repo_bytes": 7540,
+          "identical": true
+        },
+        {
+          "file": "assets/css/bleeding-edge.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+          "live_status": 200,
+          "live_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+          "live_bytes": 12390,
+          "repo_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+          "repo_bytes": 12390,
+          "identical": true
+        },
+        {
+          "file": "assets/css/editor.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+          "live_status": 200,
+          "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+          "live_bytes": 5343,
+          "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+          "repo_bytes": 5343,
+          "identical": true
+        },
+        {
+          "file": "assets/css/revive-port.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+          "live_status": 200,
+          "live_md5": "737818af24412ef23a8493249c5ee9e4",
+          "live_bytes": 27630,
+          "repo_md5": "f1ffb49f638fcbb8956ffb0aff4b69ea",
+          "repo_bytes": 28495,
+          "identical": false
+        },
+        {
+          "file": "assets/css/typography-refined.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+          "live_status": 200,
+          "live_md5": "69e3035368a854cb3dc56accc4e44c1a",
+          "live_bytes": 16735,
+          "repo_md5": "69e3035368a854cb3dc56accc4e44c1a",
+          "repo_bytes": 16735,
+          "identical": true
+        }
+      ]
+    }
+  },
+  "boost": {
+    "baseline_css_bundle_hash": "78b2cf14fa",
+    "candidate_css_bundle_hash": "78b2cf14fa",
+    "changed": false,
+    "candidate": {
+      "source": "https://kriskrug.co/",
+      "home_status": 200,
+      "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/78b2cf14fa.min.css",
+      "css_bundle_hash": "78b2cf14fa",
+      "css_bundle_md5": "8dad4baf6c2e420e8cb83000247f75fd",
+      "css_bundle_bytes": 138229,
+      "js_bundle_hash": "80bc38e6a8"
+    }
+  },
+  "pairs": [
+    {
+      "key": "home/mobile",
+      "route": "home",
+      "path": "/",
+      "viewport": "mobile",
+      "candidate_sha256": "05b4cfd9bf47bfa6676ff7dc1613ba2c9f7bac802d79e0cf9568ca8c0dfa6f79",
+      "baseline_sha256": "05b4cfd9bf47bfa6676ff7dc1613ba2c9f7bac802d79e0cf9568ca8c0dfa6f79",
+      "candidate_height": 18454,
+      "baseline_height": 18454,
+      "candidate_scroll_height": 9227,
+      "baseline_scroll_height": 9227,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "home/tablet",
+      "route": "home",
+      "path": "/",
+      "viewport": "tablet",
+      "candidate_sha256": "60507d74243c55b62cb8cd702ee25bdf201a4b1de7992aa568899c91dbd462ed",
+      "baseline_sha256": "60507d74243c55b62cb8cd702ee25bdf201a4b1de7992aa568899c91dbd462ed",
+      "candidate_height": 21322,
+      "baseline_height": 21322,
+      "candidate_scroll_height": 10661,
+      "baseline_scroll_height": 10661,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "home/desktop",
+      "route": "home",
+      "path": "/",
+      "viewport": "desktop",
+      "candidate_sha256": "57649ed19de69f0bb2bd7b2f46a2d0e9702dca45349c7367e661d699307bbfcc",
+      "baseline_sha256": "57649ed19de69f0bb2bd7b2f46a2d0e9702dca45349c7367e661d699307bbfcc",
+      "candidate_height": 12886,
+      "baseline_height": 12886,
+      "candidate_scroll_height": 6443,
+      "baseline_scroll_height": 6443,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "about/mobile",
+      "route": "about",
+      "path": "/about/",
+      "viewport": "mobile",
+      "candidate_sha256": "efdfa63faeabed8fbc80ac45ef5671dba3fbbd8169ad833a940a153b8a559139",
+      "baseline_sha256": "efdfa63faeabed8fbc80ac45ef5671dba3fbbd8169ad833a940a153b8a559139",
+      "candidate_height": 12544,
+      "baseline_height": 12544,
+      "candidate_scroll_height": 6272,
+      "baseline_scroll_height": 6272,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "about/tablet",
+      "route": "about",
+      "path": "/about/",
+      "viewport": "tablet",
+      "candidate_sha256": "9e7066edd757529ff72113152b28813d2c80bdb5c1b388c89ad15f543b3d3bed",
+      "baseline_sha256": "9e7066edd757529ff72113152b28813d2c80bdb5c1b388c89ad15f543b3d3bed",
+      "candidate_height": 10760,
+      "baseline_height": 10760,
+      "candidate_scroll_height": 5380,
+      "baseline_scroll_height": 5380,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "about/desktop",
+      "route": "about",
+      "path": "/about/",
+      "viewport": "desktop",
+      "candidate_sha256": "4df37fabe0fd2282cb6fbe0928b0671a86284ae448f965f5cc0e17eee35eae18",
+      "baseline_sha256": "4df37fabe0fd2282cb6fbe0928b0671a86284ae448f965f5cc0e17eee35eae18",
+      "candidate_height": 9076,
+      "baseline_height": 9076,
+      "candidate_scroll_height": 4538,
+      "baseline_scroll_height": 4538,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "services/mobile",
+      "route": "services",
+      "path": "/generative-ai-services/",
+      "viewport": "mobile",
+      "candidate_sha256": "6608948dee3a71b1c2460ab0b418c517a046840f91e55f763be8380cb2ee3f98",
+      "baseline_sha256": "6608948dee3a71b1c2460ab0b418c517a046840f91e55f763be8380cb2ee3f98",
+      "candidate_height": 9774,
+      "baseline_height": 9774,
+      "candidate_scroll_height": 4887,
+      "baseline_scroll_height": 4887,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "services/tablet",
+      "route": "services",
+      "path": "/generative-ai-services/",
+      "viewport": "tablet",
+      "candidate_sha256": "4d23aeedbaf525c2ca5e3ebf48e0136e3f172c45570d14081ded920a54402475",
+      "baseline_sha256": "4d23aeedbaf525c2ca5e3ebf48e0136e3f172c45570d14081ded920a54402475",
+      "candidate_height": 9078,
+      "baseline_height": 9078,
+      "candidate_scroll_height": 4539,
+      "baseline_scroll_height": 4539,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "services/desktop",
+      "route": "services",
+      "path": "/generative-ai-services/",
+      "viewport": "desktop",
+      "candidate_sha256": "fbd2eda3ad54001563a23621ebb79065166b213489a771aea57212a201cdc8b9",
+      "baseline_sha256": "fbd2eda3ad54001563a23621ebb79065166b213489a771aea57212a201cdc8b9",
+      "candidate_height": 7128,
+      "baseline_height": 7128,
+      "candidate_scroll_height": 3564,
+      "baseline_scroll_height": 3564,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "speaking/mobile",
+      "route": "speaking",
+      "path": "/speaking/",
+      "viewport": "mobile",
+      "candidate_sha256": "6a01da359292468085689f290596bce2a9f3b8643a813ad5898e9c79c0a7e301",
+      "baseline_sha256": "6a01da359292468085689f290596bce2a9f3b8643a813ad5898e9c79c0a7e301",
+      "candidate_height": 11784,
+      "baseline_height": 11784,
+      "candidate_scroll_height": 5892,
+      "baseline_scroll_height": 5892,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "speaking/tablet",
+      "route": "speaking",
+      "path": "/speaking/",
+      "viewport": "tablet",
+      "candidate_sha256": "b9426205ecccec4cc78f3e0b090c121e2270d6b00fa401d10b475b226edb4f14",
+      "baseline_sha256": "b9426205ecccec4cc78f3e0b090c121e2270d6b00fa401d10b475b226edb4f14",
+      "candidate_height": 10442,
+      "baseline_height": 10442,
+      "candidate_scroll_height": 5221,
+      "baseline_scroll_height": 5221,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "speaking/desktop",
+      "route": "speaking",
+      "path": "/speaking/",
+      "viewport": "desktop",
+      "candidate_sha256": "776220f843219cd3d8da9cb6266f57078f7f2747440236c4b892289e103c59dc",
+      "baseline_sha256": "776220f843219cd3d8da9cb6266f57078f7f2747440236c4b892289e103c59dc",
+      "candidate_height": 8674,
+      "baseline_height": 8674,
+      "candidate_scroll_height": 4337,
+      "baseline_scroll_height": 4337,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "work/mobile",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "mobile",
+      "candidate_sha256": "b68956eff1aa42cdd4095b3cf9301456b196b46f0f856c11e5f9a8db9455c610",
+      "baseline_sha256": "b68956eff1aa42cdd4095b3cf9301456b196b46f0f856c11e5f9a8db9455c610",
+      "candidate_height": 11774,
+      "baseline_height": 11774,
+      "candidate_scroll_height": 5887,
+      "baseline_scroll_height": 5887,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "work/tablet",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "tablet",
+      "candidate_sha256": "a65134378ce6d5702f2760cc8c48ccd085c4fc107e00fe57b17913bfd1ea391d",
+      "baseline_sha256": "a65134378ce6d5702f2760cc8c48ccd085c4fc107e00fe57b17913bfd1ea391d",
+      "candidate_height": 11672,
+      "baseline_height": 11672,
+      "candidate_scroll_height": 5836,
+      "baseline_scroll_height": 5836,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "work/desktop",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "desktop",
+      "candidate_sha256": "6de36d98afb18d45155c8583ac108eb350e4d325b9345e46b000da66427f95bb",
+      "baseline_sha256": "6de36d98afb18d45155c8583ac108eb350e4d325b9345e46b000da66427f95bb",
+      "candidate_height": 8850,
+      "baseline_height": 8850,
+      "candidate_scroll_height": 4425,
+      "baseline_scroll_height": 4425,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "photography/mobile",
+      "route": "photography",
+      "path": "/photography/",
+      "viewport": "mobile",
+      "candidate_sha256": "eb8e70680e0e480623186f5082f95a83626cf05243b68fa5319482d62e3182b4",
+      "baseline_sha256": "eb8e70680e0e480623186f5082f95a83626cf05243b68fa5319482d62e3182b4",
+      "candidate_height": 17080,
+      "baseline_height": 17080,
+      "candidate_scroll_height": 8540,
+      "baseline_scroll_height": 8540,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "photography/tablet",
+      "route": "photography",
+      "path": "/photography/",
+      "viewport": "tablet",
+      "candidate_sha256": "7a178a3b8c2263ea911f79b1632ee55404558da8c9649e5bba7ec672ef7684eb",
+      "baseline_sha256": "ce3f5bb94f1b9f7f08073e8120067dabba6939e6f5e6f04b14280475ebd84380",
+      "candidate_height": 11808,
+      "baseline_height": 11808,
+      "candidate_scroll_height": 5904,
+      "baseline_scroll_height": 5904,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "method": "pixel",
+      "diff_pct": 0,
+      "diff_pixels": 0,
+      "total_pixels": 18137088,
+      "verdict": "pass"
+    },
+    {
+      "key": "photography/desktop",
+      "route": "photography",
+      "path": "/photography/",
+      "viewport": "desktop",
+      "candidate_sha256": "5f31d33a026323f9f1d95c0cda3a7e5af3ee517c364fdcbffc607d8a913b0811",
+      "baseline_sha256": "eb9043c59ee863d99485ca5597c91eef9cdb57920f2e3e6df6e1124882d7928d",
+      "candidate_height": 9026,
+      "baseline_height": 9026,
+      "candidate_scroll_height": 4513,
+      "baseline_scroll_height": 4513,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "method": "pixel",
+      "diff_pct": 0,
+      "diff_pixels": 0,
+      "total_pixels": 25994880,
+      "verdict": "pass"
+    },
+    {
+      "key": "blog/mobile",
+      "route": "blog",
+      "path": "/blog/",
+      "viewport": "mobile",
+      "candidate_sha256": "ef0e8b39e749a44b0310bd446372e91290494395b55874e2d37dbf731c2de91f",
+      "baseline_sha256": "ef0e8b39e749a44b0310bd446372e91290494395b55874e2d37dbf731c2de91f",
+      "candidate_height": 23118,
+      "baseline_height": 23118,
+      "candidate_scroll_height": 11559,
+      "baseline_scroll_height": 11559,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "blog/tablet",
+      "route": "blog",
+      "path": "/blog/",
+      "viewport": "tablet",
+      "candidate_sha256": "818e969e8572c8c1f9b4730855a5f051b7e70d6d93f0d892ec21569690358ed2",
+      "baseline_sha256": "818e969e8572c8c1f9b4730855a5f051b7e70d6d93f0d892ec21569690358ed2",
+      "candidate_height": 13682,
+      "baseline_height": 13682,
+      "candidate_scroll_height": 6841,
+      "baseline_scroll_height": 6841,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "blog/desktop",
+      "route": "blog",
+      "path": "/blog/",
+      "viewport": "desktop",
+      "candidate_sha256": "8af1eb2509ba1e326545febcca19afc3c04d4d4358f5bfca464d65e97bb7aacb",
+      "baseline_sha256": "8af1eb2509ba1e326545febcca19afc3c04d4d4358f5bfca464d65e97bb7aacb",
+      "candidate_height": 10894,
+      "baseline_height": 10894,
+      "candidate_scroll_height": 5447,
+      "baseline_scroll_height": 5447,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "contact/mobile",
+      "route": "contact",
+      "path": "/contact/",
+      "viewport": "mobile",
+      "candidate_sha256": "6a290b233bce6e9a76375f00fc1b41a73a8b9b8c9c199bf624490d961ef0967f",
+      "baseline_sha256": "6a290b233bce6e9a76375f00fc1b41a73a8b9b8c9c199bf624490d961ef0967f",
+      "candidate_height": 9434,
+      "baseline_height": 9434,
+      "candidate_scroll_height": 4717,
+      "baseline_scroll_height": 4717,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "contact/tablet",
+      "route": "contact",
+      "path": "/contact/",
+      "viewport": "tablet",
+      "candidate_sha256": "cb550cb7cd65c933d165baefdb69dad551c535989c1cea5aa3277fedf561ca99",
+      "baseline_sha256": "cb550cb7cd65c933d165baefdb69dad551c535989c1cea5aa3277fedf561ca99",
+      "candidate_height": 6520,
+      "baseline_height": 6520,
+      "candidate_scroll_height": 3260,
+      "baseline_scroll_height": 3260,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "contact/desktop",
+      "route": "contact",
+      "path": "/contact/",
+      "viewport": "desktop",
+      "candidate_sha256": "f4c97988e02a1566012879f338847b5eb4c49e1f91d6da0ed52e813e4fb52f80",
+      "baseline_sha256": "f4c97988e02a1566012879f338847b5eb4c49e1f91d6da0ed52e813e4fb52f80",
+      "candidate_height": 5836,
+      "baseline_height": 5836,
+      "candidate_scroll_height": 2918,
+      "baseline_scroll_height": 2918,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "single-post/mobile",
+      "route": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "viewport": "mobile",
+      "candidate_sha256": "97332769a82e7e257397235d26873771c6a990886b7a62e7bca6b6934c492ab5",
+      "baseline_sha256": "97332769a82e7e257397235d26873771c6a990886b7a62e7bca6b6934c492ab5",
+      "candidate_height": 40274,
+      "baseline_height": 40274,
+      "candidate_scroll_height": 20137,
+      "baseline_scroll_height": 20137,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "single-post/tablet",
+      "route": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "viewport": "tablet",
+      "candidate_sha256": "f5ea66eda2ba89df7a00f57d802861f50c52a71ce385e0cbb3f3c1c5fdec2406",
+      "baseline_sha256": "f5ea66eda2ba89df7a00f57d802861f50c52a71ce385e0cbb3f3c1c5fdec2406",
+      "candidate_height": 32634,
+      "baseline_height": 32634,
+      "candidate_scroll_height": 16317,
+      "baseline_scroll_height": 16317,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "single-post/desktop",
+      "route": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "viewport": "desktop",
+      "candidate_sha256": "cf90fcc186554e9ac98d85223148b0d8842367c18b6de71861ba63c0c87edc2d",
+      "baseline_sha256": "cf90fcc186554e9ac98d85223148b0d8842367c18b6de71861ba63c0c87edc2d",
+      "candidate_height": 35086,
+      "baseline_height": 35086,
+      "candidate_scroll_height": 17543,
+      "baseline_scroll_height": 17543,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "not-found/mobile",
+      "route": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "viewport": "mobile",
+      "candidate_sha256": "e227d463d8de568b3fc00a66ee527f52e1b05923ba877225358f62d634a4aaad",
+      "baseline_sha256": "e227d463d8de568b3fc00a66ee527f52e1b05923ba877225358f62d634a4aaad",
+      "candidate_height": 5464,
+      "baseline_height": 5464,
+      "candidate_scroll_height": 2732,
+      "baseline_scroll_height": 2732,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "not-found/tablet",
+      "route": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "viewport": "tablet",
+      "candidate_sha256": "bcb01a370804ff958152722f30edb80054c20cb0a5d3773363c96e6176fed4be",
+      "baseline_sha256": "bcb01a370804ff958152722f30edb80054c20cb0a5d3773363c96e6176fed4be",
+      "candidate_height": 4338,
+      "baseline_height": 4338,
+      "candidate_scroll_height": 2169,
+      "baseline_scroll_height": 2169,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "not-found/desktop",
+      "route": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "viewport": "desktop",
+      "candidate_sha256": "1cb75c0380edeb30005fbb1ec4e97a95cffa5ac6abf7ebaed02373da1230c5ac",
+      "baseline_sha256": "1cb75c0380edeb30005fbb1ec4e97a95cffa5ac6abf7ebaed02373da1230c5ac",
+      "candidate_height": 4122,
+      "baseline_height": 4122,
+      "candidate_scroll_height": 2061,
+      "baseline_scroll_height": 2061,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "category-archive/mobile",
+      "route": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "viewport": "mobile",
+      "candidate_sha256": "66a393226c91fad96a4a77067b220c2799ae4912e5145f4da7150735cd6d55ef",
+      "baseline_sha256": "66a393226c91fad96a4a77067b220c2799ae4912e5145f4da7150735cd6d55ef",
+      "candidate_height": 23190,
+      "baseline_height": 23190,
+      "candidate_scroll_height": 11595,
+      "baseline_scroll_height": 11595,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "category-archive/tablet",
+      "route": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "viewport": "tablet",
+      "candidate_sha256": "f5a8df79e678983de7fa5b6c13a6b3e696024e29d484bd7687d4d06dbad80642",
+      "baseline_sha256": "f5a8df79e678983de7fa5b6c13a6b3e696024e29d484bd7687d4d06dbad80642",
+      "candidate_height": 17448,
+      "baseline_height": 17448,
+      "candidate_scroll_height": 8724,
+      "baseline_scroll_height": 8724,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    },
+    {
+      "key": "category-archive/desktop",
+      "route": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "viewport": "desktop",
+      "candidate_sha256": "d68300cd5ddee8bde2084f544e82ce23c767be5e0312a07e1275e4c0b78f7438",
+      "baseline_sha256": "d68300cd5ddee8bde2084f544e82ce23c767be5e0312a07e1275e4c0b78f7438",
+      "candidate_height": 17894,
+      "baseline_height": 17894,
+      "candidate_scroll_height": 8947,
+      "baseline_scroll_height": 8947,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "diff_pct": 0.0,
+      "diff_pixels": 0,
+      "method": "sha256-identical",
+      "verdict": "pass"
+    }
+  ]
+}

--- a/docs/current-state/reports/visual-baseline/manifest-BASE1.json
+++ b/docs/current-state/reports/visual-baseline/manifest-BASE1.json
@@ -1,0 +1,1448 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "run_id": "BASE1",
+  "issue": 473,
+  "created_at": "2026-07-25T21:01:27+00:00",
+  "base_url": "https://kriskrug.co",
+  "artifact_dir": "docs/current-state/reports/visual-baseline/BASE1",
+  "artifacts_committed": false,
+  "tools": {
+    "node": "/opt/node22/bin/node",
+    "node_version": "v22.22.2",
+    "playwright": "1.56.1",
+    "chromium_exec": "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    "browsers_path": "/opt/pw-browsers"
+  },
+  "settings": {
+    "device_scale": 2,
+    "reduced_motion": "reduce",
+    "color_scheme": "light",
+    "forced_colors": "none",
+    "timezone": "America/Vancouver",
+    "settle_ms": 900,
+    "cache_bust": true,
+    "strip_srcset": true,
+    "mask_color": "#FF00FF",
+    "allow_hosts": [
+      "kriskrug.co",
+      "s5102.pcdn.co",
+      "i0.wp.com",
+      "i1.wp.com",
+      "i2.wp.com"
+    ],
+    "full_page": true
+  },
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "reveals": [
+    {
+      "selector": ".is-aurora-lux-reveal",
+      "add_class": "is-revealed"
+    },
+    {
+      "selector": ".aurora-fade-up",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-scale-in",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-hero-text",
+      "add_class": "is-visible"
+    }
+  ],
+  "routes": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "expect_status": 200,
+      "note": "canonical target of /services/ (301)"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "expect_status": 200
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "expect_status": 200
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "expect_status": 404
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "expect_status": 200,
+      "note": "stands in for the marquee board post; /marquee/ is 404 on live"
+    }
+  ],
+  "route_preflight": [
+    {
+      "id": "home",
+      "path": "/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "status": 404,
+      "expected": 404
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "status": 200,
+      "expected": 200
+    }
+  ],
+  "viewports": [
+    {
+      "name": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2
+    },
+    {
+      "name": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2
+    },
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2
+    }
+  ],
+  "fetch_stats": {
+    "fetched": 132,
+    "cached": 384,
+    "blocked": 78,
+    "failed": 0
+  },
+  "captures": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 9227,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-mobile.png",
+      "ok": true,
+      "sha256": "05b4cfd9bf47bfa6676ff7dc1613ba2c9f7bac802d79e0cf9568ca8c0dfa6f79",
+      "bytes": 5115989,
+      "png_width": 750,
+      "png_height": 18454,
+      "rel_path": "BASE1/png/home-mobile.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 6272,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-mobile.png",
+      "ok": true,
+      "sha256": "efdfa63faeabed8fbc80ac45ef5671dba3fbbd8169ad833a940a153b8a559139",
+      "bytes": 2857543,
+      "png_width": 750,
+      "png_height": 12544,
+      "rel_path": "BASE1/png/about-mobile.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4887,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-mobile.png",
+      "ok": true,
+      "sha256": "6608948dee3a71b1c2460ab0b418c517a046840f91e55f763be8380cb2ee3f98",
+      "bytes": 2289818,
+      "png_width": 750,
+      "png_height": 9774,
+      "rel_path": "BASE1/png/services-mobile.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5892,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-mobile.png",
+      "ok": true,
+      "sha256": "6a01da359292468085689f290596bce2a9f3b8643a813ad5898e9c79c0a7e301",
+      "bytes": 2619651,
+      "png_width": 750,
+      "png_height": 11784,
+      "rel_path": "BASE1/png/speaking-mobile.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5887,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-mobile.png",
+      "ok": true,
+      "sha256": "b68956eff1aa42cdd4095b3cf9301456b196b46f0f856c11e5f9a8db9455c610",
+      "bytes": 5126153,
+      "png_width": 750,
+      "png_height": 11774,
+      "rel_path": "BASE1/png/work-mobile.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 8540,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-mobile.png",
+      "ok": true,
+      "sha256": "eb8e70680e0e480623186f5082f95a83626cf05243b68fa5319482d62e3182b4",
+      "bytes": 11790334,
+      "png_width": 750,
+      "png_height": 17080,
+      "rel_path": "BASE1/png/photography-mobile.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 11559,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-mobile.png",
+      "ok": true,
+      "sha256": "ef0e8b39e749a44b0310bd446372e91290494395b55874e2d37dbf731c2de91f",
+      "bytes": 10234512,
+      "png_width": 750,
+      "png_height": 23118,
+      "rel_path": "BASE1/png/blog-mobile.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4717,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-mobile.png",
+      "ok": true,
+      "sha256": "6a290b233bce6e9a76375f00fc1b41a73a8b9b8c9c199bf624490d961ef0967f",
+      "bytes": 2054239,
+      "png_width": 750,
+      "png_height": 9434,
+      "rel_path": "BASE1/png/contact-mobile.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 20137,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-mobile.png",
+      "ok": true,
+      "sha256": "97332769a82e7e257397235d26873771c6a990886b7a62e7bca6b6934c492ab5",
+      "bytes": 6201010,
+      "png_width": 750,
+      "png_height": 40274,
+      "rel_path": "BASE1/png/single-post-mobile.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2732,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-mobile.png",
+      "ok": true,
+      "sha256": "e227d463d8de568b3fc00a66ee527f52e1b05923ba877225358f62d634a4aaad",
+      "bytes": 1165768,
+      "png_width": 750,
+      "png_height": 5464,
+      "rel_path": "BASE1/png/not-found-mobile.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 11595,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-mobile.png",
+      "ok": true,
+      "sha256": "66a393226c91fad96a4a77067b220c2799ae4912e5145f4da7150735cd6d55ef",
+      "bytes": 2101847,
+      "png_width": 750,
+      "png_height": 23190,
+      "rel_path": "BASE1/png/category-archive-mobile.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 10661,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-tablet.png",
+      "ok": true,
+      "sha256": "60507d74243c55b62cb8cd702ee25bdf201a4b1de7992aa568899c91dbd462ed",
+      "bytes": 13537377,
+      "png_width": 1536,
+      "png_height": 21322,
+      "rel_path": "BASE1/png/home-tablet.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5380,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-tablet.png",
+      "ok": true,
+      "sha256": "9e7066edd757529ff72113152b28813d2c80bdb5c1b388c89ad15f543b3d3bed",
+      "bytes": 5936769,
+      "png_width": 1536,
+      "png_height": 10760,
+      "rel_path": "BASE1/png/about-tablet.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4539,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-tablet.png",
+      "ok": true,
+      "sha256": "4d23aeedbaf525c2ca5e3ebf48e0136e3f172c45570d14081ded920a54402475",
+      "bytes": 5663598,
+      "png_width": 1536,
+      "png_height": 9078,
+      "rel_path": "BASE1/png/services-tablet.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5221,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-tablet.png",
+      "ok": true,
+      "sha256": "b9426205ecccec4cc78f3e0b090c121e2270d6b00fa401d10b475b226edb4f14",
+      "bytes": 5770366,
+      "png_width": 1536,
+      "png_height": 10442,
+      "rel_path": "BASE1/png/speaking-tablet.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5836,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-tablet.png",
+      "ok": true,
+      "sha256": "a65134378ce6d5702f2760cc8c48ccd085c4fc107e00fe57b17913bfd1ea391d",
+      "bytes": 11448815,
+      "png_width": 1536,
+      "png_height": 11672,
+      "rel_path": "BASE1/png/work-tablet.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5904,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-tablet.png",
+      "ok": true,
+      "sha256": "ce3f5bb94f1b9f7f08073e8120067dabba6939e6f5e6f04b14280475ebd84380",
+      "bytes": 15146119,
+      "png_width": 1536,
+      "png_height": 11808,
+      "rel_path": "BASE1/png/photography-tablet.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 6841,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-tablet.png",
+      "ok": true,
+      "sha256": "818e969e8572c8c1f9b4730855a5f051b7e70d6d93f0d892ec21569690358ed2",
+      "bytes": 12708191,
+      "png_width": 1536,
+      "png_height": 13682,
+      "rel_path": "BASE1/png/blog-tablet.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 3260,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-tablet.png",
+      "ok": true,
+      "sha256": "cb550cb7cd65c933d165baefdb69dad551c535989c1cea5aa3277fedf561ca99",
+      "bytes": 3263753,
+      "png_width": 1536,
+      "png_height": 6520,
+      "rel_path": "BASE1/png/contact-tablet.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 16317,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-tablet.png",
+      "ok": true,
+      "sha256": "f5ea66eda2ba89df7a00f57d802861f50c52a71ce385e0cbb3f3c1c5fdec2406",
+      "bytes": 16390487,
+      "png_width": 1536,
+      "png_height": 32634,
+      "rel_path": "BASE1/png/single-post-tablet.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2169,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-tablet.png",
+      "ok": true,
+      "sha256": "bcb01a370804ff958152722f30edb80054c20cb0a5d3773363c96e6176fed4be",
+      "bytes": 2657993,
+      "png_width": 1536,
+      "png_height": 4338,
+      "rel_path": "BASE1/png/not-found-tablet.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 8724,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-tablet.png",
+      "ok": true,
+      "sha256": "f5a8df79e678983de7fa5b6c13a6b3e696024e29d484bd7687d4d06dbad80642",
+      "bytes": 3684304,
+      "png_width": 1536,
+      "png_height": 17448,
+      "rel_path": "BASE1/png/category-archive-tablet.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 6443,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-desktop.png",
+      "ok": true,
+      "sha256": "57649ed19de69f0bb2bd7b2f46a2d0e9702dca45349c7367e661d699307bbfcc",
+      "bytes": 11464303,
+      "png_width": 2880,
+      "png_height": 12886,
+      "rel_path": "BASE1/png/home-desktop.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4538,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-desktop.png",
+      "ok": true,
+      "sha256": "4df37fabe0fd2282cb6fbe0928b0671a86284ae448f965f5cc0e17eee35eae18",
+      "bytes": 6393786,
+      "png_width": 2880,
+      "png_height": 9076,
+      "rel_path": "BASE1/png/about-desktop.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 3564,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-desktop.png",
+      "ok": true,
+      "sha256": "fbd2eda3ad54001563a23621ebb79065166b213489a771aea57212a201cdc8b9",
+      "bytes": 5612474,
+      "png_width": 2880,
+      "png_height": 7128,
+      "rel_path": "BASE1/png/services-desktop.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4337,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-desktop.png",
+      "ok": true,
+      "sha256": "776220f843219cd3d8da9cb6266f57078f7f2747440236c4b892289e103c59dc",
+      "bytes": 6008519,
+      "png_width": 2880,
+      "png_height": 8674,
+      "rel_path": "BASE1/png/speaking-desktop.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4425,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-desktop.png",
+      "ok": true,
+      "sha256": "6de36d98afb18d45155c8583ac108eb350e4d325b9345e46b000da66427f95bb",
+      "bytes": 9963219,
+      "png_width": 2880,
+      "png_height": 8850,
+      "rel_path": "BASE1/png/work-desktop.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4513,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-desktop.png",
+      "ok": true,
+      "sha256": "eb9043c59ee863d99485ca5597c91eef9cdb57920f2e3e6df6e1124882d7928d",
+      "bytes": 15289310,
+      "png_width": 2880,
+      "png_height": 9026,
+      "rel_path": "BASE1/png/photography-desktop.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 5447,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-desktop.png",
+      "ok": true,
+      "sha256": "8af1eb2509ba1e326545febcca19afc3c04d4d4358f5bfca464d65e97bb7aacb",
+      "bytes": 14964328,
+      "png_width": 2880,
+      "png_height": 10894,
+      "rel_path": "BASE1/png/blog-desktop.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2918,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-desktop.png",
+      "ok": true,
+      "sha256": "f4c97988e02a1566012879f338847b5eb4c49e1f91d6da0ed52e813e4fb52f80",
+      "bytes": 4865454,
+      "png_width": 2880,
+      "png_height": 5836,
+      "rel_path": "BASE1/png/contact-desktop.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 17543,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-desktop.png",
+      "ok": true,
+      "sha256": "cf90fcc186554e9ac98d85223148b0d8842367c18b6de71861ba63c0c87edc2d",
+      "bytes": 19971108,
+      "png_width": 2880,
+      "png_height": 35086,
+      "rel_path": "BASE1/png/single-post-desktop.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2061,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-desktop.png",
+      "ok": true,
+      "sha256": "1cb75c0380edeb30005fbb1ec4e97a95cffa5ac6abf7ebaed02373da1230c5ac",
+      "bytes": 3914028,
+      "png_width": 2880,
+      "png_height": 4122,
+      "rel_path": "BASE1/png/not-found-desktop.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 8947,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-desktop.png",
+      "ok": true,
+      "sha256": "d68300cd5ddee8bde2084f544e82ce23c767be5e0312a07e1275e4c0b78f7438",
+      "bytes": 5115504,
+      "png_width": 2880,
+      "png_height": 17894,
+      "rel_path": "BASE1/png/category-archive-desktop.png"
+    }
+  ],
+  "kind": "baseline",
+  "css_identity": {
+    "files": [
+      {
+        "file": "style.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+        "live_status": 200,
+        "live_md5": "28a523c46532dc0fcebf58df32f63cf5",
+        "live_bytes": 111255,
+        "repo_md5": "0ab1fadf9e64d0c2444d25d6a90e9fb7",
+        "repo_bytes": 113860,
+        "identical": false
+      },
+      {
+        "file": "assets/css/animations.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+        "live_status": 200,
+        "live_md5": "7645e93ae4fd628b59893794c70a8432",
+        "live_bytes": 7540,
+        "repo_md5": "7645e93ae4fd628b59893794c70a8432",
+        "repo_bytes": 7540,
+        "identical": true
+      },
+      {
+        "file": "assets/css/bleeding-edge.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+        "live_status": 200,
+        "live_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+        "live_bytes": 12390,
+        "repo_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+        "repo_bytes": 12390,
+        "identical": true
+      },
+      {
+        "file": "assets/css/editor.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+        "live_status": 200,
+        "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "live_bytes": 5343,
+        "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "repo_bytes": 5343,
+        "identical": true
+      },
+      {
+        "file": "assets/css/revive-port.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+        "live_status": 200,
+        "live_md5": "737818af24412ef23a8493249c5ee9e4",
+        "live_bytes": 27630,
+        "repo_md5": "f1ffb49f638fcbb8956ffb0aff4b69ea",
+        "repo_bytes": 28495,
+        "identical": false
+      },
+      {
+        "file": "assets/css/typography-refined.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+        "live_status": 200,
+        "live_md5": "69e3035368a854cb3dc56accc4e44c1a",
+        "live_bytes": 16735,
+        "repo_md5": "69e3035368a854cb3dc56accc4e44c1a",
+        "repo_bytes": 16735,
+        "identical": true
+      }
+    ],
+    "all_identical": false,
+    "live_theme_version": "1.4.3",
+    "repo_theme_version": "1.4.5"
+  },
+  "boost": {
+    "source": "https://kriskrug.co/",
+    "home_status": 200,
+    "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/78b2cf14fa.min.css",
+    "css_bundle_hash": "78b2cf14fa",
+    "css_bundle_md5": "8dad4baf6c2e420e8cb83000247f75fd",
+    "css_bundle_bytes": 138229,
+    "js_bundle_hash": "80bc38e6a8"
+  }
+}

--- a/docs/current-state/reports/visual-baseline/manifest-BASE2.json
+++ b/docs/current-state/reports/visual-baseline/manifest-BASE2.json
@@ -1,0 +1,1449 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "run_id": "BASE2",
+  "issue": 473,
+  "created_at": "2026-07-25T21:05:08+00:00",
+  "base_url": "https://kriskrug.co",
+  "artifact_dir": "docs/current-state/reports/visual-baseline/BASE2",
+  "artifacts_committed": false,
+  "tools": {
+    "node": "/opt/node22/bin/node",
+    "node_version": "v22.22.2",
+    "playwright": "1.56.1",
+    "chromium_exec": "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    "browsers_path": "/opt/pw-browsers"
+  },
+  "settings": {
+    "device_scale": 2,
+    "reduced_motion": "reduce",
+    "color_scheme": "light",
+    "forced_colors": "none",
+    "timezone": "America/Vancouver",
+    "settle_ms": 900,
+    "cache_bust": true,
+    "strip_srcset": true,
+    "mask_color": "#FF00FF",
+    "allow_hosts": [
+      "kriskrug.co",
+      "s5102.pcdn.co",
+      "i0.wp.com",
+      "i1.wp.com",
+      "i2.wp.com"
+    ],
+    "full_page": true
+  },
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "reveals": [
+    {
+      "selector": ".is-aurora-lux-reveal",
+      "add_class": "is-revealed"
+    },
+    {
+      "selector": ".aurora-fade-up",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-scale-in",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-hero-text",
+      "add_class": "is-visible"
+    }
+  ],
+  "routes": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "expect_status": 200,
+      "note": "canonical target of /services/ (301)"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "expect_status": 200
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "expect_status": 200
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "expect_status": 404
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "expect_status": 200,
+      "note": "stands in for the marquee board post; /marquee/ is 404 on live"
+    }
+  ],
+  "route_preflight": [
+    {
+      "id": "home",
+      "path": "/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "status": 404,
+      "expected": 404
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "status": 200,
+      "expected": 200
+    }
+  ],
+  "viewports": [
+    {
+      "name": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2
+    },
+    {
+      "name": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2
+    },
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2
+    }
+  ],
+  "fetch_stats": {
+    "fetched": 125,
+    "cached": 400,
+    "blocked": 78,
+    "failed": 0
+  },
+  "captures": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 9227,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-mobile.png",
+      "ok": true,
+      "sha256": "05b4cfd9bf47bfa6676ff7dc1613ba2c9f7bac802d79e0cf9568ca8c0dfa6f79",
+      "bytes": 5115989,
+      "png_width": 750,
+      "png_height": 18454,
+      "rel_path": "BASE2/png/home-mobile.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 6272,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-mobile.png",
+      "ok": true,
+      "sha256": "efdfa63faeabed8fbc80ac45ef5671dba3fbbd8169ad833a940a153b8a559139",
+      "bytes": 2857543,
+      "png_width": 750,
+      "png_height": 12544,
+      "rel_path": "BASE2/png/about-mobile.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4887,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-mobile.png",
+      "ok": true,
+      "sha256": "6608948dee3a71b1c2460ab0b418c517a046840f91e55f763be8380cb2ee3f98",
+      "bytes": 2289818,
+      "png_width": 750,
+      "png_height": 9774,
+      "rel_path": "BASE2/png/services-mobile.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5892,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-mobile.png",
+      "ok": true,
+      "sha256": "6a01da359292468085689f290596bce2a9f3b8643a813ad5898e9c79c0a7e301",
+      "bytes": 2619651,
+      "png_width": 750,
+      "png_height": 11784,
+      "rel_path": "BASE2/png/speaking-mobile.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5887,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-mobile.png",
+      "ok": true,
+      "sha256": "b68956eff1aa42cdd4095b3cf9301456b196b46f0f856c11e5f9a8db9455c610",
+      "bytes": 5126153,
+      "png_width": 750,
+      "png_height": 11774,
+      "rel_path": "BASE2/png/work-mobile.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 8540,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-mobile.png",
+      "ok": true,
+      "sha256": "eb8e70680e0e480623186f5082f95a83626cf05243b68fa5319482d62e3182b4",
+      "bytes": 11790334,
+      "png_width": 750,
+      "png_height": 17080,
+      "rel_path": "BASE2/png/photography-mobile.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 11559,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-mobile.png",
+      "ok": true,
+      "sha256": "ef0e8b39e749a44b0310bd446372e91290494395b55874e2d37dbf731c2de91f",
+      "bytes": 10234512,
+      "png_width": 750,
+      "png_height": 23118,
+      "rel_path": "BASE2/png/blog-mobile.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4717,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-mobile.png",
+      "ok": true,
+      "sha256": "6a290b233bce6e9a76375f00fc1b41a73a8b9b8c9c199bf624490d961ef0967f",
+      "bytes": 2054239,
+      "png_width": 750,
+      "png_height": 9434,
+      "rel_path": "BASE2/png/contact-mobile.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 20137,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-mobile.png",
+      "ok": true,
+      "sha256": "97332769a82e7e257397235d26873771c6a990886b7a62e7bca6b6934c492ab5",
+      "bytes": 6201010,
+      "png_width": 750,
+      "png_height": 40274,
+      "rel_path": "BASE2/png/single-post-mobile.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2732,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-mobile.png",
+      "ok": true,
+      "sha256": "e227d463d8de568b3fc00a66ee527f52e1b05923ba877225358f62d634a4aaad",
+      "bytes": 1165768,
+      "png_width": 750,
+      "png_height": 5464,
+      "rel_path": "BASE2/png/not-found-mobile.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 11595,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-mobile.png",
+      "ok": true,
+      "sha256": "66a393226c91fad96a4a77067b220c2799ae4912e5145f4da7150735cd6d55ef",
+      "bytes": 2101847,
+      "png_width": 750,
+      "png_height": 23190,
+      "rel_path": "BASE2/png/category-archive-mobile.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 10661,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-tablet.png",
+      "ok": true,
+      "sha256": "60507d74243c55b62cb8cd702ee25bdf201a4b1de7992aa568899c91dbd462ed",
+      "bytes": 13537377,
+      "png_width": 1536,
+      "png_height": 21322,
+      "rel_path": "BASE2/png/home-tablet.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5380,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-tablet.png",
+      "ok": true,
+      "sha256": "9e7066edd757529ff72113152b28813d2c80bdb5c1b388c89ad15f543b3d3bed",
+      "bytes": 5936769,
+      "png_width": 1536,
+      "png_height": 10760,
+      "rel_path": "BASE2/png/about-tablet.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4539,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-tablet.png",
+      "ok": true,
+      "sha256": "4d23aeedbaf525c2ca5e3ebf48e0136e3f172c45570d14081ded920a54402475",
+      "bytes": 5663598,
+      "png_width": 1536,
+      "png_height": 9078,
+      "rel_path": "BASE2/png/services-tablet.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5221,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-tablet.png",
+      "ok": true,
+      "sha256": "b9426205ecccec4cc78f3e0b090c121e2270d6b00fa401d10b475b226edb4f14",
+      "bytes": 5770366,
+      "png_width": 1536,
+      "png_height": 10442,
+      "rel_path": "BASE2/png/speaking-tablet.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5836,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-tablet.png",
+      "ok": true,
+      "sha256": "a65134378ce6d5702f2760cc8c48ccd085c4fc107e00fe57b17913bfd1ea391d",
+      "bytes": 11448815,
+      "png_width": 1536,
+      "png_height": 11672,
+      "rel_path": "BASE2/png/work-tablet.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 5904,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-tablet.png",
+      "ok": true,
+      "sha256": "7a178a3b8c2263ea911f79b1632ee55404558da8c9649e5bba7ec672ef7684eb",
+      "bytes": 15131879,
+      "png_width": 1536,
+      "png_height": 11808,
+      "rel_path": "BASE2/png/photography-tablet.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 6841,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-tablet.png",
+      "ok": true,
+      "sha256": "818e969e8572c8c1f9b4730855a5f051b7e70d6d93f0d892ec21569690358ed2",
+      "bytes": 12708191,
+      "png_width": 1536,
+      "png_height": 13682,
+      "rel_path": "BASE2/png/blog-tablet.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 3260,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-tablet.png",
+      "ok": true,
+      "sha256": "cb550cb7cd65c933d165baefdb69dad551c535989c1cea5aa3277fedf561ca99",
+      "bytes": 3263753,
+      "png_width": 1536,
+      "png_height": 6520,
+      "rel_path": "BASE2/png/contact-tablet.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 16317,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-tablet.png",
+      "ok": true,
+      "sha256": "f5ea66eda2ba89df7a00f57d802861f50c52a71ce385e0cbb3f3c1c5fdec2406",
+      "bytes": 16390487,
+      "png_width": 1536,
+      "png_height": 32634,
+      "rel_path": "BASE2/png/single-post-tablet.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2169,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-tablet.png",
+      "ok": true,
+      "sha256": "bcb01a370804ff958152722f30edb80054c20cb0a5d3773363c96e6176fed4be",
+      "bytes": 2657993,
+      "png_width": 1536,
+      "png_height": 4338,
+      "rel_path": "BASE2/png/not-found-tablet.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 8724,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-tablet.png",
+      "ok": true,
+      "sha256": "f5a8df79e678983de7fa5b6c13a6b3e696024e29d484bd7687d4d06dbad80642",
+      "bytes": 3684304,
+      "png_width": 1536,
+      "png_height": 17448,
+      "rel_path": "BASE2/png/category-archive-tablet.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 10,
+        "beehiiv": 0
+      },
+      "scroll_height": 6443,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-desktop.png",
+      "ok": true,
+      "sha256": "57649ed19de69f0bb2bd7b2f46a2d0e9702dca45349c7367e661d699307bbfcc",
+      "bytes": 11464303,
+      "png_width": 2880,
+      "png_height": 12886,
+      "rel_path": "BASE2/png/home-desktop.png"
+    },
+    {
+      "id": "about",
+      "path": "/about/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4538,
+      "doc_title": "About Kris Kr\u00fcg | AI Speaker, Creative Technologist & Community Builder",
+      "file": "about-desktop.png",
+      "ok": true,
+      "sha256": "4df37fabe0fd2282cb6fbe0928b0671a86284ae448f965f5cc0e17eee35eae18",
+      "bytes": 6393786,
+      "png_width": 2880,
+      "png_height": 9076,
+      "rel_path": "BASE2/png/about-desktop.png"
+    },
+    {
+      "id": "services",
+      "path": "/generative-ai-services/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 3,
+        "painted": 3
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 3564,
+      "doc_title": "Generative AI Creative Services & Strategy \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "services-desktop.png",
+      "ok": true,
+      "sha256": "fbd2eda3ad54001563a23621ebb79065166b213489a771aea57212a201cdc8b9",
+      "bytes": 5612474,
+      "png_width": 2880,
+      "png_height": 7128,
+      "rel_path": "BASE2/png/services-desktop.png"
+    },
+    {
+      "id": "speaking",
+      "path": "/speaking/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 5,
+        "painted": 5
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4337,
+      "doc_title": "AI Keynote Speaker Kris Kr\u00fcg | Humanizing AI, Creativity & Community",
+      "file": "speaking-desktop.png",
+      "ok": true,
+      "sha256": "776220f843219cd3d8da9cb6266f57078f7f2747440236c4b892289e103c59dc",
+      "bytes": 6008519,
+      "png_width": 2880,
+      "png_height": 8674,
+      "rel_path": "BASE2/png/speaking-desktop.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4425,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-desktop.png",
+      "ok": true,
+      "sha256": "6de36d98afb18d45155c8583ac108eb350e4d325b9345e46b000da66427f95bb",
+      "bytes": 9963219,
+      "png_width": 2880,
+      "png_height": 8850,
+      "rel_path": "BASE2/png/work-desktop.png"
+    },
+    {
+      "id": "photography",
+      "path": "/photography/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 18,
+        "painted": 18
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 4513,
+      "doc_title": "Photography \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "photography-desktop.png",
+      "ok": true,
+      "sha256": "5f31d33a026323f9f1d95c0cda3a7e5af3ee517c364fdcbffc607d8a913b0811",
+      "bytes": 15297278,
+      "png_width": 2880,
+      "png_height": 9026,
+      "rel_path": "BASE2/png/photography-desktop.png"
+    },
+    {
+      "id": "blog",
+      "path": "/blog/",
+      "template": "index.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 19,
+        "painted": 19
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 20,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 5447,
+      "doc_title": "Blog \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "blog-desktop.png",
+      "ok": true,
+      "sha256": "8af1eb2509ba1e326545febcca19afc3c04d4d4358f5bfca464d65e97bb7aacb",
+      "bytes": 14964328,
+      "png_width": 2880,
+      "png_height": 10894,
+      "rel_path": "BASE2/png/blog-desktop.png"
+    },
+    {
+      "id": "contact",
+      "path": "/contact/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 2,
+        "painted": 2
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2918,
+      "doc_title": "Contact Kris Kr\u00fcg \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "contact-desktop.png",
+      "ok": true,
+      "sha256": "f4c97988e02a1566012879f338847b5eb4c49e1f91d6da0ed52e813e4fb52f80",
+      "bytes": 4865454,
+      "png_width": 2880,
+      "png_height": 5836,
+      "rel_path": "BASE2/png/contact-desktop.png"
+    },
+    {
+      "id": "single-post",
+      "path": "/2026/07/18/i-am-nomad-ai-film/",
+      "template": "single.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 9,
+        "painted": 9
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 76,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 8,
+        "beehiiv": 0
+      },
+      "scroll_height": 17543,
+      "doc_title": "I AM NOMAD: Nine Cuts, One Melting Whale, and a Very Patient AI Editor \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "single-post-desktop.png",
+      "ok": true,
+      "sha256": "cf90fcc186554e9ac98d85223148b0d8842367c18b6de71861ba63c0c87edc2d",
+      "bytes": 19971108,
+      "png_width": 2880,
+      "png_height": 35086,
+      "rel_path": "BASE2/png/single-post-desktop.png"
+    },
+    {
+      "id": "not-found",
+      "path": "/definitely-not-a-page-404-probe/",
+      "template": "404.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 404,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 2061,
+      "doc_title": "Page not found \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "not-found-desktop.png",
+      "ok": true,
+      "sha256": "1cb75c0380edeb30005fbb1ec4e97a95cffa5ac6abf7ebaed02373da1230c5ac",
+      "bytes": 3914028,
+      "png_width": 2880,
+      "png_height": 4122,
+      "rel_path": "BASE2/png/not-found-desktop.png"
+    },
+    {
+      "id": "category-archive",
+      "path": "/category/vancouver-ai-ecosystem/",
+      "template": "archive.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 1,
+        "painted": 1
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 38,
+        "beehiiv": 0
+      },
+      "scroll_height": 8947,
+      "doc_title": "Vancouver AI Ecosystem \u2014 Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "category-archive-desktop.png",
+      "ok": true,
+      "sha256": "d68300cd5ddee8bde2084f544e82ce23c767be5e0312a07e1275e4c0b78f7438",
+      "bytes": 5115504,
+      "png_width": 2880,
+      "png_height": 17894,
+      "rel_path": "BASE2/png/category-archive-desktop.png"
+    }
+  ],
+  "kind": "candidate",
+  "css_identity": {
+    "files": [
+      {
+        "file": "style.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+        "live_status": 200,
+        "live_md5": "28a523c46532dc0fcebf58df32f63cf5",
+        "live_bytes": 111255,
+        "repo_md5": "0ab1fadf9e64d0c2444d25d6a90e9fb7",
+        "repo_bytes": 113860,
+        "identical": false
+      },
+      {
+        "file": "assets/css/animations.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+        "live_status": 200,
+        "live_md5": "7645e93ae4fd628b59893794c70a8432",
+        "live_bytes": 7540,
+        "repo_md5": "7645e93ae4fd628b59893794c70a8432",
+        "repo_bytes": 7540,
+        "identical": true
+      },
+      {
+        "file": "assets/css/bleeding-edge.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+        "live_status": 200,
+        "live_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+        "live_bytes": 12390,
+        "repo_md5": "88d0fc9c77d881ed0baa39f2f4edcb6f",
+        "repo_bytes": 12390,
+        "identical": true
+      },
+      {
+        "file": "assets/css/editor.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+        "live_status": 200,
+        "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "live_bytes": 5343,
+        "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "repo_bytes": 5343,
+        "identical": true
+      },
+      {
+        "file": "assets/css/revive-port.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+        "live_status": 200,
+        "live_md5": "737818af24412ef23a8493249c5ee9e4",
+        "live_bytes": 27630,
+        "repo_md5": "f1ffb49f638fcbb8956ffb0aff4b69ea",
+        "repo_bytes": 28495,
+        "identical": false
+      },
+      {
+        "file": "assets/css/typography-refined.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+        "live_status": 200,
+        "live_md5": "69e3035368a854cb3dc56accc4e44c1a",
+        "live_bytes": 16735,
+        "repo_md5": "69e3035368a854cb3dc56accc4e44c1a",
+        "repo_bytes": 16735,
+        "identical": true
+      }
+    ],
+    "all_identical": false,
+    "live_theme_version": "1.4.3",
+    "repo_theme_version": "1.4.5"
+  },
+  "boost": {
+    "source": "https://kriskrug.co/",
+    "home_status": 200,
+    "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/78b2cf14fa.min.css",
+    "css_bundle_hash": "78b2cf14fa",
+    "css_bundle_md5": "8dad4baf6c2e420e8cb83000247f75fd",
+    "css_bundle_bytes": 138229,
+    "js_bundle_hash": "80bc38e6a8"
+  },
+  "baseline_run": "BASE1"
+}

--- a/docs/current-state/reports/visual-baseline/report-BASE2.md
+++ b/docs/current-state/reports/visual-baseline/report-BASE2.md
@@ -1,0 +1,58 @@
+## Visual regression — PASS
+
+Baseline `BASE1` → candidate `BASE2` against `https://kriskrug.co`, generated 2026-07-25T21:05:13+00:00.
+
+**33 pass · 0 warn · 0 fail · 0 error** across 33 route/viewport pairs.
+
+Tolerance: pass ≤ 0.1% differing pixels · warn ≤ 1.0% · fail > 1.0% or > 2.0% full-page height delta · per-pixel threshold 0.2.
+
+| Route | Viewport | Diff % | Height Δ% | Method | Verdict |
+|---|---|---:|---:|---|---|
+| `/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/about/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/about/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/about/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/generative-ai-services/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/generative-ai-services/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/generative-ai-services/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/speaking/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/speaking/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/speaking/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/work/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/work/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/work/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/photography/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/photography/` | tablet | 0 | 0 | pixel | **PASS** |
+| `/photography/` | desktop | 0 | 0 | pixel | **PASS** |
+| `/blog/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/blog/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/blog/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/contact/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/contact/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/contact/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/2026/07/18/i-am-nomad-ai-film/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/2026/07/18/i-am-nomad-ai-film/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/2026/07/18/i-am-nomad-ai-film/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/definitely-not-a-page-404-probe/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/definitely-not-a-page-404-probe/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/definitely-not-a-page-404-probe/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+| `/category/vancouver-ai-ecosystem/` | mobile | 0 | 0 | sha256-identical | **PASS** |
+| `/category/vancouver-ai-ecosystem/` | tablet | 0 | 0 | sha256-identical | **PASS** |
+| `/category/vancouver-ai-ecosystem/` | desktop | 0 | 0 | sha256-identical | **PASS** |
+
+### Environment readback
+
+- Live theme version: **1.4.3** (repo `theme/kk-aurora/style.css`: **1.4.5**)
+- Live-vs-repo CSS md5 identity: **DRIFT**
+  - `style.css` ≠ live `28a523c46532` / repo `0ab1fadf9e64`
+  - `assets/css/animations.css` = live `7645e93ae4fd` / repo `7645e93ae4fd`
+  - `assets/css/bleeding-edge.css` = live `88d0fc9c77d8` / repo `88d0fc9c77d8`
+  - `assets/css/editor.css` = live `4b0cb7208888` / repo `4b0cb7208888`
+  - `assets/css/revive-port.css` ≠ live `737818af2441` / repo `f1ffb49f638f`
+  - `assets/css/typography-refined.css` = live `69e3035368a8` / repo `69e3035368a8`
+- Jetpack Boost CSS bundle: baseline `78b2cf14fa` → candidate `78b2cf14fa` (unchanged)
+  - If a deploy happened between these two runs, an unchanged Boost hash means it did not reach the edge (risk R-2) — not that it had no visual effect. Purge Boost + PressCACHE and re-run before reading this as a green light.
+
+_Screenshots cannot see focus, hover or keyboard behaviour (#424 remains a separate gate), and there is no staging environment — this compares post-deploy live against pre-deploy live (§4.7)._

--- a/scripts/visual_baseline.py
+++ b/scripts/visual_baseline.py
@@ -1,0 +1,1961 @@
+#!/usr/bin/env python3
+"""visual_baseline.py — visual-regression baseline harness for kriskrug.co (issue #473).
+
+Implements step 1 / §4 of docs/current-state/AURORA-STYLESHEET-REBUILD-PLAN.md.
+This is the gate for the Aurora stylesheet rebuild (#423): no rebuild step may
+land unless a `make visual-diff` run against it is green.
+
+WHAT IT DOES
+------------
+Captures full-page screenshots of 11 logged-out routes at 3 viewports
+(375 / 768 / 1440), with reduced-motion and light color-scheme forced and a
+scroll-settle pass, masking the known non-deterministic regions (marquee board,
+live dates, Beehiiv embed). It then records a hash manifest — never the pixels —
+plus the live-vs-repo md5 identity of every theme CSS file and the Jetpack Boost
+bundle hash for the same run.
+
+    make visual-baseline            # freeze a baseline, write manifest-<ts>.json
+    make visual-diff BASE=<ts>      # capture a candidate, compare, pass/warn/fail
+    make visual-diff-report         # markdown table for the PR body
+
+HOW IT TALKS TO THE SITE
+------------------------
+Chromium in this sandbox cannot reach kriskrug.co directly — the agent HTTPS
+proxy resets browser connections (ERR_CONNECTION_RESET) while curl gets 200.
+So every request the browser makes is intercepted by Playwright and fulfilled
+from a curl fetch, keyed by URL and cached on disk for the run. The page's own
+origin is preserved (we navigate to the real https://kriskrug.co/<route> and
+fulfil it), so no URL rewriting is needed and same-origin CSS stays readable.
+This is the same constraint scripts/interaction_state_probe.js works around; the
+mechanism here is request interception rather than a rewritten local mirror.
+
+Hosts outside the allowlist (kriskrug.co, the Pagely CDN, the Jetpack image CDN)
+are fulfilled with an empty 200 rather than fetched. That is deliberate: GTM,
+social embeds and third-party widgets are the largest source of run-to-run
+nondeterminism, and their layout boxes are declared in markup/CSS, not by the
+response body.
+
+WHY THE DIFF RUNS IN CHROMIUM
+-----------------------------
+Neither `pixelmatch`/`pngjs` (node) nor `Pillow`/`numpy` (python) are installed
+here, and a pure-Python PNG decode of a 2880x20000 full-page capture is far too
+slow to be a usable gate. Chromium is already a hard dependency and decodes PNG
+natively, so the comparison is done in-page over typed arrays using pixelmatch's
+YIQ delta at threshold 0.2, strip by strip to bound canvas memory.
+
+STORAGE — issue #318
+--------------------
+PNGs are NEVER committed. `docs/current-state/reports/visual-baseline/*` is
+git-ignored wholesale; only `manifest-*.json`, `diff-*.json` and `report-*.md`
+at its top level are un-ignored by name. `visual_baseline.py guard` re-checks
+that invariant against the git index after every capture and diff, and the make
+targets fail if it trips. See `--help` of the `guard` subcommand.
+
+CHROMIUM
+--------
+Chromium is preinstalled at /opt/pw-browsers. This script REFUSES to download a
+browser: if PLAYWRIGHT_BROWSERS_PATH is unset, missing, or Chromium is not
+present under it, preflight exits 2 with a FATAL message. Every node child is
+spawned with PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 so even a bug cannot fetch one.
+
+Read-only with respect to WordPress: it issues GETs and nothing else.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ROOT = REPO_ROOT / "docs" / "current-state" / "reports" / "visual-baseline"
+ARTIFACT_ROOT_REL = "docs/current-state/reports/visual-baseline"
+
+BASE_URL = "https://kriskrug.co"
+
+# Hosts whose responses are really fetched. Everything else is fulfilled with an
+# empty 200 so third-party widgets cannot make the baseline nondeterministic.
+ALLOW_HOSTS = ("kriskrug.co", "s5102.pcdn.co", "i0.wp.com", "i1.wp.com", "i2.wp.com")
+
+# --------------------------------------------------------------------------
+# Routes — §4.2. Eleven logged-out routes, chosen to cover distinct templates.
+#
+# `expect_status` is asserted by preflight before any capture runs: a route that
+# starts redirecting or 404ing must break the run loudly, not be captured as a
+# silently different page. That is the difference between a gate and theatre.
+# --------------------------------------------------------------------------
+ROUTES: tuple[dict[str, Any], ...] = (
+    {"id": "home", "path": "/", "template": "front-page.html", "expect_status": 200},
+    {"id": "about", "path": "/about/", "template": "page.html", "expect_status": 200},
+    {
+        "id": "services",
+        "path": "/generative-ai-services/",
+        "template": "page.html",
+        "expect_status": 200,
+        # §4.2 lists /services/; live 301s it to /generative-ai-services/.
+        # Captured at the canonical target so the capture is of a page, not of a
+        # redirect. Verified 2026-07-25.
+        "note": "canonical target of /services/ (301)",
+    },
+    {"id": "speaking", "path": "/speaking/", "template": "page.html", "expect_status": 200},
+    {"id": "work", "path": "/work/", "template": "page.html", "expect_status": 200},
+    {"id": "photography", "path": "/photography/", "template": "page.html", "expect_status": 200},
+    {"id": "blog", "path": "/blog/", "template": "index.html", "expect_status": 200},
+    {"id": "contact", "path": "/contact/", "template": "page.html", "expect_status": 200},
+    {
+        "id": "single-post",
+        "path": "/2026/07/18/i-am-nomad-ai-film/",
+        "template": "single.html",
+        "expect_status": 200,
+    },
+    {
+        "id": "not-found",
+        "path": "/definitely-not-a-page-404-probe/",
+        "template": "404.html",
+        "expect_status": 404,
+    },
+    {
+        "id": "category-archive",
+        "path": "/category/vancouver-ai-ecosystem/",
+        "template": "archive.html",
+        "expect_status": 200,
+        # §4.2 asks for a marquee board post here (the theme's only inline
+        # <style>). kk-marquee-board is repo-side only: /marquee/ returns 404 on
+        # live as of 2026-07-25, so there is no board post to capture. The
+        # category archive is substituted because archive.html is otherwise
+        # uncovered by the other ten. See MARQUEE_ROUTE below — flip it on and
+        # drop this one once the plugin is deployed.
+        "note": "stands in for the marquee board post; /marquee/ is 404 on live",
+    },
+)
+
+# Not captured today. Kept here so the substitution above is explicit and
+# reversible rather than a silently missing route.
+MARQUEE_ROUTE = {
+    "id": "marquee-board",
+    "path": "/marquee/",
+    "template": "single-marquee_board.html",
+    "expect_status": 200,
+    "enabled": False,
+    "note": "kk-marquee-board is not deployed to live; /marquee/ 404s (checked 2026-07-25)",
+}
+
+VIEWPORTS: tuple[dict[str, Any], ...] = (
+    {"name": "mobile", "width": 375, "height": 812},
+    {"name": "tablet", "width": 768, "height": 1024},
+    {"name": "desktop", "width": 1440, "height": 900},
+)
+
+DEFAULT_DEVICE_SCALE = 2  # §4.3
+
+# --------------------------------------------------------------------------
+# Masks — §4.3: "declared in the manifest, not hardcoded". They live here as the
+# default declaration, are written into every manifest, and can be overridden
+# per run with --masks <file.json>. A selector that matches nothing is not an
+# error; the per-capture match counts are recorded so a mask silently ceasing to
+# match (a class rename) is visible in the manifest instead of surfacing as a
+# mystery diff.
+# --------------------------------------------------------------------------
+DEFAULT_MASKS: dict[str, list[str]] = {
+    "marquee": [
+        ".aurora-woven-marquee",
+        ".aurora-woven-marquee-track",
+        ".kkm",
+        ".kkm-board",
+        "[class*='marquee']",
+    ],
+    "dates": [
+        "time",
+        ".wp-block-post-date",
+        ".aurora-article-date",
+        ".aurora-masthead-date",
+        "[class*='now-showing']",
+        "[class*='entry-date']",
+        "[class*='posted-on']",
+    ],
+    "beehiiv": [
+        "iframe[src*='beehiiv']",
+        "[class*='beehiiv']",
+        "[id*='beehiiv']",
+        "[data-beehiiv]",
+    ],
+}
+MASK_COLOR = "#FF00FF"
+
+# --------------------------------------------------------------------------
+# Reveal end-states.
+#
+# Aurora gates several components behind JS-added classes and starts them at
+# `opacity: 0` (style.css: `.aurora-fade-up`, `.aurora-scale-in`,
+# `.is-aurora-lux-reveal`; animations.css: `.aurora-hero-text .word`). A
+# full-page screenshot renders content that was never scrolled into view, so
+# whether an IntersectionObserver fired is a race — and an element that lost the
+# race is captured invisible. Measured on /blog/: reveal-gated cards rendered at
+# partial opacity, which is both wrong (no visitor sees that) and unstable.
+#
+# So after the scroll pass we add the theme's OWN "revealed" class rather than
+# overriding opacity/transform in CSS. Driving the theme's end state through its
+# own selectors means a real regression in those rules still shows up in the
+# pixels; a blanket `opacity: 1 !important` would hide it.
+#
+# Declared here, written into the manifest, and the per-run match counts are
+# recorded — so a class rename surfaces as a count of 0 rather than as a diff
+# nobody can explain.
+# --------------------------------------------------------------------------
+DEFAULT_REVEALS: list[dict[str, str]] = [
+    {"selector": ".is-aurora-lux-reveal", "add_class": "is-revealed"},
+    {"selector": ".aurora-fade-up", "add_class": "is-visible"},
+    {"selector": ".aurora-scale-in", "add_class": "is-visible"},
+    {"selector": ".aurora-hero-text", "add_class": "is-visible"},
+]
+
+# --------------------------------------------------------------------------
+# Tolerance — §4.4
+# --------------------------------------------------------------------------
+TOLERANCE = {
+    "pixel_threshold": 0.2,  # per-pixel YIQ antialias tolerance (pixelmatch default)
+    "pass_pct": 0.1,  # <= this share of differing pixels -> pass
+    "warn_pct": 1.0,  # <= this -> warn (human review); above -> fail
+    "height_delta_pct": 2.0,  # any full-page height change beyond this -> fail
+}
+
+# Theme CSS files whose live-vs-repo md5 identity is recorded per run (§4.5/§1.6).
+THEME_CSS_FILES = (
+    "style.css",
+    "assets/css/animations.css",
+    "assets/css/bleeding-edge.css",
+    "assets/css/editor.css",
+    "assets/css/revive-port.css",
+    "assets/css/typography-refined.css",
+)
+THEME_LIVE_BASE = "/wp-content/themes/kk-aurora/"
+THEME_REPO_DIR = REPO_ROOT / "theme" / "kk-aurora"
+
+SETTLE_MS = 900
+IMAGE_BUDGET_MS = 25_000  # per-image ceiling in the force-load pass
+NAV_TIMEOUT_MS = 90_000
+
+MANIFEST_SCHEMA = "kk-visual-baseline/1"
+
+
+# ==========================================================================
+# small helpers
+# ==========================================================================
+
+
+def fatal(msg: str, code: int = 2) -> None:
+    print(f"FATAL: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def info(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def run_id_now() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def png_dimensions(path: Path) -> tuple[int, int]:
+    """Width/height from the IHDR chunk. Avoids decoding the image."""
+    with path.open("rb") as fh:
+        head = fh.read(24)
+    if len(head) < 24 or head[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"not a PNG: {path}")
+    width = int.from_bytes(head[16:20], "big")
+    height = int.from_bytes(head[20:24], "big")
+    return width, height
+
+
+def curl_bytes(url: str, timeout: int = 60) -> tuple[int, bytes]:
+    """GET a URL with curl. Returns (http_status, body). Never raises on 4xx/5xx."""
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        dest = Path(tf.name)
+    try:
+        proc = subprocess.run(
+            [
+                "curl", "-sS", "-L",
+                "--max-time", str(timeout),
+                "-H", "Cache-Control: no-cache",
+                "-H", "Pragma: no-cache",
+                "-o", str(dest),
+                "-w", "%{http_code}",
+                url,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"curl failed for {url}: {proc.stderr.strip()}")
+        status = int((proc.stdout or "0").strip() or 0)
+        return status, dest.read_bytes()
+    finally:
+        dest.unlink(missing_ok=True)
+
+
+def curl_status(url: str, timeout: int = 45) -> int:
+    proc = subprocess.run(
+        ["curl", "-sS", "-o", os.devnull, "-w", "%{http_code}", "--max-time", str(timeout), url],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"curl failed for {url}: {proc.stderr.strip()}")
+    return int((proc.stdout or "0").strip() or 0)
+
+
+def git(*args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args], capture_output=True, text=True, check=False
+    )
+    return proc.stdout
+
+
+# ==========================================================================
+# preflight — Chromium, node, playwright, routes
+# ==========================================================================
+
+NODE_CANDIDATES = ("node", "/opt/node22/bin/node")
+NODE_PATH_CANDIDATES = (
+    "/opt/node22/lib/node_modules",
+    "/usr/lib/node_modules",
+    "/usr/local/lib/node_modules",
+)
+
+
+def resolve_node() -> str:
+    for cand in NODE_CANDIDATES:
+        exe = shutil.which(cand) if "/" not in cand else (cand if Path(cand).exists() else None)
+        if exe:
+            return exe
+    fatal(
+        "node was not found. Tried: " + ", ".join(NODE_CANDIDATES) + "\n"
+        "The capture driver is a Node/Playwright program; there is no pure-Python fallback."
+    )
+    raise AssertionError  # unreachable
+
+
+def node_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["NODE_PATH"] = os.pathsep.join(
+        [p for p in NODE_PATH_CANDIDATES if Path(p).is_dir()] + [env.get("NODE_PATH", "")]
+    ).strip(os.pathsep)
+    # Belt and braces: even a bug in the driver cannot pull a browser down.
+    env["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] = "1"
+    env["PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS"] = "1"
+    return env
+
+
+def preflight_browser() -> dict[str, str]:
+    """Assert Chromium is present and usable. Exits 2 loudly; never downloads."""
+    bpath = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if not bpath:
+        fatal(
+            "PLAYWRIGHT_BROWSERS_PATH is unset.\n"
+            "  Chromium is preinstalled at /opt/pw-browsers. Re-run as:\n"
+            "    PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers make visual-baseline\n"
+            "  Refusing to run `playwright install` or trigger any browser download\n"
+            "  (AURORA-STYLESHEET-REBUILD-PLAN.md §4.1/§4.6)."
+        )
+    if not Path(bpath).is_dir():
+        fatal(
+            f"PLAYWRIGHT_BROWSERS_PATH={bpath} does not exist or is not a directory.\n"
+            "  Refusing to download a browser. Point it at an existing Playwright\n"
+            "  browsers directory (here: /opt/pw-browsers)."
+        )
+    chromium_dirs = sorted(p.name for p in Path(bpath).glob("chromium*") if p.is_dir())
+    if not chromium_dirs:
+        fatal(
+            f"no chromium* directory under PLAYWRIGHT_BROWSERS_PATH={bpath}.\n"
+            f"  Found: {sorted(p.name for p in Path(bpath).iterdir()) if Path(bpath).is_dir() else '[]'}\n"
+            "  Refusing to download a browser."
+        )
+
+    node = resolve_node()
+    probe = (
+        "const pw=require('playwright');"
+        "const fs=require('fs');"
+        "let exec=null,err=null;"
+        "try{exec=pw.chromium.executablePath();}catch(e){err=String(e&&e.message||e);}"
+        "process.stdout.write(JSON.stringify({"
+        "version:require('playwright/package.json').version,"
+        "exec:exec,execExists:exec?fs.existsSync(exec):false,err:err,node:process.version}));"
+    )
+    proc = subprocess.run(
+        [node, "-e", probe], capture_output=True, text=True, env=node_env(), check=False
+    )
+    if proc.returncode != 0:
+        fatal(
+            "the `playwright` node package is not resolvable.\n"
+            f"  node: {node}\n"
+            f"  NODE_PATH: {node_env().get('NODE_PATH')}\n"
+            f"  stderr: {proc.stderr.strip()[:500]}\n"
+            "  Install it globally (npm i -g playwright) or set NODE_PATH.\n"
+            "  Do NOT run `playwright install` — the browser is already at /opt/pw-browsers."
+        )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        fatal(f"could not parse playwright probe output: {proc.stdout[:300]!r}")
+        raise AssertionError  # unreachable
+    if not data.get("exec") or not data.get("execExists"):
+        fatal(
+            "Chromium executable is missing.\n"
+            f"  playwright {data.get('version')} resolved executablePath to: {data.get('exec')}\n"
+            f"  PLAYWRIGHT_BROWSERS_PATH={bpath} contains: {chromium_dirs}\n"
+            f"  probe error: {data.get('err')}\n"
+            "  Refusing to download it. Fix the install out of band."
+        )
+    return {
+        "node": node,
+        "node_version": data.get("node", ""),
+        "playwright": data.get("version", ""),
+        "chromium_exec": data.get("exec", ""),
+        "browsers_path": bpath,
+    }
+
+
+def enabled_routes(only: list[str] | None) -> list[dict[str, Any]]:
+    routes = [dict(r) for r in ROUTES if r.get("enabled", True)]
+    if only:
+        wanted = set(only)
+        unknown = wanted - {r["id"] for r in routes} - {r["path"] for r in routes}
+        if unknown:
+            fatal(f"unknown route selector(s): {sorted(unknown)}")
+        routes = [r for r in routes if r["id"] in wanted or r["path"] in wanted]
+    return routes
+
+
+def selected_viewports(only: list[str] | None, scale: int) -> list[dict[str, Any]]:
+    vps = [dict(v, scale=scale) for v in VIEWPORTS]
+    if only:
+        wanted = set(only)
+        unknown = wanted - {v["name"] for v in vps}
+        if unknown:
+            fatal(f"unknown viewport(s): {sorted(unknown)}")
+        vps = [v for v in vps if v["name"] in wanted]
+    return vps
+
+
+def preflight_routes(base: str, routes: list[dict[str, Any]], strict: bool = True) -> list[dict]:
+    """Assert every route still answers with the status the config expects."""
+    out = []
+    problems = []
+    for r in routes:
+        url = base.rstrip("/") + r["path"]
+        # No -L here: a route that started redirecting is a config drift we want
+        # to see, not follow.
+        proc = subprocess.run(
+            ["curl", "-sS", "-o", os.devnull, "-w", "%{http_code}", "--max-time", "45", url],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        status = int((proc.stdout or "0").strip() or 0)
+        out.append({"id": r["id"], "path": r["path"], "status": status, "expected": r["expect_status"]})
+        if status != r["expect_status"]:
+            problems.append(f"  {r['id']:<18} {r['path']}  expected {r['expect_status']}, got {status}")
+    if problems and strict:
+        fatal(
+            "route preflight failed — the route list has drifted from live:\n"
+            + "\n".join(problems)
+            + "\n  Fix ROUTES in scripts/visual_baseline.py (and say so in the PR) before\n"
+            "  capturing. A baseline of the wrong page is worse than no baseline."
+        )
+    return out
+
+
+# ==========================================================================
+# live-vs-repo CSS identity + Boost bundle hash (§4.3 / §4.5)
+# ==========================================================================
+
+
+def theme_version(css_text: str) -> str | None:
+    m = re.search(r"^\s*Version:\s*(.+?)\s*$", css_text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def css_identity(base: str) -> dict[str, Any]:
+    """md5 of each theme CSS file, live vs repo, plus both theme versions."""
+    rows = []
+    live_version = None
+    repo_version = None
+    for rel in THEME_CSS_FILES:
+        url = base.rstrip("/") + THEME_LIVE_BASE + rel
+        row: dict[str, Any] = {"file": rel, "live_url": url}
+        try:
+            status, body = curl_bytes(url)
+            row["live_status"] = status
+            if status == 200:
+                row["live_md5"] = hashlib.md5(body).hexdigest()
+                row["live_bytes"] = len(body)
+                if rel == "style.css":
+                    live_version = theme_version(body.decode("utf-8", "replace"))
+            else:
+                row["live_md5"] = None
+        except Exception as exc:  # network flake must not be silent
+            row["live_status"] = None
+            row["live_md5"] = None
+            row["error"] = str(exc)[:200]
+        repo_path = THEME_REPO_DIR / rel
+        if repo_path.exists():
+            data = repo_path.read_bytes()
+            row["repo_md5"] = hashlib.md5(data).hexdigest()
+            row["repo_bytes"] = len(data)
+            if rel == "style.css":
+                repo_version = theme_version(data.decode("utf-8", "replace"))
+        else:
+            row["repo_md5"] = None
+        row["identical"] = bool(row.get("live_md5")) and row.get("live_md5") == row.get("repo_md5")
+        rows.append(row)
+    return {
+        "files": rows,
+        "all_identical": all(r["identical"] for r in rows),
+        "live_theme_version": live_version,
+        "repo_theme_version": repo_version,
+    }
+
+
+BOOST_CSS_RE = re.compile(r"""["']([^"']*/boost-cache/static/([0-9a-f]+)\.min\.css)["']""")
+BOOST_JS_RE = re.compile(r"""["']([^"']*/boost-cache/static/([0-9a-f]+)\.min\.js)["']""")
+
+
+def boost_bundle(base: str) -> dict[str, Any]:
+    """Jetpack Boost concatenated bundle hash — R-2's detection control.
+
+    An unchanged hash after a deploy means the deploy did not reach the edge, not
+    that the deploy had no visual effect. Recorded per run so the two readings
+    can be compared.
+    """
+    out: dict[str, Any] = {"source": base.rstrip("/") + "/"}
+    try:
+        status, body = curl_bytes(out["source"])
+        html = body.decode("utf-8", "replace")
+        out["home_status"] = status
+    except Exception as exc:
+        out["error"] = str(exc)[:200]
+        return out
+    m = BOOST_CSS_RE.search(html)
+    if m:
+        url = m.group(1)
+        out["css_bundle_url"] = url
+        out["css_bundle_hash"] = m.group(2)
+        try:
+            st, css = curl_bytes(url if url.startswith("http") else base.rstrip("/") + url)
+            if st == 200:
+                out["css_bundle_md5"] = hashlib.md5(css).hexdigest()
+                out["css_bundle_bytes"] = len(css)
+        except Exception as exc:
+            out["css_bundle_error"] = str(exc)[:200]
+    else:
+        out["css_bundle_url"] = None
+        out["note"] = "no Jetpack Boost concatenated CSS bundle found on the homepage"
+    mj = BOOST_JS_RE.search(html)
+    out["js_bundle_hash"] = mj.group(2) if mj else None
+    return out
+
+
+# ==========================================================================
+# the Node capture driver
+# ==========================================================================
+
+CAPTURE_JS = r"""
+'use strict';
+/* Capture driver for scripts/visual_baseline.py (issue #473).
+ * Written into the run directory at runtime; never tracked by git.
+ * Reads a JSON config on argv[2], writes <out>/captures.json. */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const execFileP = promisify(execFile);
+
+function loadPlaywright() {
+  for (const c of ['playwright', '/opt/node22/lib/node_modules/playwright',
+                   '/usr/lib/node_modules/playwright', '/usr/local/lib/node_modules/playwright']) {
+    try { return require(c); } catch (_) { /* next */ }
+  }
+  console.error('FATAL: playwright is not resolvable from the capture driver.');
+  process.exit(2);
+}
+
+const cfg = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+const CACHE = cfg.cacheDir;
+fs.mkdirSync(CACHE, { recursive: true });
+fs.mkdirSync(cfg.pngDir, { recursive: true });
+
+const allow = new Set(cfg.allowHosts);
+const inflight = new Map();
+const stats = { fetched: 0, cached: 0, blocked: 0, failed: 0 };
+
+function cacheKey(url) { return crypto.createHash('sha256').update(url).digest('hex').slice(0, 40); }
+
+async function fetchThroughCurl(url) {
+  const key = cacheKey(url);
+  const bodyFile = path.join(CACHE, key + '.bin');
+  const metaFile = path.join(CACHE, key + '.json');
+  if (fs.existsSync(metaFile) && fs.existsSync(bodyFile)) {
+    stats.cached++;
+    return { meta: JSON.parse(fs.readFileSync(metaFile, 'utf8')), body: fs.readFileSync(bodyFile) };
+  }
+  if (inflight.has(key)) return inflight.get(key);
+  const p = (async () => {
+    const hdrFile = path.join(CACHE, key + '.hdr');
+    const args = ['-sS', '-L', '--max-time', String(cfg.curlTimeout || 60),
+                  '-H', 'Cache-Control: no-cache', '-H', 'Pragma: no-cache',
+                  '-o', bodyFile, '-D', hdrFile, '-w', '%{http_code}', url];
+    const { stdout } = await execFileP('curl', args, { maxBuffer: 1 << 24 });
+    const headers = fs.readFileSync(hdrFile, 'utf8');
+    const ct = headers.match(/^content-type:\s*(.+)$/im);
+    const meta = { status: Number(String(stdout).trim()) || 200,
+                   contentType: ct ? ct[1].trim() : 'application/octet-stream' };
+    fs.writeFileSync(metaFile, JSON.stringify(meta));
+    fs.rmSync(hdrFile, { force: true });
+    stats.fetched++;
+    return { meta, body: fs.readFileSync(bodyFile) };
+  })().finally(() => inflight.delete(key));
+  inflight.set(key, p);
+  return p;
+}
+
+// Empty bodies for blocked hosts, typed so the browser does not warn-and-retry.
+const EMPTY = {
+  script: { contentType: 'application/javascript', body: '' },
+  stylesheet: { contentType: 'text/css', body: '' },
+  document: { contentType: 'text/html', body: '<!doctype html><html><head></head><body></body></html>' },
+  image: { contentType: 'image/gif',
+           body: Buffer.from('R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7', 'base64') },
+  _: { contentType: 'text/plain', body: '' },
+};
+
+async function installRouting(ctx) {
+  await ctx.route('**/*', async (route) => {
+    const req = route.request();
+    const url = req.url();
+    let host;
+    try { host = new URL(url).hostname; } catch (_) { return route.abort(); }
+    if (!allow.has(host)) {
+      stats.blocked++;
+      const e = EMPTY[req.resourceType()] || EMPTY._;
+      return route.fulfill({ status: 200, contentType: e.contentType, body: e.body });
+    }
+    try {
+      const r = await fetchThroughCurl(url);
+      return route.fulfill({ status: r.meta.status, contentType: r.meta.contentType, body: r.body });
+    } catch (e) {
+      stats.failed++;
+      const em = EMPTY[req.resourceType()] || EMPTY._;
+      return route.fulfill({ status: 599, contentType: em.contentType, body: em.body });
+    }
+  });
+}
+
+// Determinism: kill animation/transition/caret even where the theme's own
+// prefers-reduced-motion blocks do not (11 @keyframes, 6 rm blocks per §1.3),
+// and stop scroll-behavior:smooth from interfering with the settle pass.
+const FREEZE_CSS = `
+*, *::before, *::after {
+  animation-delay: -0.0001s !important;
+  animation-duration: 0.0001s !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.0001s !important;
+  transition-delay: 0s !important;
+  caret-color: transparent !important;
+}
+html { scroll-behavior: auto !important; }
+`;
+
+/* Force every image to load and decode NOW.
+ *
+ * This is the single most important determinism control in the harness. A
+ * full-page screenshot renders content that was never scrolled into view, so
+ * `loading="lazy"` images below the fold can be captured blank — and whether
+ * they are blank depends on network timing, which means the same page produces
+ * different pixels on consecutive runs. Measured on the homepage before this
+ * existed: 2.65% of pixels differed between two back-to-back runs, entirely
+ * from two image rows that painted in one run and not the other.
+ *
+ * So: flip loading to eager, drop async decoding, un-hide Jetpack/WP lazy
+ * placeholders, then await decode() on every image rather than trusting
+ * `complete` (which is true for a lazy image that has not started). */
+const NORMALISE_IMG_SRC = `(function(stripSrcset){
+  window.__vrNormaliseImg = function (i) {
+    if (!i || i.tagName !== 'IMG') return;
+    if (i.loading === 'lazy') i.loading = 'eager';
+    i.decoding = 'sync';
+    // Common lazy-loader attribute swaps (Jetpack, WP core, Boost).
+    for (const pair of [['data-lazy-src', 'src'], ['data-src', 'src'],
+                        ['data-lazy-srcset', 'srcset'], ['data-srcset', 'srcset']]) {
+      const v = i.getAttribute(pair[0]);
+      if (v && i.getAttribute(pair[1]) !== v) i.setAttribute(pair[1], v);
+    }
+    if (stripSrcset && (i.hasAttribute('srcset') || i.hasAttribute('sizes'))) {
+      // Which srcset candidate the browser picks depends on the layout width at
+      // the moment the parser reaches the tag, which is a race: the same page
+      // can resolve to a different candidate on consecutive runs, and with
+      // object-fit: cover a different candidate crops differently. Measured on
+      // /blog/ before this: card imagery shifted between two back-to-back runs.
+      // Dropping srcset/sizes pins every run to the single src URL. Layout is
+      // unaffected (width/height and CSS own the box); only bitmap resolution
+      // changes, identically in baseline and candidate.
+      i.removeAttribute('srcset');
+      i.removeAttribute('sizes');
+    }
+    const p = i.parentElement;
+    if (stripSrcset && p && p.tagName === 'PICTURE') {
+      for (const s of Array.from(p.querySelectorAll('source'))) s.remove();
+    }
+  };
+  // Normalise as the parser produces nodes, not after load — by load time the
+  // candidate has already been chosen and the race has already happened.
+  const mo = new MutationObserver(function (records) {
+    for (const r of records) {
+      for (const n of r.addedNodes) {
+        if (n.nodeType !== 1) continue;
+        if (n.tagName === 'IMG') window.__vrNormaliseImg(n);
+        else if (n.querySelectorAll) {
+          for (const im of n.querySelectorAll('img')) window.__vrNormaliseImg(im);
+        }
+      }
+    }
+  });
+  const start = function () {
+    mo.observe(document.documentElement, { childList: true, subtree: true });
+    for (const im of document.querySelectorAll('img')) window.__vrNormaliseImg(im);
+  };
+  if (document.documentElement) start();
+  else document.addEventListener('readystatechange', start, { once: true });
+})(STRIP_SRCSET);`;
+
+const FORCE_IMAGES = () => {
+  const imgs = Array.from(document.images);
+  for (const i of imgs) {
+    if (window.__vrNormaliseImg) window.__vrNormaliseImg(i);
+    else { if (i.loading === 'lazy') i.loading = 'eager'; i.decoding = 'sync'; }
+  }
+  for (const el of Array.from(document.querySelectorAll('iframe[loading="lazy"]'))) {
+    el.loading = 'eager';
+  }
+  return imgs.length;
+};
+
+const AWAIT_IMAGES = (budgetMs) => {
+  const settled = (i) => new Promise((res) => {
+    const done = () => res();
+    if (i.complete) return i.decode().then(done, done);
+    i.addEventListener('load', () => i.decode().then(done, done), { once: true });
+    i.addEventListener('error', done, { once: true });
+    setTimeout(done, budgetMs);
+  });
+  return Promise.all(Array.from(document.images).map(settled)).then(() => ({
+    total: document.images.length,
+    painted: Array.from(document.images).filter((i) => i.complete && i.naturalWidth > 0).length,
+  }));
+};
+
+async function settle(page, opts) {
+  // Fonts first: a late webfont swap is the classic false diff.
+  await page.evaluate(() => (document.fonts ? document.fonts.ready.then(() => true) : true))
+    .catch(() => {});
+  await page.evaluate(FORCE_IMAGES).catch(() => {});
+  // Scroll to the bottom in viewport-sized steps to trip IntersectionObserver
+  // reveals and any JS-driven lazy loader, then back to the top.
+  await page.evaluate(async () => {
+    const step = Math.max(200, window.innerHeight);
+    const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+    let y = 0;
+    // Height can grow as content loads; re-read it each iteration, bounded.
+    for (let i = 0; i < 300; i++) {
+      const max = document.documentElement.scrollHeight;
+      if (y >= max) break;
+      window.scrollTo(0, y);
+      await pause(60);
+      y += step;
+    }
+    window.scrollTo(0, document.documentElement.scrollHeight);
+    await pause(250);
+    window.scrollTo(0, 0);
+    await pause(250);
+  });
+  // Anything the scroll pass newly inserted also gets forced.
+  await page.evaluate(FORCE_IMAGES).catch(() => {});
+  // Drive reveal-gated components to the state a visitor actually sees.
+  const revealCounts = await page.evaluate((reveals) => {
+    const counts = {};
+    for (const r of reveals) {
+      const els = Array.from(document.querySelectorAll(r.selector));
+      counts[r.selector] = els.length;
+      for (const el of els) el.classList.add(r.add_class);
+    }
+    return counts;
+  }, opts.reveals).catch(() => null);
+  let imageState = null;
+  try {
+    imageState = await page.evaluate(AWAIT_IMAGES, opts.imageBudgetMs);
+  } catch (_) { /* reported as null below */ }
+  await page.waitForLoadState('networkidle', { timeout: 20000 }).catch(() => {});
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.waitForTimeout(opts.settleMs);
+  // Re-read after the settle delay: this is the number that goes in the
+  // manifest, so an unpainted image is visible as data, not as a mystery diff.
+  try {
+    imageState = await page.evaluate(() => ({
+      total: document.images.length,
+      painted: Array.from(document.images).filter((i) => i.complete && i.naturalWidth > 0).length,
+    }));
+  } catch (_) { /* keep the earlier reading */ }
+  return { images: imageState, reveals: revealCounts };
+}
+
+async function main() {
+  const { chromium } = loadPlaywright();
+  const browser = await chromium.launch({ args: ['--no-sandbox', '--force-color-profile=srgb',
+                                                 '--disable-lcd-text', '--hide-scrollbars'] });
+  const results = [];
+  const maskSelectors = [];
+  for (const group of Object.keys(cfg.masks)) {
+    for (const sel of cfg.masks[group]) maskSelectors.push({ group, sel });
+  }
+
+  for (const vp of cfg.viewports) {
+    const ctx = await browser.newContext({
+      viewport: { width: vp.width, height: vp.height },
+      deviceScaleFactor: vp.scale,
+      reducedMotion: 'reduce',
+      colorScheme: 'light',
+      forcedColors: 'none',
+      locale: 'en-US',
+      timezoneId: cfg.timezone,
+      javaScriptEnabled: true,
+      bypassCSP: true,
+    });
+    await installRouting(ctx);
+    await ctx.addInitScript({
+      content: NORMALISE_IMG_SRC.replace('STRIP_SRCSET', cfg.stripSrcset ? 'true' : 'false'),
+    });
+    const page = await ctx.newPage();
+    page.setDefaultTimeout(cfg.navTimeout);
+
+    for (const route of cfg.routes) {
+      const url = cfg.baseUrl.replace(/\/$/, '') + route.path +
+        (cfg.cacheBust ? (route.path.includes('?') ? '&' : '?') + 'vrb=' + cfg.runId : '');
+      const rec = { id: route.id, path: route.path, template: route.template,
+                    viewport: vp.name, width: vp.width, height: vp.height, scale: vp.scale };
+      try {
+        const resp = await page.goto(url, { waitUntil: 'load', timeout: cfg.navTimeout });
+        rec.http_status = resp ? resp.status() : null;
+        await page.addStyleTag({ content: FREEZE_CSS }).catch(() => {});
+        const settled = await settle(page, cfg);
+        rec.images = settled.images;
+        rec.reveal_matches = settled.reveals;
+
+        const counts = {};
+        for (const m of maskSelectors) {
+          counts[m.group] = (counts[m.group] || 0) +
+            await page.locator(m.sel).count().catch(() => 0);
+        }
+        rec.mask_matches = counts;
+        rec.scroll_height = await page.evaluate(() => document.documentElement.scrollHeight);
+        rec.doc_title = await page.title();
+
+        const file = path.join(cfg.pngDir, route.id + '-' + vp.name + '.png');
+        await page.screenshot({
+          path: file,
+          fullPage: true,
+          animations: 'disabled',
+          caret: 'hide',
+          scale: 'device',
+          mask: maskSelectors.map((m) => page.locator(m.sel)),
+          maskColor: cfg.maskColor,
+          timeout: cfg.navTimeout,
+        });
+        rec.file = path.basename(file);
+        rec.ok = true;
+      } catch (e) {
+        rec.ok = false;
+        rec.error = String((e && e.message) || e).slice(0, 400);
+      }
+      process.stderr.write(`  ${rec.ok ? 'ok  ' : 'FAIL'} ${route.id}/${vp.name}` +
+        (rec.error ? ' — ' + rec.error.split('\n')[0]
+                   : ` (${rec.scroll_height}px, img ${rec.images ? rec.images.painted + '/' + rec.images.total : '?'})`) + '\n');
+      results.push(rec);
+    }
+    await ctx.close();
+  }
+  await browser.close();
+  fs.writeFileSync(path.join(cfg.outDir, 'captures.json'),
+    JSON.stringify({ stats, results }, null, 2));
+}
+
+main().catch((e) => { console.error('FATAL:', (e && e.stack) || e); process.exit(1); });
+"""
+
+
+COMPARE_JS = r"""
+'use strict';
+/* Pixel comparison driver for scripts/visual_baseline.py (issue #473).
+ *
+ * Runs in Chromium because neither pixelmatch/pngjs (node) nor Pillow/numpy
+ * (python) exist in this environment, and Chromium decodes PNG natively. The
+ * algorithm is pixelmatch's: YIQ colour-space delta with an antialias-tolerant
+ * threshold. Images are processed in horizontal strips so a 2880x20000 full-page
+ * capture does not need three full-size canvases resident at once. */
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+
+function loadPlaywright() {
+  for (const c of ['playwright', '/opt/node22/lib/node_modules/playwright',
+                   '/usr/lib/node_modules/playwright', '/usr/local/lib/node_modules/playwright']) {
+    try { return require(c); } catch (_) { /* next */ }
+  }
+  console.error('FATAL: playwright is not resolvable from the compare driver.');
+  process.exit(2);
+}
+
+const cfg = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+
+function serve(roots, port) {
+  const srv = http.createServer((req, res) => {
+    const rel = decodeURIComponent(req.url.split('?')[0]);
+    const m = rel.match(/^\/(base|cand|diff)\/(.+)$/);
+    if (!m) {
+      // The comparison page itself. Serving it from this origin (rather than
+      // about:blank via setContent) is what keeps the canvas untainted so
+      // getImageData is allowed.
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end('<!doctype html><html><head><title>vrdiff</title></head><body></body></html>');
+      return;
+    }
+    const file = path.join(roots[m[1]], m[2]);
+    if (!file.startsWith(roots[m[1]])) { res.writeHead(403); res.end(); return; }
+    fs.readFile(file, (err, data) => {
+      if (err) { res.writeHead(404); res.end(); return; }
+      res.writeHead(200, {
+        'content-type': 'image/png',
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      });
+      res.end(data);
+    });
+  });
+  return new Promise((r) => srv.listen(port, '127.0.0.1', () => r(srv)));
+}
+
+const PAGE_FN = function (baseUrl, candUrl, threshold, stripHeight, wantDiff) {
+  return new Promise(async (resolve) => {
+    const load = (src) => new Promise((res, rej) => {
+      const im = new Image();
+      im.crossOrigin = 'anonymous';  // belt and braces against canvas tainting
+      im.onload = () => res(im);
+      im.onerror = () => rej(new Error('image load failed: ' + src));
+      im.src = src;
+    });
+    let a, b;
+    try { a = await load(baseUrl); b = await load(candUrl); }
+    catch (e) { return resolve({ error: String(e.message || e) }); }
+
+    const W = Math.max(a.naturalWidth, b.naturalWidth);
+    const H = Math.max(a.naturalHeight, b.naturalHeight);
+    const out = {
+      base: { w: a.naturalWidth, h: a.naturalHeight },
+      cand: { w: b.naturalWidth, h: b.naturalHeight },
+      compareW: W, compareH: H,
+    };
+    // Pixels outside the smaller image count as differing: a page that got
+    // taller has changed, and that must show up in the percentage too.
+    const cw = Math.min(a.naturalWidth, b.naturalWidth);
+    const ch = Math.min(a.naturalHeight, b.naturalHeight);
+    let diffPixels = (W * H) - (cw * ch);
+
+    const ca = document.createElement('canvas');
+    const cb = document.createElement('canvas');
+    ca.width = cw; cb.width = cw;
+    const ga = ca.getContext('2d', { willReadFrequently: true });
+    const gb = cb.getContext('2d', { willReadFrequently: true });
+
+    let dctx = null;
+    if (wantDiff) {
+      const cd = document.createElement('canvas');
+      cd.width = W; cd.height = H;
+      dctx = cd.getContext('2d');
+      dctx.fillStyle = '#ffffff';
+      dctx.fillRect(0, 0, W, H);
+      window.__diffCanvas = cd;
+    }
+
+    // pixelmatch's YIQ deltas.
+    const rgb2y = (r, g, bl) => r * 0.29889531 + g * 0.58662247 + bl * 0.11448223;
+    const rgb2i = (r, g, bl) => r * 0.59597799 - g * 0.27417610 - bl * 0.32180189;
+    const rgb2q = (r, g, bl) => r * 0.21147017 - g * 0.52261711 + bl * 0.31114694;
+    const maxDelta = 35215 * threshold * threshold;
+
+    for (let y0 = 0; y0 < ch; y0 += stripHeight) {
+      const h = Math.min(stripHeight, ch - y0);
+      ca.height = h; cb.height = h;
+      ga.clearRect(0, 0, cw, h); gb.clearRect(0, 0, cw, h);
+      ga.drawImage(a, 0, y0, cw, h, 0, 0, cw, h);
+      gb.drawImage(b, 0, y0, cw, h, 0, 0, cw, h);
+      const da = ga.getImageData(0, 0, cw, h).data;
+      const db = gb.getImageData(0, 0, cw, h).data;
+      let dimg = null;
+      if (dctx) dimg = dctx.createImageData(cw, h);
+      for (let i = 0; i < da.length; i += 4) {
+        const r1 = da[i], g1 = da[i + 1], b1 = da[i + 2], a1 = da[i + 3];
+        const r2 = db[i], g2 = db[i + 1], b2 = db[i + 2], a2 = db[i + 3];
+        let delta = 0;
+        if (r1 !== r2 || g1 !== g2 || b1 !== b2 || a1 !== a2) {
+          const y1 = rgb2y(r1, g1, b1), y2 = rgb2y(r2, g2, b2);
+          const dy = y1 - y2;
+          const di = rgb2i(r1, g1, b1) - rgb2i(r2, g2, b2);
+          const dq = rgb2q(r1, g1, b1) - rgb2q(r2, g2, b2);
+          const dalpha = (a1 - a2) * 0.5;
+          delta = 0.5053 * dy * dy + 0.299 * di * di + 0.1957 * dq * dq + 0.25 * dalpha * dalpha;
+        }
+        if (delta > maxDelta) {
+          diffPixels++;
+          if (dimg) { dimg.data[i] = 255; dimg.data[i + 1] = 0; dimg.data[i + 2] = 60; dimg.data[i + 3] = 255; }
+        } else if (dimg) {
+          // Unchanged pixels ghosted so the red marks are readable in context.
+          const v = 255 - (255 - (r1 * 0.299 + g1 * 0.587 + b1 * 0.114)) * 0.15;
+          dimg.data[i] = v; dimg.data[i + 1] = v; dimg.data[i + 2] = v; dimg.data[i + 3] = 255;
+        }
+      }
+      if (dctx && dimg) dctx.putImageData(dimg, 0, y0);
+    }
+    out.diffPixels = diffPixels;
+    out.totalPixels = W * H;
+    out.diffPct = W * H ? (diffPixels / (W * H)) * 100 : 0;
+    resolve(out);
+  });
+};
+
+async function main() {
+  const { chromium } = loadPlaywright();
+  const srv = await serve({ base: cfg.baseDir, cand: cfg.candDir, diff: cfg.diffDir }, cfg.port);
+  fs.mkdirSync(cfg.diffDir, { recursive: true });
+  const browser = await chromium.launch({ args: ['--no-sandbox', '--force-color-profile=srgb'] });
+  const ctx = await browser.newContext({ viewport: { width: 400, height: 300 } });
+  const page = await ctx.newPage();
+  await page.goto(`http://127.0.0.1:${cfg.port}/`);
+  await page.evaluate(`window.__cmp = ${PAGE_FN.toString()}`);
+
+  const results = [];
+  for (const pair of cfg.pairs) {
+    const r = await page.evaluate(
+      ([b, c, t, s, w]) => window.__cmp(b, c, t, s, w),
+      [`http://127.0.0.1:${cfg.port}/base/${pair.baseFile}`,
+       `http://127.0.0.1:${cfg.port}/cand/${pair.candFile}`,
+       cfg.threshold, cfg.stripHeight, !!pair.wantDiff]
+    );
+    r.key = pair.key;
+    if (pair.wantDiff && !r.error) {
+      const b64 = await page.evaluate(() =>
+        window.__diffCanvas ? window.__diffCanvas.toDataURL('image/png').split(',')[1] : null);
+      if (b64) {
+        fs.writeFileSync(path.join(cfg.diffDir, pair.diffFile), Buffer.from(b64, 'base64'));
+        r.diffFile = pair.diffFile;
+      }
+      await page.evaluate(() => { window.__diffCanvas = null; });
+    }
+    process.stderr.write(`  cmp ${pair.key}: ` +
+      (r.error ? 'ERROR ' + r.error : r.diffPct.toFixed(4) + '% of ' + r.totalPixels) + '\n');
+    results.push(r);
+  }
+  await browser.close();
+  srv.close();
+  fs.writeFileSync(cfg.outFile, JSON.stringify({ results }, null, 2));
+}
+
+main().catch((e) => { console.error('FATAL:', (e && e.stack) || e); process.exit(1); });
+"""
+
+
+def write_driver(run_dir: Path, name: str, source: str) -> Path:
+    """Materialise a driver into the (git-ignored) run directory."""
+    p = run_dir / name
+    p.write_text(source, encoding="utf-8")
+    return p
+
+
+# ==========================================================================
+# capture
+# ==========================================================================
+
+
+def do_capture(
+    *,
+    base: str,
+    routes: list[dict[str, Any]],
+    viewports: list[dict[str, Any]],
+    masks: dict[str, list[str]],
+    reveals: list[dict[str, str]],
+    run_id: str,
+    tools: dict[str, str],
+    settle_ms: int,
+    cache_bust: bool,
+    keep_cache: bool,
+    strip_srcset: bool = True,
+) -> tuple[Path, dict[str, Any]]:
+    run_dir = ARTIFACT_ROOT / run_id
+    png_dir = run_dir / "png"
+    cache_dir = run_dir / "cache"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    assert_ignored(run_dir)
+
+    cfg = {
+        "runId": run_id,
+        "baseUrl": base,
+        "routes": routes,
+        "viewports": viewports,
+        "masks": masks,
+        "reveals": reveals,
+        "maskColor": MASK_COLOR,
+        "allowHosts": list(ALLOW_HOSTS),
+        "outDir": str(run_dir),
+        "pngDir": str(png_dir),
+        "cacheDir": str(cache_dir),
+        "settleMs": settle_ms,
+        "imageBudgetMs": IMAGE_BUDGET_MS,
+        "navTimeout": NAV_TIMEOUT_MS,
+        "curlTimeout": 60,
+        "cacheBust": cache_bust,
+        "stripSrcset": strip_srcset,
+        "timezone": "America/Vancouver",
+    }
+    cfg_path = run_dir / "capture-config.json"
+    cfg_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    driver = write_driver(run_dir, "capture-driver.js", CAPTURE_JS)
+
+    info(f"capturing {len(routes)} routes x {len(viewports)} viewports -> {png_dir}")
+    proc = subprocess.run(
+        [tools["node"], str(driver), str(cfg_path)], env=node_env(), check=False
+    )
+    if proc.returncode != 0:
+        fatal(f"capture driver exited {proc.returncode}", code=1)
+
+    captures_path = run_dir / "captures.json"
+    if not captures_path.exists():
+        fatal("capture driver produced no captures.json", code=1)
+    driver_out = json.loads(captures_path.read_text(encoding="utf-8"))
+
+    captures = []
+    failures = []
+    for rec in driver_out["results"]:
+        entry = dict(rec)
+        if rec.get("ok") and rec.get("file"):
+            f = png_dir / rec["file"]
+            entry["sha256"] = sha256_file(f)
+            entry["bytes"] = f.stat().st_size
+            w, h = png_dimensions(f)
+            entry["png_width"] = w
+            entry["png_height"] = h
+            entry["rel_path"] = f"{run_id}/png/{rec['file']}"
+        else:
+            failures.append(f"{rec['id']}/{rec['viewport']}: {rec.get('error', 'unknown')}")
+        captures.append(entry)
+
+    if failures:
+        fatal(
+            "capture failed for "
+            + str(len(failures))
+            + " route/viewport pair(s):\n  "
+            + "\n  ".join(failures)
+            + "\n  A partial baseline is not a baseline. Nothing was written.",
+            code=1,
+        )
+
+    manifest = {
+        "schema": MANIFEST_SCHEMA,
+        "run_id": run_id,
+        "issue": 473,
+        "created_at": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "base_url": base,
+        "artifact_dir": f"{ARTIFACT_ROOT_REL}/{run_id}",
+        "artifacts_committed": False,
+        "tools": tools,
+        "settings": {
+            "device_scale": viewports[0]["scale"] if viewports else DEFAULT_DEVICE_SCALE,
+            "reduced_motion": "reduce",
+            "color_scheme": "light",
+            "forced_colors": "none",
+            "timezone": "America/Vancouver",
+            "settle_ms": settle_ms,
+            "cache_bust": cache_bust,
+            "strip_srcset": strip_srcset,
+            "mask_color": MASK_COLOR,
+            "allow_hosts": list(ALLOW_HOSTS),
+            "full_page": True,
+        },
+        "tolerance": TOLERANCE,
+        "masks": masks,
+        "reveals": reveals,
+        "routes": routes,
+        "route_preflight": [],  # filled by the caller
+        "viewports": viewports,
+        "fetch_stats": driver_out.get("stats", {}),
+        "captures": captures,
+    }
+    if not keep_cache and cache_dir.exists():
+        shutil.rmtree(cache_dir, ignore_errors=True)
+    return run_dir, manifest
+
+
+# ==========================================================================
+# storage guard — the mechanism that makes "never commit PNGs" enforceable
+# ==========================================================================
+
+# Only JSON manifests / diff results and markdown reports may be tracked under the
+# artifact root. The run-id part is permissive (a human may pass --run-id), but the
+# stem and extension are not: nothing binary can match this.
+ALLOWED_TRACKED_RE = re.compile(
+    r"^(?:manifest|diff)-[0-9A-Za-z._-]+\.json$|^report-[0-9A-Za-z._-]+\.md$|^README\.md$"
+)
+BINARY_EXT = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".bmp", ".tiff", ".mp4", ".zip")
+
+
+def assert_ignored(path: Path) -> None:
+    """Refuse to write artifacts into a directory git would track."""
+    rel = path.relative_to(REPO_ROOT)
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "check-ignore", "-q", str(rel)],
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        fatal(
+            f"{rel} is NOT git-ignored. Refusing to write capture artifacts into a\n"
+            f"  tracked path — that is issue #318's failure mode.\n"
+            f"  Add to .gitignore:\n    {ARTIFACT_ROOT_REL}/*\n"
+            f"    !{ARTIFACT_ROOT_REL}/manifest-*.json\n"
+            f"    !{ARTIFACT_ROOT_REL}/diff-*.json\n"
+            f"    !{ARTIFACT_ROOT_REL}/report-*.md"
+        )
+
+
+def do_guard(quiet: bool = False) -> int:
+    """Fail if any capture binary is tracked or staged. Run after every capture."""
+    problems: list[str] = []
+
+    tracked = [p for p in git("ls-files", "--", ARTIFACT_ROOT_REL).splitlines() if p.strip()]
+    for p in tracked:
+        name = Path(p).name
+        if not ALLOWED_TRACKED_RE.match(name):
+            problems.append(f"tracked file under the artifact root is not an allowed manifest: {p}")
+
+    staged = [p for p in git("diff", "--cached", "--name-only").splitlines() if p.strip()]
+    for p in staged:
+        if p.lower().endswith(BINARY_EXT):
+            problems.append(f"binary staged for commit: {p}")
+
+    # The ignore rule itself must be live, not merely written down.
+    probe = ARTIFACT_ROOT / "__guard_probe__" / "probe.png"
+    rel = probe.relative_to(REPO_ROOT)
+    rc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "check-ignore", "-q", str(rel)],
+        capture_output=True,
+        check=False,
+    ).returncode
+    if rc != 0:
+        problems.append(
+            f"{rel} would NOT be ignored by git — the .gitignore rule for "
+            f"{ARTIFACT_ROOT_REL}/* is missing or broken"
+        )
+
+    if problems:
+        print("FATAL: visual-baseline storage guard failed (issue #318):", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "  PNGs from this harness must never be tracked. Unstage them "
+            "(git restore --staged <file>) and fix .gitignore.",
+            file=sys.stderr,
+        )
+        return 1
+    if not quiet:
+        print(
+            f"visual-baseline storage guard OK — {len(tracked)} tracked file(s) under "
+            f"{ARTIFACT_ROOT_REL}, all manifests/reports; no binaries staged."
+        )
+    return 0
+
+
+# ==========================================================================
+# manifest / run discovery
+# ==========================================================================
+
+
+def manifest_path(run_id: str) -> Path:
+    return ARTIFACT_ROOT / f"manifest-{run_id}.json"
+
+
+def _created_at(p: Path) -> str:
+    try:
+        return json.loads(p.read_text(encoding="utf-8")).get("created_at", "")
+    except Exception:
+        return ""
+
+
+def list_manifests(kind: str | None = None) -> list[Path]:
+    """Manifests oldest-first, ordered by their recorded `created_at`.
+
+    Deliberately not ordered by filename: run ids can be overridden with
+    --run-id, and a lexicographic sort would then put "BASE1" after a real
+    timestamp and silently pick the wrong "newest".
+    """
+    if not ARTIFACT_ROOT.exists():
+        return []
+    paths = list(ARTIFACT_ROOT.glob("manifest-*.json"))
+    if kind:
+        paths = [
+            p
+            for p in paths
+            if json.loads(p.read_text(encoding="utf-8")).get("kind") == kind
+        ]
+    return sorted(paths, key=lambda p: (_created_at(p), p.name))
+
+
+def resolve_base_manifest(base_arg: str | None) -> Path:
+    if base_arg:
+        cand = Path(base_arg)
+        if cand.exists() and cand.is_file():
+            return cand
+        p = manifest_path(base_arg)
+        if p.exists():
+            return p
+        fatal(
+            f"no baseline manifest for BASE={base_arg}.\n"
+            f"  Looked for {p}\n"
+            f"  Available: {[m.name for m in list_manifests()] or 'none — run `make visual-baseline` first'}"
+        )
+    # Default to the newest manifest of kind "baseline". Falling back to a
+    # candidate manifest would quietly compare a candidate against a candidate.
+    manifests = list_manifests(kind="baseline")
+    if not manifests:
+        any_manifests = list_manifests()
+        fatal(
+            "no baseline manifest found. Run `make visual-baseline` first.\n"
+            f"  (looked in {ARTIFACT_ROOT_REL}/manifest-*.json for kind=baseline)\n"
+            + (
+                f"  Found only candidate manifests: {[m.name for m in any_manifests]}"
+                if any_manifests
+                else ""
+            )
+        )
+    return manifests[-1]
+
+
+# ==========================================================================
+# verdicts
+# ==========================================================================
+
+
+def verdict_for(diff_pct: float | None, height_delta_pct: float | None, tol: dict) -> str:
+    if diff_pct is None:
+        return "error"
+    if height_delta_pct is not None and abs(height_delta_pct) > tol["height_delta_pct"]:
+        return "fail"
+    if diff_pct > tol["warn_pct"]:
+        return "fail"
+    if diff_pct > tol["pass_pct"]:
+        return "warn"
+    return "pass"
+
+
+WORST_ORDER = {"pass": 0, "warn": 1, "fail": 2, "error": 3}
+
+
+# ==========================================================================
+# subcommands
+# ==========================================================================
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    tools = preflight_browser()
+    print("Chromium/Playwright preflight OK")
+    for k, v in tools.items():
+        print(f"  {k}: {v}")
+    routes = enabled_routes(args.routes)
+    checks = preflight_routes(args.base, routes, strict=not args.no_strict_routes)
+    print(f"route preflight ({len(checks)} routes):")
+    for c in checks:
+        flag = "ok " if c["status"] == c["expected"] else "!! "
+        print(f"  {flag}{c['status']}  {c['path']}")
+    print(f"storage guard: {'OK' if do_guard(quiet=True) == 0 else 'FAILED'}")
+    return 0
+
+
+def cmd_capture(args: argparse.Namespace) -> int:
+    tools = preflight_browser()
+    routes = enabled_routes(args.routes)
+    viewports = selected_viewports(args.viewports, args.scale)
+    masks = DEFAULT_MASKS
+    reveals = DEFAULT_REVEALS
+    if args.masks:
+        override = json.loads(Path(args.masks).read_text(encoding="utf-8"))
+        masks = override.get("masks", override)
+        reveals = override.get("reveals", reveals)
+
+    strip_srcset = not args.keep_srcset
+    checks = preflight_routes(args.base, routes, strict=not args.no_strict_routes)
+    run_id = args.run_id or run_id_now()
+
+    info(f"run {run_id}: css identity + Boost bundle readback")
+    css = css_identity(args.base)
+    boost = boost_bundle(args.base)
+
+    if args.expect_theme_version and css.get("live_theme_version") != args.expect_theme_version:
+        fatal(
+            "live theme version is "
+            f"{css.get('live_theme_version')!r}, expected {args.expect_theme_version!r}.\n"
+            "  Refusing to freeze a baseline against an unexpected deploy "
+            "(AURORA-STYLESHEET-REBUILD-PLAN.md §4.6)."
+        )
+
+    run_dir, manifest = do_capture(
+        base=args.base,
+        routes=routes,
+        viewports=viewports,
+        masks=masks,
+        reveals=reveals,
+        run_id=run_id,
+        tools=tools,
+        settle_ms=args.settle_ms,
+        cache_bust=not args.no_cache_bust,
+        keep_cache=args.keep_cache,
+        strip_srcset=strip_srcset,
+    )
+    manifest["kind"] = args.kind
+    manifest["route_preflight"] = checks
+    manifest["css_identity"] = css
+    manifest["boost"] = boost
+
+    mpath = manifest_path(run_id)
+    mpath.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    total_bytes = sum(c.get("bytes", 0) for c in manifest["captures"])
+    print()
+    print(f"baseline run {run_id}")
+    print(f"  captures : {len(manifest['captures'])}  ({total_bytes / 1e6:.1f} MB, NOT committed)")
+    print(f"  images   : {run_dir.relative_to(REPO_ROOT)}/png/  (git-ignored)")
+    print(f"  manifest : {mpath.relative_to(REPO_ROOT)}  <- commit this")
+    print(
+        f"  theme    : live {css.get('live_theme_version')} / repo {css.get('repo_theme_version')}"
+        f"  css identical: {css.get('all_identical')}"
+    )
+    print(f"  boost    : css bundle {boost.get('css_bundle_hash')} js {boost.get('js_bundle_hash')}")
+    if not css.get("all_identical"):
+        drifted = [r["file"] for r in css["files"] if not r["identical"]]
+        print(f"  NOTE     : live != repo for {drifted} — expected while a deploy is pending")
+    print()
+    return do_guard()
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    tools = preflight_browser()
+    base_manifest_path = resolve_base_manifest(args.base_run)
+    base_manifest = json.loads(base_manifest_path.read_text(encoding="utf-8"))
+    if base_manifest.get("schema") != MANIFEST_SCHEMA:
+        fatal(f"{base_manifest_path} has schema {base_manifest.get('schema')!r}, expected {MANIFEST_SCHEMA!r}")
+
+    base_run = base_manifest["run_id"]
+    base_png_dir = ARTIFACT_ROOT / base_run / "png"
+
+    routes = enabled_routes(args.routes)
+    viewports = selected_viewports(args.viewports, args.scale or base_manifest["settings"]["device_scale"])
+    if viewports and viewports[0]["scale"] != base_manifest["settings"]["device_scale"]:
+        fatal(
+            f"device scale mismatch: baseline was captured at "
+            f"{base_manifest['settings']['device_scale']}x, this run would use "
+            f"{viewports[0]['scale']}x. Captures at different scales are not comparable."
+        )
+
+    # Capture settings must match the baseline's, not this invocation's defaults.
+    strip_srcset = base_manifest["settings"].get("strip_srcset", True)
+    checks = preflight_routes(args.base, routes, strict=not args.no_strict_routes)
+    run_id = args.run_id or run_id_now()
+    info(f"candidate run {run_id} (baseline {base_run})")
+    css = css_identity(args.base)
+    boost = boost_bundle(args.base)
+
+    run_dir, manifest = do_capture(
+        base=args.base,
+        routes=routes,
+        viewports=viewports,
+        # Masks and reveal end-states must match the baseline exactly, or the
+        # comparison is between two different pages.
+        masks=base_manifest["masks"],
+        reveals=base_manifest.get("reveals", DEFAULT_REVEALS),
+        run_id=run_id,
+        tools=tools,
+        settle_ms=args.settle_ms,
+        cache_bust=not args.no_cache_bust,
+        keep_cache=args.keep_cache,
+        strip_srcset=strip_srcset,
+    )
+    manifest["kind"] = "candidate"
+    manifest["route_preflight"] = checks
+    manifest["css_identity"] = css
+    manifest["boost"] = boost
+    manifest["baseline_run"] = base_run
+    manifest_path(run_id).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    base_by_key = {f"{c['id']}/{c['viewport']}": c for c in base_manifest["captures"]}
+    cand_by_key = {f"{c['id']}/{c['viewport']}": c for c in manifest["captures"]}
+
+    pairs = []
+    rows: dict[str, dict[str, Any]] = {}
+    tol = base_manifest.get("tolerance", TOLERANCE)
+
+    for key, cand in cand_by_key.items():
+        base_cap = base_by_key.get(key)
+        row: dict[str, Any] = {
+            "key": key,
+            "route": cand["id"],
+            "path": cand["path"],
+            "viewport": cand["viewport"],
+            "candidate_sha256": cand.get("sha256"),
+            "baseline_sha256": base_cap.get("sha256") if base_cap else None,
+            "candidate_height": cand.get("png_height"),
+            "baseline_height": base_cap.get("png_height") if base_cap else None,
+            "candidate_scroll_height": cand.get("scroll_height"),
+            "baseline_scroll_height": base_cap.get("scroll_height") if base_cap else None,
+            "mask_matches": cand.get("mask_matches"),
+        }
+        if base_cap is None:
+            row["verdict"] = "error"
+            row["note"] = "no baseline capture for this route/viewport pair"
+            rows[key] = row
+            continue
+
+        bh, chh = base_cap.get("png_height") or 0, cand.get("png_height") or 0
+        row["height_delta_pct"] = ((chh - bh) / bh * 100) if bh else None
+
+        if base_cap.get("sha256") and base_cap["sha256"] == cand.get("sha256"):
+            # Byte-identical PNGs. Zero differing pixels by construction; no need
+            # to decode. This is the fast path a stable site should take.
+            row["diff_pct"] = 0.0
+            row["diff_pixels"] = 0
+            row["method"] = "sha256-identical"
+            row["verdict"] = verdict_for(0.0, row["height_delta_pct"], tol)
+            rows[key] = row
+            continue
+
+        base_file = base_png_dir / (base_cap.get("file") or "")
+        if not base_file.exists():
+            row["verdict"] = "error"
+            row["method"] = "hash-only"
+            row["note"] = (
+                f"hashes differ but baseline PNG {base_file.relative_to(REPO_ROOT)} is gone "
+                "(images are never committed). Re-freeze the baseline: make visual-baseline"
+            )
+            rows[key] = row
+            continue
+
+        row["method"] = "pixel"
+        rows[key] = row
+        pairs.append(
+            {
+                "key": key,
+                "baseFile": base_cap["file"],
+                "candFile": cand["file"],
+                "diffFile": f"{cand['id']}-{cand['viewport']}-diff.png",
+                "wantDiff": not args.no_diff_images,
+            }
+        )
+
+    diff_dir = run_dir / "diff"
+    if pairs:
+        info(f"comparing {len(pairs)} changed pair(s) in Chromium")
+        cmp_cfg = {
+            "baseDir": str(base_png_dir),
+            "candDir": str(run_dir / "png"),
+            "diffDir": str(diff_dir),
+            "outFile": str(run_dir / "compare.json"),
+            "pairs": pairs,
+            "threshold": tol["pixel_threshold"],
+            "stripHeight": args.strip_height,
+            "port": args.port,
+        }
+        cmp_cfg_path = run_dir / "compare-config.json"
+        cmp_cfg_path.write_text(json.dumps(cmp_cfg, indent=2), encoding="utf-8")
+        driver = write_driver(run_dir, "compare-driver.js", COMPARE_JS)
+        proc = subprocess.run(
+            [tools["node"], str(driver), str(cmp_cfg_path)], env=node_env(), check=False
+        )
+        if proc.returncode != 0:
+            fatal(f"compare driver exited {proc.returncode}", code=1)
+        cmp_out = json.loads((run_dir / "compare.json").read_text(encoding="utf-8"))
+        for res in cmp_out["results"]:
+            row = rows[res["key"]]
+            if res.get("error"):
+                row["verdict"] = "error"
+                row["note"] = res["error"]
+                continue
+            row["diff_pct"] = round(res["diffPct"], 6)
+            row["diff_pixels"] = res["diffPixels"]
+            row["total_pixels"] = res["totalPixels"]
+            if res.get("diffFile"):
+                row["diff_image"] = f"{run_dir.relative_to(REPO_ROOT)}/diff/{res['diffFile']}"
+            row["verdict"] = verdict_for(row["diff_pct"], row.get("height_delta_pct"), tol)
+
+    # Report order follows the route/viewport declaration order, not the sort
+    # order of the keys — a PR reviewer reads it top-to-bottom as the site.
+    route_rank = {r["id"]: i for i, r in enumerate(routes)}
+    vp_rank = {v["name"]: i for i, v in enumerate(viewports)}
+    ordered = sorted(
+        rows.values(),
+        key=lambda r: (route_rank.get(r["route"], 99), vp_rank.get(r["viewport"], 99)),
+    )
+    worst = max((WORST_ORDER[r["verdict"]] for r in ordered), default=0)
+    worst_name = [k for k, v in WORST_ORDER.items() if v == worst][0]
+
+    # Prune diff images for pairs that passed — they are noise and they are bytes.
+    if diff_dir.exists() and not args.keep_all_diffs:
+        keep = {Path(r["diff_image"]).name for r in ordered if r.get("diff_image") and r["verdict"] != "pass"}
+        for f in diff_dir.glob("*.png"):
+            if f.name not in keep:
+                f.unlink()
+        for r in ordered:
+            if r.get("diff_image") and Path(r["diff_image"]).name not in keep:
+                r.pop("diff_image", None)
+
+    result = {
+        "schema": MANIFEST_SCHEMA,
+        "kind": "diff",
+        "issue": 473,
+        "created_at": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "baseline_run": base_run,
+        "candidate_run": run_id,
+        "base_url": args.base,
+        "tolerance": tol,
+        "masks": base_manifest["masks"],
+        "verdict": worst_name,
+        "counts": {
+            v: sum(1 for r in ordered if r["verdict"] == v) for v in ("pass", "warn", "fail", "error")
+        },
+        "css_identity": {
+            "baseline": {
+                "live_theme_version": base_manifest.get("css_identity", {}).get("live_theme_version"),
+                "all_identical": base_manifest.get("css_identity", {}).get("all_identical"),
+            },
+            "candidate": {
+                "live_theme_version": css.get("live_theme_version"),
+                "repo_theme_version": css.get("repo_theme_version"),
+                "all_identical": css.get("all_identical"),
+                "files": css["files"],
+            },
+        },
+        "boost": {
+            "baseline_css_bundle_hash": base_manifest.get("boost", {}).get("css_bundle_hash"),
+            "candidate_css_bundle_hash": boost.get("css_bundle_hash"),
+            "changed": base_manifest.get("boost", {}).get("css_bundle_hash")
+            != boost.get("css_bundle_hash"),
+            "candidate": boost,
+        },
+        "pairs": ordered,
+    }
+    dpath = ARTIFACT_ROOT / f"diff-{run_id}.json"
+    dpath.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+    print()
+    print(f"visual-diff {base_run} -> {run_id}: {worst_name.upper()}")
+    for v in ("pass", "warn", "fail", "error"):
+        print(f"  {v:<6} {result['counts'][v]}")
+    print(f"  report data: {dpath.relative_to(REPO_ROOT)}")
+    print(f"  markdown   : make visual-diff-report DIFF={run_id}")
+    print()
+
+    guard_rc = do_guard()
+    if guard_rc != 0:
+        return guard_rc
+    if worst_name in ("fail", "error"):
+        return 1
+    if worst_name == "warn" and args.strict:
+        return 1
+    return 0
+
+
+def _fmt_pct(v: float | None) -> str:
+    if v is None:
+        return "—"
+    if v == 0:
+        return "0"
+    return f"{v:.4f}"
+
+
+VERDICT_MARK = {"pass": "PASS", "warn": "WARN", "fail": "FAIL", "error": "ERROR"}
+
+
+def render_report(result: dict[str, Any]) -> str:
+    L: list[str] = []
+    L.append(f"## Visual regression — {result['verdict'].upper()}")
+    L.append("")
+    L.append(
+        f"Baseline `{result['baseline_run']}` → candidate `{result['candidate_run']}` "
+        f"against `{result['base_url']}`, generated {result['created_at']}."
+    )
+    L.append("")
+    c = result["counts"]
+    L.append(
+        f"**{c['pass']} pass · {c['warn']} warn · {c['fail']} fail · {c['error']} error** "
+        f"across {len(result['pairs'])} route/viewport pairs."
+    )
+    L.append("")
+    tol = result["tolerance"]
+    L.append(
+        f"Tolerance: pass ≤ {tol['pass_pct']}% differing pixels · warn ≤ {tol['warn_pct']}% · "
+        f"fail > {tol['warn_pct']}% or > {tol['height_delta_pct']}% full-page height delta · "
+        f"per-pixel threshold {tol['pixel_threshold']}."
+    )
+    L.append("")
+    L.append("| Route | Viewport | Diff % | Height Δ% | Method | Verdict |")
+    L.append("|---|---|---:|---:|---|---|")
+    for p in result["pairs"]:
+        L.append(
+            f"| `{p['path']}` | {p['viewport']} | {_fmt_pct(p.get('diff_pct'))} | "
+            f"{_fmt_pct(p.get('height_delta_pct'))} | {p.get('method', '—')} | "
+            f"**{VERDICT_MARK[p['verdict']]}** |"
+        )
+    L.append("")
+
+    notes = [p for p in result["pairs"] if p.get("note")]
+    if notes:
+        L.append("### Notes")
+        L.append("")
+        for p in notes:
+            L.append(f"- `{p['key']}`: {p['note']}")
+        L.append("")
+
+    imgs = [p for p in result["pairs"] if p.get("diff_image")]
+    if imgs:
+        L.append("### Diff images")
+        L.append("")
+        L.append(
+            "Not committed. Attach these to the PR comment or upload as CI artifacts "
+            "(AURORA-STYLESHEET-REBUILD-PLAN.md §4.5.4):"
+        )
+        L.append("")
+        for p in imgs:
+            L.append(f"- `{p['key']}` → `{p['diff_image']}`")
+        L.append("")
+
+    L.append("### Environment readback")
+    L.append("")
+    cand = result["css_identity"]["candidate"]
+    L.append(
+        f"- Live theme version: **{cand.get('live_theme_version')}** "
+        f"(repo `theme/kk-aurora/style.css`: **{cand.get('repo_theme_version')}**)"
+    )
+    L.append(
+        f"- Live-vs-repo CSS md5 identity: **{'all identical' if cand.get('all_identical') else 'DRIFT'}**"
+    )
+    for f in cand.get("files", []):
+        mark = "=" if f["identical"] else "≠"
+        L.append(f"  - `{f['file']}` {mark} live `{(f.get('live_md5') or '')[:12]}` / repo `{(f.get('repo_md5') or '')[:12]}`")
+    b = result["boost"]
+    L.append(
+        f"- Jetpack Boost CSS bundle: baseline `{b.get('baseline_css_bundle_hash')}` → "
+        f"candidate `{b.get('candidate_css_bundle_hash')}` "
+        f"({'CHANGED' if b.get('changed') else 'unchanged'})"
+    )
+    if not b.get("changed"):
+        L.append(
+            "  - If a deploy happened between these two runs, an unchanged Boost hash means "
+            "it did not reach the edge (risk R-2) — not that it had no visual effect. Purge "
+            "Boost + PressCACHE and re-run before reading this as a green light."
+        )
+    L.append("")
+    L.append(
+        "_Screenshots cannot see focus, hover or keyboard behaviour (#424 remains a separate "
+        "gate), and there is no staging environment — this compares post-deploy live against "
+        "pre-deploy live (§4.7)._"
+    )
+    return "\n".join(L)
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    if args.diff_run:
+        p = Path(args.diff_run)
+        if not p.exists():
+            p = ARTIFACT_ROOT / f"diff-{args.diff_run}.json"
+    else:
+        diffs = (
+            sorted(ARTIFACT_ROOT.glob("diff-*.json"), key=lambda p: (_created_at(p), p.name))
+            if ARTIFACT_ROOT.exists()
+            else []
+        )
+        if not diffs:
+            fatal(
+                "no diff result found. Run `make visual-diff BASE=<ts>` first.\n"
+                f"  (looked in {ARTIFACT_ROOT_REL}/diff-*.json)"
+            )
+        p = diffs[-1]
+    if not p.exists():
+        fatal(f"{p} does not exist")
+    result = json.loads(p.read_text(encoding="utf-8"))
+    md = render_report(result)
+    if args.out:
+        out = Path(args.out)
+        if not out.is_absolute():
+            out = REPO_ROOT / out
+    else:
+        out = ARTIFACT_ROOT / f"report-{result['candidate_run']}.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(md + "\n", encoding="utf-8")
+    print(md)
+    print()
+    print(f"(written to {out.relative_to(REPO_ROOT)})", file=sys.stderr)
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    manifests = list_manifests()
+    if not manifests:
+        print("no baseline manifests yet — run `make visual-baseline`")
+        return 0
+    print(f"{'run':<20} {'kind':<10} {'theme':<8} {'boost':<12} {'captures':>8}  images")
+    for m in manifests:
+        d = json.loads(m.read_text(encoding="utf-8"))
+        png_dir = ARTIFACT_ROOT / d["run_id"] / "png"
+        n_png = len(list(png_dir.glob("*.png"))) if png_dir.exists() else 0
+        print(
+            f"{d['run_id']:<20} {d.get('kind', '?'):<10} "
+            f"{str(d.get('css_identity', {}).get('live_theme_version')):<8} "
+            f"{str(d.get('boost', {}).get('css_bundle_hash')):<12} "
+            f"{len(d.get('captures', [])):>8}  {n_png} png on disk"
+        )
+    return 0
+
+
+def cmd_guard(args: argparse.Namespace) -> int:
+    return do_guard()
+
+
+def cmd_prune(args: argparse.Namespace) -> int:
+    """Delete capture directories, keeping the newest N. Manifests are kept."""
+    if not ARTIFACT_ROOT.exists():
+        print("nothing to prune")
+        return 0
+    dirs = sorted(p for p in ARTIFACT_ROOT.iterdir() if p.is_dir())
+    victims = dirs[: max(0, len(dirs) - args.keep)]
+    freed = 0
+    for d in victims:
+        freed += sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
+        shutil.rmtree(d, ignore_errors=True)
+        print(f"removed {d.relative_to(REPO_ROOT)}")
+    print(f"kept {min(args.keep, len(dirs))} run dir(s); freed {freed / 1e6:.1f} MB")
+    print("Manifests are untouched — a lost baseline is one `make visual-baseline` away (§4.5.5).")
+    return 0
+
+
+# ==========================================================================
+# CLI
+# ==========================================================================
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="visual_baseline.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    def common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--base", default=BASE_URL, help="origin to capture (default %(default)s)")
+        p.add_argument("--routes", nargs="*", help="subset of route ids or paths")
+        p.add_argument("--viewports", nargs="*", help="subset of viewport names")
+        p.add_argument(
+            "--no-strict-routes",
+            action="store_true",
+            help="warn instead of aborting when a route's HTTP status is unexpected",
+        )
+
+    def capture_opts(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--scale", type=int, default=DEFAULT_DEVICE_SCALE, help="device scale factor")
+        p.add_argument("--settle-ms", type=int, default=SETTLE_MS)
+        p.add_argument("--no-cache-bust", action="store_true")
+        p.add_argument("--keep-cache", action="store_true", help="keep the per-run curl cache")
+        p.add_argument("--run-id", help="override the run id (default: UTC timestamp)")
+        p.add_argument("--masks", help="path to a JSON file overriding masks/reveals")
+        p.add_argument(
+            "--keep-srcset",
+            action="store_true",
+            help="keep srcset/sizes (higher fidelity, but candidate selection is a race)",
+        )
+
+    p = sub.add_parser("preflight", help="check Chromium, routes and the storage guard")
+    common(p)
+    p.set_defaults(func=cmd_preflight)
+
+    p = sub.add_parser("capture", help="capture and freeze a baseline (make visual-baseline)")
+    common(p)
+    capture_opts(p)
+    p.add_argument("--kind", default="baseline", choices=["baseline", "candidate"])
+    p.add_argument(
+        "--expect-theme-version",
+        help="abort unless live style.css reports this Version (§4.6)",
+    )
+    p.set_defaults(func=cmd_capture)
+
+    p = sub.add_parser("diff", help="capture a candidate and compare (make visual-diff)")
+    common(p)
+    capture_opts(p)
+    p.add_argument("--base-run", help="baseline run id or manifest path (default: newest)")
+    p.add_argument("--strict", action="store_true", help="treat warn as failure")
+    p.add_argument("--no-diff-images", action="store_true")
+    p.add_argument("--keep-all-diffs", action="store_true", help="keep diff images for passing pairs too")
+    p.add_argument("--strip-height", type=int, default=1024)
+    p.add_argument("--port", type=int, default=8763)
+    # Unlike `capture`, diff's --scale inherits the baseline's unless given.
+    p.set_defaults(func=cmd_diff, scale=None)
+
+    p = sub.add_parser("report", help="markdown summary of a diff (make visual-diff-report)")
+    p.add_argument("--diff-run", help="diff run id or path (default: newest)")
+    p.add_argument("--out", help="write markdown here instead of the artifact root")
+    p.set_defaults(func=cmd_report)
+
+    p = sub.add_parser("list", help="list baseline manifests and which still have images on disk")
+    p.set_defaults(func=cmd_list)
+
+    p = sub.add_parser("guard", help="fail if any capture binary is tracked or staged (#318)")
+    p.set_defaults(func=cmd_guard)
+
+    p = sub.add_parser("prune", help="delete old capture directories (manifests kept)")
+    p.add_argument("--keep", type=int, default=2)
+    p.set_defaults(func=cmd_prune)
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Step 1 of the Path A rebuild, and **the gate for every subsequent step**. #423's safety rule is that the ground-up stylesheet rebuild ships behind visual-regression screenshots of every key page — this is that instrument.

**AC 1 is verified, not asserted:** two consecutive full runs against live production, **33 pass · 0 warn · 0 fail · 0 error**.

## Related Issue

Fixes #473
Unblocks #474, #475, #476, #477, #478, #479, #480, #481
Relates to #423, #318

## Changes

- `scripts/visual_baseline.py` — stdlib-only Python driving Playwright via Node drivers written into the ignored run dir at runtime
- `docs/current-state/AURORA-VISUAL-BASELINE-RUNBOOK.md`
- Committed evidence: `manifest-BASE1.json`, `manifest-BASE2.json`, `diff-BASE2.json`, `report-BASE2.md`
- Targets appended under `# --- #473 visual regression ---` with local `.PHONY`: `visual-baseline`, `visual-diff`, `visual-diff-report`, plus `visual-preflight`, `visual-guard`, `visual-list`, `visual-prune`

The branch was rebased onto the newer `main` after #472/#489 landed mid-flight; the Makefile conflict resolved by keeping both blocks. Verified: `# --- #472 css inventory ---` at line 332 and `# --- #473 visual regression ---` at 352 both survive.

## The two-run verification

11 routes × 3 viewports × DSF 2 against `https://kriskrug.co`, twice:

```
33 pass · 0 warn · 0 fail · 0 error
31 pairs byte-identical by SHA-256
/photography/ tablet + desktop: PNG bytes differed, 0 differing pixels above threshold
No height changed on any route.
```

Getting there meant fixing three **real** false positives, each measured — this is the part that makes the gate trustworthy rather than noisy:

| Cause | Diff it produced |
|---|---|
| Lazy images below the fold captured blank | **2.65%** of homepage pixels |
| `srcset` candidate selection racing layout (`object-fit: cover` crops differently) | **0.089%** of `/blog/` pixels |
| Reveal-gated cards captured faded | qualitative |

A harness that reported 2.65% drift on an unchanged site would have been abandoned within a week.

**One control the spec doesn't mention:** `.aurora-fade-up` / `.aurora-scale-in` / `.is-aurora-lux-reveal` start at `opacity: 0` and only reveal when JS fires, so full-page captures rendered them invisible. The harness adds *the theme's own* reveal class rather than overriding opacity — so a regression in those rules still shows up in the pixels rather than being masked by the fix.

## Route list — two departures from §4.2, both verified against live

`/` · `/about/` · `/generative-ai-services/` · `/speaking/` · `/work/` · `/photography/` · `/blog/` · `/contact/` · a single post · a 404 probe · `/category/vancouver-ai-ecosystem/`

- **`/services/` 301s** to `/generative-ai-services/`, so the canonical target is captured
- **The marquee board post does not exist on live** — `kk-marquee-board` is repo-side only and `/marquee/` 404s. A category archive takes the slot, since `archive.html` was otherwise uncovered. The marquee route stays declared with `enabled: False`.

⚠️ **Inline marquee CSS is therefore not covered by this gate.** That's the one §4 item not implemented, and it's stated in the runbook rather than buried.

Route statuses are asserted before every capture; drift aborts the run.

**Masking:** three declared groups (marquee / dates / beehiiv), manifest-recorded and `--masks`-overridable, painted at screenshot time so layout is unaffected. Per-capture match counts are recorded — the `beehiiv` mask matched **0 elements on all 33 captures** (it's a link on these routes, not an embed). Surfaced as data rather than silently doing nothing.

## 🔒 #318 compliance — verified by attack, not by inspection

The reviewing session tried to commit a PNG:

```
git add -A over the run tree          → 0 PNGs staged          ✓
git add -f <run>/shot.png             → guard exits 1          ✓
    caught twice: "tracked file under the artifact root"
                  "binary staged for commit"
git diff --numstat origin/main...HEAD → 0 binary files         ✓
```

Three independent mechanisms: `.gitignore` denies at `visual-baseline/*` (one level down, so git never descends into a run dir) with explicit allow-lists for the four evidence formats; the script refuses to write into a tracked path (`git check-ignore` before any capture); and `guard` re-asserts against the index after every capture and diff.

Given `.git` is already ~303 MB and a screenshot harness is the single most likely thing to make that worse, this was the acceptance criterion worth attacking rather than reading.

## Missing Chromium — fails loudly, never downloads

Verified with `PLAYWRIGHT_BROWSERS_PATH` pointed at a nonexistent directory:

```
$ visual_baseline.py preflight   → exit 2
$ visual_baseline.py capture     → exit 2
FATAL: PLAYWRIGHT_BROWSERS_PATH=... does not exist or is not a directory.
  Refusing to download a browser. Point it at an existing Playwright
  browsers directory (here: /opt/pw-browsers).
```

Nothing was fetched. Node children also inherit `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`.

*(My first attempt at this test used a subcommand that doesn't exist, so argparse returned 2 and it looked like a pass. Re-tested with the real subcommands — the numbers above are the corrected run.)*

## Network approach

Chromium genuinely cannot reach kriskrug.co through this environment's proxy. Every browser request is intercepted and fulfilled from a cached `curl` fetch **while preserving the real page origin** — no URL rewriting, unlike `interaction_state_probe.js`'s mirror. Non-allowlisted hosts get an empty 200. This works identically for someone with direct network access.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] `make python-test` — **464 tests, 0 failures**, independently re-run
- [x] `docs_truth_check` — passes
- [x] `css-ratchet` — passes (no CSS touched)
- [x] Two-run AC verified against live production; evidence committed
- [x] PNG-commit prevention verified by attempting it
- [x] Missing-Chromium path verified on both subcommands

> The test count is 464, not the 439 quoted in the issue — `main` moved while this was in flight (#489 added 25). No file under `scripts/tests/` was touched.

## Deployment Notes

- [x] No special deployment steps required

## Known limits, stated plainly

- A full run is **~250 MB of PNG on disk** (~500 MB for a baseline+candidate pair). `make visual-prune` exists for this and was used — the two verification runs are gone from disk, manifests kept.
- **Stripping `srcset`** means captures use each image's `src`, not the 2× candidate a retina visitor gets. Layout is identical and identical on both sides of a comparison. `--keep-srcset` restores fidelity at the cost of stability.
- Inline marquee CSS uncovered, as above.

## Next

With this merged, **#474 (cascade layers + token scaffold) is unblocked** — but its blocking preflight still stands: verify live Code Snippet **#14** is inactive and delete media **#12631** before any rebuild upload, or a stale zip silently clobbers the deploy (risk R-3).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmwowSk2h5ypG9dySKrUfv)_