### PR TITLE
docs: ready testimonials showpiece v2 swarm for later kickoff

### DIFF
--- a/content/drafts/2026-08-01-testimonials-overhaul/README.md
+++ b/content/drafts/2026-08-01-testimonials-overhaul/README.md
@@ -1,7 +1,9 @@
 # Testimonials page overhaul — 2026-08-01
 
+> **Showpiece v2 kickoff:** see [`START-HERE.md`](./START-HERE.md) and epic [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593). v1 below shipped; v2 swarm extends it.
+
 **Track:** A (content) · **Live target:** WP page **2409** · `/testimonials/`  
-**Plan:** Cursor plan `testimonials_page_overhaul_bb42a748`  
+**Plan:** Cursor plan `testimonials_page_overhaul_bb42a748` (v1); showpiece v2 = epic #593  
 **Narrative:** Career arc — AI era first, photography/community archive second.
 
 ## Goal

--- a/content/drafts/2026-08-01-testimonials-overhaul/START-HERE.md
+++ b/content/drafts/2026-08-01-testimonials-overhaul/START-HERE.md
@@ -1,0 +1,52 @@
+# START HERE — Testimonials showpiece v2
+
+**Status:** Ready to swarm — do not deploy until Wave 4.  
+**Epic:** [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593)  
+**Board:** [`issues-to-create/testimonials-showpiece-v2-swarm-2026-08-01.md`](../../../issues-to-create/testimonials-showpiece-v2-swarm-2026-08-01.md)
+
+This packet already has **v1** artifacts (live enrichment shipped via #582/#584). Showpiece v2 **extends** them — do not delete v1 files; add `*-v2` / `consent-log` / expand inventory per exclusive ownership.
+
+## When you come back — kickoff in order
+
+### 0. Hygiene (30 seconds)
+```bash
+cd /Users/kk/Code/kriskrug-wp
+git fetch origin main
+git checkout -B codex/593-tstm-<lane> origin/main   # one branch per issue
+curl -s https://kriskrug.co/wp-content/themes/kk-aurora/style.css | grep -i '^Version:'
+# Expect live ≥ 1.5.3 as of 2026-08-01; TSTM-3 bumps NEXT patch (not 1.6.0 — #478)
+```
+
+Do **not** start from `cursor/publications-aurora-tearsheet` or any dirty pubs/theme WIP branch.
+
+### 1. Wave 1 — four parallel agents (exclusive files)
+
+| Issue | Branch suggestion | Writes only |
+|-------|-------------------|-------------|
+| [#594](https://github.com/WalksWithASwagger/kriskrug-wp/issues/594) TSTM-1 | `codex/593-tstm-1-quote-inventory` | `quote-inventory.md` (expand in place or clearly section as v2) |
+| [#595](https://github.com/WalksWithASwagger/kriskrug-wp/issues/595) TSTM-2 | `codex/593-tstm-2-linkedin-gaps` | `linkedin-gaps.md` |
+| [#596](https://github.com/WalksWithASwagger/kriskrug-wp/issues/596) TSTM-3 | `codex/593-tstm-3-aurora-tstm-css` | `theme/kk-aurora/style.css` only |
+| [#597](https://github.com/WalksWithASwagger/kriskrug-wp/issues/597) TSTM-4 | `codex/593-tstm-4-copy-v2` | `copy-v2.md` (new) |
+
+### 2. Then Wave 2 → 3 → 4
+- #598 curate + consent-log → #599 payload + #600 outreach → #601 theme deploy → #602 body deploy  
+- #601 / #602 stay `blocked` until KK unlocks
+
+## Hard blocks (every lane)
+William Jordan · Stephanie McKay · tilde/unresolved names · Butterfield **conference/camera** mis-quote.  
+Butterfield **2006 photography LinkedIn rec** OK in Archive only.
+
+## Class contract (do not rename)
+See epic #593 / board. Payload dual-classes `aurora-tstm-*` + existing `aurora-quote-card` fallbacks.
+
+## Consume — do not re-mine from scratch
+- Notion Master Directory + RAP consent (links on #593)
+- v1 packet files in this directory + live payload `…/wp-payloads/testimonials.html`
+- Harvest notes in Cursor plan + agent transcripts (Power 50, LinkedIn recs, meetup T1, WhatsApp T2)
+- Backups: `backup/20260801-testimonials/` and `backup/20260801-testimonials-enrichment/`
+
+## KK judgment parked for Wave 2
+Peter Bowles “Don't fucking stop…” — include/exclude called out in #598.
+
+## Out of scope
+Homepage #415 · Jetpack CPT · Review schema · headshots · auto-sync · starting Wave 4 without KK.

--- a/issues-to-create/testimonials-showpiece-v2-swarm-2026-08-01.md
+++ b/issues-to-create/testimonials-showpiece-v2-swarm-2026-08-01.md
@@ -1,0 +1,106 @@
+# Testimonials Showpiece v2 — Swarm Issue Board
+
+**Status:** Filed + ready to kick Wave 1 later (no implementation started)  
+**Epic:** [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593)  
+**Plan:** Testimonials showpiece v2 (Cursor plan)  
+**Live target:** https://kriskrug.co/testimonials/ (WP page **2409**)  
+**Kickoff doc:** [`content/drafts/2026-08-01-testimonials-overhaul/START-HERE.md`](../content/drafts/2026-08-01-testimonials-overhaul/START-HERE.md)  
+**Out of scope forever:** homepage #415, Jetpack CPT, Review schema, headshots, auto-sync
+
+## Later kickoff (copy-paste)
+
+```bash
+git fetch origin main
+# Four parallel agents from origin/main — see START-HERE.md
+# Open: #594 #595 #596 #597
+curl -s https://kriskrug.co/wp-content/themes/kk-aurora/style.css | grep -i '^Version:'
+```
+
+## Wave diagram
+
+```
+Wave 1 (parallel, zero file overlap):
+  TSTM-1 inventory ──┐
+  TSTM-2 linkedin  ──┼──► Wave 2: TSTM-5 curate+consent
+  TSTM-4 copy      ──┘              │
+  TSTM-3 theme CSS (Track B, parallel; class contract fixed in EPIC)
+                                    ▼
+Wave 3:              TSTM-6 payload HTML  +  TSTM-7 consent outreach
+                                    ▼
+Wave 4 (human gates): TSTM-8 theme pixel deploy  →  TSTM-9 content body deploy
+```
+
+## Exclusive file ownership (no overlap)
+
+| Issue | Owns (write) | Must not touch |
+|-------|--------------|----------------|
+| TSTM-1 #594 | `content/drafts/2026-08-01-testimonials-overhaul/quote-inventory.md` | curated-set, consent-log, payload, theme |
+| TSTM-2 #595 | `…/linkedin-gaps.md` | inventory rows (read-only), payload |
+| TSTM-3 #596 | `theme/kk-aurora/style.css` (`.aurora-tstm-*` block + Version bump only) | any Track A content/payload |
+| TSTM-4 #597 | `…/copy-v2.md` | quote picks, payload HTML |
+| TSTM-5 #598 | `…/curated-set-v2.md`, `…/consent-log.md` | theme, payload HTML, linkedin-gaps writes |
+| TSTM-6 #599 | `content/source-packs/…/testimonials.html`, `page-map.json` markers | theme CSS, consent outreach |
+| TSTM-7 #600 | `…/consent-outreach.md`, packet `README.md` | payload, theme, live WP |
+| TSTM-8 #601 | live theme SFTP + pixel artifacts | page 2409 body |
+| TSTM-9 #602 | live page 2409 body via content_architecture_deploy | theme files |
+
+## Fixed class contract (shared read-only between TSTM-3 and TSTM-6)
+
+Do not invent alternate names. Payload uses **dual class** (`aurora-tstm-*` + existing fallbacks).
+
+- `.aurora-tstm` — page root wrapper
+- `.aurora-tstm-hero` — hero block
+- `.aurora-tstm-stats` / `.aurora-tstm-stat` — stat chips
+- `.aurora-tstm-press` — institutional / press band
+- `.aurora-tstm-featured` — oversized featured quotes
+- `.aurora-tstm-section` — era/section header + intro
+- `.aurora-tstm-wall` — CSS-columns quote wall
+- `.aurora-tstm-card` — card (also keep `.aurora-quote-card`)
+- `.aurora-tstm-cite` — name + optional LinkedIn
+- `.aurora-tstm-chip` — context chip (meetup #, RAP, etc.)
+- `.aurora-tstm-cta` — bottom CTA
+
+## Version bump rule
+
+Live readback (2026-08-01 afternoon): Aurora **1.5.3**. Repo `main` theme header may still read **1.5.0** — always re-curl live before bumping. Issue **#478** claims **1.6.0** for dead-CSS consolidation. TSTM-3 must bump to the **next unused patch after live** (likely **1.5.4**) — never steal `#478`'s 1.6.0 label.
+
+## Hard blocks (every content/deploy issue)
+
+Never publish: William Jordan, Stephanie McKay, unresolved/tilde names, Butterfield **conference/camera** mis-attribution. Butterfield **2006 photography LinkedIn rec only** is allowed in Archive.
+
+## Locked page sections (order)
+
+1. Hero + stat chips  
+2. Press band (Power 50, Portfolio.YVR, CreativeMornings, BC Studies)  
+3. Featured (3 oversized)  
+4. The Rooms (meetup T1)  
+5. Programs (RAP consented)  
+6. Talks and teaching  
+7. Coaching and training  
+8. Community threads (T2 logged)  
+9. Film Club / satellites  
+10. Archive (photography/connector)  
+11. CTA
+
+## Pre-existing on main (v1 — keep)
+
+| Path | Notes |
+|------|--------|
+| `content/drafts/2026-08-01-testimonials-overhaul/{README,copy,curated-set,linkedin-gaps,quote-inventory}.md` | v1 packet; Wave 1 expands / adds v2 files |
+| `content/source-packs/…/wp-payloads/testimonials.html` | live-enriched body; TSTM-6 rebuilds |
+| `backup/20260801-testimonials*` | rollback for v1 deploys |
+
+## Filed issue numbers
+
+| Key | Issue | Wave | Ready now? |
+|-----|-------|------|------------|
+| EPIC | [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593) | — | board |
+| TSTM-1 | [#594](https://github.com/WalksWithASwagger/kriskrug-wp/issues/594) | 1 | yes `swarm-ready` |
+| TSTM-2 | [#595](https://github.com/WalksWithASwagger/kriskrug-wp/issues/595) | 1 | yes `swarm-ready` |
+| TSTM-3 | [#596](https://github.com/WalksWithASwagger/kriskrug-wp/issues/596) | 1 | yes `swarm-ready` (KK review before merge) |
+| TSTM-4 | [#597](https://github.com/WalksWithASwagger/kriskrug-wp/issues/597) | 1 | yes `swarm-ready` |
+| TSTM-5 | [#598](https://github.com/WalksWithASwagger/kriskrug-wp/issues/598) | 2 | after #594+#595 |
+| TSTM-6 | [#599](https://github.com/WalksWithASwagger/kriskrug-wp/issues/599) | 3 | after #597+#598 |
+| TSTM-7 | [#600](https://github.com/WalksWithASwagger/kriskrug-wp/issues/600) | 3 | after #598 |
+| TSTM-8 | [#601](https://github.com/WalksWithASwagger/kriskrug-wp/issues/601) | 4 | `blocked` until KK |
+| TSTM-9 | [#602](https://github.com/WalksWithASwagger/kriskrug-wp/issues/602) | 4 | `blocked` until KK |


### PR DESCRIPTION
## Summary
- Adds `START-HERE.md` kickoff handoff for epic #593
- Stages the swarm board with filed issue links (#594–#602)
- Points v1 packet README at showpiece v2; refreshes live Aurora version facts (1.5.3 → next patch for TSTM-3)

No Wave 1 implementation. Merge when convenient so later agents start from `main`.

## Test plan
- [ ] Open `content/drafts/2026-08-01-testimonials-overhaul/START-HERE.md` and confirm Wave 1 issue links resolve
- [ ] Confirm no theme/payload/deploy files in this PR

Closes nothing — Refs #593

Made with [Cursor](https://cursor.com)