### PR TITLE
docs(#565): morning-truth report 2026-07-31

### DIFF
--- a/docs/current-state/reports/morning-truth-20260731-223940Z.md
+++ b/docs/current-state/reports/morning-truth-20260731-223940Z.md
@@ -1,0 +1,469 @@
+# Morning Truth Report - 2026-07-31 22:39:40 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `5`
+- Open issues: `52`
+- WordPress version (smoke): `7.0.2`
+- Draft queue: future posts `0`, draft posts `66`, draft pages `4`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `(not found)`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `22`
+- `aurora-v2`: `2`
+- `track-b`: `15`
+- `swarm-ready`: `24`
+- `swarm-parked`: `0`
+- `needs-human-review`: `24`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 1 | 5 | YES |
+| Open Issues | 43 | 52 | YES |
+| WordPress Version | 7.0.2 | 7.0.2 | no |
+| Scheduled Posts | 0 | 0 | no |
+| Draft Posts | 65 | 66 | YES |
+| Draft Pages | 4 | 4 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Data Availability
+
+- All startup truth data sources resolved.
+
+## Aurora Risk (Read-Only)
+
+- Local `aurora/v2` worktree not detected from porcelain list.
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+stderr:
+```text
+From https://github.com/WalksWithASwagger/kriskrug-wp
+ - [deleted]         (none)     -> origin/codex/415-homepage-trust-identity
+ - [deleted]         (none)     -> origin/codex/approved-community-photo-20260720
+ - [deleted]         (none)     -> origin/codex/publications-editorial-archive
+ - [deleted]         (none)     -> origin/cursor/494-pixel-gate-f196
+ - [deleted]         (none)     -> origin/cursor/agentic-crush-plan-6351
+ - [deleted]         (none)     -> origin/cursor/reclaim-ad-369-6351
+ - [deleted]         (none)     -> origin/cursor/truth-reclaim-lanes-6351
+```
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## ops/565-morning-truth-20260731
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+c69012d docs: agentic crush plan 2026-07-31 (full audit) (#559)
+d8d5e44 ops(#369): reclaim A+D binaries (~212 MB tracked) (#558)
+c369eef docs: truth reset 2026-07-30 + archive May–June crust (#549) (#557)
+451fc32 Merge pull request #564 from WalksWithASwagger/feature/2940-ai-lands-essay
+0074d54 Merge pull request #563 from WalksWithASwagger/feature/2942-biv-publications-payload
+f0fd21b docs: ready surgical BIV card patch for live Publications page
+80a2c49 content: stage BIV ecosystem context screenshot for Publications (#2938)
+1d4b9f9 docs: add AI Lands kriskrug.co draft package (Refs WalksWithASwagger/kk-kb#2940)
+3de8746 docs: feature July 31 BIV ecosystem clipping on Publications payload
+a6608e3 docs: reconcile AGENTS.md version block to 1.5.0 == live after #493 merge
+1b08460 docs: morning-truth report 2026-07-27 (post-1.5.0 reconcile)
+25a5499 feat(#474): cascade @layer scaffold + --kk-* tokens (Aurora 1.5.0) (#493)
+1c1fedf ops(#547): restore morning-truth report cadence (#553)
+5cc772f docs(#544): correct AGENTS.md + current-state theme-version state (#551)
+5058c7b ci: loosen over-engineered PR checks (#555)
+372b239 docs(#548): add kk-aurora CHANGELOG with deploy ledger (#554)
+182be89 test(#546): live-vs-repo theme version parity check (#552)
+5a8ebc1 docs: week work plan 2026-07-26 (1.5.0 pixel-gate keystone + rebuild chain)
+771228e feat(#416): homepage newsletter section rewrite + thumbnails (#505)
+ab58eeb docs: wind-down merge cleanup after swarm PR squash
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+```text
+574	fix: wire WordPress MCP credential aliases into Varlock	chore/wp-api-credential-aliases	OPEN	2026-07-31T22:38:01Z
+562	chore(deps): bump actions/setup-node from 4.4.0 to 7.0.0	dependabot/github_actions/actions/setup-node-7.0.0	OPEN	2026-07-31T15:28:45Z
+561	chore(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1	dependabot/github_actions/actions/upload-artifact-7.0.1	OPEN	2026-07-31T15:27:27Z
+560	chore(deps): bump peter-evans/create-pull-request from 6.1.0 to 8.1.1	dependabot/github_actions/peter-evans/create-pull-request-8.1.1	OPEN	2026-07-31T15:27:12Z
+556	chore(deps-dev): bump wp-coding-standards/wpcs from 3.4.0 to 3.4.1	dependabot/composer/wp-coding-standards/wpcs-3.4.1	OPEN	2026-07-30T19:09:40Z
+```
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+573	OPEN	[SWARM DISPATCH] Command board — 2026-07-31 (master workplan: merge queue, truth refresh, Futureproof, rebuild chain)	swarm-ready, roadmap	2026-07-31T22:35:19Z
+572	OPEN	[DECISION] Git history rewrite (filter-repo) after #369 working-tree reclaim	priority:low, tech-debt, needs-decision, blocked	2026-07-31T22:34:51Z
+571	OPEN	[DECISION] Parked plugins: deploy, keep parked, or archive kk-sidebar-promos + kk-marquee-board	priority:low, needs-human-review, deployment, needs-decision	2026-07-31T22:34:48Z
+570	OPEN	[OPS] Issue label hygiene: retire stale swarm-wave and blocked labels	priority:low, needs-human-review, tech-debt	2026-07-31T22:34:45Z
+569	OPEN	[OPS] Draft-queue cleanup: archive empty content/drafts shells	priority:low, content, needs-human-review, swarm-ready, agent-safe, tech-debt	2026-07-31T22:34:43Z
+568	OPEN	[OPS] Remote branch prune: inventory merged/stale origin branches	priority:low, needs-human-review, swarm-ready, swarm-wave-1, agent-safe, tech-debt	2026-07-31T22:34:41Z
+567	OPEN	[BUG] Publisher dry-run should not hard-require WP credentials	bug, priority:medium, swarm-ready, swarm-wave-1, agent-safe	2026-07-31T22:34:39Z
+566	OPEN	[DOCS] Refresh front-door current-state docs past 2026-07-16	documentation, priority:high, tech-debt, blocked	2026-07-31T22:34:37Z
+565	OPEN	[OPS] Morning-truth cadence: run + commit fresh report (2026-07-31)	documentation, priority:medium, swarm-ready, swarm-wave-1, agent-safe	2026-07-31T22:34:35Z
+549	OPEN	[OPS] Archive stale docs/current-state May–June plans into archive/	documentation, priority:low, needs-human-review, tech-debt	2026-07-27T05:03:53Z
+500	OPEN	[CONTENT] Futureproof post: verify + create WP draft (no publish)	priority:high, content, needs-human-review, swarm-wave-3, deployment	2026-07-26T16:33:51Z
+499	OPEN	[CONTENT] Futureproof post: write the story in KK voice	priority:high, content, needs-human-review, swarm-wave-2	2026-07-26T16:33:50Z
+498	OPEN	[CONTENT] Futureproof post: verify + assemble public speaker lineup	priority:high, content, needs-human-review, swarm-ready, swarm-wave-1	2026-07-26T16:33:48Z
+497	OPEN	[CONTENT] Futureproof post: stage design assets + alt text	priority:medium, content, swarm-ready, swarm-wave-1, agent-safe	2026-07-26T16:33:46Z
+496	OPEN	[EPIC] Futureproof Festival announcement post (Track A)	priority:high, content, swarm-ready	2026-07-26T16:34:03Z
+495	OPEN	[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)	swarm-ready, roadmap	2026-07-26T15:50:39Z
+481	OPEN	[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1	priority:medium, needs-human-review, track-b, refactor, blocked	2026-07-26T15:51:34Z
+480	OPEN	[CONTENT] Retire Track A page-content CSS blocks (six live routes)	priority:medium, content, needs-human-review, tech-debt, blocked	2026-07-26T15:51:32Z
+479	OPEN	[THEME] Consolidate 12 breakpoints into a 3-step scale	priority:medium, mobile, track-b, swarm-ready, refactor, blocked	2026-07-26T15:51:30Z
+478	OPEN	[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0	priority:medium, track-b, swarm-ready, tech-debt, blocked	2026-07-26T15:51:29Z
+477	OPEN	[EPIC] Component migration: one component per PR — Aurora 1.5.3+	priority:medium, track-b, swarm-ready, roadmap, refactor, blocked	2026-07-26T15:51:27Z
+476	OPEN	[THEME] Primitives layer + block-editor parity — Aurora 1.5.2	priority:high, track-b, swarm-ready, refactor, blocked	2026-07-26T15:51:25Z
+475	OPEN	[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1	priority:medium, track-b, swarm-ready, refactor	2026-07-27T18:25:43Z
+424	OPEN	[QA] Site-wide hover, focus, and interactivity pass	priority:medium, accessibility, ux, track-b, swarm-ready, swarm-wave-2, blocked	2026-07-26T15:51:36Z
+423	OPEN	[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair	priority:high, track-b, swarm-wave-2, tech-debt, refactor	2026-07-27T17:57:35Z
+420	OPEN	[PAGE] Services page: rethink language, layout, and scroll depth	priority:medium, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:19Z
+419	OPEN	[PAGE] Speaking page: multimedia rebuild that sells keynotes	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:17Z
+418	OPEN	[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:16Z
+416	OPEN	[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-27T16:48:50Z
+415	OPEN	[HOME] 'What People Say' redesign + network diagram spike	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-17T14:44:10Z
+414	OPEN	[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-17T14:44:09Z
+413	OPEN	[HOME] Bring back the client logo soup: monochromatic and interactive	priority:high, content, ux, needs-human-review, swarm-ready, swarm-wave-2	2026-07-19T23:47:00Z
+412	OPEN	[HOME] Creative Labs section redesign: layout, image crops, clarity	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-17T14:44:05Z
+411	OPEN	[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states	priority:high, content, ux, needs-human-review, track-b, swarm-ready, swarm-wave-2	2026-07-24T21:33:31Z
+403	OPEN	[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown	priority:high, ux, track-b, roadmap	2026-07-17T14:44:46Z
+402	OPEN	[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs	enhancement, help wanted	2026-07-17T04:25:24Z
+385	OPEN	Normalize the WordPress workflow skill without breaking automation		2026-07-17T01:12:49Z
+369	OPEN	[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)		2026-07-25T18:53:36Z
+339	OPEN	[SEO] Run the measured July Kris publisher batch	priority:high, seo, needs-human-review	2026-07-14T07:28:42Z
+331	OPEN	[SEO] Shrink taxonomy sitemap bloat and define archive indexability	priority:high, seo, needs-human-review, roadmap	2026-07-24T22:41:40Z
+318	OPEN	[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history	priority:medium, tech-debt	2026-07-12T05:46:59Z
+277	OPEN	[FORMS] Decide whether the lightweight contact CTA is enough	priority:medium, platform, content, needs-human-review	2026-07-01T21:18:37Z
+276	OPEN	[OPS] Delete inactive Jetpack after rollback window	priority:medium, platform, needs-human-review, deployment, tech-debt	2026-07-01T21:18:35Z
+274	OPEN	[SEO] Submit canonical sitemap in Search Console and monitor indexing	priority:high, seo, needs-human-review, roadmap	2026-07-16T14:43:11Z
+249	OPEN	[SEO] Measure 'you can't drink data' striking-distance after #233 deploy	content, seo	2026-07-13T05:25:21Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, swarm-wave-2, blocked	2026-06-17T21:27:05Z
+125	OPEN	[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup	priority:medium, performance, track-b, tech-debt	2026-07-02T21:01:24Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-05-26T16:41:34Z
+86	OPEN	[QA] Post-Jetpack real-site performance, accessibility, and tracking QA	priority:high, mobile, accessibility, performance, track-b	2026-07-02T21:01:25Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-07-02T00:32:38Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-07-02T00:32:38Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD c69012db5308f18ebc173724d4a292360f9c1344
+branch refs/heads/ops/565-morning-truth-20260731
+
+worktree /Users/kk/Code/kriskrug-wp/.worktrees/2940-ai-lands-essay
+HEAD 1d4b9f9e4aa6f35836a8040afde8a7a753f1a256
+branch refs/heads/feature/2940-ai-lands-essay
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `128`
+
+stderr:
+```text
+fatal: ambiguous argument 'origin/aurora/v2...origin/main': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":573,"title":"[SWARM DISPATCH] Command board — 2026-07-31 (master workplan: merge queue, truth refresh, Futureproof, rebuild chain)","updatedAt":"2026-07-31T22:35:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":572,"title":"[DECISION] Git history rewrite (filter-repo) after #369 working-tree reclaim","updatedAt":"2026-07-31T22:34:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"}],"number":571,"title":"[DECISION] Parked plugins: deploy, keep parked, or archive kk-sidebar-promos + kk-marquee-board","updatedAt":"2026-07-31T22:34:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":570,"title":"[OPS] Issue label hygiene: retire stale swarm-wave and blocked labels","updatedAt":"2026-07-31T22:34:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":569,"title":"[OPS] Draft-queue cleanup: archive empty content/drafts shells","updatedAt":"2026-07-31T22:34:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":568,"title":"[OPS] Remote branch prune: inventory merged/stale origin branches","updatedAt":"2026-07-31T22:34:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":567,"title":"[BUG] Publisher dry-run should not hard-require WP credentials","updatedAt":"2026-07-31T22:34:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":566,"title":"[DOCS] Refresh front-door current-state docs past 2026-07-16","updatedAt":"2026-07-31T22:34:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":565,"title":"[OPS] Morning-truth cadence: run + commit fresh report (2026-07-31)","updatedAt":"2026-07-31T22:34:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":549,"title":"[OPS] Archive stale docs/current-state May–June plans into archive/","updatedAt":"2026-07-27T05:03:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"}],"number":500,"title":"[CONTENT] Futureproof post: verify + create WP draft (no publish)","updatedAt":"2026-07-26T16:33:51Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":499,"title":"[CONTENT] Futureproof post: write the story in KK voice","updatedAt":"2026-07-26T16:33:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":498,"title":"[CONTENT] Futureproof post: verify + assemble public speaker lineup","updatedAt":"2026-07-26T16:33:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxqwQ","name":"agent-safe","description":"Narrow scope, safe for autonomous agent","color":"0E8A16"}],"number":497,"title":"[CONTENT] Futureproof post: stage design assets + alt text","updatedAt":"2026-07-26T16:33:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":496,"title":"[EPIC] Futureproof Festival announcement post (Track A)","updatedAt":"2026-07-26T16:34:03Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":495,"title":"[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)","updatedAt":"2026-07-26T15:50:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":481,"title":"[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1","updatedAt":"2026-07-26T15:51:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":480,"title":"[CONTENT] Retire Track A page-content CSS blocks (six live routes)","updatedAt":"2026-07-26T15:51:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":479,"title":"[THEME] Consolidate 12 breakpoints into a 3-step scale","updatedAt":"2026-07-26T15:51:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":478,"title":"[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0","updatedAt":"2026-07-26T15:51:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":477,"title":"[EPIC] Component migration: one component per PR — Aurora 1.5.3+","updatedAt":"2026-07-26T15:51:27Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":476,"title":"[THEME] Primitives layer + block-editor parity — Aurora 1.5.2","updatedAt":"2026-07-26T15:51:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":475,"title":"[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1","updatedAt":"2026-07-27T18:25:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":424,"title":"[QA] Site-wide hover, focus, and interactivity pass","updatedAt":"2026-07-26T15:51:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":423,"title":"[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair","updatedAt":"2026-07-27T17:57:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":420,"title":"[PAGE] Services page: rethink language, layout, and scroll depth","updatedAt":"2026-07-17T14:44:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":419,"title":"[PAGE] Speaking page: multimedia rebuild that sells keynotes","updatedAt":"2026-07-17T14:44:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":418,"title":"[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'","updatedAt":"2026-07-17T14:44:16Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":416,"title":"[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA","updatedAt":"2026-07-27T16:48:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":415,"title":"[HOME] 'What People Say' redesign + network diagram spike","updatedAt":"2026-07-17T14:44:10Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":414,"title":"[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity","updatedAt":"2026-07-17T14:44:09Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":413,"title":"[HOME] Bring back the client logo soup: monochromatic and interactive","updatedAt":"2026-07-19T23:47:00Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":412,"title":"[HOME] Creative Labs section redesign: layout, image crops, clarity","updatedAt":"2026-07-17T14:44:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"}],"number":411,"title":"[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states","updatedAt":"2026-07-24T21:33:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":403,"title":"[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown","updatedAt":"2026-07-17T14:44:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEw","name":"help wanted","description":"Extra attention is needed","color":"008672"}],"number":402,"title":"[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs","updatedAt":"2026-07-17T04:25:24Z"},{"labels":[],"number":385,"title":"Normalize the WordPress workflow skill without breaking automation","updatedAt":"2026-07-17T01:12:49Z"},{"labels":[],"number":369,"title":"[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)","updatedAt":"2026-07-25T18:53:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":339,"title":"[SEO] Run the measured July Kris publisher batch","updatedAt":"2026-07-14T07:28:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":331,"title":"[SEO] Shrink taxonomy sitemap bloat and define archive indexability","updatedAt":"2026-07-24T22:41:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":318,"title":"[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history","updatedAt":"2026-07-12T05:46:59Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":277,"title":"[FORMS] Decide whether the lightweight contact CTA is enough","updatedAt":"2026-07-01T21:18:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":276,"title":"[OPS] Delete inactive Jetpack after rollback window","updatedAt":"2026-07-01T21:18:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":274,"title":"[SEO] Submit canonical sitemap in Search Console and monitor indexing","updatedAt":"2026-07-16T14:43:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":249,"title":"[SEO] Measure 'you can't drink data' striking-distance after #233 deploy","updatedAt":"2026-07-13T05:25:21Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-06-17T21:27:05Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":125,"title":"[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup","updatedAt":"2026-07-02T21:01:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-05-26T16:41:34Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"}],"number":86,"title":"[QA] Post-Jetpack real-site performance, accessibility, and tracking QA","updatedAt":"2026-07-02T21:01:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-07-02T00:32:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-07-02T00:32:38Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[{"number":574,"title":"fix: wire WordPress MCP credential aliases into Varlock","updatedAt":"2026-07-31T22:38:48Z"},{"number":562,"title":"chore(deps): bump actions/setup-node from 4.4.0 to 7.0.0","updatedAt":"2026-07-31T15:29:34Z"},{"number":561,"title":"chore(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1","updatedAt":"2026-07-31T15:29:06Z"},{"number":560,"title":"chore(deps): bump peter-evans/create-pull-request from 6.1.0 to 8.1.1","updatedAt":"2026-07-31T15:29:07Z"},{"number":556,"title":"chore(deps-dev): bump wp-coding-standards/wpcs from 3.4.0 to 3.4.1","updatedAt":"2026-07-30T19:10:51Z"}]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=0, draft_posts=66, draft_pages=4
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 7.0.2 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.184.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "7.0.2"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/work/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/explat",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "application/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/wp-sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "7.0.2",
+  "started_at": "2026-07-31T22:39:47Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/CURRENT-STATE-2026-07-30.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 1,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 5,
+      "status": "drift"
+    },
+    {
+      "declared": 43,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 52,
+      "status": "drift"
+    },
+    {
+      "declared": "7.0.2",
+      "drift": false,
+      "evaluated": true,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "7.0.2",
+      "status": "no drift"
+    },
+    {
+      "declared": 0,
+      "drift": false,
+      "evaluated": true,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 0,
+      "status": "no drift"
+    },
+    {
+      "declared": 65,
+      "drift": true,
+      "evaluated": true,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 66,
+      "status": "drift"
+    },
+    {
+      "declared": 4,
+      "drift": false,
+      "evaluated": true,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 4,
+      "status": "no drift"
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/CURRENT-STATE-2026-07-30.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301 
+date: Fri, 31 Jul 2026 22:40:00 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+server: Pagely-ARES/1.22.28
+x-gateway-request-id: a45e882f8018c83ea98d40c60f84dee7
+x-jetpack-boost-cache: miss
+expires: Fri, 31 Jul 2026 23:40:00 GMT
+cache-control: max-age=3600
+x-redirect-by: redirection
+location: /work/
+x-gateway-cache-key: 1784933659.113|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: MISS
+x-gateway-skip-cache: 0
+```


### PR DESCRIPTION
## Summary
- Adds committed morning-truth report for 2026-07-31 (Lane A1 / #565).
- Docs-only; no product or theme changes.

Closes #565

## Test plan
- [x] `make morning-truth` produced `docs/current-state/reports/morning-truth-20260731-223940Z.md`
- [x] Commit contains only that report file
- [ ] Review drift table in report summary (Open PRs / Open Issues / Draft Posts YES)


Made with [Cursor](https://cursor.com)