### PR TITLE
ops(#547): restore morning-truth cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ Run `make morning-truth` at session start (or before execution) to emit a timest
 
 If the task explicitly forbids file changes, run `make status-readonly` instead. It prints the same startup truth shape to stdout and does not write a report file.
 
+**Keeping the cadence alive:** `make morning-truth` writes the `.md` but does *not* auto-commit it — the report only becomes the shared source of truth once someone commits it. The report others read stays current only if the session that runs `morning-truth` also commits the fresh `docs/current-state/reports/morning-truth-*.md` (these `.md` summaries are tracked; only `reports/` PNG/HTML/CSV captures are gitignored). If the newest committed report is more than a few days stale, that means recent sessions ran `status-readonly` (stdout-only) or skipped the commit — not that the target is broken. Regenerate and commit one.
+
 ## Cursor Cloud specific instructions
 
 This repo is CLI tooling + a WordPress theme/plugins line — there is **no local web app or server to boot**. "Running" it means executing the Python CLIs (`scripts/notion-to-wp/`, `scripts/*.py`) and the PHP lint/smoke checks. Standard commands (`make test`, `make validate`, `make verify`, connector usage) are already documented in `CONTRIBUTING.md`, `Makefile`, and `scripts/notion-to-wp/README.md`; use those.

--- a/docs/current-state/reports/morning-truth-20260727-051348Z.md
+++ b/docs/current-state/reports/morning-truth-20260727-051348Z.md
@@ -1,0 +1,475 @@
+# Morning Truth Report - 2026-07-27 05:13:48 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `2`
+- Open issues: `52`
+- WordPress version (smoke): `7.0.2`
+- Draft queue: `unavailable` (see Draft Queue Counts stderr)
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `(not found)`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `26`
+- `aurora-v2`: `2`
+- `track-b`: `21`
+- `swarm-ready`: `25`
+- `swarm-parked`: `0`
+- `needs-human-review`: `23`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 2 | YES |
+| Open Issues | 77 | 52 | YES |
+| WordPress Version | 7.0.2 | 7.0.2 | no |
+| Scheduled Posts | 5 | unavailable | not evaluated |
+| Draft Posts | 64 | unavailable | not evaluated |
+| Draft Pages | 4 | unavailable | not evaluated |
+
+Drift checker errors:
+- WordPress credentials unavailable: missing env file: /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1/scripts/notion-to-wp/.env and WP_USER/WP_APP_PASSWORD not set in process env
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Data Availability
+
+- `unavailable`: draft queue counts unavailable: WordPress credentials unavailable: missing env file: /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1/scripts/notion-to-wp/.env and WP_USER/WP_APP_PASSWORD not set in process env
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` worktree not detected from porcelain list.
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## ops/547-morning-truth-cadence
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+5a8ebc1 docs: week work plan 2026-07-26 (1.5.0 pixel-gate keystone + rebuild chain)
+771228e feat(#416): homepage newsletter section rewrite + thumbnails (#505)
+ab58eeb docs: wind-down merge cleanup after swarm PR squash
+6771c53 docs(#495): PR merge-queue review — Cloud cannot approve (#537)
+cf15a88 docs(#495): swarm dispatch round-3 closeout 2026-07-26 (#536)
+c806c1d docs(#495): swarm dispatch round-2 closeout 2026-07-26 (#525)
+509d0fd docs(#495): swarm dispatch closeout report 2026-07-26 (#514)
+b4629e6 docs(#385): status report — WP skill normalize blocked on kk-agents#2 (#542)
+ee60de9 docs(#290): fold disposition for #269+#270 into About/bio plan (#541)
+7142547 docs(#495): disposition package for stale epics #360/#379/#384/#222/#366 (#540)
+b304742 docs(#318): add repo-bloat next-steps from #369 reclaim list (#539)
+fbae2dd docs(#364): hub-link wraps execution checklist prep (#538)
+d296f3a docs(#369): add ranked reclaim list for KK approval (#502)
+2cf703a docs(#125): post-Jetpack Boost Critical CSS stabilization plan (#534)
+6b39efa docs(#46): WCAG smoke audit report 2026-07-26 (#533)
+d0c9532 docs(#276): Jetpack core delete prep checklist (no live delete) (#532)
+c5e6ac6 docs(#86): post-Jetpack public QA matrix 2026-07-26 (#531)
+7d53c15 docs(#339): prep measured July publisher batch inventory (#530)
+7539e3c docs(#48): fold disposition into #288 with residual publish gates (#529)
+92ae1c9 docs(#95): media appearances review (already published) (#528)
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+```text
+551	docs(#544): correct theme-version state (live 1.5.0 / main 1.4.9 / PR #493 open)	docs/544-version-state-fix	DRAFT	2026-07-27T05:11:45Z
+493	feat(#474): cascade @layer scaffold + --kk-* tokens (Aurora 1.5.0)	theme/474-cascade-layers-scaffold	OPEN	2026-07-26T07:10:29Z
+```
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+550	OPEN	[HOUSEKEEPING] Verify #416 and #290 landed on main and close	priority:low, content, needs-human-review	2026-07-27T05:03:55Z
+549	OPEN	[OPS] Archive stale docs/current-state May–June plans into archive/	documentation, priority:low, needs-human-review, tech-debt	2026-07-27T05:03:53Z
+548	OPEN	[DOCS] Add theme CHANGELOG tracking version → deploy status	documentation, priority:medium, track-b, swarm-ready, agent-safe	2026-07-27T05:03:52Z
+547	OPEN	[OPS] Restore morning-truth cadence (newest committed report is 2026-07-16)	priority:medium, swarm-ready, agent-safe, tech-debt	2026-07-27T05:03:13Z
+546	OPEN	[TEST] Add live-vs-repo theme version parity check (make check-live-parity)	priority:high, track-b, swarm-ready, tests, agent-safe	2026-07-27T05:03:11Z
+545	OPEN	[OPS] Reconcile live Aurora 1.5.0 against PR #493 and main	priority:high, needs-human-review, track-b, deployment, needs-decision	2026-07-27T05:03:09Z
+544	OPEN	[DOCS] Correct AGENTS.md + CURRENT-STATE theme-version state (live 1.5.0 / main 1.4.9 / PR #493 open)	documentation, priority:high, track-b, swarm-ready, agent-safe	2026-07-27T05:03:07Z
+500	OPEN	[CONTENT] Futureproof post: verify + create WP draft (no publish)	priority:high, content, needs-human-review, swarm-wave-3, deployment	2026-07-26T16:33:51Z
+499	OPEN	[CONTENT] Futureproof post: write the story in KK voice	priority:high, content, needs-human-review, swarm-wave-2	2026-07-26T16:33:50Z
+498	OPEN	[CONTENT] Futureproof post: verify + assemble public speaker lineup	priority:high, content, needs-human-review, swarm-ready, swarm-wave-1	2026-07-26T16:33:48Z
+497	OPEN	[CONTENT] Futureproof post: stage design assets + alt text	priority:medium, content, swarm-ready, swarm-wave-1, agent-safe	2026-07-26T16:33:46Z
+496	OPEN	[EPIC] Futureproof Festival announcement post (Track A)	priority:high, content, swarm-ready	2026-07-26T16:34:03Z
+495	OPEN	[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)	swarm-ready, roadmap	2026-07-26T15:50:39Z
+494	OPEN	[SWARM][Wave 0] Verify + merge PR #493 through the pixel gate (Aurora 1.5.0)	priority:high, track-b, swarm-ready, refactor	2026-07-27T04:15:26Z
+481	OPEN	[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1	priority:medium, needs-human-review, track-b, refactor, blocked	2026-07-26T15:51:34Z
+480	OPEN	[CONTENT] Retire Track A page-content CSS blocks (six live routes)	priority:medium, content, needs-human-review, tech-debt, blocked	2026-07-26T15:51:32Z
+479	OPEN	[THEME] Consolidate 12 breakpoints into a 3-step scale	priority:medium, mobile, track-b, swarm-ready, refactor, blocked	2026-07-26T15:51:30Z
+478	OPEN	[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0	priority:medium, track-b, swarm-ready, tech-debt, blocked	2026-07-26T15:51:29Z
+477	OPEN	[EPIC] Component migration: one component per PR — Aurora 1.5.3+	priority:medium, track-b, swarm-ready, roadmap, refactor, blocked	2026-07-26T15:51:27Z
+476	OPEN	[THEME] Primitives layer + block-editor parity — Aurora 1.5.2	priority:high, track-b, swarm-ready, refactor, blocked	2026-07-26T15:51:25Z
+475	OPEN	[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1	priority:medium, track-b, swarm-ready, refactor, blocked	2026-07-26T15:51:23Z
+474	OPEN	[THEME] Cascade layers + token scaffold (behavior-neutral) — Aurora 1.5.0	priority:high, track-b, swarm-ready, tech-debt, refactor, blocked	2026-07-26T15:52:04Z
+424	OPEN	[QA] Site-wide hover, focus, and interactivity pass	priority:medium, accessibility, ux, track-b, swarm-ready, swarm-wave-2, blocked	2026-07-26T15:51:36Z
+423	OPEN	[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair	priority:high, track-b, swarm-wave-2, tech-debt, refactor	2026-07-26T15:52:05Z
+420	OPEN	[PAGE] Services page: rethink language, layout, and scroll depth	priority:medium, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:19Z
+419	OPEN	[PAGE] Speaking page: multimedia rebuild that sells keynotes	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:17Z
+418	OPEN	[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:16Z
+416	OPEN	[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-24T22:26:21Z
+415	OPEN	[HOME] 'What People Say' redesign + network diagram spike	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:10Z
+414	OPEN	[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-17T14:44:09Z
+413	OPEN	[HOME] Bring back the client logo soup: monochromatic and interactive	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-19T23:47:00Z
+412	OPEN	[HOME] Creative Labs section redesign: layout, image crops, clarity	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-17T14:44:05Z
+411	OPEN	[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-24T21:33:31Z
+403	OPEN	[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown	priority:high, ux, track-b, roadmap	2026-07-17T14:44:46Z
+402	OPEN	[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs	enhancement, help wanted	2026-07-17T04:25:24Z
+385	OPEN	Normalize the WordPress workflow skill without breaking automation		2026-07-17T01:12:49Z
+369	OPEN	[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)		2026-07-25T18:53:36Z
+339	OPEN	[SEO] Run the measured July Kris publisher batch	priority:high, seo, needs-human-review	2026-07-14T07:28:42Z
+331	OPEN	[SEO] Shrink taxonomy sitemap bloat and define archive indexability	priority:high, seo, needs-human-review, roadmap	2026-07-24T22:41:40Z
+318	OPEN	[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history	priority:medium, tech-debt	2026-07-12T05:46:59Z
+290	OPEN	[CONTENT] Consolidate About/bio archive updates into a body-only payload plan	priority:medium, content, needs-human-review	2026-07-27T00:39:54Z
+277	OPEN	[FORMS] Decide whether the lightweight contact CTA is enough	priority:medium, platform, content, needs-human-review	2026-07-01T21:18:37Z
+276	OPEN	[OPS] Delete inactive Jetpack after rollback window	priority:medium, platform, needs-human-review, deployment, tech-debt	2026-07-01T21:18:35Z
+274	OPEN	[SEO] Submit canonical sitemap in Search Console and monitor indexing	priority:high, seo, needs-human-review, roadmap	2026-07-16T14:43:11Z
+249	OPEN	[SEO] Measure 'you can't drink data' striking-distance after #233 deploy	content, seo	2026-07-13T05:25:21Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, swarm-wave-2, blocked	2026-06-17T21:27:05Z
+125	OPEN	[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup	priority:medium, performance, track-b, tech-debt	2026-07-02T21:01:24Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+86	OPEN	[QA] Post-Jetpack real-site performance, accessibility, and tracking QA	priority:high, mobile, accessibility, performance, track-b	2026-07-02T21:01:25Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-07-02T00:32:38Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-07-02T00:32:38Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD 5a8ebc1a0ba6146c850ae743582d0ec1a02c4ba0
+branch refs/heads/docs/548-theme-changelog
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-a20fb8f49a6da4741
+HEAD 5a8ebc1a0ba6146c850ae743582d0ec1a02c4ba0
+branch refs/heads/test/546-live-parity-check
+locked claude agent agent-a20fb8f49a6da4741 (pid 33483 start Mon Jul 27 04:53:55 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-a60d4ae1d2a7abd20
+HEAD 8a1e147e340d5bed7f7d1fc67d42e471ada292bc
+branch refs/heads/docs/544-version-state-fix
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-a9289345598f43fb4
+HEAD 5a8ebc1a0ba6146c850ae743582d0ec1a02c4ba0
+branch refs/heads/worktree-agent-a9289345598f43fb4
+locked claude agent agent-a9289345598f43fb4 (pid 33483 start Mon Jul 27 04:53:55 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1
+HEAD 5a8ebc1a0ba6146c850ae743582d0ec1a02c4ba0
+branch refs/heads/ops/547-morning-truth-cadence
+locked claude agent agent-aa8cdc13efb8a10b1 (pid 33483 start Mon Jul 27 04:53:55 2026)
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `128`
+
+stderr:
+```text
+fatal: ambiguous argument 'origin/aurora/v2...origin/main': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":550,"title":"[HOUSEKEEPING] Verify #416 and #290 landed on main and close","updatedAt":"2026-07-27T05:03:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":549,"title":"[OPS] Archive stale docs/current-state May–June plans into archive/","updatedAt":"2026-07-27T05:03:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":548,"title":"[DOCS] Add theme CHANGELOG tracking version → deploy status","updatedAt":"2026-07-27T05:03:52Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":547,"title":"[OPS] Restore morning-truth cadence (newest committed report is 2026-07-16)","updatedAt":"2026-07-27T05:03:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqUg","name":"tests","description":"Automated test work","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":546,"title":"[TEST] Add live-vs-repo theme version parity check (make check-live-parity)","updatedAt":"2026-07-27T05:03:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"}],"number":545,"title":"[OPS] Reconcile live Aurora 1.5.0 against PR #493 and main","updatedAt":"2026-07-27T05:03:09Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":544,"title":"[DOCS] Correct AGENTS.md + CURRENT-STATE theme-version state (live 1.5.0 / main 1.4.9 / PR #493 open)","updatedAt":"2026-07-27T05:03:07Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"}],"number":500,"title":"[CONTENT] Futureproof post: verify + create WP draft (no publish)","updatedAt":"2026-07-26T16:33:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":499,"title":"[CONTENT] Futureproof post: write the story in KK voice","updatedAt":"2026-07-26T16:33:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":498,"title":"[CONTENT] Futureproof post: verify + assemble public speaker lineup","updatedAt":"2026-07-26T16:33:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":497,"title":"[CONTENT] Futureproof post: stage design assets + alt text","updatedAt":"2026-07-26T16:33:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":496,"title":"[EPIC] Futureproof Festival announcement post (Track A)","updatedAt":"2026-07-26T16:34:03Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":495,"title":"[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)","updatedAt":"2026-07-26T15:50:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":494,"title":"[SWARM][Wave 0] Verify + merge PR #493 through the pixel gate (Aurora 1.5.0)","updatedAt":"2026-07-27T04:15:26Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":481,"title":"[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1","updatedAt":"2026-07-26T15:51:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":480,"title":"[CONTENT] Retire Track A page-content CSS blocks (six live routes)","updatedAt":"2026-07-26T15:51:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":479,"title":"[THEME] Consolidate 12 breakpoints into a 3-step scale","updatedAt":"2026-07-26T15:51:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":478,"title":"[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0","updatedAt":"2026-07-26T15:51:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":477,"title":"[EPIC] Component migration: one component per PR — Aurora 1.5.3+","updatedAt":"2026-07-26T15:51:27Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":476,"title":"[THEME] Primitives layer + block-editor parity — Aurora 1.5.2","updatedAt":"2026-07-26T15:51:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":475,"title":"[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1","updatedAt":"2026-07-26T15:51:23Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":474,"title":"[THEME] Cascade layers + token scaffold (behavior-neutral) — Aurora 1.5.0","updatedAt":"2026-07-26T15:52:04Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":424,"title":"[QA] Site-wide hover, focus, and interactivity pass","updatedAt":"2026-07-26T15:51:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":423,"title":"[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair","updatedAt":"2026-07-26T15:52:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":420,"title":"[PAGE] Services page: rethink language, layout, and scroll depth","updatedAt":"2026-07-17T14:44:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":419,"title":"[PAGE] Speaking page: multimedia rebuild that sells keynotes","updatedAt":"2026-07-17T14:44:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":418,"title":"[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'","updatedAt":"2026-07-17T14:44:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":416,"title":"[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA","updatedAt":"2026-07-24T22:26:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":415,"title":"[HOME] 'What People Say' redesign + network diagram spike","updatedAt":"2026-07-17T14:44:10Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":414,"title":"[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity","updatedAt":"2026-07-17T14:44:09Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":413,"title":"[HOME] Bring back the client logo soup: monochromatic and interactive","updatedAt":"2026-07-19T23:47:00Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":412,"title":"[HOME] Creative Labs section redesign: layout, image crops, clarity","updatedAt":"2026-07-17T14:44:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":411,"title":"[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states","updatedAt":"2026-07-24T21:33:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":403,"title":"[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown","updatedAt":"2026-07-17T14:44:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEw","name":"help wanted","description":"Extra attention is needed","color":"008672"}],"number":402,"title":"[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs","updatedAt":"2026-07-17T04:25:24Z"},{"labels":[],"number":385,"title":"Normalize the WordPress workflow skill without breaking automation","updatedAt":"2026-07-17T01:12:49Z"},{"labels":[],"number":369,"title":"[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)","updatedAt":"2026-07-25T18:53:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":339,"title":"[SEO] Run the measured July Kris publisher batch","updatedAt":"2026-07-14T07:28:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":331,"title":"[SEO] Shrink taxonomy sitemap bloat and define archive indexability","updatedAt":"2026-07-24T22:41:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":318,"title":"[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history","updatedAt":"2026-07-12T05:46:59Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":290,"title":"[CONTENT] Consolidate About/bio archive updates into a body-only payload plan","updatedAt":"2026-07-27T00:39:54Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":277,"title":"[FORMS] Decide whether the lightweight contact CTA is enough","updatedAt":"2026-07-01T21:18:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":276,"title":"[OPS] Delete inactive Jetpack after rollback window","updatedAt":"2026-07-01T21:18:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":274,"title":"[SEO] Submit canonical sitemap in Search Console and monitor indexing","updatedAt":"2026-07-16T14:43:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":249,"title":"[SEO] Measure 'you can't drink data' striking-distance after #233 deploy","updatedAt":"2026-07-13T05:25:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-06-17T21:27:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":125,"title":"[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup","updatedAt":"2026-07-02T21:01:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"}],"number":86,"title":"[QA] Post-Jetpack real-site performance, accessibility, and tracking QA","updatedAt":"2026-07-02T21:01:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-07-02T00:32:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-07-02T00:32:38Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[{"number":551,"title":"docs(#544): correct theme-version state (live 1.5.0 / main 1.4.9 / PR #493 open)","updatedAt":"2026-07-27T05:12:42Z"},{"number":493,"title":"feat(#474): cascade @layer scaffold + --kk-* tokens (Aurora 1.5.0)","updatedAt":"2026-07-27T01:44:05Z"}]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `1`
+
+stderr:
+```text
+WordPress credentials unavailable: missing env file: /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1/scripts/notion-to-wp/.env and WP_USER/WP_APP_PASSWORD not set in process env
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 7.0.2 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.183.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "7.0.2"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/work/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/explat",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "application/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/wp-sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "7.0.2",
+  "started_at": "2026-07-27T05:13:53Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/CURRENT-STATE-2026-07-16.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 2,
+      "status": "drift"
+    },
+    {
+      "declared": 77,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 52,
+      "status": "drift"
+    },
+    {
+      "declared": "7.0.2",
+      "drift": false,
+      "evaluated": true,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "7.0.2",
+      "status": "no drift"
+    },
+    {
+      "declared": 5,
+      "drift": false,
+      "evaluated": false,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": null,
+      "status": "not evaluated"
+    },
+    {
+      "declared": 64,
+      "drift": false,
+      "evaluated": false,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": null,
+      "status": "not evaluated"
+    },
+    {
+      "declared": 4,
+      "drift": false,
+      "evaluated": false,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": null,
+      "status": "not evaluated"
+    }
+  ],
+  "errors": [
+    "WordPress credentials unavailable: missing env file: /Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1/scripts/notion-to-wp/.env and WP_USER/WP_APP_PASSWORD not set in process env"
+  ],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aa8cdc13efb8a10b1/docs/current-state/CURRENT-STATE-2026-07-16.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301 
+date: Mon, 27 Jul 2026 05:14:09 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+server: Pagely-ARES/1.22.28
+x-gateway-request-id: 1a123a6aeb0f46efc24f231856720546
+x-jetpack-boost-cache: miss
+expires: Mon, 27 Jul 2026 06:11:52 GMT
+cache-control: max-age=3600
+x-redirect-by: redirection
+location: /work/
+x-gateway-cache-key: 1784933659.113|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: HIT
+x-gateway-skip-cache: 0
+```


### PR DESCRIPTION
Closes #547.

## Root-cause finding

The cadence lapsed because **nobody committed the generated report** — not a gitignore issue and not a broken target.

- **Not gitignored:** `.md` morning-truth reports are tracked. `.gitignore` only ignores `reports/` PNG/HTML/CSV captures and `visual-baseline/*` (with `!` re-includes). Proof: `git check-ignore -v docs/current-state/reports/morning-truth-20260727-051348Z.md` returns empty (exit 1 / no match).
- **Not a broken target:** `make morning-truth` runs cleanly and writes a complete report to `docs/current-state/reports/morning-truth-<stamp>.md`.
- **Actual cause:** the last commit touching a morning-truth report was `95c72e1` (2026-07-16). Since then, sessions either ran `make status-readonly` (stdout-only, writes no file) or ran `morning-truth` locally without committing the written `.md`. The report is written but never auto-committed, so it only becomes the shared source of truth when a session commits it.

## What changed

- **Fresh report committed:** `docs/current-state/reports/morning-truth-20260727-051348Z.md` (regenerated 2026-07-27). Generated with graceful degradation in this credential-less worktree: WP smoke (`7.0.2`), open issues/PRs, worktrees, and drift all resolved; only the draft-queue field reads `unavailable` because this worktree lacks the `scripts/notion-to-wp/.env` cache / `WP_USER`+`WP_APP_PASSWORD`. The target did not hard-exit.
- **AGENTS.md** "Morning truth command" section: added a "Keeping the cadence alive" note — `morning-truth` writes but does not auto-commit; the session that runs it must commit the fresh `.md` for it to become source of truth. A stale newest report means recent sessions ran `status-readonly` or skipped the commit, not that the target broke.

## Verification

- `git check-ignore -v docs/current-state/reports/morning-truth-20260727-051348Z.md` → empty (exit 1, NOT ignored)
- `git status` showed the new report as a tracked add (`A`), not ignored

## Out of scope / notes

- Credential blocker: draft-queue counts are `unavailable` in this worktree (no WP creds). Not fixed here — the report degrades gracefully and remains a valid truth artifact.
- No new checks or report-format changes (per issue out-of-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)