### PR TITLE
docs: AI Lands inside every profession draft package (kk-kb#2940)

### DIFF
--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/alt-text.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/alt-text.md
@@ -1,0 +1,30 @@
+# Image, caption, and alt-text record
+
+## Featured image (chosen candidate)
+
+- Status: **pending upload to kriskrug.co media library** — not published
+- Candidate: Michelle Diamond photograph of Vancouver AI Meetup 30 at the H.R. MacMillan Space Centre, June 2026
+- Rights note: Community photographer Michelle Diamond; already published with credit on https://bc-ai.ca/about and https://futureproof.website/. Confirm reuse scope with Michelle / BC + AI ops before setting as kriskrug.co hero if not already blanket-licensed.
+- Editorial reason: Best thematic fit for "rooms" / connective tissue / drumbeat — documentary community room, not portrait scrape.
+- WordPress media ID: `null` until uploaded
+- Suggested alt:
+
+> Crowded Vancouver AI Meetup gathering in the H.R. MacMillan Space Centre planetarium, June 2026. Photo by Michelle Diamond.
+
+- Suggested caption / credit line:
+
+> Vancouver AI Meetup 30 at the H.R. MacMillan Space Centre, June 2026. Photo by Michelle Diamond.
+
+## Alternate hero (if Space Centre reuse blocked)
+
+- KK-owned / KK-submitted portrait continuity with The Tyee compute thread
+- Tyee clipping notes "Photo submitted by Kris Krüg; published by The Tyee."
+- Prefer the underlying KK photo, not a Tyee layout screenshot, as the clean hero crop.
+
+## Explicitly rejected for featured image
+
+- Rob Kruyt portrait of Kris from the Business in Vancouver article — BIV / Rob Kruyt copyright; no rights clearance in this package. Link the article; do not lift the portrait.
+
+## Inline images
+
+None required for this draft. Prefer linking BIV, Futureproof, membership, and Tyee over packing screenshot chrome.

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/internal-links.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/internal-links.md
@@ -1,0 +1,39 @@
+# Internal linking plan
+
+URLs verified against the kk-kb research pack (Issue #2939 / PR #2952) on 2026-07-31. Each URL appears **once** in `post.md` with a descriptive anchor.
+
+## Included in the body
+
+1. [Business in Vancouver](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298)
+   - Opening press cite (Daisy Xiong, 2026-07-31).
+2. [H.R. MacMillan Space Centre](https://spacecentre.ca/)
+   - Venue / home for the meetup after the studio outgrew itself.
+3. [origin arc separately](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/)
+   - Prior KK ecosystem essay ("Zero to One"); deep-link without replaying the whole origin story.
+4. [events calendar](https://lu.ma/vancouver-ai)
+   - Weekly-programming / drumbeat proof.
+5. [Futureproof Festival](https://futureproof.website/)
+   - Operating receipt: Oct 28–30, 2026 at the Space Centre.
+6. [The Tyee carried a piece of it last week](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/)
+   - Compute / public-agency thread ("Who Gets a Say in AI Adoption?").
+7. [Join BC + AI](https://bc-ai.ca/membership)
+   - Closing CTA.
+
+## Unique URL inventory
+
+| URL | Anchor |
+|---|---|
+| https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298 | Business in Vancouver |
+| https://spacecentre.ca/ | H.R. MacMillan Space Centre |
+| https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/ | origin arc separately |
+| https://lu.ma/vancouver-ai | events calendar |
+| https://futureproof.website/ | Futureproof Festival |
+| https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/ | The Tyee carried a piece of it last week |
+| https://bc-ai.ca/membership | Join BC + AI |
+
+## Not linked in body (available if Kris wants denser cluster)
+
+- https://bc-ai.ca/news/both-hands-on-the-grid — sibling owned compute piece (Tyee already covers the "elsewhere" pointer)
+- https://bc-ai.ca/about — metrics floor / photo credit home
+- https://kriskrug.co/2026/01/24/both-hands-full/ — related both/and essay
+- https://kriskrug.co/2026/05/23/you-cant-drink-data/ — related compute / protest essay

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md
@@ -1,0 +1,117 @@
+---
+title: "AI Lands Inside Every Profession"
+slug: ai-lands-inside-every-profession
+post_date: "2026-07-31"
+status: draft
+post_type: post
+author_wp_id: 1
+categories:
+  - "Responsible AI & Policy"
+  - "BC + AI"
+tags:
+  - "BC + AI"
+  - "Vancouver AI"
+  - "ecosystem"
+  - "Business in Vancouver"
+  - "Futureproof"
+  - "responsible ai"
+  - "community infrastructure"
+featured: false
+featured_media_id: null
+featured_image_candidate: "Michelle Diamond — Vancouver AI Meetup 30 at H.R. MacMillan Space Centre (June 2026). Upload/credit before publish. Do not use Rob Kruyt/BIV portrait."
+excerpt: "Business in Vancouver got the thesis right: AI lands inside every profession. Here is the connective infrastructure B.C. still has to build — and what BC + AI is already doing."
+seo:
+  meta_title: "AI Lands Inside Every Profession | Kris Krüg"
+  meta_description: "AI does not stay in an AI sector. It lands in every profession. What BIV got right — and the connective tissue B.C. still has to build."
+source_manifest: sources.md
+approval: pending-kris
+kk_kb_issue: 2940
+kk_kb_epic: 2937
+---
+
+Daisy Xiong asked me a clean question for [Business in Vancouver](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298): why does B.C. need a stronger AI community?
+
+Because artificial intelligence does not stay inside an AI sector.
+
+It lands inside healthcare systems deciding what clinicians can trust. Inside government procurement writing the rules for tools nobody fully understands yet. Inside game studios and film pipelines rewriting production labour. Inside HR teams drowning in synthetic applications. Inside schools, law firms, credit unions, unions, and nonprofits trying to adopt without getting played.
+
+If your map of "the AI ecosystem" only includes companies with AI in the pitch deck, you are missing most of the people who will live with the consequences.
+
+That is the line Daisy put in the paper. The rest of this is the part that does not fit in a news brief.
+
+## We do not lack talent. We lack connective tissue.
+
+B.C. already has researchers, studios, startups, adopters, investors, and public servants doing serious work. Rob Goehring at AInBC is right that the province's applied AI base is large, diverse, and still young. Sev Geraskin at the Economy of Wisdom Foundation is right that we need better measurement and clearer power-capacity decisions.
+
+What we have underbuilt is the boring, recurring infrastructure that turns scattered excellence into a region that can learn together, hire across silos, form companies, and show up in policy conversations with a shared memory.
+
+Not another isolated lab.
+Not another one-off summit.
+A drumbeat.
+
+## What BC + AI is actually doing
+
+This is not a proposal.
+
+The Vancouver AI meetup started in my studio in January 2024. We outgrew it. Lorraine Lowe and the [H.R. MacMillan Space Centre](https://spacecentre.ca/) gave the work a home. About a year later we registered the BC + AI Ecosystem Association as a B.C. society and launched paid membership. I wrote the [origin arc separately](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/); this piece is about what the press got right and what still has to be built.
+
+Today that looks like:
+
+- about 300 paid annual members
+- 11 community subgroups across the province
+- weekly programming, not just a monthly flagship — see the [events calendar](https://lu.ma/vancouver-ai)
+- more than 3,000 people through the door since launch
+- Responsible AI Professional training in active use
+- hackathons that put real money into builders' hands
+- [Futureproof Festival](https://futureproof.website/), October 28–30, 2026, at the Space Centre — a homegrown annual gathering with local and international speakers
+
+We are bootstrapped on memberships, tickets, certifications, and sponsorship. That is not a romance about grit. It is a design choice. Community infrastructure that only exists when a grant arrives is not infrastructure.
+
+## The product is interconnectedness
+
+Three hundred people who do not know each other are a labour market.
+Three hundred people who share context, trust, and practice are a capability.
+
+That is the whole bet. A region gets smarter when ideas can travel between a life-sciences operator, a procurement officer, a creative technologist, and a founder without waiting for a conference badge or a ministerial panel.
+
+Ecosystem is not a vibe. It is repeated contact with consequences.
+
+## Brain circulation, not brain drain
+
+Young people will leave for larger hubs. Some should. The failure mode is not departure. The failure mode is a province with no serious pathway home.
+
+I want sea turtles: people who go get scars, capital, networks, and taste elsewhere, then return because B.C. has rooms worth rejoining, companies worth building in, and public institutions that know how to work with them.
+
+Retention slogans are cheap. Return pathways are policy.
+
+## A B.C. lane, not a Silicon Valley cosplay
+
+We should not try to photocopy the hyperscaler business model and call it strategy.
+
+Proximity to the Valley is an advantage. Copying its defaults is not. B.C. can combine applied AI, creative technology, university research, clean electricity, Indigenous ownership and data-sovereignty principles, and a livable Pacific time zone into something distinct.
+
+That includes compute. We have a chance to build clean, green, Indigenous-owned, hydropower data centres as a counterpoint to extractive defaults — if communities help write the terms instead of rubber-stamping blank cheques. I have written about that bargain elsewhere; [The Tyee carried a piece of it last week](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/). The point here is simpler: infrastructure without public agency is just someone else's factory on our grid.
+
+## What Daisy's piece is useful for
+
+Daisy's BIV article does something important for a business audience. It puts industry association work, grassroots community work, and ethics/measurement work on the same page. That is healthier politics than pretending only one organization owns "the ecosystem."
+
+Different mandates can coexist:
+
+- advocacy and industry coordination
+- recurring professional community across sectors
+- ethics, governance, and impact measurement
+- research and talent pipelines
+- capital and commercialization
+
+The job is to stitch those layers without flattening them into one logo.
+
+## If you want in
+
+If AI is landing in your profession and you do not have a room yet, that is the product.
+
+[Join BC + AI](https://bc-ai.ca/membership). Come to a meetup. Bring the people from your sector who are making decisions in the dark. The point is not to cheerlead AI. The point is to build enough shared practice that this province can compete, govern, and create on purpose.
+
+Daisy got the thesis right.
+
+Now we keep building the rooms that make it true.

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/publish-gate.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/publish-gate.md
@@ -1,0 +1,26 @@
+# Publication gate
+
+Current authorization: **draft package only** — pending-kris. No live WordPress publish in Issue #2940.
+
+## Required before publication
+
+- [ ] Kris approves public body wording and voice
+- [ ] Confirm membership language still **about / nearly 300** or replace with a recorded backend count
+- [ ] Confirm Michelle Diamond Space Centre photo reuse scope; upload to media library; set `featured_media_id`
+- [ ] Confirm Tyee relative-time phrase ("last week") still reads correctly at publish date
+- [ ] Recheck all external links (BIV may soft-wall; Cloudflare ok for agents)
+- [ ] Confirm categories, tags, excerpt, SEO title, and meta description in WordPress
+- [ ] Obtain explicit publication authorization
+
+## Explicitly out of scope for #2940
+
+- Publishing or scheduling the post on kriskrug.co
+- Buffer / social scheduling
+- BC + AI `/news` implementation (separate issue)
+- Publications page deployment
+- Scraping or reusing the Rob Kruyt / BIV portrait
+
+## Tracking
+
+- kk-kb Issue #2940 · Epic #2937
+- Depends on research pack #2939 / PR #2952

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/seo-meta.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/seo-meta.md
@@ -1,0 +1,21 @@
+# SEO metadata
+
+- Focus keyphrase: `AI lands inside every profession`
+- Secondary phrases: `BC AI ecosystem`, `BC + AI`, `Business in Vancouver AI`, `Futureproof Festival`, `connective tissue AI community`
+- H1: `AI Lands Inside Every Profession`
+- SEO title: `AI Lands Inside Every Profession | Kris Krüg`
+- SEO title length: 45 characters
+- Meta description: `AI does not stay in an AI sector. It lands in every profession. What BIV got right — and the connective tissue B.C. still has to build.`
+- Meta description length: 136 characters
+- Slug: `ai-lands-inside-every-profession`
+- Canonical target: `https://kriskrug.co/2026/07/31/ai-lands-inside-every-profession/`
+- Excerpt: `Business in Vancouver got the thesis right: AI lands inside every profession. Here is the connective infrastructure B.C. still has to build — and what BC + AI is already doing.`
+- Status: draft / pending-kris — do not publish live from this package
+
+## Search intent
+
+Follow-up to Daisy Xiong's Business in Vancouver piece on B.C. AI groups. Explains why community infrastructure matters beyond the "AI sector," what BC + AI is already operating, and how different mandates (industry advocacy, grassroots community, ethics/measurement) can coexist.
+
+## Internal-link cluster
+
+Body links once each to verified external + owned URLs documented in `internal-links.md` (BIV, membership, Futureproof, Tyee, Zero to One, Space Centre, Luma calendar).

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/sources.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/sources.md
@@ -1,0 +1,47 @@
+# Source manifest
+
+Grounded in the kk-kb research pack for Issue #2939 (PR #2952) and polished under Issue #2940. Public body uses only allowed claims from the claims ledger.
+
+## Primary press
+
+- [Business in Vancouver — BC groups push to build a stronger AI ecosystem](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298) (Daisy Xiong, 2026-07-31)
+  - Trigger article. Agent fetch may hit Cloudflare; URL treated as live from same-day clipping log.
+  - KB clipping: `kk-kb/content/projects/05-marketing-and-outreach/press-and-media/press-clippings/2026-07-31-biv-stronger-ai-ecosystem.md`
+- [The Tyee — Who Gets a Say in AI Adoption?](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/) (2026-07-24)
+  - Free/public. Supports the compute / public-agency paragraph.
+
+## Interview / proof base (kk-kb)
+
+- `content/media/interviews/2026-07-16-business-in-vancouver-daisy-xiong-recap.md` — safe public proof points
+- `content/media/interviews/2026-07-16-business-in-vancouver-daisy-xiong-debrief.md` — internal claim gate only; not for publish
+- `content/media/interviews/2026-07-16-business-in-vancouver-daisy-xiong-transcript.md` — quote source of truth
+- Research pack: `content/drafts/2026-07-31-ai-lands-inside-every-profession/{sources,internal-links,claims-ledger,image-candidates,voice-pass}.md`
+
+## Operating / org proof
+
+- [BC + AI membership](https://bc-ai.ca/membership) — CTA
+- [BC + AI about](https://bc-ai.ca/about) — public metrics floor (paid members 250+; people through doors 3,000+); Michelle Diamond photo credit
+- [Futureproof Festival](https://futureproof.website/) — Oct 28–30, 2026 · H.R. MacMillan Space Centre
+- [BC + AI Events on Luma](https://lu.ma/vancouver-ai) — recurring calendar
+- [H.R. MacMillan Space Centre](https://spacecentre.ca/) — venue partner
+- [OrgBook S0083444](https://www.orgbook.gov.bc.ca/entity/S0083444) — BC + AI Ecosystem Association, registered 2025-08-22, status ACT
+- Ops snapshot: `kk-kb/content/projects/02-bc-ai-ecosystem-nonprofit/operations/metrics-snapshot-2026-06.md`
+
+## Prior owned essays
+
+- [Zero to One: From Meetup to Movement](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/) — origin arc deep-link
+- Optional siblings (not required in body): [Both Hands Full](https://kriskrug.co/2026/01/24/both-hands-full/), [You Can't Drink Data](https://kriskrug.co/2026/05/23/you-cant-drink-data/), [Both Hands on the Grid](https://bc-ai.ca/news/both-hands-on-the-grid)
+
+## Membership language
+
+Public wording stays **about 300** / **nearly 300**. No live membership-backend pull was recorded in the research pack. Exact integers (285 / 290 / 295) are denied for this draft.
+
+## Denied for public body
+
+- Any AInBC financial speculation, staffing gossip, "life support," "handouts," or similar
+- Rob Kruyt / BIV portrait as featured image without rights clearance
+- Exact membership price, hackathon prize totals, unsupported studio HQ rankings
+
+## Featured image
+
+See `alt-text.md`. Chosen candidate: Michelle Diamond Space Centre room photo. Not uploaded / not published in this issue.


### PR DESCRIPTION
## Summary
- Add draft-only package at `content/drafts/2026-07-31-ai-lands-inside-every-profession/` with `post.md`, `seo-meta.md`, `alt-text.md`, `internal-links.md`, `sources.md`, and `publish-gate.md`.
- Slug: `ai-lands-inside-every-profession`. Featured image candidate: Michelle Diamond Space Centre Meetup 30 photo (credit required; not Rob Kruyt/BIV portrait).
- No live WordPress publish — pending-kris only.

## Test plan
- [x] `test -f content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md`
- [x] `rg -n "biv.com/news/technology/bc-groups-push|bc-ai.ca/membership|futureproof" .../post.md`
- [x] `rg -n "life support|handouts|slave state" .../post.md` → no matches
- [x] Each body URL listed once in `internal-links.md`
- [ ] Kris approval + featured-image upload before publish

Refs WalksWithASwagger/kk-kb#2940


Made with [Cursor](https://cursor.com)