### PR TITLE
content: BC-AI depth layer for AI-lands essay (WP 12653, now live)

### DIFF
--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/ASSETS.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/ASSETS.md
@@ -22,6 +22,9 @@ Caption: Vancouver AI Meetup 30 at the H.R. MacMillan Space Centre, June 2026. P
 | `images/biv-ecosystem-context.jpg` | **In body** — "Three groups, one page" (uploaded as `biv-headline-clean.jpg`, media 12654) | Contextual screenshot · Business in Vancouver / Daisy Xiong · ad-free recapture 2026-07-31 · do not scrape Rob Kruyt portrait as hero | Local capture from kk-kb press-clippings |
 | `images/biv-quote-context.jpg` | Archive / optional second BIV proof (uploaded as `biv-quote-clean.jpg`, media 12655; not in body — quote runs as text pullquote) | Same · ad-free recapture 2026-07-31 | Local capture |
 | `images/tyee-ai-adoption-headline.jpg` | Near compute / Tyee paragraph | Contextual screenshot · The Tyee | Local capture |
+| `images/aefl-parker-street-room.jpg` | "The rooms multiplied" — AEFL beat (media 12657) | BC + AI · AEFL 5 recap post | https://bc-ai.ca/images/news/ai-ethical-futures-lab-5-july-recap/aefl-5-room-wide-01.jpg |
+| `images/comox-valley-meetup-room.jpg` | "The rooms multiplied" — Comox beat (media 12658) | BC + AI · Comox Valley post | https://bc-ai.ca/images/communities/comox-valley/meetup-room.webp |
+| `images/vanai-conversation-pair.jpg` | "The product is interconnectedness" (media 12659) | BC + AI · from-one-room post / event archive | https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/news/vancouver-ai-building-bcs-ai-future/img_30.png |
 
 ## Video embeds
 

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/alt-text.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/alt-text.md
@@ -26,6 +26,9 @@
 | 12651 | biv-quote-context.jpg (ad-heavy, superseded) | — | Retired; replaced by 12655. |
 | 12654 | biv-headline-clean.jpg | Business in Vancouver headline: B.C. groups push to build a stronger AI ecosystem, by Daisy Xiong. | B.C. groups push to build a stronger AI ecosystem · Business in Vancouver · Daisy Xiong · July 31, 2026. |
 | 12655 | biv-quote-clean.jpg | Business in Vancouver passage quoting Kris Krüg: artificial intelligence lands inside every single profession. | Archive / optional proof — quote runs as text pullquote in body. |
+| 12657 | aefl-parker-street-room.jpg | AI Ethical Futures Lab session at Parker Street Studios: about twenty people seated in a loose circle in an art-filled studio, mid-discussion. | AI Ethical Futures Lab at Parker Street Studios, July 2026 — the room got real. Photo: BC + AI. |
+| 12658 | comox-valley-meetup-room.jpg | Comox Valley AI meetup in a Courtenay community hall: rows of seated attendees facing a presentation screen. | Comox Valley AI in Courtenay — becoming its own thing. Photo: BC + AI. |
+| 12659 | vanai-conversation-pair.jpg | Two attendees in animated one-on-one conversation at a Vancouver AI gathering, hands mid-gesture. | The actual product. From one room to province-wide infrastructure. Photo: BC + AI. |
 | 12652 | tyee-ai-adoption-headline.jpg | Screenshot of The Tyee headline: Who Gets a Say in AI Adoption? | Related press · The Tyee · July 24, 2026. |
 
 ## Video embeds

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/internal-links.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/internal-links.md
@@ -29,6 +29,23 @@ URLs verified 2026-07-31 (depth/polish/voice revision round). Prefer one primary
 | https://bc-ai.ca/membership | Join BC + AI |
 | https://www.youtube.com/watch?v=-XEsqsEbpoo | Whistler Institute keynote (text link, deliberately not a third embed) |
 
+## BC-AI depth layer (added 2026-07-31 evening round)
+
+| URL | Anchor / role |
+|---|---|
+| https://bc-ai.ca/news/why-we-need-to-double-down | DigiBC cluster paragraph — "very first weeks of this project" |
+| https://bc-ai.ca/news/launching-the-bc-ai-film-club | receipts list — AI Film Club |
+| https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap | AEFL "civic infrastructure" beat + room photo link |
+| https://bc-ai.ca/news/what-we-learned-running-the-first-ai-animation-accelerator | Film Club / accelerator beat ($100 commercial, festival) |
+| https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing | Comox Meetup #0 story + room photo link |
+| https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure | interconnectedness image caption |
+| https://bc-ai.ca/news/documenting-the-bc-ai-ecosystem-movement | BC Studies peer-reviewed case study (Pennefather / Gaertner) |
+| https://bc-ai.ca/news/bcs-response-to-the-canada-s-ai-task-force | task force — 645 B.C. respondents |
+| https://bc-ai.ca/news/bc-ai-s-platform-for-canada-s-ai-task-force | task force — community platform |
+| https://bc-ai.ca/news/bc-ai-report-2024 | paper-trail paragraph |
+| https://bc-ai.ca/news/state-of-the-bc-ai-economy | paper-trail paragraph — field map |
+| https://bc-ai.ca/news/what-does-the-bc-ai-ecosystem-need | paper-trail paragraph — listening exercise |
+
 ## Removed in this revision
 
 - OrgBook `S0083444` registry link (inside baseball)

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/media-upload-map.json
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/media-upload-map.json
@@ -43,5 +43,20 @@
     "id": 12655,
     "source_url": "https://kriskrug.co/wp-content/uploads/2026/07/biv-quote-clean.jpg",
     "placeholder": null
+  },
+  "aefl-parker-street-room.jpg": {
+    "id": 12657,
+    "source_url": "https://kriskrug.co/wp-content/uploads/2026/07/aefl-parker-street-room.jpg",
+    "placeholder": null
+  },
+  "comox-valley-meetup-room.jpg": {
+    "id": 12658,
+    "source_url": "https://kriskrug.co/wp-content/uploads/2026/07/comox-valley-meetup-room.jpg",
+    "placeholder": null
+  },
+  "vanai-conversation-pair.jpg": {
+    "id": 12659,
+    "source_url": "https://kriskrug.co/wp-content/uploads/2026/07/vanai-conversation-pair.jpg",
+    "placeholder": null
   }
 }

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.html
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.html
@@ -43,7 +43,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. Nobody had done that for AI yet.</p>
+<p>And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. I have been making the case that AI deserves the same deliberate treatment since <a href="https://bc-ai.ca/news/why-we-need-to-double-down">the very first weeks of this project</a> — the entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -69,7 +69,7 @@
 <!-- wp:list -->
 <ul class="wp-block-list">
 <li>about 300 paid annual members who actually know each other</li>
-<li>11 community subgroups — an AI Film Club run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)</li>
+<li>11 community subgroups — an <a href="https://bc-ai.ca/news/launching-the-bc-ai-film-club">AI Film Club</a> run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)</li>
 <li>weekly programming, not just a monthly flagship — the <a href="https://lu.ma/vancouver-ai">events calendar</a> does not take weeks off</li>
 <li>more than 3,000 people through the door since launch</li>
 <li><a href="https://bc-ai.ca/certification/responsible-ai-professional">Responsible AI Professional</a> training in active use</li>
@@ -105,6 +105,34 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:image -->
 
 <!-- wp:heading -->
+<h2 class="wp-block-heading">The rooms multiplied</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>"Eleven subgroups" is an org-chart fact. Here is what it feels like from inside.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The AI Ethical Futures Lab meets at Parker Street Studios, and somewhere around its fifth session it <a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap">stopped feeling like an event series and started feeling like civic infrastructure</a> — a room people can come back to, where somebody can raise disability access and somebody else can raise data-centre heat and both threads belong to the same conversation. Public AI discourse keeps getting flattened into the shiny demo or the red-alert siren. The Lab is where we stop pretending that contradiction is a branding problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap"><img src="https://kriskrug.co/wp-content/uploads/2026/07/aefl-parker-street-room.jpg" alt="AI Ethical Futures Lab session at Parker Street Studios: about twenty people seated in a loose circle in an art-filled studio, mid-discussion."/></a><figcaption class="wp-element-caption">AI Ethical Futures Lab at Parker Street Studios, July 2026 — <a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap">the room got real</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>The Film Club is where the professions argument gets cinematic. Kevin Friel spent twenty-five years at DNEG, BRON, and MPC; now he calls this the orchestration era — not one model, but a pipeline you conduct — and gives away every shortcut he knows on a Wednesday night. When we ran the <a href="https://bc-ai.ca/news/what-we-learned-running-the-first-ai-animation-accelerator">first AI Animation Accelerator</a>, one of our filmmakers showed a thirty-second commercial he had made for about a hundred dollars — work that would have carried a six-figure budget at his old studio. Two hundred and fifty people packed the Space Centre for our first film festival to watch six AI-made shorts. That is a profession renegotiating itself in public, in real time, in our rooms.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And it is not a Vancouver story anymore. When we took the meetup to Courtenay, I called the first one Meetup #0 because I did not want to show up from the city pretending to know what the Island needed. We expected a dozen people. <a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing">About sixty-five showed up</a> — farmers, teachers, local government folks, software people, artists, retirees. The valley was already having the conversation. You just have to give it a room.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing"><img src="https://kriskrug.co/wp-content/uploads/2026/07/comox-valley-meetup-room.jpg" alt="Comox Valley AI meetup in a Courtenay community hall: rows of seated attendees facing a presentation screen."/></a><figcaption class="wp-element-caption">Comox Valley AI in Courtenay — <a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing">becoming its own thing</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
 <h2 class="wp-block-heading">What it looks like up close</h2>
 <!-- /wp:heading -->
 
@@ -130,6 +158,14 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 
 <!-- wp:paragraph -->
 <p>The people in these rooms have each other's numbers in their phones. That sounds small. It is not. A region gets smarter when ideas can travel between a life-sciences operator, a procurement officer, a creative technologist, and a founder without waiting for a conference badge or a ministerial panel.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure"><img src="https://kriskrug.co/wp-content/uploads/2026/07/vanai-conversation-pair.jpg" alt="Two attendees in animated one-on-one conversation at a Vancouver AI gathering, hands mid-gesture."/></a><figcaption class="wp-element-caption">The actual product. <a href="https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure">From one room to province-wide infrastructure</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>Do not take my word for it. UBC researchers Patrick Pennefather and David Gaertner studied this community and published the result with me as a peer-reviewed case study in <em>BC Studies</em> — <a href="https://bc-ai.ca/news/documenting-the-bc-ai-ecosystem-movement">"Building a Grass Roots AI Community of Practice"</a> (No. 224, April 2025). Their finding on what makes a local technology community hold together: not a platform, not a growth hack. Regular gatherings, porous participation, continuous documentation, and room for both formal and informal learning. In other words: the boring, recurring infrastructure. The stuff nobody funds.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -165,6 +201,10 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
+<p>Ottawa is starting to notice. When Canada's AI Task Force ran its national consultation, <a href="https://bc-ai.ca/news/bcs-response-to-the-canada-s-ai-task-force">645 British Columbians answered</a> — a fifth of every response in the country, second only to Ontario. We took the community <a href="https://bc-ai.ca/news/bc-ai-s-platform-for-canada-s-ai-task-force">a platform built from those rooms</a>, and then I read all thirty-two expert reports, because somebody should. Buried in them: three different Task Force experts, independently, naming Vancouver as a strategic location for federal AI investment. Not vague nods to "regional representation." Specific proposals about specific capability. The ground truth we have been building is starting to show up in the national paperwork.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p>That includes compute. We have a chance to build clean, green, Indigenous-owned, hydropower data centres as a counterpoint to extractive defaults — if communities help write the terms instead of rubber-stamping blank cheques (<a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">You Can't Drink Data</a>). <a href="https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/">The Tyee carried a piece of that argument on July 24</a>. The point is simpler than the policy detail: infrastructure without public agency is just someone else's factory on our grid.</p>
 <!-- /wp:paragraph -->
 
@@ -189,7 +229,7 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>I have been telling this story since before it had institutions attached — the 2024 sketch is still up: <a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver's Thriving AI Ecosystem</a>. Watching a business paper treat community infrastructure as economic news two years later? That is the drumbeat working.</p>
+<p>I have been telling this story since before it had institutions attached, and writing it down the whole way. The 2024 sketch is still up: <a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver's Thriving AI Ecosystem</a>. Then the <a href="https://bc-ai.ca/news/bc-ai-report-2024">BC + AI Report 2024</a> and a <a href="https://bc-ai.ca/news/state-of-the-bc-ai-economy">field map of the provincial AI economy</a> that December. Then <a href="https://bc-ai.ca/news/what-does-the-bc-ai-ecosystem-need">a province-wide listening exercise</a> asking British Columbians what the ecosystem actually needs, because the people living inside an ecosystem should shape it before decisions get announced. Watching a business paper treat community infrastructure as economic news two years into that paper trail? That is the drumbeat working.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md
@@ -2,7 +2,7 @@
 title: "AI Lands Inside Every Profession"
 slug: ai-lands-inside-every-profession
 post_date: "2026-07-31"
-status: draft
+status: publish  # flipped to publish in wp-admin by owner 2026-07-31 18:40 PT; live URL https://kriskrug.co/2026/07/31/ai-lands-inside-every-profession/
 post_type: post
 author_wp_id: 1
 wp_draft_id: 12653
@@ -26,7 +26,7 @@ seo:
 source_manifest: sources.md
 assets_manifest: ASSETS.md
 approval: pending-kris
-revision: "2026-07-31 depth/polish/voice round — interview stories, named rooms, back-catalog links, clean BIV screenshots, de-inside-baseball pass"
+revision: "2026-07-31 depth/polish/voice round + same-day BC-AI depth layer — interview stories, named rooms, back-catalog links, clean BIV screenshots, de-inside-baseball pass, 11 bc-ai.ca news links, 3 BC-AI post images (AEFL, Comox, conversation), task-force + BC Studies + paper-trail beats"
 kk_kb_issue: 2940
 kk_kb_epic: 2937
 ---
@@ -56,7 +56,7 @@ B.C. already has researchers, studios, startups, adopters, investors, and public
 
 What we have underbuilt is the boring, recurring infrastructure that turns scattered excellence into a region that can learn together, hire across silos, form companies, and show up in policy conversations with a shared memory.
 
-And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. Nobody had done that for AI yet.
+And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. I have been making the case that AI deserves the same deliberate treatment since [the very first weeks of this project](https://bc-ai.ca/news/why-we-need-to-double-down) — the entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement.
 
 Not another isolated lab.
 Not another one-off summit.
@@ -71,7 +71,7 @@ Eighty-five people crammed into that studio by the end. We were bursting. Then L
 A year later we made it official as the [BC + AI Ecosystem Association](https://bc-ai.ca/about), a member-funded nonprofit. I wrote the [origin arc separately](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/). The short version of where that stands today:
 
 - about 300 paid annual members who actually know each other
-- 11 community subgroups — an AI Film Club run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)
+- 11 community subgroups — an [AI Film Club](https://bc-ai.ca/news/launching-the-bc-ai-film-club) run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)
 - weekly programming, not just a monthly flagship — the [events calendar](https://lu.ma/vancouver-ai) does not take weeks off
 - more than 3,000 people through the door since launch
 - [Responsible AI Professional](https://bc-ai.ca/certification/responsible-ai-professional) training in active use
@@ -90,6 +90,24 @@ We are bootstrapped on memberships, tickets, certifications, and sponsorship. Th
 
 *[Futureproof Festival](https://futureproof.website/) — October 28–30, 2026 · Space Centre.*
 
+## The rooms multiplied
+
+"Eleven subgroups" is an org-chart fact. Here is what it feels like from inside.
+
+The AI Ethical Futures Lab meets at Parker Street Studios, and somewhere around its fifth session it [stopped feeling like an event series and started feeling like civic infrastructure](https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap) — a room people can come back to, where somebody can raise disability access and somebody else can raise data-centre heat and both threads belong to the same conversation. Public AI discourse keeps getting flattened into the shiny demo or the red-alert siren. The Lab is where we stop pretending that contradiction is a branding problem.
+
+[![AI Ethical Futures Lab at Parker Street Studios](https://kriskrug.co/wp-content/uploads/2026/07/aefl-parker-street-room.jpg)](https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap)
+
+*AI Ethical Futures Lab at Parker Street Studios, July 2026. Photo: BC + AI.*
+
+The Film Club is where the professions argument gets cinematic. Kevin Friel spent twenty-five years at DNEG, BRON, and MPC; now he calls this the orchestration era — not one model, but a pipeline you conduct — and gives away every shortcut he knows on a Wednesday night. When we ran the [first AI Animation Accelerator](https://bc-ai.ca/news/what-we-learned-running-the-first-ai-animation-accelerator), one of our filmmakers showed a thirty-second commercial he had made for about a hundred dollars — work that would have carried a six-figure budget at his old studio. Two hundred and fifty people packed the Space Centre for our first film festival to watch six AI-made shorts. That is a profession renegotiating itself in public, in real time, in our rooms.
+
+And it is not a Vancouver story anymore. When we took the meetup to Courtenay, I called the first one Meetup #0 because I did not want to show up from the city pretending to know what the Island needed. We expected a dozen people. [About sixty-five showed up](https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing) — farmers, teachers, local government folks, software people, artists, retirees. The valley was already having the conversation. You just have to give it a room.
+
+[![Comox Valley AI meetup in Courtenay](https://kriskrug.co/wp-content/uploads/2026/07/comox-valley-meetup-room.jpg)](https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing)
+
+*Comox Valley AI in Courtenay — becoming its own thing. Photo: BC + AI.*
+
 ## What it looks like up close
 
 A health-tech CEO cornered me at one of our gatherings with a question that has stayed with me: when is this technology trustworthy enough for patient outcomes — for the responsibility that used to live entirely in the hands of doctors?
@@ -104,6 +122,12 @@ Three hundred people who do not know each other are a labour market.
 Three hundred people who share context, trust, and practice are a capability.
 
 The people in these rooms have each other's numbers in their phones. That sounds small. It is not. A region gets smarter when ideas can travel between a life-sciences operator, a procurement officer, a creative technologist, and a founder without waiting for a conference badge or a ministerial panel.
+
+[![Two attendees in animated conversation at a Vancouver AI gathering](https://kriskrug.co/wp-content/uploads/2026/07/vanai-conversation-pair.jpg)](https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure)
+
+*The actual product. [From one room to province-wide infrastructure](https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure). Photo: BC + AI.*
+
+Do not take my word for it. UBC researchers Patrick Pennefather and David Gaertner studied this community and published the result with me as a peer-reviewed case study in *BC Studies* — ["Building a Grass Roots AI Community of Practice"](https://bc-ai.ca/news/documenting-the-bc-ai-ecosystem-movement) (No. 224, April 2025). Their finding on what makes a local technology community hold together: not a platform, not a growth hack. Regular gatherings, porous participation, continuous documentation, and room for both formal and informal learning. In other words: the boring, recurring infrastructure. The stuff nobody funds.
 
 Ecosystem is not a vibe. It is repeated contact with consequences.
 
@@ -121,6 +145,8 @@ Vancouver is a ninety-minute flight from Silicon Valley, in the same time zone, 
 
 B.C. can combine applied AI, creative technology, university research, clean electricity, Indigenous ownership and data-sovereignty principles, and a livable Pacific coast into something distinct. I have made the long version of this argument in [Sovereign AI for Whom?](https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/) and [Canada Doesn't Need a Bigger AI Machine. It Needs a Better One.](https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/)
 
+Ottawa is starting to notice. When Canada's AI Task Force ran its national consultation, [645 British Columbians answered](https://bc-ai.ca/news/bcs-response-to-the-canada-s-ai-task-force) — a fifth of every response in the country, second only to Ontario. We took the community [a platform built from those rooms](https://bc-ai.ca/news/bc-ai-s-platform-for-canada-s-ai-task-force), and then I read all thirty-two expert reports, because somebody should. Buried in them: three different Task Force experts, independently, naming Vancouver as a strategic location for federal AI investment. Not vague nods to "regional representation." Specific proposals about specific capability. The ground truth we have been building is starting to show up in the national paperwork.
+
 That includes compute. We have a chance to build clean, green, Indigenous-owned, hydropower data centres as a counterpoint to extractive defaults — if communities help write the terms instead of rubber-stamping blank cheques ([You Can't Drink Data](https://kriskrug.co/2026/05/23/you-cant-drink-data/)). [The Tyee carried a piece of that argument on July 24](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/). The point is simpler than the policy detail: infrastructure without public agency is just someone else's factory on our grid.
 
 [![The Tyee headline screenshot](https://kriskrug.co/wp-content/uploads/2026/07/tyee-ai-adoption-headline.jpg)](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/)
@@ -135,7 +161,7 @@ Here is what I appreciated most about Daisy's reporting. She came to this story 
 
 Advocacy work, recurring community, ethics and measurement, research pipelines, capital — a healthy region needs all of those layers, run by people with different mandates who talk to each other. The job is to stitch them together without flattening them into one logo. Nobody owns "the ecosystem." That is the point of the word.
 
-I have been telling this story since before it had institutions attached — the 2024 sketch is still up: [Future Proof: Inside Vancouver's Thriving AI Ecosystem](https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/). Watching a business paper treat community infrastructure as economic news two years later? That is the drumbeat working.
+I have been telling this story since before it had institutions attached, and writing it down the whole way. The 2024 sketch is still up: [Future Proof: Inside Vancouver's Thriving AI Ecosystem](https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/). Then the [BC + AI Report 2024](https://bc-ai.ca/news/bc-ai-report-2024) and a [field map of the provincial AI economy](https://bc-ai.ca/news/state-of-the-bc-ai-economy) that December. Then [a province-wide listening exercise](https://bc-ai.ca/news/what-does-the-bc-ai-ecosystem-need) asking British Columbians what the ecosystem actually needs, because the people living inside an ecosystem should shape it before decisions get announced. Watching a business paper treat community infrastructure as economic news two years into that paper trail? That is the drumbeat working.
 
 ## If you want in
 

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.wp-resolved.html
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/post.wp-resolved.html
@@ -43,7 +43,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. Nobody had done that for AI yet.</p>
+<p>And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. I have been making the case that AI deserves the same deliberate treatment since <a href="https://bc-ai.ca/news/why-we-need-to-double-down">the very first weeks of this project</a> — the entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -69,7 +69,7 @@
 <!-- wp:list -->
 <ul class="wp-block-list">
 <li>about 300 paid annual members who actually know each other</li>
-<li>11 community subgroups — an AI Film Club run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)</li>
+<li>11 community subgroups — an <a href="https://bc-ai.ca/news/launching-the-bc-ai-film-club">AI Film Club</a> run by Kevin Friel on a philosophy of "every human in every loop," an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you're on the Island)</li>
 <li>weekly programming, not just a monthly flagship — the <a href="https://lu.ma/vancouver-ai">events calendar</a> does not take weeks off</li>
 <li>more than 3,000 people through the door since launch</li>
 <li><a href="https://bc-ai.ca/certification/responsible-ai-professional">Responsible AI Professional</a> training in active use</li>
@@ -105,6 +105,34 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:image -->
 
 <!-- wp:heading -->
+<h2 class="wp-block-heading">The rooms multiplied</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>"Eleven subgroups" is an org-chart fact. Here is what it feels like from inside.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The AI Ethical Futures Lab meets at Parker Street Studios, and somewhere around its fifth session it <a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap">stopped feeling like an event series and started feeling like civic infrastructure</a> — a room people can come back to, where somebody can raise disability access and somebody else can raise data-centre heat and both threads belong to the same conversation. Public AI discourse keeps getting flattened into the shiny demo or the red-alert siren. The Lab is where we stop pretending that contradiction is a branding problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap"><img src="https://kriskrug.co/wp-content/uploads/2026/07/aefl-parker-street-room.jpg" alt="AI Ethical Futures Lab session at Parker Street Studios: about twenty people seated in a loose circle in an art-filled studio, mid-discussion."/></a><figcaption class="wp-element-caption">AI Ethical Futures Lab at Parker Street Studios, July 2026 — <a href="https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap">the room got real</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>The Film Club is where the professions argument gets cinematic. Kevin Friel spent twenty-five years at DNEG, BRON, and MPC; now he calls this the orchestration era — not one model, but a pipeline you conduct — and gives away every shortcut he knows on a Wednesday night. When we ran the <a href="https://bc-ai.ca/news/what-we-learned-running-the-first-ai-animation-accelerator">first AI Animation Accelerator</a>, one of our filmmakers showed a thirty-second commercial he had made for about a hundred dollars — work that would have carried a six-figure budget at his old studio. Two hundred and fifty people packed the Space Centre for our first film festival to watch six AI-made shorts. That is a profession renegotiating itself in public, in real time, in our rooms.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And it is not a Vancouver story anymore. When we took the meetup to Courtenay, I called the first one Meetup #0 because I did not want to show up from the city pretending to know what the Island needed. We expected a dozen people. <a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing">About sixty-five showed up</a> — farmers, teachers, local government folks, software people, artists, retirees. The valley was already having the conversation. You just have to give it a room.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing"><img src="https://kriskrug.co/wp-content/uploads/2026/07/comox-valley-meetup-room.jpg" alt="Comox Valley AI meetup in a Courtenay community hall: rows of seated attendees facing a presentation screen."/></a><figcaption class="wp-element-caption">Comox Valley AI in Courtenay — <a href="https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing">becoming its own thing</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:heading -->
 <h2 class="wp-block-heading">What it looks like up close</h2>
 <!-- /wp:heading -->
 
@@ -130,6 +158,14 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 
 <!-- wp:paragraph -->
 <p>The people in these rooms have each other's numbers in their phones. That sounds small. It is not. A region gets smarter when ideas can travel between a life-sciences operator, a procurement officer, a creative technologist, and a founder without waiting for a conference badge or a ministerial panel.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","linkDestination":"custom"} -->
+<figure class="wp-block-image size-large"><a href="https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure"><img src="https://kriskrug.co/wp-content/uploads/2026/07/vanai-conversation-pair.jpg" alt="Two attendees in animated one-on-one conversation at a Vancouver AI gathering, hands mid-gesture."/></a><figcaption class="wp-element-caption">The actual product. <a href="https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure">From one room to province-wide infrastructure</a>. Photo: BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>Do not take my word for it. UBC researchers Patrick Pennefather and David Gaertner studied this community and published the result with me as a peer-reviewed case study in <em>BC Studies</em> — <a href="https://bc-ai.ca/news/documenting-the-bc-ai-ecosystem-movement">"Building a Grass Roots AI Community of Practice"</a> (No. 224, April 2025). Their finding on what makes a local technology community hold together: not a platform, not a growth hack. Regular gatherings, porous participation, continuous documentation, and room for both formal and informal learning. In other words: the boring, recurring infrastructure. The stuff nobody funds.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -165,6 +201,10 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
+<p>Ottawa is starting to notice. When Canada's AI Task Force ran its national consultation, <a href="https://bc-ai.ca/news/bcs-response-to-the-canada-s-ai-task-force">645 British Columbians answered</a> — a fifth of every response in the country, second only to Ontario. We took the community <a href="https://bc-ai.ca/news/bc-ai-s-platform-for-canada-s-ai-task-force">a platform built from those rooms</a>, and then I read all thirty-two expert reports, because somebody should. Buried in them: three different Task Force experts, independently, naming Vancouver as a strategic location for federal AI investment. Not vague nods to "regional representation." Specific proposals about specific capability. The ground truth we have been building is starting to show up in the national paperwork.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
 <p>That includes compute. We have a chance to build clean, green, Indigenous-owned, hydropower data centres as a counterpoint to extractive defaults — if communities help write the terms instead of rubber-stamping blank cheques (<a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">You Can't Drink Data</a>). <a href="https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/">The Tyee carried a piece of that argument on July 24</a>. The point is simpler than the policy detail: infrastructure without public agency is just someone else's factory on our grid.</p>
 <!-- /wp:paragraph -->
 
@@ -189,7 +229,7 @@ https://www.youtube.com/watch?v=MB3YnobJcEU
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>I have been telling this story since before it had institutions attached — the 2024 sketch is still up: <a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver's Thriving AI Ecosystem</a>. Watching a business paper treat community infrastructure as economic news two years later? That is the drumbeat working.</p>
+<p>I have been telling this story since before it had institutions attached, and writing it down the whole way. The 2024 sketch is still up: <a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver's Thriving AI Ecosystem</a>. Then the <a href="https://bc-ai.ca/news/bc-ai-report-2024">BC + AI Report 2024</a> and a <a href="https://bc-ai.ca/news/state-of-the-bc-ai-economy">field map of the provincial AI economy</a> that December. Then <a href="https://bc-ai.ca/news/what-does-the-bc-ai-ecosystem-need">a province-wide listening exercise</a> asking British Columbians what the ecosystem actually needs, because the people living inside an ecosystem should shape it before decisions get announced. Watching a business paper treat community infrastructure as economic news two years into that paper trail? That is the drumbeat working.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/content/drafts/2026-07-31-ai-lands-inside-every-profession/publish-gate.md
+++ b/content/drafts/2026-07-31-ai-lands-inside-every-profession/publish-gate.md
@@ -1,6 +1,8 @@
 # Publication gate
 
-Current authorization: **WordPress draft exists** (ID `12653`) — still pending-kris for **publish**. Multimedia package staged 2026-07-31; depth/polish/voice revision round applied same day (interview stories, named rooms, back-catalog links, ad-free BIV screenshots media 12654/12655, OrgBook cut, "Three groups, one page" reframe).
+Current status: **LIVE** — post `12653` was flipped to publish **in wp-admin by the owner at 2026-07-31 18:40 PT** (not by agent; agent updates sent content only). Live URL: https://kriskrug.co/2026/07/31/ai-lands-inside-every-profession/
+
+History: multimedia package staged 2026-07-31; depth/polish/voice revision round applied same day (interview stories, named rooms, back-catalog links, ad-free BIV screenshots media 12654/12655, OrgBook cut, "Three groups, one page" reframe); BC-AI depth layer applied same evening (11 bc-ai.ca news links, 3 BC-AI post images media 12657–12659, task-force + BC Studies + paper-trail beats) — this last update landed at 18:51 PT, after the owner's publish flip, so the live post carries the deepened version.
 
 ## Required before publication
 


### PR DESCRIPTION
## Summary

- Evening depth round applied to the now-live post: new "The rooms multiplied" section (AEFL at Parker Street, Film Club / animation accelerator, Comox Valley Meetup #0), BC Studies peer-reviewed case study beat (Pennefather / Gaertner), Canada AI Task Force beat (645 B.C. respondents, three experts naming Vancouver), and the 2024→2026 ecosystem paper trail — 11 bc-ai.ca news links, 3 images rehosted from BC-AI posts (WP media 12657–12659).
- `publish-gate.md` records that the owner flipped 12653 to publish in wp-admin at 18:40 PT (before the agent's 18:51 PT content update); live at https://kriskrug.co/2026/07/31/ai-lands-inside-every-profession/

Companion kk-kb PR: WalksWithASwagger/kk-kb#3022.

## Test plan

- [x] Claims sweep clean; all stats from published bc-ai.ca posts
- [x] 34 unique body URLs verified
- [x] WP raw body contains all depth beats; package matches