### PR TITLE
docs(#48): fold accessibility statement into #288

### DIFF
--- a/docs/current-state/reports/issue-48-fold-into-288-20260726.md
+++ b/docs/current-state/reports/issue-48-fold-into-288-20260726.md
@@ -1,0 +1,117 @@
+# Issue #48 fold into #288 — disposition package (2026-07-26)
+
+**Mode:** docs / queue hygiene only. No live WordPress writes. No issue closes via API.  
+**Branch:** `cursor/48-a11y-statement-fold-f196`  
+**Compared against:** `origin/cursor/288-a11y-statement-f196` @ `972b7f9` · draft PR [#516](https://github.com/WalksWithASwagger/kriskrug-wp/pull/516)
+
+| | |
+|---|---|
+| Source issue | [#48](https://github.com/WalksWithASwagger/kriskrug-wp/issues/48) `[A11Y] Create Accessibility Statement` — OPEN |
+| Canonical tracker | [#288](https://github.com/WalksWithASwagger/kriskrug-wp/issues/288) `[A11Y] Draft accessibility statement for human review` — OPEN |
+| Active packet | `content/drafts/2026-07-26-accessibility-statement/` (`statement.md` + `README.md`) |
+| Related (keep open) | [#46](https://github.com/WalksWithASwagger/kriskrug-wp/issues/46) full WCAG audit — **not** folded |
+| Related (already closed) | [#365](https://github.com/WalksWithASwagger/kriskrug-wp/issues/365) WP-draft-only day ticket — CLOSED |
+
+## Verdict
+
+**Fold #48 into #288.** Close #48 as superseded after KK pastes the comment below.
+
+Draft acceptance for the statement itself is already owned by #288 + PR #516. Keeping #48 open duplicates the same page, the same placeholders, and the same publish gates under a second high-priority label. Residual publish work belongs as **phased gates on #288**, not as a parallel umbrella issue.
+
+This report does **not** close any GitHub issue. Agent write to issues/PRs may be blocked; KK closes in the UI.
+
+## Acceptance matrix: #48 vs #288 package
+
+| #48 acceptance criterion | Covered by #288 / PR #516 draft? | Notes |
+|---|---|---|
+| Statement published at `/accessibility/` | **No** (intentional) | Packet is draft-only. Live probe cited in packet: `/accessibility/` still **404** (2026-07-26). Publish is a post-review gate on #288. |
+| Current status documented | **Yes** | `statement.md` → “Where the site stands” (partially conformant WCAG 2.1 AA; self-evaluation, not certification). |
+| Known issues listed transparently | **Yes** | “Known limitations” (alt text, focus inconsistency, mobile QA gap, archive variance, third-party embeds, no full audit). |
+| Reporting mechanism clear | **Yes, gated** | `/contact/` + `mailto:feelmoreplants@gmail.com` with `[KK: confirm…]` placeholder. |
+| Accommodation process documented | **Yes** | “If you need another format” + informal follow-up path; formal escalation is a KK placeholder. |
+| Roadmap included | **Yes** | “What I am working on next” (five prioritized items; no fake deadlines). |
+| Linked from footer | **No** (intentional) | Packet forbids footer/theme edits while URL is 404. Track B after 200. |
+| Page itself WCAG 2.1 AAA accessible | **Not verified** | Draft only. Packet KK gate #7 asks confirm AAA (#48) vs AA + plain structure. |
+
+### #288 own acceptance (draft lane)
+
+| #288 criterion | Status on PR #516 |
+|---|---|
+| Draft copy suitable for `/accessibility/` | Met — publishable copy below marker |
+| Posture, limitations, feedback, remediation intent | Met |
+| Plain, non-legalistic language | Met (first-person, no compliance badge) |
+| Unknown contact/reporting as placeholders | Met (`[KK: …]` markers) |
+| Human review before publishing | Met by design — no WP writes in packet |
+
+**Conclusion:** Every *content* criterion from #48 is already drafted under #288. Only *execution* criteria remain (KK answers → WP draft/publish → footer → page a11y check). Those should track on #288 after fold.
+
+## Residual gaps after fold (absorb onto #288)
+
+Do not invent a new issue unless KK wants publish split out later. Comment these onto #288 when closing #48:
+
+1. **KK placeholders** — contact email, reply-time language, escalation route, WCAG 2.1 vs 2.2 naming, “Last reviewed” date, AAA vs AA page gate.
+2. **WP draft** — create/update draft page slug `accessibility`; check whether private draft `11886` (from earlier #48 prep) still exists and reuse or delete — no duplicate.
+3. **Publish** — after KK approval, publish so `https://kriskrug.co/accessibility/` returns **200**.
+4. **Footer link (Track B, separate session)** — add `Accessibility` next to Privacy/Contact in `theme/kk-aurora/parts/footer.html` only after the URL is live.
+5. **Page a11y smoke** — keyboard, zoom, mobile, heading structure on the live page; confirm whether #48’s AAA bar is kept or relaxed to AA + plain structure.
+6. **Do not close #46** — full audit remains separate; the statement correctly says no independent audit has been done.
+
+## Why fold (not keep both)
+
+- #48 comment (2026-07-02) already pointed reviewers at the #288 draft.
+- Docs crust audit (2026-07-16) already preferred “#288/#365 as active a11y draft lane” for #48; #365 is closed.
+- PR #516 README still labels #48 as “publish umbrella,” which was useful while draft and publish were split across tickets. With one active draft PR and one open draft issue, the umbrella is queue noise.
+- Historical prep under #48 (`content/drafts/accessibility-statement-2026-05/`, WP draft `11886`) is superseded by `content/drafts/2026-07-26-accessibility-statement/` (explicit supersession list in the packet).
+
+**Alternative if KK prefers two-phase tracking:** keep #48 open *only* as publish+footer+AAA execution, retitle it accordingly, and close nothing. That is valid but weaker for swarm triage; this package recommends the fold.
+
+## Proposed GitHub close comment (paste on #48)
+
+```markdown
+Folding into #288.
+
+The accessibility-statement *content* acceptance from this issue is covered by the #288 draft packet on PR #516 (`content/drafts/2026-07-26-accessibility-statement/`). Remaining work is execution, not a second drafting lane:
+
+1. KK fills the `[KK: …]` placeholders (contact, reply window, escalation, WCAG edition, last-reviewed date, AAA vs AA page bar).
+2. Create/update WP **draft** page `accessibility` (reuse or delete old draft `11886` if it still exists — no duplicate).
+3. Publish after approval → `/accessibility/` returns 200.
+4. Separate Track B session: footer `Accessibility` link only after the URL is live.
+5. Page keyboard/zoom/mobile smoke; confirm AAA (#48 original) vs AA + plain structure.
+
+Full WCAG audit stays on #46 — not closed by this fold.
+
+Disposition report: `docs/current-state/reports/issue-48-fold-into-288-20260726.md`
+
+Closing #48 as superseded by #288. Please add the residual checklist above as a comment on #288 so publish gates stay visible there.
+```
+
+## Proposed follow-up comment (paste on #288 after #48 closes)
+
+```markdown
+#48 folded here (see close comment on #48).
+
+Residual publish gates now owned by this issue (in addition to draft review):
+
+- [ ] KK placeholders answered
+- [ ] WP draft page `accessibility` (check/reuse `11886`)
+- [ ] Publish → `/accessibility/` 200
+- [ ] Track B footer link after 200
+- [ ] Page a11y smoke; AAA vs AA decision recorded
+- [ ] Leave #46 open for full audit
+
+Active packet: PR #516 / `content/drafts/2026-07-26-accessibility-statement/`
+```
+
+## Agent boundaries for this pass
+
+| Allowed | Forbidden |
+|---|---|
+| This disposition report, commit, push | Closing #48 / #288 / #46 via API |
+| Cite PR #516 packet as source of truth | Live WP create/update/publish |
+| Recommend exact close-comment text for KK | Footer/theme edits, redirects, menus |
+
+## Refs
+
+- Issues: #48, #288, #46, #365 (closed)
+- PR: #516 (`cursor/288-a11y-statement-f196`)
+- Prior notes: `docs/current-state/reports/issue-365-a11y-draft-gates-20260716.md`, `docs/current-state/reports/docs-crust-audit-20260716.md` (#48 → prefer #288 lane)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disposition for #48 → fold into #288 (draft already in PR #516).

## Report
`docs/current-state/reports/issue-48-fold-into-288-20260726.md`

Paste-ready close comment included. Residual publish/footer work stays on #288. No issues closed via API; no live WP.

Refs #288, #516, #46.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ff5-03d9-7811-b160-b82e45b0f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ff5-03d9-7811-b160-b82e45b0f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

