### PR TITLE
ci: loosen over-engineered PR checks (scope-gate css-ratchet + Trivy, drop title nag)

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -19,6 +19,8 @@ jobs:
     outputs:
       has_php: ${{ steps.changed-files.outputs.has_php }}
       has_docs: ${{ steps.changed-files.outputs.has_docs }}
+      has_css: ${{ steps.changed-files.outputs.has_css }}
+      has_deps: ${{ steps.changed-files.outputs.has_deps }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
@@ -40,43 +42,26 @@ jobs:
               name.startsWith('docs/') ||
               ['AGENTS.md', 'README.md', 'CONTRIBUTING.md', 'Makefile', 'scripts/docs_truth_check.py'].includes(name)
             );
+            const hasCss = names.some((name) => name.endsWith('.css'));
+            const hasDeps = names.some((name) =>
+              ['composer.json', 'composer.lock', 'package.json', 'package-lock.json'].includes(name) ||
+              /(?:^|\/)requirements[\w.-]*\.txt$/.test(name)
+            );
             core.info(`Changed files: ${names.length}`);
-            core.info(`has_php=${hasPhp} has_docs=${hasDocs}`);
+            core.info(`has_php=${hasPhp} has_docs=${hasDocs} has_css=${hasCss} has_deps=${hasDeps}`);
             core.setOutput('has_php', hasPhp ? 'true' : 'false');
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
-
-      - name: Check PR title format
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const title = pr.title;
-
-            const validPrefixes = ['Fix:', 'Add:', 'Update:', 'Refactor:', 'Docs:', 'Chore:', 'Feature:'];
-            const hasValidPrefix = validPrefixes.some(prefix => title.startsWith(prefix));
-
-            if (!hasValidPrefix) {
-              core.warning(`PR title should start with one of: ${validPrefixes.join(', ')}`);
-            }
+            core.setOutput('has_css', hasCss ? 'true' : 'false');
+            core.setOutput('has_deps', hasDeps ? 'true' : 'false');
 
       - name: Check PR links to issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || '';
-
+            const body = context.payload.pull_request.body || '';
             const hasIssueLink = /(?:fixes|closes|resolves)\s+#\d+/i.test(body);
-
             if (!hasIssueLink) {
-              core.warning('PR should link to an issue using "Fixes #123" or similar');
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: `⚠️ **Missing Issue Link**\n\nThis PR doesn't appear to link to an issue.\n\nPlease add a line like:\n- \`Fixes #123\`\n- \`Closes #456\`\n- \`Resolves #789\`\n\nThis ensures the issue is automatically closed when the PR is merged.`
-              });
+              core.warning('PR does not link an issue with "Fixes #123" / "Closes #123" — fine for standalone changes.');
             }
 
   # WordPress/PHP validation
@@ -125,6 +110,7 @@ jobs:
   # count. Raising the ceiling requires a waiver recorded in .css-budget.json.
   css-ratchet:
     needs: validate
+    if: needs.validate.outputs.has_css == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -188,8 +174,12 @@ jobs:
       - name: Check docs for stale current-state claims
         run: python3 scripts/docs_truth_check.py
 
-  # Security scanning
+  # Security scanning — only when dependency manifests change (Trivy fs scan).
+  # Already non-blocking (SARIF output, no exit-code); this stops it running on
+  # every docs/CSS/content PR that changes no dependencies.
   security-scan:
+    needs: validate
+    if: needs.validate.outputs.has_deps == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4


### PR DESCRIPTION
From the weekend audit + PR-review pass. Loosens the PR gate so checks run where they matter instead of on every PR.

## Changes (test-pr.yml)
- **Remove PR-title-format check.** It warned unless titles started with \`Fix:/Add:/Docs:/…\`, which contradicts the repo's actual Conventional Commits convention (\`docs(#544):\`, \`feat(#416):\`). Every correct title tripped it.
- **Drop the auto-comment** on missing issue links; keep a silent \`core.warning\` (fine for standalone changes).
- **Gate css-ratchet** on \`.css\` changes only. It was doing a full-history fetch + inventory on every docs/python/config PR (all four audit PRs ran it for nothing).
- **Gate security-scan (Trivy fs)** on dependency-manifest changes only. It was already non-blocking (SARIF output, no \`exit-code\`); this stops it scanning the tree on one-line docs PRs.

## Why safe
Gating uses the same \`needs.validate.outputs.has_*\` pattern already used by \`php-validation\` and \`docs-truth-check\`. The \`summary\` job counts \`skipped\` as passing, and repo history shows docs PRs merge fine with \`php-validation\` skipped — so skipped conditional jobs do not block.

## HITL / one thing to confirm before merge
If branch protection lists \`css-ratchet\` or \`security-scan\` as *individually required* status checks, gating them to skip could leave a PR "waiting." The gate is almost certainly \`summary\`, not the individual jobs (docs PRs already merge with php-validation skipped), but please confirm the required-checks list before merging. I cannot read/change branch protection.

Not touching: python-tests (fast/safe everywhere), the CSS budget numbers themselves (that is the #472/#423 rebuild lane's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)