### PR TITLE
content(#22): land acknowledgment draft package

### DIFF
--- a/content/drafts/2026-07-26-land-acknowledgment/AUDIT.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/AUDIT.md
@@ -1,0 +1,61 @@
+# Audit - live land acknowledgment evidence (#22)
+
+Read-only checks on 2026-07-26. No writes.
+
+## Summary
+
+| Surface | Status | Notes |
+|---|---|---|
+| Site footer (Aurora brand tile) | Present | Short Musqueam / Squamish / Tsleil-Waututh line |
+| Footer bottom utility | Present | Link labeled `Reconciliation` → dedicated page |
+| About page body | Absent | Land line not in About entry content (footer still shows) |
+| Dedicated page | Present | `/reconciliation-indigenous-land-acknowledgement/` with Nation links |
+
+## Footer (sitewide)
+
+Source of truth in repo theme: `theme/kk-aurora/parts/footer.html` (Track B). Live homepage and About both render:
+
+> AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.
+
+Footer bottom also links:
+
+- `/reconciliation-indigenous-land-acknowledgement/` (label: Reconciliation)
+- `/the-kk-worldview/` (label: Worldview)
+
+## About page (`/about/`, WP ID 1208)
+
+- Entry content: no Musqueam / Squamish / Tsleil-Waututh / land acknowledgment copy in the page body (checked after stripping `<footer>`).
+- The footer acknowledgment still appears because it is site chrome.
+- #290 plan already deferred body placement: keep chrome; decide #22 separately; no first-slice About rewrite.
+- #418 draft unifies backgrounds / kills double "public trail" and does not add land copy. Do not inject into that payload.
+
+## Reconciliation page
+
+URL: https://kriskrug.co/reconciliation-indigenous-land-acknowledgement/
+
+Public body (compressed):
+
+- Opening commitment to honour Indigenous presence and sovereignty; reconciliation language.
+- Core acknowledgment (live text includes Coast Salish peoples + Musqueam / Squamish / Tsleil-Waututh with Nation site links). Live characters may mangle in some extracts; treat Nation English names + linked URLs as the stable public intent.
+- Links: Musqueam, Squamish, Tsleil-Waututh Nation sites; Land Back campaign.
+- Supporting photography captions (Tribal Journey / Squamish Nation Youths).
+
+## Vancouver / Host Nation naming (verify for KK)
+
+City of Vancouver and common local institutional wording name the **xʷməθkʷəy̓əm (Musqueam), Sḵwx̱wú7mesh (Squamish), and səlilwətaɬ (Tsleil-Waututh) Nations** on unceded traditional territories. Musqueam is appropriate for Vancouver context, not optional trivia.
+
+"Coast Salish" names a broader cultural / linguistic grouping. Respectful Vancouver practice usually **names the three Host Nations** and may add "Coast Salish peoples" as the collective frame (as the Reconciliation page already does). Treating "Coast Salish" as a fourth Nation, or listing Coast Salish *instead of* Musqueam, is weaker than the local standard.
+
+Issue #22 acceptance text lists Coast Salish, Squamish, Tsleil-Waututh. This packet includes Musqueam because that matches City of Vancouver practice, the live footer, and the live Reconciliation page.
+
+## Earlier repo note (historical)
+
+`fixes/issue-22-land-acknowledgment.md` suggested adding footer copy as if none existed. That note is outdated relative to current Aurora footer + Reconciliation page. Prefer this 2026-07-26 package.
+
+## Gap vs #22 acceptance
+
+1. Visibility: largely met via footer + dedicated page.
+2. Tone / authenticity: KK still needs to pick stronger or quieter copy if the current one-liner feels too buried in brand blurb.
+3. Nation links in the always-on surface: not in footer paragraph today; present on Reconciliation page.
+4. About placement: optional; currently empty in body by design of #290/#418.
+5. WCAG: see `wcag-notes.md` (contrast, link purpose, Unicode names, mobile).

--- a/content/drafts/2026-07-26-land-acknowledgment/README.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/README.md
@@ -1,0 +1,45 @@
+# Indigenous land acknowledgment draft package (#22)
+
+Track A draft only. No live WordPress write. No theme publish from this packet.
+
+**Issue:** [#22](https://github.com/WalksWithASwagger/kriskrug-wp/issues/22)  
+**Related (coordinate, do not conflict):**
+- [#290](https://github.com/WalksWithASwagger/kriskrug-wp/issues/290) About/bio payload: `content/drafts/2026-07-26-about-bio-payload/` (esp. `land-acknowledgment.md` + O6 snippet)
+- [#418](https://github.com/WalksWithASwagger/kriskrug-wp/issues/418) About page unify: `content/drafts/2026-07-26-about-page/` on branch `cursor/418-about-page-draft-f196`
+
+## Verdict for KK
+
+Site chrome already carries a short territorial acknowledgment in the Aurora footer brand tile, plus a dedicated Reconciliation page with Nation links. Gap vs #22 is not "missing entirely." It is: (1) whether footer copy should name Coast Salish peoples and/or link Nations, (2) whether About should also carry a short values-adjacent module, (3) tone choice.
+
+**Recommended path:** Keep footer as the always-on placement. Pick tone Option A (or B). Nation links stay on the Reconciliation page; footer already deep-links `Reconciliation`. Treat About-body land copy as the same optional O6 lane documented in the #290 package: skip on first About write unless KK wants narrative ownership; if approved, place after Receipts / before CTA, and only after #418 layout/copy lands.
+
+## Package files
+
+| File | Role |
+|---|---|
+| `AUDIT.md` | Live evidence (footer, About, Reconciliation page) |
+| `copy-options.md` | Three tone options for KK picker |
+| `placement.md` | Footer and/or About recommendation + #290/#418 coordination |
+| `nation-links.md` | Optional Nation website links (verified 200) |
+| `wcag-notes.md` | WCAG 2.1 AA notes for placement and markup |
+| `proposed-footer-snippet.html` | Apply-ready footer paragraph variants (Track B later) |
+| `proposed-about-section.html` | Optional About module (after #418; not for first About write) |
+| `publish-gate.md` | Human gates before any live change |
+
+## Acceptance mapping (#22)
+
+| Criterion | Draft status |
+|---|---|
+| Visible (footer or About) | Footer already visible sitewide; About optional later |
+| Coast Salish / Squamish / Tsleil-Waututh | Options name Coast Salish peoples + the three Host Nations (incl. Musqueam for Vancouver standard) |
+| Respectful, authentic tone | Three options in `copy-options.md` |
+| Optional Nation website links | Documented; recommended on Reconciliation page (already live) |
+| Mobile responsive | Footer already in Aurora bento; About module uses existing page grid |
+| WCAG 2.1 AA | Notes in `wcag-notes.md`; no conformance claim |
+
+## Out of scope (this packet)
+
+- Live WP REST updates
+- Theme file edits (`theme/kk-aurora/parts/footer.html` is Track B)
+- Rewriting the full Reconciliation page body
+- Mixing into #418 About payload or #290 first About body slice

--- a/content/drafts/2026-07-26-land-acknowledgment/copy-options.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/copy-options.md
@@ -1,0 +1,76 @@
+# Copy options - land acknowledgment (#22)
+
+**Rule:** no em dashes.  
+**Audience:** site visitors (footer always-on) and About readers (optional longer module).  
+**Nation set (recommended):** Coast Salish peoples of the Musqueam, Squamish, and Tsleil-Waututh Nations. Musqueam included for Vancouver standard.
+
+Unicode autonyms (xʷməθkʷəy̓əm / Sḵwx̱wú7mesh / səlilwətaɬ) belong on the dedicated Reconciliation page. Prefer English Nation names in the footer so small type remains readable and copy-paste safe. See `wcag-notes.md`.
+
+## Live baseline (footer today)
+
+> AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.
+
+Strengths: names the three Host Nations; uses "unceded"; already sitewide.  
+Gaps vs #22 list: does not say "Coast Salish"; acknowledgment is fused into a brand sentence; no Nation links in-paragraph.
+
+---
+
+## Option A - Recommended: clear acknowledgment, still short (footer)
+
+Keep the brand headline. Separate the acknowledgment into its own sentence so it is not only a location clause inside a services pitch.
+
+**Footer paragraph (replace brand tile body):**
+
+> I live and work on the traditional, ancestral, and unceded territories of the Coast Salish peoples, including the Musqueam, Squamish, and Tsleil-Waututh Nations. Grateful to build community here, and committed to Indigenous sovereignty.
+
+Optional second line (only if KK wants a services bridge without burying the ack):
+
+> AI keynotes, workshops, and ecosystem work start from that commitment.
+
+**Why recommend:** Meets #22 naming (Coast Salish + Squamish + Tsleil-Waututh) and correctly includes Musqueam. Separates respect from marketing. Stays short enough for footer.
+
+---
+
+## Option B - Quiet institutional (footer)
+
+Closer to City of Vancouver / campus style. Less personal voice.
+
+> This site is produced on the unceded traditional territories of the xʷməθkʷəy̓əm (Musqueam), Sḵwx̱wú7mesh (Squamish), and səlilwətaɬ (Tsleil-Waututh) Nations.
+
+English-only variant if Unicode in footer is a concern:
+
+> This site is produced on the unceded traditional territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.
+
+**Tradeoff:** Formal and clear. Less KK voice. Autonyms need WCAG / font checks if used in footer.
+
+---
+
+## Option C - Values-forward (About module; aligns with #290 O6)
+
+For optional About placement only. Do not paste into footer. Same lane as #290 draft-snippets O6: after Receipts / before CTA; skip on first About write unless KK wants it.
+
+**Kicker / heading:** Land and values / Work on unceded land
+
+> This work happens on the traditional, ancestral, and unceded territories of the Coast Salish peoples of the Musqueam, Squamish, and Tsleil-Waututh Nations. Indigenous sovereignty is not an add-on to the bio. It is part of how I think about community, technology, and futures.
+
+Button: `Read the full land acknowledgment` → `/reconciliation-indigenous-land-acknowledgement/`
+
+**Tradeoff:** Stronger values signal on About. Must wait until after #418 layout/copy so it does not fight the unify packet. Keep Indigenomics / partnership claims out unless KK confirms current wording separately. Do not ship both this and a divergent O6.
+
+---
+
+## Options explicitly not drafted
+
+- Listing Coast Salish *instead of* Musqueam for Vancouver.
+- Performative multi-paragraph footer essays.
+- Claiming consultation, partnership, or Nation approval without KK confirmation.
+- Rewriting the full Reconciliation page in this packet.
+
+## KK picker
+
+- [ ] **A (recommended)** - dedicated footer acknowledgment sentence + Coast Salish peoples + three Nations
+- [ ] B - quiet institutional (Unicode or English-only)
+- [ ] C - About values module (after #418), keep current or lightly tuned footer
+- [ ] A + C - footer Option A and later About Option C
+- [ ] Keep live baseline; close #22 as already visible via footer + Reconciliation page
+- [ ] Custom: _______________________

--- a/content/drafts/2026-07-26-land-acknowledgment/nation-links.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/nation-links.md
@@ -1,0 +1,45 @@
+# Optional Nation website links (#22)
+
+Verified HTTP 200 on 2026-07-26 (follow redirects).
+
+| Nation (English) | Autonym (common orthography) | Official site | Live on Reconciliation page? |
+|---|---|---|---|
+| Musqueam | xʷməθkʷəy̓əm | https://www.musqueam.bc.ca/ | Yes |
+| Squamish | Sḵwx̱wú7mesh | https://www.squamish.net/ | Yes |
+| Tsleil-Waututh | səlilwətaɬ / səl̓ilw̓ətaʔɬ (orthographies vary) | https://twnation.ca/ | Yes |
+
+Related (already linked on Reconciliation page, not a Host Nation government site):
+
+| Resource | URL |
+|---|---|
+| Land Back | https://landback.org/ |
+
+## Recommendation
+
+1. **Keep Nation links on the Reconciliation page** as the canonical place for autonyms + external sites.
+2. **Footer:** link the word `Reconciliation` (already present) or add a short "Full acknowledgment" text link next to the acknowledgment sentence. Avoid three external Nation URLs in the brand tile (crowded, easy to miss focus styles, harder on mobile).
+3. **About Option C (if used):** one internal link to the Reconciliation page; optional secondary line with Nation links only if KK wants them in-body.
+
+## Markup pattern (About or Reconciliation polish)
+
+Use clear link text (Nation English names), not "click here". Open in same tab by default. Mark external destinations with visible text or an accessible external-link pattern only if the rest of the site already does so consistently.
+
+Example (draft; not applied):
+
+```html
+<p>
+  I live and work on the traditional, ancestral, and unceded territories of the
+  Coast Salish peoples of the
+  <a href="https://www.musqueam.bc.ca/">Musqueam</a>,
+  <a href="https://www.squamish.net/">Squamish</a>, and
+  <a href="https://twnation.ca/">Tsleil-Waututh</a> Nations.
+  <a href="/reconciliation-indigenous-land-acknowledgement/">Full acknowledgment</a>.
+</p>
+```
+
+## KK picker
+
+- [ ] Nation links stay on Reconciliation page only (recommended with footer Option A)
+- [ ] Footer gets internal "Full acknowledgment" link beside Option A sentence
+- [ ] About Option C includes Nation links in-body
+- [ ] Other: _______________________

--- a/content/drafts/2026-07-26-land-acknowledgment/placement.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/placement.md
@@ -1,0 +1,55 @@
+# Placement recommendation (#22)
+
+## Decision frame
+
+#22 allows footer **or** About. Live site already uses footer. About body currently has no land module. Dedicated Reconciliation page holds the long form + Nation links.
+
+## Recommendation
+
+| Placement | Action | Timing |
+|---|---|---|
+| Footer brand tile | Keep always-on. Prefer Option A wording from `copy-options.md`. | Track B theme edit after KK picks copy (`parts/footer.html`) |
+| Footer bottom | Keep `Reconciliation` link (already live). Do not duplicate a second ack paragraph in the bottom bar. | None unless label tweak |
+| About body | Optional Option C / #290 O6 **after** #418 ships. Do not add to #418 `payload-body.html`. Skip on first #290 write by default. | Later Track A page body write |
+| Reconciliation page | Keep as canonical long form + Nation links. Optional micro-polish only with separate KK approval. | Out of scope for this packet unless KK asks |
+
+## Why footer first
+
+1. Acceptance allows footer alone; it is already sitewide and mobile-rendered in Aurora.
+2. #290 explicitly deferred land acknowledgment out of the first About body slice.
+3. #418 is a layout/background/"public trail" packet. Injecting land copy there mixes concerns and risks merge conflict with that draft PR.
+4. A buried one-liner inside a services sentence is easier to miss than a dedicated acknowledgment sentence. Improving the footer copy addresses visibility without a second surface.
+
+## Coordination with #290
+
+Source pack (historical): `content/source-packs/content-architecture-2026/about-bio-payload-plan-2026-07-08.md` deferred About-body rewrite.
+
+Sibling draft (active): `content/drafts/2026-07-26-about-bio-payload/land-acknowledgment.md` reaches the same verdict: footer is primary sitewide home; About-body O6 is optional values reinforcement, not a second system. O6 placement: **after Receipts / origin beat, before CTA**. Default first #290 write: **skip O6**.
+
+This #22 packet owns footer tone options + WCAG/nation-link notes. It does not replace #290's About payload plan. If both packages propose About copy, prefer one KK-approved module (O6 or Option C), not both.
+
+## Coordination with #418
+
+`content/drafts/2026-07-26-about-page/` (branch `cursor/418-about-page-draft-f196`) owns About CSS/grid and "public trail" copy. Land acknowledgment is **not** in that payload. Leave it out.
+
+If KK later wants Option C / O6 on About:
+
+1. Let #418 apply (or explicitly supersede) first.
+2. Snapshot page 1208 again.
+3. Append one land section after Receipts / before CTA, matching #418 paper/panel tokens.
+4. Do not reopen "public trail" copy in the same commit.
+5. Do not ship competing O6 + Option C blocks.
+
+## Implementation lanes (when KK approves)
+
+- **Footer wording change:** Track B. Edit `theme/kk-aurora/parts/footer.html`, bump theme Version per Aurora practice, deploy with KK go-ahead.
+- **About Option C:** Track A. Body-only REST update to page 1208 after snapshot; no title change.
+- **Nation links in footer paragraph:** Optional. Prefer linking the existing Reconciliation route rather than three external Nation URLs in small footer type (see `nation-links.md` and `wcag-notes.md`).
+
+## Anti-conflict checklist
+
+- [ ] No edits to `content/drafts/2026-07-26-about-page/` from this issue
+- [ ] No competing rewrite of `content/drafts/2026-07-26-about-bio-payload/` O6 from this issue (reference it; do not fork)
+- [ ] No About body land module in the same PR as #418 unify
+- [ ] No live WP write from this draft package
+- [ ] Theme footer change lands in a Track B commit if/when approved

--- a/content/drafts/2026-07-26-land-acknowledgment/proposed-about-section.html
+++ b/content/drafts/2026-07-26-land-acknowledgment/proposed-about-section.html
@@ -1,0 +1,27 @@
+<!-- Draft only. Optional About body module (Option C / aligns with #290 O6).
+     DO NOT merge into content/drafts/2026-07-26-about-page/payload-body.html.
+     Coordinate with content/drafts/2026-07-26-about-bio-payload/ (O6): ship ONE module, not both.
+     Place after Receipts / origin beat, before CTA.
+     Apply only after #418 layout/copy is decided, with a fresh page-1208 snapshot.
+     Match #418 paper/panel tokens if that pack is live; otherwise use existing About styles. -->
+
+<section class="aurora-proof-section kk-land-ack" aria-labelledby="kk-land-ack-heading">
+  <p class="aurora-kicker">Land and values</p>
+  <h2 id="kk-land-ack-heading">Work on unceded land</h2>
+  <p>
+    This work happens on the traditional, ancestral, and unceded territories of the
+    Coast Salish peoples of the Musqueam, Squamish, and Tsleil-Waututh Nations.
+    Indigenous sovereignty is not an add-on to the bio. It is part of how I think about
+    community, technology, and futures.
+  </p>
+  <p>
+    <a class="aurora-button aurora-button-secondary" href="/reconciliation-indigenous-land-acknowledgement/">Read the full land acknowledgment</a>
+  </p>
+  <!-- Optional Nation links (KK picker in nation-links.md). Prefer the button above alone.
+  <p>
+    <a href="https://www.musqueam.bc.ca/">Musqueam</a> ·
+    <a href="https://www.squamish.net/">Squamish</a> ·
+    <a href="https://twnation.ca/">Tsleil-Waututh</a>
+  </p>
+  -->
+</section>

--- a/content/drafts/2026-07-26-land-acknowledgment/proposed-footer-snippet.html
+++ b/content/drafts/2026-07-26-land-acknowledgment/proposed-footer-snippet.html
@@ -1,0 +1,43 @@
+<!-- Draft only. Track B apply later after KK picks copy.
+     Target: theme/kk-aurora/parts/footer.html brand tile body <p>.
+     Do not commit theme edits from the #22 Track A draft package. -->
+
+<!-- OPTION A (recommended): replace the current brand-tile body paragraph -->
+<p>
+  I live and work on the traditional, ancestral, and unceded territories of the
+  Coast Salish peoples, including the Musqueam, Squamish, and Tsleil-Waututh Nations.
+  Grateful to build community here, and committed to Indigenous sovereignty.
+</p>
+<!-- Optional services bridge as a second paragraph if KK wants it:
+<p>AI keynotes, workshops, and ecosystem work start from that commitment.</p>
+-->
+<p>
+  <a href="/reconciliation-indigenous-land-acknowledgement/">Full acknowledgment</a>
+</p>
+
+<!-- OPTION B English-only institutional -->
+<!--
+<p>
+  This site is produced on the unceded traditional territories of the Musqueam,
+  Squamish, and Tsleil-Waututh Nations.
+</p>
+<p>
+  <a href="/reconciliation-indigenous-land-acknowledgement/">Full acknowledgment</a>
+</p>
+-->
+
+<!-- OPTION B Unicode (smoke-test fonts / AT before shipping) -->
+<!--
+<p>
+  This site is produced on the unceded traditional territories of the
+  xʷməθkʷəy̓əm (Musqueam), Sḵwx̱wú7mesh (Squamish), and səlilwətaɬ (Tsleil-Waututh) Nations.
+</p>
+<p>
+  <a href="/reconciliation-indigenous-land-acknowledgement/">Full acknowledgment</a>
+</p>
+-->
+
+<!-- LIVE BASELINE (for reference; do not leave commented in production file) -->
+<!--
+<p>AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
+-->

--- a/content/drafts/2026-07-26-land-acknowledgment/publish-gate.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/publish-gate.md
@@ -1,0 +1,37 @@
+# Publish gate - land acknowledgment (#22)
+
+**Mode:** draft package for KK. No live WordPress write and no theme deploy from this packet.
+
+## Already true on production (do not "add from zero")
+
+- Footer brand tile includes Musqueam / Squamish / Tsleil-Waututh unceded territories line.
+- Footer bottom links to `/reconciliation-indigenous-land-acknowledgement/`.
+- Dedicated Reconciliation page includes Coast Salish framing, three Nations, and Nation website links.
+
+## Human gates before any change
+
+- [ ] KK picks a copy option in `copy-options.md` (or "keep baseline / close as visible").
+- [ ] KK confirms Musqueam remains named (recommended for Vancouver).
+- [ ] KK confirms placement: footer only / About later / both.
+- [ ] KK confirms Nation-link strategy in `nation-links.md`.
+- [ ] If footer wording changes: Track B PR for `theme/kk-aurora/parts/footer.html` + theme version bump + deploy approval.
+- [ ] If About Option C: wait until #418 is applied or explicitly deferred; fresh snapshot of page 1208; body-only update; no title change.
+- [ ] Dry-run / screenshot review at 375 / 768 / 1440.
+- [ ] WCAG smoke from `wcag-notes.md`.
+- [ ] Pagely purge for touched routes after live apply.
+- [ ] Rollback path: restore prior footer part or About `content.raw` snapshot.
+
+## Do not
+
+- Patch live WP from this folder.
+- Edit #418 About payload files in the same change set.
+- Claim Nation consultation or endorsement.
+- Ship Unicode footer autonyms without a font/AT smoke.
+- Use em dashes in approved copy.
+
+## Suggested issue close conditions
+
+Close #22 when KK either:
+
+1. Accepts live baseline as meeting "visible" (footer + Reconciliation page), or
+2. Approves and ships footer Option A/B (and optionally schedules About Option C after #418).

--- a/content/drafts/2026-07-26-land-acknowledgment/wcag-notes.md
+++ b/content/drafts/2026-07-26-land-acknowledgment/wcag-notes.md
@@ -1,0 +1,64 @@
+# WCAG notes - land acknowledgment (#22)
+
+Working reference: WCAG 2.1 AA. This is guidance for the draft, not a conformance claim for the live site.
+
+## What already helps
+
+- Footer sits in `<footer role="contentinfo">` with labeled tiles (`aria-label` on brand / newsletter / nav sections).
+- Acknowledgment is plain text in a paragraph (not an image of text).
+- Reconciliation route is a real HTML page with an `h1`.
+- Decorative woven SVG strip uses `aria-hidden="true"`.
+
+## Risks to watch when changing copy or placement
+
+### 1. Contrast (1.4.3 Contrast Minimum)
+
+- Footer brand tile uses Aurora cream/ink system. Any new acknowledgment sentence must keep AA contrast against the footer background.
+- Do not style the acknowledgment in muted gray that fails AA on cream or dark bands.
+- If About Option C lands inside #418's paper (`#efe6d2`) / panel (`#e6dcc2`) system, use the same ink tokens as the rest of that pack. No new low-contrast accent color for "solemn" tone.
+
+### 2. Link purpose (2.4.4 Link Purpose in Context)
+
+- Prefer link text like `Musqueam`, `Squamish`, `Tsleil-Waututh`, or `Full acknowledgment`.
+- Avoid bare URLs or `Learn more` / `click here` without surrounding context.
+- If footer already has a `Reconciliation` link, do not add a second adjacent link with identical purpose and different wording without a reason.
+
+### 3. Unicode Nation names (1.3.1 / readable text)
+
+- Autonyms are respectful and belong on the Reconciliation page.
+- Small footer type + complex Unicode can fail font coverage or look like mojibake in some extracts/clients.
+- Recommendation: English Nation names in footer; autonyms on the dedicated page where type is larger and intentional.
+- If Option B Unicode footer is chosen, smoke-test with system fonts on iOS Safari, Android Chrome, and a desktop screen reader. Confirm characters announce usefully or provide English in parentheses (already common pattern).
+
+### 4. Mobile / reflow (1.4.10 Reflow, 1.4.4 Resize Text)
+
+- Keep footer acknowledgment to one short paragraph. Long essays break the bento tile on 320 to 375px widths.
+- Do not force nowrap on Nation names.
+- About module should use the same single-column collapse as #418 grids (`max-width: 720px` pattern), not a fixed multi-column land block.
+
+### 5. Keyboard and focus (2.1.1, 2.4.7)
+
+- Nation links and the Reconciliation link must show visible focus styles consistent with Aurora buttons/links.
+- Do not wrap the whole footer brand tile in one giant link.
+
+### 6. Semantics / headings
+
+- Footer: keep acknowledgment as `<p>`, not an `h2` competing with "Still paying attention…"
+- About Option C: use one `h2` (or `h3` if nested under an existing section scheme) named clearly, e.g. `Land and commitments`. One job per section.
+
+### 7. Language of parts (3.1.2)
+
+- If autonyms are included, wrapping them in `lang` (or leaving them as proper names with English gloss in parentheses) is ideal when practical. Do not invent incorrect `lang` codes. English gloss in parentheses is an acceptable fallback used widely in Vancouver acknowledgments.
+
+## Suggested smoke checks after any live apply
+
+1. Keyboard-only tab through footer brand links + Reconciliation link.
+2. Zoom to 200% on a 1280px viewport; acknowledgment still readable, no horizontal clip.
+3. Contrast check on footer paragraph and any new About module text.
+4. Screen reader skim: Nation names announced; Reconciliation link purpose clear.
+5. Mobile screenshot at 375px of footer brand tile.
+
+## Non-claims
+
+- Do not mark the acknowledgment block with `aria-label="land acknowledgment"` unless UX research says visitors need that landmark; over-labeling can add noise.
+- Do not claim the site is WCAG AA compliant because this sentence was added.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Draft package for #22. Finding: footer already acknowledges Musqueam/Squamish/Tsleil-Waututh; this is tone/visibility polish, not a missing acknowledgment.

## Package
`content/drafts/2026-07-26-land-acknowledgment/` — tone options A–C, placement, nation links, WCAG notes.

No live theme/WP publish. Coordinates with #290/#418.

Refs #290, #288.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ff5-03d9-7811-b160-b82e45b0f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ff5-03d9-7811-b160-b82e45b0f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

