### PR TITLE
theme+content: full-bleed krug-1 portrait hero on Home and About

### DIFF
--- a/content/source-packs/content-architecture-2026/wp-payloads/about.html
+++ b/content/source-packs/content-architecture-2026/wp-payloads/about.html
@@ -1,9 +1,146 @@
 <!-- wp:html -->
 <!-- content-architecture-2026:about -->
+<style>
+.aurora-page-2026:has(.aurora-about-page) .aurora-page-header { display: none; }
+.aurora-page-2026:has(.aurora-about-page) {
+  overflow-x: clip;
+}
+/* Break the hero out of the prose column so About owns a true first viewport. */
+.aurora-about-page > .aurora-hero-2026 {
+  width: 100vw;
+  max-width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  min-height: clamp(640px, 88vh, 900px);
+  position: relative;
+}
+.aurora-about-page > .aurora-hero-2026 .aurora-hero-media img {
+  /* Match home: zoom + left-anchor so left scrim/copy clears the face. */
+  bottom: 0;
+  left: 0;
+  max-width: none;
+  object-position: 68% 26%;
+  right: auto;
+  top: 0;
+  width: 145%;
+}
+@media (max-width: 900px) {
+  .aurora-about-page > .aurora-hero-2026 .aurora-hero-media img {
+    left: 0;
+    right: 0;
+    object-position: 88% 20%;
+    width: 100%;
+  }
+}
+.aurora-about-page > .aurora-hero-2026 .aurora-hero-copy {
+  margin: 0 auto 0 max(0px, calc((100% - 1200px) / 2));
+  max-width: min(34rem, 100%);
+  min-height: clamp(640px, 88vh, 900px);
+  box-sizing: border-box;
+}
+.aurora-about-page > .aurora-hero-2026 .aurora-hero-dek {
+  max-width: 42ch;
+}
+.aurora-about-page :where(p, li)::first-letter {
+  initial-letter: normal !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  float: none !important;
+  margin: 0 !important;
+  line-height: inherit !important;
+  color: inherit !important;
+  background: transparent !important;
+}
+
+/* Light ink over dark portrait hero — cream-paper forces dark !important on h2/p. */
+.aurora-about-page .aurora-hero-2026 :where(#aurora-about-title, .aurora-hero-copy h2) {
+  color: #f7f7f2 !important;
+  -webkit-text-fill-color: #f7f7f2 !important;
+}
+.aurora-about-page .aurora-hero-2026 :where(.aurora-hero-dek, .aurora-hero-copy p:not(.aurora-kicker)) {
+  color: #c8cac8 !important;
+  -webkit-text-fill-color: #c8cac8 !important;
+}
+.aurora-about-page .aurora-hero-2026 .aurora-kicker {
+  color: #e8b53a !important;
+  -webkit-text-fill-color: #e8b53a !important;
+}
+.aurora-about-page .aurora-hero-2026 .aurora-button-secondary {
+  background: rgba(247, 247, 242, 0.08) !important;
+  border-color: rgba(247, 247, 242, 0.35) !important;
+  color: #f7f7f2 !important;
+  -webkit-text-fill-color: #f7f7f2 !important;
+}
+.aurora-about-page .aurora-hero-copy h2 {
+  font-size: clamp(2.6rem, 5.2vw, 4.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+  margin: 0;
+  max-width: 16ch;
+  text-wrap: balance;
+  overflow-wrap: normal;
+  hyphens: manual;
+}
+@media (max-width: 700px) {
+  .aurora-about-page .aurora-hero-copy h2 {
+    font-size: clamp(2.1rem, 9vw, 3rem);
+    line-height: 1.05;
+    max-width: 14ch;
+  }
+}
+.aurora-about-page .aurora-proof-section .aurora-button,
+.aurora-about-page .aurora-proof-section a.aurora-button {
+  display: inline-block;
+  padding: 0.7rem 1.1rem;
+  border: 1px solid #171310;
+  border-radius: 2px;
+  background: #171310;
+  color: #efe6d2 !important;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none !important;
+}
+.aurora-about-page .aurora-proof-section .aurora-button:hover,
+.aurora-about-page .aurora-proof-section a.aurora-button:hover {
+  background: #d94a1f;
+  border-color: #d94a1f;
+  color: #efe6d2 !important;
+  text-decoration: none !important;
+}
+.aurora-about-page .aurora-card,
+.aurora-about-page .aurora-media-card {
+  border-radius: 2px !important;
+  box-shadow: none !important;
+}
+</style>
+<div class="aurora-about-page">
+<section class="aurora-hero-2026" aria-labelledby="aurora-about-title">
+  <figure class="aurora-hero-media" aria-label="Portrait of Kris Krüg">
+    <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=2000&amp;ssl=1"
+      srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=640&amp;ssl=1 640w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=960&amp;ssl=1 960w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1280&amp;ssl=1 1280w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1600&amp;ssl=1 1600w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=2000&amp;ssl=1 2000w"
+      sizes="100vw"
+      alt="Portrait of Kris Krüg"
+      width="2000"
+      height="1827"
+      fetchpriority="high"
+      decoding="async"/>
+  </figure>
+  <div class="aurora-hero-scrim" aria-hidden="true"></div>
+  <div class="aurora-hero-copy">
+    <p class="aurora-kicker">About</p>
+    <h2 id="aurora-about-title">I build culture around emerging technology.</h2>
+    <p class="aurora-hero-dek">I am Kris Krug: photographer, creative technologist, community builder, speaker, and field-note person for the weird edge where humans meet the machines they keep inventing.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="/contact/">Contact Kris</a>
+      <a class="aurora-button aurora-button-secondary" href="/work/">See the work</a>
+    </div>
+  </div>
+</section>
+
 <section class="aurora-proof-section">
-  <p class="aurora-section-kicker">About</p>
-  <h2 class="aurora-display-heading">I build culture around emerging technology.</h2>
-  <p class="aurora-page-lead">I am Kris Krug: photographer, creative technologist, community builder, speaker, and field-note person for the weird edge where humans meet the machines they keep inventing.</p>
   <p>I have spent two decades documenting technology, art, activism, conferences, communities, and the back rooms where culture actually changes. These days, most of that work points at one question: how do we use AI to increase human capacity instead of flattening human judgment?</p>
 </section>
 
@@ -12,7 +149,7 @@
   <div class="aurora-proof-grid">
     <article class="aurora-media-card">
       <a href="https://bc-ai.ca/">
-        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC plus AI ecosystem graphic" loading="lazy">
+        <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=1200&amp;ssl=1" alt="BC plus AI ecosystem graphic" loading="lazy"/>
         <div>
           <h3>BC + AI Ecosystem</h3>
           <p>Building grassroots AI literacy, events, and community infrastructure across British Columbia.</p>
@@ -21,7 +158,7 @@
     </article>
     <article class="aurora-media-card">
       <a href="/speaking/">
-        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&amp;ssl=1" alt="Punk Rock AI CreativeMornings Vancouver keynote banner" loading="lazy">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?w=1280&amp;ssl=1" alt="Punk Rock AI CreativeMornings Vancouver keynote banner" loading="lazy"/>
         <div>
           <h3>AI keynotes and workshops</h3>
           <p>Helping audiences understand AI through taste, courage, responsibility, and useful live demos.</p>
@@ -30,7 +167,7 @@
     </article>
     <article class="aurora-media-card">
       <a href="/photography/">
-        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1200&amp;ssl=1" alt="Portrait of Kris Krug" loading="lazy">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/20067931301_e7a16b6f2c_k-1.jpg?w=1200&amp;ssl=1" alt="Archive photograph from Kris Krug photography practice" loading="lazy"/>
         <div>
           <h3>Visual storytelling</h3>
           <p>A long public archive of people, movements, music, technology, and the strange theatre of modern life.</p>
@@ -39,7 +176,7 @@
     </article>
     <article class="aurora-media-card">
       <a href="/work/">
-        <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full keynote graphic" loading="lazy">
+        <img src="https://www.bothhandsfull.com/opengraph-image?46af5f0ff830fe03" alt="Both Hands Full keynote graphic" loading="lazy"/>
         <div>
           <h3>Creative AI systems</h3>
           <p>Projects, publishing loops, and experiments for staying distinct in the synthetic age.</p>
@@ -78,4 +215,5 @@
     <p><a class="aurora-button" href="/contact/">Contact Kris</a></p>
   </div>
 </section>
+</div>
 <!-- /wp:html -->

--- a/content/source-packs/content-architecture-2026/wp-payloads/page-map.json
+++ b/content/source-packs/content-architecture-2026/wp-payloads/page-map.json
@@ -25,7 +25,7 @@
     "slug": "about",
     "url": "https://kriskrug.co/about/",
     "payload": "about.html",
-    "markers": ["I build culture around emerging technology", "The rooms I am in now", "A two-decade public trail"]
+    "markers": ["I build culture around emerging technology", "The rooms I am in now", "A two-decade public trail", "aurora-hero-2026", "2023/07/krug-1.jpg"]
   },
   "speaking": {
     "id": 1887,

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -366,7 +366,8 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
 }
 
 /* R6: rainbow word readable at a glance (slightly larger italic + richer sweep) */
-.aurora-masthead-copy h1 .aurora-rainbow-word {
+.aurora-masthead-copy h1 .aurora-rainbow-word,
+.aurora-hero-copy h1 .aurora-rainbow-word {
   display: inline-block;
   font-size: 1.08em;
   font-style: italic;
@@ -1265,6 +1266,51 @@ body.aurora-theme .aurora-primary-nav a {
     border: 0 !important;
     border-radius: 0 !important;
   }
+}
+
+/* Full-bleed photo hero: restore light ink over dark scrim.
+   Global Revive remaps --aurora-ink to cream-paper ink; without this the
+   left-scrim copy paints dark-on-dark. Temporary .aurora-stage-photo--portrait
+   override removed — Home no longer uses that slot. */
+body.aurora-theme #aurora-main .aurora-hero-2026 {
+  --aurora-ink: #f7f7f2;
+  --aurora-ink-soft: #c8cac8;
+  --aurora-ink-muted: #8f9697;
+  --aurora-line: rgba(247, 247, 242, 0.22);
+  --aurora-line-strong: rgba(247, 247, 242, 0.4);
+}
+
+body.aurora-theme #aurora-main .aurora-hero-2026 :where(
+  #aurora-home-title,
+  .aurora-hero-copy h1
+) {
+  color: #f7f7f2 !important;
+  -webkit-text-fill-color: #f7f7f2 !important;
+}
+
+body.aurora-theme #aurora-main .aurora-hero-2026 :where(
+  .aurora-hero-dek,
+  .aurora-hero-copy p:not(.aurora-kicker)
+) {
+  color: #c8cac8 !important;
+  -webkit-text-fill-color: #c8cac8 !important;
+}
+
+body.aurora-theme #aurora-main .aurora-hero-2026 .aurora-kicker {
+  color: #e8b53a !important;
+  -webkit-text-fill-color: #e8b53a !important;
+}
+
+body.aurora-theme #aurora-main .aurora-hero-2026 .aurora-rainbow-word {
+  color: transparent !important;
+  -webkit-text-fill-color: transparent !important;
+}
+
+body.aurora-theme #aurora-main .aurora-hero-2026 .aurora-button-secondary {
+  background: rgba(247, 247, 242, 0.08) !important;
+  border-color: rgba(247, 247, 242, 0.35) !important;
+  color: #f7f7f2 !important;
+  -webkit-text-fill-color: #f7f7f2 !important;
 }
 
 }

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.5.0
+Version: 1.5.7
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0
@@ -808,8 +808,20 @@ a {
 .aurora-hero-media img {
   height: 100%;
   object-fit: cover;
-  object-position: 50% 34%;
+  object-position: 68% 26%;
   width: 100%;
+}
+
+/* Home hero only: nearly-square krug-1 fills a short wide band with no
+   horizontal crop, so object-position alone can't clear the face. Zoom +
+   left-anchor keeps scrim/copy on the open left and parks the portrait right. */
+.aurora-home-2026 .aurora-hero-media img {
+  bottom: 0;
+  left: 0;
+  max-width: none;
+  right: auto;
+  top: 0;
+  width: 145%;
 }
 
 /* Scrim backs the left-aligned copy for legibility without burying the photo.
@@ -829,6 +841,23 @@ a {
   min-height: clamp(600px, 80vh, 800px);
   padding: clamp(4rem, 8vw, 6rem) clamp(1rem, 3vw, 2rem) clamp(2rem, 4vw, 3rem);
   place-content: center start;
+}
+
+/* Home: pin copy to the left content edge and keep it narrow so it sits in
+   the open left of the zoomed portrait instead of over the face. */
+.aurora-home-2026 .aurora-hero-copy {
+  margin: 0 auto 0 max(0px, calc((100% - var(--aurora-max)) / 2));
+  max-width: min(34rem, 100%);
+}
+
+.aurora-home-2026 .aurora-hero-dek {
+  max-width: 42ch;
+}
+
+.aurora-hero-2026 .aurora-kicker {
+  /* Long kickers must wrap on narrow viewports; hero has overflow:hidden. */
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .aurora-hero-copy h1 {
@@ -3164,7 +3193,15 @@ body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-butto
   }
 
   .aurora-hero-media img {
-    object-position: 62% 30%;
+    object-position: 88% 20%;
+  }
+
+  .aurora-home-2026 .aurora-hero-media img {
+    /* Tall mobile viewports already crop horizontally — drop the desktop zoom. */
+    left: 0;
+    right: 0;
+    width: 100%;
+    object-position: 88% 20%;
   }
 
   .aurora-hero-copy h1 {
@@ -4540,6 +4577,13 @@ body.aurora-theme :where(.aurora-kicker, .aurora-section-kicker, .aurora-hero-de
 
 body.aurora-theme :where(.aurora-kicker, .aurora-section-kicker) {
   color: var(--aurora-readable-accent) !important;
+}
+
+/* Full-bleed photo hero (krug-1 portrait): the legibility plates above would
+   paint a dark card over the photo; the hero scrim already handles contrast. */
+body.aurora-theme .aurora-hero-2026 :where(.aurora-hero-copy),
+body.aurora-theme .aurora-hero-2026 :where(.aurora-hero-copy h1, .aurora-hero-copy h2, #aurora-home-title, #aurora-about-title) {
+  background-color: transparent !important;
 }
 
 body.aurora-theme :where(.aurora-writing-pagination a, .aurora-writing-pagination .page-numbers, .aurora-writing-pagination .wp-block-query-pagination-previous, .aurora-writing-pagination .wp-block-query-pagination-next, .aurora-feed-link-grid a) {

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -4,40 +4,30 @@
 <main id="aurora-main" class="wp-block-group aurora-home-2026 aurora-home-revive aurora-keynote-first">
 
   <!-- wp:html -->
-  <section class="aurora-masthead" aria-labelledby="aurora-home-title" data-reveal>
-    <div class="aurora-masthead-rule">
-      <span>Vancouver, BC · Kris Krug</span>
-      <span class="aurora-masthead-date" data-live-date>Friday, July 24, 2026</span>
-    </div>
-    <div class="aurora-masthead-grid">
-      <div class="aurora-masthead-copy">
-        <p class="aurora-kicker">AI keynote speaker · Creative technologist · Community builder</p>
-        <h1 id="aurora-home-title">The model is the <span class="aurora-rainbow-word">message</span>.</h1>
-        <p class="aurora-masthead-dek">Kris Krug builds public-interest trust infrastructure for the age of generative intelligence — on stage, inside BC + AI, and at Futureproof Festival.</p>
-        <div class="aurora-action-row">
-          <a class="aurora-button aurora-button-primary" href="/services/">Work with me</a>
-          <a class="aurora-button aurora-button-secondary" href="/work/">Current work →</a>
-        </div>
+  <section class="aurora-hero-2026" aria-labelledby="aurora-home-title">
+    <figure class="aurora-hero-media" aria-label="Portrait of Kris Krüg">
+      <img
+        src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=2000&amp;ssl=1"
+        srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=640&amp;ssl=1 640w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=960&amp;ssl=1 960w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1280&amp;ssl=1 1280w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=1600&amp;ssl=1 1600w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/krug-1.jpg?w=2000&amp;ssl=1 2000w"
+        sizes="100vw"
+        alt="Portrait of Kris Krüg"
+        width="2000"
+        height="1827"
+        fetchpriority="high"
+        decoding="async"
+      >
+    </figure>
+    <div class="aurora-hero-scrim" aria-hidden="true"></div>
+    <div class="aurora-hero-copy" data-reveal>
+      <p class="aurora-kicker">AI keynote speaker · Creative technologist · Community builder</p>
+      <h1 id="aurora-home-title">The model is the <span class="aurora-rainbow-word">message</span>.</h1>
+      <p class="aurora-hero-dek">Kris Krug builds public-interest trust infrastructure for the age of generative intelligence — on stage, inside BC + AI, and at Futureproof Festival.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="/services/">Work with me</a>
+        <a class="aurora-button aurora-button-secondary" href="/work/">Current work →</a>
       </div>
-      <aside class="aurora-dossier" aria-label="At a glance">
-        <p class="aurora-kicker">At a glance</p>
-        <dl>
-          <div class="aurora-dossier-row"><dt>Based</dt><dd>Vancouver, BC</dd></div>
-          <div class="aurora-dossier-row"><dt>Building</dt><dd>BC + AI · Futureproof</dd></div>
-          <div class="aurora-dossier-row"><dt>Stages</dt><dd>140+ since 2004</dd></div>
-          <div class="aurora-dossier-row"><dt>Booking</dt><dd>2026 open</dd></div>
-        </dl>
-      </aside>
     </div>
   </section>
-
-  <figure class="aurora-stage-photo" aria-label="Kris Krug speaking on stage">
-    <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1600&amp;ssl=1" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=640&amp;ssl=1 640w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=960&amp;ssl=1 960w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1280&amp;ssl=1 1280w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1600&amp;ssl=1 1600w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=2200&amp;ssl=1 2200w" sizes="100vw" alt="Kris Krug presenting on stage at LaSalle College Vancouver" width="2200" height="1467" fetchpriority="high">
-    <figcaption class="aurora-stage-caption">
-      <span>▸ LaSalle College Vancouver · Both Hands Full</span>
-      <span class="aurora-hide-mobile">Photograph / working archive</span>
-    </figcaption>
-  </figure>
 
   <section class="aurora-proof-strip" id="stages" aria-labelledby="aurora-stages-label" data-reveal>
     <div class="aurora-proof-strip-inner">


### PR DESCRIPTION
## Summary
- Home: replace masthead + stage-band with `aurora-hero-2026` + full-res `krug-1.jpg` (media 2682); crop/zoom so left scrim copy clears the face; Revive light-ink over dark photo.
- About: same hero pattern in the content-architecture payload, hide template page-title H1, full-bleed breakout from the prose column, rooms/trail/CTA sections preserved.
- Aurora theme line bumped to **1.5.7** (already SFTP-deployed live; this PR syncs repo to live).

## Test plan
- [ ] Cache-bypass `/` and `/about/` show `aurora-hero-2026` + `krug-1.jpg?w=2000`, no `aurora-masthead` / `aurora-stage-photo` on home
- [ ] Desktop: face sits right; left copy readable over scrim
- [ ] Mobile: no horizontal overflow; face readable under scrim
- [ ] About: template H1 hidden; featured media still 2682; no body `h1` in payload
- [ ] Theme public readback: `style.css` Version 1.5.7

## Rollback
- Theme: rename `kk-aurora.bak-*` back to `kk-aurora` over SFTP
- About: restore from `backup/20260801-about-hero-bleed/`

## Notes
- Track B + Track A as two commits on one branch (hero composition spans both). Merge only after KK approval (theme/live-rendering).
- Pixel gate / visual-diff not re-run in this closeout; live screenshots verified via headless Chrome during the session.


Made with [Cursor](https://cursor.com)