### PR TITLE
fix: wire WordPress MCP credential aliases into Varlock

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -3,6 +3,9 @@
 # Agents may inspect this schema, but must not read local value files.
 # @import(~/.agents/env/values/.env.shared.local, pick=[WP_USER, WP_APP_PASSWORD, NOTION_TOKEN], allowMissing=true)
 # @import(~/.agents/env/values/.env.kriskrug-wp.local, pick=[WP_USER, WP_APP_PASSWORD, NOTION_TOKEN, WP_BASE_URL, WP_DEFAULT_AUTHOR_ID, WP_AUTH_MODE], allowMissing=true)
+# Working Application Password store for this machine (MCP + REST). Same secret
+# as WP_USER/WP_APP_PASSWORD; scripts/common.py accepts either name pair.
+# @import(~/.agents/env/wordpress/.env.local, pick=[WP_API_USERNAME, WP_API_PASSWORD], allowMissing=true)
 # @defaultRequired=false @defaultSensitive=false
 # ---
 
@@ -14,6 +17,13 @@
 WP_USER=
 # @sensitive
 WP_APP_PASSWORD=
+
+# Aliases used by ~/.agents/env/wordpress and mcp-wordpress-remote.sh.
+# Prefer these when WP_USER / WP_APP_PASSWORD are unset in values/.
+# @sensitive @optional
+WP_API_USERNAME=
+# @sensitive @optional
+WP_API_PASSWORD=
 
 # Optional WP overrides (defaults are fine for production ops).
 # @optional @example="https://kriskrug.co"

--- a/backup/20260731T223456Z-publications-biv-surgical/content.raw.html
+++ b/backup/20260731T223456Z-publications-biv-surgical/content.raw.html
@@ -1,0 +1,134 @@
+<!-- wp:html -->
+<style>
+.kk-publications {
+  --kk-ink:#f0f0f5; --kk-ink-2:#fff; --kk-muted:#a6a6b3;
+  --kk-line:rgba(255,255,255,.14); --kk-paper:rgba(255,255,255,.05); --kk-card:rgba(255,255,255,.04);
+  --kk-accent:#00e5ff; --kk-hot:#ff6a6a; --kk-r:14px;
+  color:var(--kk-ink);
+}
+.kk-publications p::first-letter { initial-letter:normal!important; font-size:inherit!important; font-weight:inherit!important; float:none!important; margin:0!important; line-height:inherit!important; color:inherit!important; }
+.kk-publications a { color:var(--kk-accent); font-weight:700; text-decoration:none; }
+.kk-publications a:hover, .kk-publications a:focus-visible { text-decoration:underline; text-underline-offset:3px; }
+.kk-publications-hero { padding:.4rem 0 2.2rem; border-bottom:1px solid var(--kk-line); }
+.kk-publications-kicker { margin:0 0 .65rem; text-transform:uppercase; letter-spacing:.14em; font-size:.74rem; color:var(--kk-hot); font-weight:800; }
+.kk-publications-display { margin:.1rem 0 1rem; font-size:2.25rem; line-height:1.08; letter-spacing:-.02em; font-weight:800; max-width:44rem; color:var(--kk-ink-2); }
+.kk-publications-lead { font-size:1.12rem; line-height:1.62; max-width:46rem; color:var(--kk-ink); }
+.kk-publications-proof { display:grid; grid-template-columns:repeat(auto-fit,minmax(165px,1fr)); gap:.7rem; margin-top:1.5rem; }
+.kk-publications-proof div { border:1px solid var(--kk-line); border-top:3px solid var(--kk-accent); border-radius:10px; padding:.95rem 1rem; background:var(--kk-card); }
+.kk-publications-proof strong { display:block; color:var(--kk-ink-2); font-size:1.02rem; line-height:1.2; }
+.kk-publications-proof span { display:block; color:var(--kk-muted); font-size:.9rem; margin-top:.25rem; line-height:1.45; }
+.kk-publications-section { padding:2.5rem 0; border-bottom:1px solid var(--kk-line); }
+.kk-publications-section > h2 { position:relative; padding-top:1.1rem; margin:0 0 1rem; font-size:1.62rem; line-height:1.14; letter-spacing:-.015em; font-weight:800; color:var(--kk-ink-2); }
+.kk-publications-section > h2::before { content:""; position:absolute; top:0; left:0; width:2.4rem; height:4px; border-radius:3px; background:var(--kk-hot); }
+.kk-publications-section-intro { max-width:48rem; margin:0 0 1.4rem; color:var(--kk-muted); font-size:1.02rem; line-height:1.6; }
+.kk-publications-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:1.1rem; }
+.kk-publications-card { border:1px solid var(--kk-line); border-radius:var(--kk-r); background:var(--kk-card); padding:1.2rem; box-shadow:0 1px 2px rgba(0,0,0,.45),0 12px 28px -14px rgba(0,0,0,.7); }
+.kk-publications-card h3 { margin:.15rem 0 .45rem; font-size:1.14rem; line-height:1.25; color:var(--kk-ink-2); }
+.kk-publications-card p { margin:.45rem 0; color:var(--kk-muted); line-height:1.55; }
+.kk-publications-tag { display:inline-block; margin:0 0 .6rem; background:rgba(255,106,106,.16); color:var(--kk-hot); padding:.28rem .6rem; border-radius:999px; font-size:.66rem; font-weight:800; text-transform:uppercase; letter-spacing:.08em; }
+.kk-publications-link-list { columns:2 18rem; margin:.3rem 0 0; padding-left:1.1rem; color:var(--kk-muted); }
+.kk-publications-link-list li { break-inside:avoid; margin:.3rem 0; line-height:1.45; }
+.kk-publications-note { border:1px solid var(--kk-line); border-radius:var(--kk-r); background:var(--kk-paper); padding:1.2rem; color:var(--kk-muted); line-height:1.58; }
+@media (max-width:760px){
+  .kk-publications-display{font-size:1.75rem;}
+  .kk-publications-link-list{columns:1;}
+}
+</style>
+
+<div class="kk-publications">
+  <section class="kk-publications-hero">
+    <p class="kk-publications-kicker">Publications, interviews, citations, and source trail</p>
+    <h2 class="kk-publications-display">The public record behind the rooms, photos, essays, interviews, and weird internet artifacts.</h2>
+    <p class="kk-publications-lead">This page restores the useful part of the old Publications archive: the links, media appearances, and publication trail that show how the work has moved through journalism, technology, culture, activism, and photography over time.</p>
+    <p class="kk-publications-lead">It is not trying to be a perfect vanity bibliography. It is a proof map, a source trail, and a way to find the older interviews without burying them inside the About page.</p>
+    <div class="kk-publications-proof">
+      <div><strong>Press trail</strong><span>BBC, CBC, Forbes, Reuters, WIRED, TED, and more.</span></div>
+      <div><strong>Interview archive</strong><span>Video, audio, blogs, broadcasts, and early web history.</span></div>
+      <div><strong>Creative commons impact</strong><span>Photos cited, remixed, published, and used across the web.</span></div>
+    </div>
+  </section>
+
+  <section class="kk-publications-section">
+    <h2>Featured trail</h2>
+    <p class="kk-publications-section-intro">A cleaned-up entry point to the publication and citation history that used to live as one giant undifferentiated list.</p>
+    <div class="kk-publications-grid">
+            <article class="kk-publications-card">
+        <span class="kk-publications-tag">AI + ecosystem</span>
+        <h3><a href="https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298">Business in Vancouver: B.C. groups push to build a stronger AI ecosystem</a></h3>
+        <p>Daisy Xiong quotes Kris on AI landing inside every profession — not just an AI sector — and on clean, green, Indigenous-owned hydropower data centres as a B.C. counterpoint to hyperscaler defaults.</p>
+      </article>
+<article class="kk-publications-card">
+        <span class="kk-publications-tag">AI + public infrastructure</span>
+        <h3><a href="https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/">The Tyee: ‘We Want a Role’: Who Gets a Say in AI Adoption?</a></h3>
+        <p>Isaac Phan Nay quotes Kris on AI data centres as heavy industry, public bargaining, and consultation that can change outcomes. Read the argument behind the interview in <a href="https://bc-ai.ca/news/both-hands-on-the-grid">Both Hands on the Grid</a>.</p>
+      </article>
+      <article class="kk-publications-card">
+        <span class="kk-publications-tag">Science + crowds</span>
+        <h3><a href="http://www.popsci.com/space-industry-needs-to-blast-its-doors-open">Popular Science: NASA Needs to Harness the Genius of Crowds</a></h3>
+        <p>A legacy Publications-page link that still explains a lot about the early open-web, crowd-intelligence thread in the work.</p>
+      </article>
+      <article class="kk-publications-card">
+        <span class="kk-publications-tag">Creative Commons</span>
+        <h3><a href="http://mediashift.org/2006/10/creative-commons-flickr-22-million-sharable-photos291/">PBS MediaShift: Creative Commons + Flickr</a></h3>
+        <p>Part of the long public record around open photography, shareable media, and the social web before everyone called it content strategy.</p>
+      </article>
+      <article class="kk-publications-card">
+        <span class="kk-publications-tag">TED</span>
+        <h3><a href="https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/">TED Blog: TEDxSummit photographer Kris Krug</a></h3>
+        <p>A useful marker from the global conference, photography, and community-documentation era.</p>
+      </article>
+      <article class="kk-publications-card">
+        <span class="kk-publications-tag">Legacy interview</span>
+        <h3><a href="https://thenextweb.com/apple/2010/10/16/pro-photographer-kris-krug-talks-about-taking-killer-photos-with-the-iphone/">The Next Web: Pro photographer Kris Krug talks iPhone photography</a></h3>
+        <p>One of the restored older interviews from the mobile-photography and digital-media chapter.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="kk-publications-section">
+    <h2>Interviews and video archive</h2>
+    <p class="kk-publications-section-intro">The old page had real interview proof hiding inside raw URLs. This keeps the source trail visible while admitting that some early-web destinations may have moved or disappeared.</p>
+    <ul class="kk-publications-link-list">
+      <li><a href="http://www.straight.com/article-333509/vancouver/geek-speak-kris-krug-coauthor-killer-photos-your-iphone">Georgia Straight: Geek Speak</a></li>
+      <li><a href="http://www.kempedmonds.com/2009/07/digital-footprint-interview-from.html">Kemp Edmonds: Digital Footprint interview</a></li>
+      <li><a href="http://www.cbc.ca/bc/news/yourstory/blog/2010/06/kris-krug-at-tedxoilspill.html">CBC BC: Kris Krug at TEDxOilSpill</a></li>
+      <li><a href="https://www.youtube.com/watch?v=5uyz7dzUKbA">TEDxOilSpill video archive</a></li>
+      <li><a href="http://www.bing.com/videos/watch/video/photojounalist-kris-krug-on-documenting-the-copenhagen-protests/17w22mq0w">Bing video: documenting the Copenhagen protests</a></li>
+      <li><a href="http://en.sevenload.com/videos/IVESi2m-Kris-Krug-Interview-World-Television-Festival">World Television Festival interview</a></li>
+      <li><a href="http://www.vimeo.com/17794857">Techvibes interview for W2 Media + Culture House</a></li>
+      <li><a href="http://www.liftstudios.ca/lsb027/">Lift Studios interview</a></li>
+      <li><a href="http://www.yesmagazine.org/planet/action-is-the-antidote-to-despair">YES! Magazine: Action is the antidote to despair</a></li>
+      <li><a href="http://robertouimet.com/2010/02/video-kris-krug-at-the-multimedia-gallery/">Kris Krug at the Multimedia Gallery</a></li>
+      <li><a href="http://www.drupalove.com/drupal-video/drupal-bryght-and-raincity-studios-w-kris-krug">Drupal video: Bryght and Raincity Studios</a></li>
+      <li><a href="http://techcrunch.com/2010/09/16/geeks-on-a-planes-eye-on-asia-beijing-seoul-editions-tctv/">TechCrunch: Geeks on a Plane Asia</a></li>
+      <li><a href="http://2007.northernvoice.ca/news/2007/04/04/kris-krugs-photography-session-at-northern-voice-videoblogged-on-podtech">Northern Voice photography session</a></li>
+    </ul>
+  </section>
+
+  <section class="kk-publications-section">
+    <h2>Published, featured, or cited by</h2>
+    <p class="kk-publications-section-intro">A representative slice from the larger About-page publication index. The full old list was enormous; this version keeps the signal without turning the page into a landfill of names.</p>
+    <div class="kk-publications-grid">
+      <div class="kk-publications-card">
+        <h3>News and culture</h3>
+        <p>BBC News, CBC, Globe &amp; Mail, The Guardian, The Atlantic, The Daily Beast, The Tyee, The Walrus, Toronto Star, USA Today, Time Magazine, Rolling Stone, Slate, Vice, The Verge, WIRED.</p>
+      </div>
+      <div class="kk-publications-card">
+        <h3>Technology and business</h3>
+        <p>Ars Technica, Boing Boing, Business Insider, CNET, Fast Company, Forbes, Fortune, GeekWire, Mashable, Motherboard, Quartz, Reuters, TechCrunch, Techvibes, Wall Street Journal.</p>
+      </div>
+      <div class="kk-publications-card">
+        <h3>Environment, science, and public-interest media</h3>
+        <p>CleanTechnica, Climate Central, DeSmog, Earth Island Journal, National Geographic, National Observer, New Scientist, NPR, PBS MediaShift, The Narwhal, Yale Environment 360.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="kk-publications-section">
+    <h2>Need the current media kit?</h2>
+    <div class="kk-publications-note">
+      <p>For current bookings, podcast guesting, bios, headshots, and producer-friendly context, use the <a href="/podcast-guesting-page-epk/">Podcast Guesting / EPK page</a>. For current projects and AI work, start with <a href="/recent-projects-include/">Work</a>, <a href="/speaking/">Speaking</a>, or <a href="/generative-ai-services/">Services</a>.</p>
+    </div>
+  </section>
+</div>
+<!-- /wp:html -->

--- a/backup/20260731T223456Z-publications-biv-surgical/page-1895.after.json
+++ b/backup/20260731T223456Z-publications-biv-surgical/page-1895.after.json
@@ -1,0 +1,6 @@
+{
+  "id": 1895,
+  "modified_gmt": "2026-07-31T22:34:57",
+  "content_raw_has_12601298": true,
+  "note": "post-apply snapshot re-captured after local backup was wiped"
+}

--- a/content/source-packs/keynotes-2026/verification/PUBLICATIONS-LEGACY-BIV-SURGICAL-2026-07-31.md
+++ b/content/source-packs/keynotes-2026/verification/PUBLICATIONS-LEGACY-BIV-SURGICAL-2026-07-31.md
@@ -1,6 +1,6 @@
 # Publications legacy surgical update — BIV 2026-07-31
 
-Status: **ready to apply** once `WP_USER` + `WP_APP_PASSWORD` resolve via Varlock.
+Status: **applied live** 2026-07-31T22:34:57Z (page 1895). Auth via `~/.agents/env/wordpress` (`WP_API_USERNAME` / `WP_API_PASSWORD`); rollback snapshot under `backup/20260731T223456Z-publications-biv-surgical/`.
 
 ## Why surgical (not full redesign)
 
@@ -18,16 +18,16 @@ See `../wp-payloads/publications-legacy-biv-card-fragment.html`
 
 ## Deploy sequence (auth REST)
 
-1. `pnpm exec varlock run --inject vars --` with `WP_USER` + `WP_APP_PASSWORD` present
+1. `pnpm exec varlock run --inject vars --` with `WP_USER` + `WP_APP_PASSWORD` present (or `WP_API_*` aliases from `~/.agents/env/wordpress`)
 2. Snapshot `GET /wp-json/wp/v2/pages/1895?context=edit` → rollback JSON
 3. Patch `content.raw` (or rendered-equivalent block markup) with the fragment
 4. Dry-run diff must show **one** new card + URL `12601298`
 5. `--apply` PATCH page 1895 only
 6. Cache-bypass verify: `curl -sL "https://kriskrug.co/publications/?cb=$RANDOM" | rg 12601298`
 
-## Blocker (2026-07-31)
+## Auth note (resolved 2026-07-31)
 
-Varlock inject currently reports `WP_USER` / `WP_APP_PASSWORD` unset in this environment. No live write attempted.
+`kriskrug-wp/.env.schema` previously looked for `WP_USER` / `WP_APP_PASSWORD` under `~/.agents/env/values/`, which were unset. Working credentials live at `~/.agents/env/wordpress/.env.local` as `WP_API_USERNAME` / `WP_API_PASSWORD` (WordPress MCP / Application Password over HTTPS). Schema now imports those keys; `scripts/common.py` maps them onto the legacy names.
 
 ## Related
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -7,6 +7,7 @@ requests-based WordPress client (it does media upload and other package-specific
 work); this module is for the urllib-based scripts under scripts/ that currently
 hand-roll env loading and Basic-auth requests.
 """
+
 from __future__ import annotations
 
 import base64
@@ -47,7 +48,19 @@ DEFAULT_ENV_PATHS = (
     *_optional_env_paths(),
 )
 DEFAULT_BASE_URL = "https://kriskrug.co"
-_OVERRIDE_KEYS = ("WP_USER", "WP_APP_PASSWORD", "WP_BASE_URL", "WP_AUTH_MODE")
+_OVERRIDE_KEYS = (
+    "WP_USER",
+    "WP_APP_PASSWORD",
+    "WP_API_USERNAME",
+    "WP_API_PASSWORD",
+    "WP_BASE_URL",
+    "WP_AUTH_MODE",
+)
+# ~/.agents/env/wordpress uses MCP names; REST scripts historically use WP_USER.
+_WP_CREDENTIAL_ALIASES = (
+    ("WP_API_USERNAME", "WP_USER"),
+    ("WP_API_PASSWORD", "WP_APP_PASSWORD"),
+)
 
 
 def parse_simple_env(path: Path) -> dict[str, str]:
@@ -64,7 +77,9 @@ def parse_simple_env(path: Path) -> dict[str, str]:
     return values
 
 
-def load_env(path: Path | str | None = None, *, overlay_os: bool = True) -> dict[str, str]:
+def load_env(
+    path: Path | str | None = None, *, overlay_os: bool = True
+) -> dict[str, str]:
     """Load .env values, preferring python-dotenv when installed.
 
     With no path, searches DEFAULT_ENV_PATHS and uses the first that exists.
@@ -90,18 +105,27 @@ def load_env(path: Path | str | None = None, *, overlay_os: bool = True) -> dict
         for key in _OVERRIDE_KEYS:
             if os.environ.get(key):
                 values[key] = os.environ[key]
+    return apply_wp_credential_aliases(values)
+
+
+def apply_wp_credential_aliases(env: dict[str, str]) -> dict[str, str]:
+    """Fill WP_USER / WP_APP_PASSWORD from WP_API_* when the legacy names are empty."""
+    values = dict(env)
+    for src, dest in _WP_CREDENTIAL_ALIASES:
+        if not (values.get(dest) or "").strip() and (values.get(src) or "").strip():
+            values[dest] = values[src]
     return values
 
 
 def wp_credentials(env: dict[str, str] | None = None) -> tuple[str, str, str]:
     """Return (base_url, user, normalized app_password). Raises if missing."""
-    env = env if env is not None else load_env()
+    env = apply_wp_credential_aliases(env if env is not None else load_env())
     user = env.get("WP_USER", "")
     app_password = (env.get("WP_APP_PASSWORD", "") or "").replace(" ", "")
     base_url = env.get("WP_BASE_URL", DEFAULT_BASE_URL)
     if not user or not app_password:
         raise RuntimeError(
-            "WP_USER and WP_APP_PASSWORD required in scripts/notion-to-wp/.env"
+            "WP_USER/WP_APP_PASSWORD (or WP_API_USERNAME/WP_API_PASSWORD) required"
         )
     return base_url.rstrip("/"), user, app_password
 
@@ -173,7 +197,9 @@ class WPClient:
             profile_html = resp.read().decode(errors="replace")
         if "wp-login.php?action=logout" not in profile_html:
             raise RuntimeError("WordPress login did not produce an admin session")
-        match = re.search(r"var\s+wpApiSettings\s*=\s*(\{.*?\});", profile_html, flags=re.S)
+        match = re.search(
+            r"var\s+wpApiSettings\s*=\s*(\{.*?\});", profile_html, flags=re.S
+        )
         if not match:
             raise RuntimeError("WordPress admin session did not expose wpApiSettings")
         settings = json.loads(match.group(1))
@@ -233,7 +259,9 @@ class WPClient:
     def get(self, path: str, *, params: dict | None = None) -> Any:
         return self.request("GET", path, params=params)
 
-    def post(self, path: str, payload: Any | None = None, *, params: dict | None = None) -> Any:
+    def post(
+        self, path: str, payload: Any | None = None, *, params: dict | None = None
+    ) -> Any:
         return self.request("POST", path, payload=payload, params=params)
 
     def delete(self, path: str, *, params: dict | None = None) -> Any:

--- a/scripts/tests/test_common.py
+++ b/scripts/tests/test_common.py
@@ -8,7 +8,14 @@ from urllib.error import HTTPError
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import common  # noqa: E402
-from common import WPClient, load_env, parse_simple_env, wp_credentials, wp_queue_counts  # noqa: E402
+from common import (  # noqa: E402
+    WPClient,
+    apply_wp_credential_aliases,
+    load_env,
+    parse_simple_env,
+    wp_credentials,
+    wp_queue_counts,
+)
 
 
 def _fake_response(body: str):
@@ -31,7 +38,9 @@ class _EnvFileMixin:
         import os
         import tempfile
 
-        fd = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False, encoding="utf-8")
+        fd = tempfile.NamedTemporaryFile(
+            "w", suffix=".env", delete=False, encoding="utf-8"
+        )
         fd.write(text)
         fd.close()
         self.addCleanup(lambda: os.path.exists(fd.name) and os.unlink(fd.name))
@@ -40,7 +49,11 @@ class _EnvFileMixin:
 
 class ParseSimpleEnvTests(_EnvFileMixin, unittest.TestCase):
     def test_skips_comments_blanks_and_strips_quotes(self):
-        path = Path(self.write_env("# comment\n\nWP_USER=alice\nWP_APP_PASSWORD=\"p a s s\"\nBAD LINE\n"))
+        path = Path(
+            self.write_env(
+                '# comment\n\nWP_USER=alice\nWP_APP_PASSWORD="p a s s"\nBAD LINE\n'
+            )
+        )
         values = parse_simple_env(path)
         self.assertEqual(values, {"WP_USER": "alice", "WP_APP_PASSWORD": "p a s s"})
 
@@ -63,20 +76,28 @@ class LoadEnvTests(_EnvFileMixin, unittest.TestCase):
         self.assertEqual(values["WP_USER"], "fileuser")
 
     def test_auth_mode_os_overlay_wins(self):
-        path = self.write_env("WP_USER=fileuser\nWP_APP_PASSWORD=filepass\nWP_AUTH_MODE=basic\n")
+        path = self.write_env(
+            "WP_USER=fileuser\nWP_APP_PASSWORD=filepass\nWP_AUTH_MODE=basic\n"
+        )
         with mock.patch.dict("os.environ", {"WP_AUTH_MODE": "login"}, clear=False):
             values = load_env(path)
         self.assertEqual(values["WP_AUTH_MODE"], "login")
 
     def test_from_env_uses_auth_mode(self):
-        path = self.write_env("WP_USER=fileuser\nWP_APP_PASSWORD=filepass\nWP_AUTH_MODE=login\n")
+        path = self.write_env(
+            "WP_USER=fileuser\nWP_APP_PASSWORD=filepass\nWP_AUTH_MODE=login\n"
+        )
         client = WPClient.from_env(path)
         self.assertEqual(client.auth_mode, "login")
 
 
 class WpCredentialsTests(unittest.TestCase):
     def test_returns_tuple_and_strips_base_slash(self):
-        env = {"WP_USER": "u", "WP_APP_PASSWORD": "p a s s", "WP_BASE_URL": "https://example.com/"}
+        env = {
+            "WP_USER": "u",
+            "WP_APP_PASSWORD": "p a s s",
+            "WP_BASE_URL": "https://example.com/",
+        }
         self.assertEqual(wp_credentials(env), ("https://example.com", "u", "pass"))
 
     def test_defaults_base_url(self):
@@ -86,6 +107,33 @@ class WpCredentialsTests(unittest.TestCase):
     def test_raises_when_missing(self):
         with self.assertRaises(RuntimeError):
             wp_credentials({"WP_USER": "u"})
+
+    def test_accepts_wp_api_aliases(self):
+        env = {
+            "WP_API_USERNAME": "mcp-user",
+            "WP_API_PASSWORD": "app pass word",
+            "WP_BASE_URL": "https://example.com/",
+        }
+        self.assertEqual(
+            wp_credentials(env),
+            ("https://example.com", "mcp-user", "apppassword"),
+        )
+
+    def test_legacy_names_win_over_aliases(self):
+        env = {
+            "WP_USER": "legacy",
+            "WP_APP_PASSWORD": "legacy-pass",
+            "WP_API_USERNAME": "mcp-user",
+            "WP_API_PASSWORD": "mcp-pass",
+        }
+        self.assertEqual(wp_credentials(env)[1:], ("legacy", "legacy-pass"))
+
+    def test_apply_aliases_is_idempotent(self):
+        env = apply_wp_credential_aliases(
+            {"WP_API_USERNAME": "u", "WP_API_PASSWORD": "p"}
+        )
+        self.assertEqual(env["WP_USER"], "u")
+        self.assertEqual(apply_wp_credential_aliases(env)["WP_USER"], "u")
 
 
 class WPClientRequestTests(unittest.TestCase):
@@ -191,8 +239,10 @@ class WPClientRequestTests(unittest.TestCase):
                 raise item
             return item
 
-        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
-             mock.patch("time.sleep"):
+        with (
+            mock.patch("urllib.request.urlopen", side_effect=fake_urlopen),
+            mock.patch("time.sleep"),
+        ):
             out = self.client.get("posts")
         self.assertEqual(out, {"ok": 1})
 
@@ -202,7 +252,9 @@ class WPClientPaginationTests(unittest.TestCase):
         client = WPClient("https://example.com", "u", "p")
         pages = [[{"id": i} for i in range(100)], [{"id": 100}, {"id": 101}]]
 
-        with mock.patch.object(client, "request", side_effect=lambda *a, **k: pages.pop(0)):
+        with mock.patch.object(
+            client, "request", side_effect=lambda *a, **k: pages.pop(0)
+        ):
             items = client.get_all("posts", per_page=100)
         self.assertEqual(len(items), 102)
 
@@ -228,9 +280,21 @@ class WPQueueCountsTests(unittest.TestCase):
         self.assertEqual(
             client.get_all.call_args_list,
             [
-                mock.call("posts", params={"status": "future", "context": "edit", "_fields": "id"}, per_page=100),
-                mock.call("posts", params={"status": "draft", "context": "edit", "_fields": "id"}, per_page=100),
-                mock.call("pages", params={"status": "draft", "context": "edit", "_fields": "id"}, per_page=100),
+                mock.call(
+                    "posts",
+                    params={"status": "future", "context": "edit", "_fields": "id"},
+                    per_page=100,
+                ),
+                mock.call(
+                    "posts",
+                    params={"status": "draft", "context": "edit", "_fields": "id"},
+                    per_page=100,
+                ),
+                mock.call(
+                    "pages",
+                    params={"status": "draft", "context": "edit", "_fields": "id"},
+                    per_page=100,
+                ),
             ],
         )
 

--- a/scripts/tests/test_publications_editorial_payload.py
+++ b/scripts/tests/test_publications_editorial_payload.py
@@ -56,11 +56,11 @@ class PublicationsEditorialPayloadTest(unittest.TestCase):
 
     def test_complete_reverse_chronological_inventory(self):
         self.assertEqual(3, self.payload.count('<a class="kk-press-feature'))
-        self.assertEqual(18, self.payload.count('<article class="kk-press-entry'))
+        self.assertEqual(19, self.payload.count('<article class="kk-press-entry'))
         self.assertEqual(25, self.payload.count("<li><time"))
 
         dates = re.findall(r'datetime="(\d{4}-\d{2}-\d{2})"', self.payload)
-        self.assertEqual(46, len(dates))
+        self.assertEqual(47, len(dates))
         self.assertEqual(sorted(dates, reverse=True), dates)
 
     def test_markup_and_voice_guards(self):
@@ -70,7 +70,7 @@ class PublicationsEditorialPayloadTest(unittest.TestCase):
         self.assertIn("@media (prefers-reduced-motion:reduce)", self.payload)
 
     def test_images_have_dimensions_and_alt_text(self):
-        self.assertEqual(6, len(self.parser.images))
+        self.assertEqual(7, len(self.parser.images))
         for image in self.parser.images:
             self.assertTrue(image.get("alt"))
             self.assertTrue(image.get("width"))


### PR DESCRIPTION
## Summary
- Import `WP_API_USERNAME` / `WP_API_PASSWORD` from `~/.agents/env/wordpress/.env.local` in `.env.schema`
- Teach `scripts/common.py` to accept those names as aliases for `WP_USER` / `WP_APP_PASSWORD`
- Record the live page-1895 BIV surgical apply (verification note + rollback snapshot)

## Test plan
- [x] `python3 -m unittest scripts.tests.test_common`
- [x] `pnpm exec varlock load --agent --show-all` shows `WP_API_*` resolved
- [x] `pnpm exec varlock run --inject vars --` + `wp_credentials()` succeeds
- [x] Live https://kriskrug.co/publications/ contains `12601298`