### PR TITLE
content: curate testimonial set + rebuild payload (#598, #599)

### DIFF
--- a/content/drafts/2026-08-01-testimonials-overhaul/consent-log.md
+++ b/content/drafts/2026-08-01-testimonials-overhaul/consent-log.md
@@ -1,0 +1,127 @@
+# Consent log: testimonials showpiece v2 (TSTM-5, #598)
+
+Covers every quote shipped in `curated-set-v2.md`. Sub-issue of epic [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593). Status values match the #598 packet contract exactly: `T1-shipped`, `T2-shipped-logged`, `RAP-consented`, `PRESS-public`, `requested`, `pulled`.
+
+## Hard blocks: never publish, checked every pass
+
+| Name | Reason |
+|---|---|
+| William Jordan | RAP Cohort 1 consent tracker says no. Internal feedback only (RAP-12 in inventory). |
+| Stephanie McKay | RAP Cohort 1 consent tracker says no. Internal feedback only (RAP-13 in inventory). |
+| Any tilde or unresolved WhatsApp name | No legal name on file; Notion Phase 2 backlog. None admitted to `quote-inventory.md`, none in this log. |
+| "Anytime I see Kris at a conference, camera in hand…" attributed to Stewart Butterfield | Mis-attribution. That quote is Rob Cottingham's (LEG-ROB). Butterfield's only allowed line is the 2006 photography LinkedIn recommendation (BF-2006), Archive-only. |
+
+Verification: `rg -n 'William Jordan|Stephanie McKay' curated-set-v2.md` (run from the `content/drafts/2026-08-01-testimonials-overhaul/` directory) returns no matches; those two names only ever appear here, in the consent log, not in the curated set or payload.
+
+---
+
+## Shipped quotes: one row per card in curated-set-v2.md
+
+### Featured
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| LI-KERRIS-F | Kerris Hougardy | T1 | Public LinkedIn post (`kk-kb` capture 2026-06-20) | T1-shipped | n/a | Already live on page 2409. |
+| MT-01 | Simon Haworth | T1 | Meetup #10 feedback form, Oct 30 2024 | T1-shipped | n/a | Public event feedback form, named respondent. |
+| MT-23 | Arno Apeldoorn | T1 | Meetup #25 feedback form, Jan 28 2026 | T1-shipped | n/a | Public event feedback form, named respondent. |
+
+### Rooms
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| LI-LANDON | Landon Steele | T1 | Public LinkedIn post | T1-shipped | n/a | Already live on page 2409 (moved from Featured to Rooms this pass; see curated-set-v2.md judgment call 5). |
+| LI-CARLY | Carly Steiman | T1 | Public LinkedIn post | T1-shipped | n/a | Same move as above. |
+| LU30-SUZY | Suzy Easton | T1 | Vancouver AI Meetup #30 Luma survey | T1-shipped | n/a | Already live on page 2409. |
+| MT-20 | Jesse Benson | T1 | Meetup #19 feedback form, July 30 2025 | T1-shipped | n/a | Public event feedback form. |
+| MT-25 | Alex Samur | T1 | Meetup #25 feedback form | T1-shipped | n/a | Public event feedback form. |
+| MT-02 | Gus Santos | T1 | Meetup #10 feedback form | T1-shipped | n/a | Public event feedback form. |
+| SAT-01 | Pete Young | T2 | Ed + AI WhatsApp thread (Notion Master Directory capture) | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Inventory flags "DM before posting"; shipped per epic ruling (ship T2, log it, pull on request). |
+
+### Programs
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| LI-DAVID | David Gloyn-Cox | T1 | Public LinkedIn post | T1-shipped | n/a | Already live on page 2409. |
+| LI-FIANN | Fiann O'Hagan | T1 | Public LinkedIn post | T1-shipped | n/a | Already live on page 2409. |
+| LI-TAVIS | Tavis Yeung | T1 | Public LinkedIn post | T1-shipped | n/a | Already live on page 2409. |
+| RAP-02 | Brittney Ashley | RAP | Notion "RAP Cohort 1 Consent-Based Stories + Testimonials" | RAP-consented | n/a | Consent yes on file; value 10, recommend 10. |
+| RAP-03 | Daniel Bashaw | RAP | Notion RAP consent tracker | RAP-consented | n/a | Consent yes on file; value 10, recommend 10. |
+| RAP-05 | Rachel Krayenhoff | RAP | Notion RAP consent tracker | RAP-consented | n/a | Consent yes on file; value 10, recommend 10. |
+
+### Talks
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| KB-JAI | Jai Djwa | T1 | Repo keynote bank (`content/source-packs/keynotes-2026/testimonial-bank.md`) | T1-shipped | n/a | Already live on page 2409. |
+| KB-ED | Ed Kennedy | T1 | Repo keynote bank | T1-shipped | n/a | Already live on page 2409. |
+| REC-03 | Rob Cottingham | T1 | KK personal LinkedIn recommendations export, Oct 22 2009 | T1-shipped | n/a | Recommendation given directly to KK; public LinkedIn artifact. |
+| REC-04 | Marty Avery, P.C.C. | T1 | KK personal LinkedIn recommendations export, Nov 5 2009 | T1-shipped | n/a | Same as above. |
+| REC-05 | Kristen Hughes | T1 | KK personal LinkedIn recommendations export, Oct 20 2009 | T1-shipped | n/a | Same as above. |
+| REC-06 | Joel Solomon | T1 | KK personal LinkedIn recommendations export, Mar 13 2010 | T1-shipped | n/a | Same as above. |
+
+### Training
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| TR-01 | Jill Manuel | T2 | Notion Master Directory, AI training cohort bank | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Inventory says "confirm consent and original channel"; shipped per epic ruling. |
+| TR-02 | Harrison Reed | T2 | Notion Master Directory, AI training cohort bank | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Same as above. |
+| OH-02 | Becky Pallack | T2 | `data/testimonials/TESTIMONIAL_20251018_002.txt` | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Coaching-session feedback capture; consent status was unrecorded at capture time, shipped per epic ruling with log plus pull-on-request. |
+
+### Threads (T2)
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| WA-01 | Darren Nicholls | T2 | BC + AI Members WhatsApp export | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Shipped per epic ruling (ship T2, log it, pull on request). |
+| WA-09 | Sev Geraskin | T2 | BC + AI Members WhatsApp export | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Same as above. |
+| WA-10 | Peter Bowles | T2 | BC + AI Members WhatsApp export, 2025-07-31 | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | KK judgment call flagged in curated-set-v2.md and the PR body: profanity in the quote, shipped unedited. Flip to `pulled` and drop the card if KK says no. |
+
+### Film
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| LI-STEVE | Steve Jones, CFA | T1 | Public LinkedIn post, Jan 9 2026 | T1-shipped | n/a | Already live on page 2409. |
+| MT-13 | Tanya Slingsby | T1 | The Thinking Game premiere feedback form | T1-shipped | n/a | Public event feedback form. |
+| MT-14 | Yin Lau | T1 | The Thinking Game premiere feedback form | T1-shipped | n/a | Public event feedback form. |
+| SAT-03 | Kaoru Yoshihira | T2 | BC + AI Film Club WhatsApp / Notion Master Directory | T2-shipped-logged | outreach-standard-ask (template TBD, see #600) | Shipped per epic ruling. |
+
+### Archive
+
+| ID | Person | Tier | Source | Consent status | DM key | Notes |
+|---|---|---|---|---|---|---|
+| LEG-ROB | Rob Cottingham | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | Attribution lock: Cottingham, never Butterfield. |
+| LEG-JOSH | Joshua Dunford | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | n/a |
+| LEG-BEN | Benjamin Random | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | No verified LinkedIn match found in v1 research. |
+| LEG-COREY | Corey Dennis | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | Gnomedex-era; ambiguous modern profiles, left unlinked. |
+| LEG-CLAUDINE | Claudine Co | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | No verified LinkedIn match found. |
+| LEG-STEPH | Stephanie Vacher | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | n/a |
+| LEG-DANIE | Danie Peace | T1 | Live page 2409 (pre-existing) | T1-shipped | n/a | No verified LinkedIn match found. |
+| BF-2006 | Stewart Butterfield | T1 | KK personal LinkedIn recommendations export, Oct 23 2006 | T1-shipped | n/a | Archive-only, photography-context-only per epic hard rule. Never the conference/camera quote. |
+
+### Press band (institutional: `PRESS-public`, no personal consent needed)
+
+| ID | Item | Source | Consent status | Notes |
+|---|---|---|---|---|
+| PR-01 | Vancouver Magazine Power 50 | https://vanmag.com/city/power-50/introducing-vancouver-magazines-2026-power-50-list/ | PRESS-public | Third-party institutional recognition, not a personal quote. |
+| PR-appearance | CreativeMornings Vancouver | https://creativemornings.com/talks/kris-krug | PRESS-public | Official recording published by CreativeMornings HQ. |
+| PR-02 | BC Studies | DOI 10.14288/bcs.no224.199875 | PRESS-public | Peer-reviewed publication record. |
+
+**Count check:** 40 testimonial rows above (3 Featured, 7 Rooms, 6 Programs, 6 Talks, 3 Training, 3 Threads, 4 Film, 8 Archive) plus 3 press rows equals 43 logged items, matching `curated-set-v2.md`.
+
+---
+
+## Requested / excluded: consent or identity ambiguous, left out of the curated set
+
+| ID | Person | Tier | Consent status | Reason |
+|---|---|---|---|---|
+| MT-30 | Aynsley Vogel | T1 survey, naming ambiguous | requested | Answered the original Meetup #25 survey anonymously; identified afterward by cross-reference (`kk-kb` person profile). Publishing her name on a previously-anonymous line needs her confirmation first. Quote itself is otherwise strong (quality 5). |
+| MT-24 | Ishtar Beck | T1 quote, LinkedIn match ambiguous | requested | Quote itself is a normal named survey response, no consent issue. The LinkedIn URL #595 found carries an explicit "KK confirm logged-in before public use" flag (name and city match only, no role anchor to cross-check). Left out of this pass entirely rather than ship a half-verified link. |
+
+All T3-tier rows in `quote-inventory.md` (unresolved surnames, unverified sources, "verify from raw CSV" flags: Armin, Quine, Talib Khan, David Weng, Claudia/Moren/Emily with unresolved surnames, OH-03/04/11/12, OH-13/14, Kuo Hsiung Cho) are excluded as a class, same `requested`-equivalent logic, not itemized individually here since none of them were close enough to shipping to need a per-row entry. See the inventory's own "Hard-block and caution summary" table for the full unresolved-name list.
+
+---
+
+## Verification
+
+- `rg -n 'William Jordan|Stephanie McKay' ../curated-set-v2.md` (run from this directory) returns no matches.
+- `rg -c 'T2-shipped-logged|RAP-consented|T1-shipped|PRESS-public' consent-log.md` returns a non-zero count (40 shipped rows plus 3 press rows use these four statuses).
+- Butterfield appears exactly once in `curated-set-v2.md` (BF-2006, Archive) and once here, never paired with the conference/camera quote.

--- a/content/drafts/2026-08-01-testimonials-overhaul/curated-set-v2.md
+++ b/content/drafts/2026-08-01-testimonials-overhaul/curated-set-v2.md
@@ -1,0 +1,173 @@
+# Curated set v2: testimonials showpiece (TSTM-5, #598)
+
+Sub-issue of epic [#593](https://github.com/WalksWithASwagger/kriskrug-wp/issues/593). Reads `quote-inventory.md` (#594), `linkedin-gaps.md` (#595), and `copy-v2.md` (#597); does not edit them. Does not touch payload HTML, theme CSS, or live WP. This file supersedes v1's `curated-set.md` for shipping purposes; v1 stays in the tree as history (not deleted).
+
+**Total: 40 testimonial cards** (top of the 35 to 40 target), plus 3 institutional press-band lines that are not counted toward the 40 (see requirement below). Section order and labels match the locked order on #593 and the headings in `copy-v2.md` exactly.
+
+**Voice rule:** every quote below is verbatim from `quote-inventory.md`, trimmed only with `…` where noted. No paraphrasing. Third-party quotes keep whatever punctuation the source used, including hyphens and dashes inside their own words; that's their voice, not house copy.
+
+**Consent:** every row below has a matching entry in `consent-log.md`. The two RAP Cohort 1 consent decliners and every unresolved/tilde name are excluded from this file entirely, not just marked off; see `consent-log.md` for the named hard-block list.
+
+---
+
+## 1. Hero + stats
+
+No quotes. Hero copy, kicker, and the six stat chips are owned by `copy-v2.md` (#597). Nothing to curate here.
+
+## 2. Press band (institutional, not personal testimonials)
+
+Descriptive third-party recognition lines, not attributed quotes from a person. Copy already finalized in `copy-v2.md` section 2; repeated here only so #599 has one place to confirm consent basis (`PRESS-public`, no personal consent needed since this is public press and record).
+
+| Item | Line | Source |
+|---|---|---|
+| Vancouver Magazine Power 50 | Named to Vancouver Magazine's 2026 Power 50 list. | https://vanmag.com/city/power-50/introducing-vancouver-magazines-2026-power-50-list/ |
+| CreativeMornings | Delivered the Punk Rock AI keynote at CreativeMornings Vancouver, Vancouver Art Gallery, May 2026. Official recording published by CreativeMornings HQ. | https://creativemornings.com/talks/kris-krug |
+| BC Studies | Co-authored the peer-reviewed article "Building a Grass Roots AI Community of Practice: A Vancouver-Centered Use Case," BC Studies No. 224, Winter 2024/25. | DOI 10.14288/bcs.no224.199875; https://ojs.library.ubc.ca/index.php/bcstudies/article/view/199875 |
+
+## 3. Featured: exactly 3, oversized
+
+Per the #598 packet's own recommendation: Simon (Meetup #10), Kerris, Arno. KK may swap any of these; flagged again below in "Judgment calls."
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| LI-KERRIS-F | "Two things can be true at once. AI is here and I'm going to keep enabling it across our teams. And it can be done responsibly, with humans first, by people who treat that as the actual job rather than a disclaimer at the bottom of a deck." | Kerris Hougardy, MBA. Responsible AI Professional, Cohort 1. | T1 | https://www.linkedin.com/in/kerrishougardy/ |
+| MT-01 | "I am stumped. I arrive in Vancouver and stumble upon this strange and colourful community that has done more for my BC network than any conference. Am baffled to think: is there ANY other event where I can let my hair down, bring my music-loving wife, my media manic elder daughter, my business buddies innovating biotech and deep, deep science plus my youngest, the TikTok addict? I can't think of anything quite like it. Come and find out for yourself." | Simon Haworth. Vancouver AI Meetup #10, Oct 2024. | T1 | https://ca.linkedin.com/in/simon-haworth-uk-us-prc |
+| MT-23 | "Something is happening here. The energetic dialogue at these events is hard to describe. It feels like we are witnessing the creation of something special, here in Vancouver, as the whole world figures out how to embrace AI." | Arno Apeldoorn. Vancouver AI Meetup #25, Jan 2026. | T1 | plain text (no verified URL) |
+
+Note: Simon Haworth's URL is the corrected `-uk-us-prc` slug per the #595 flag (old `linkedin.com/in/simon-haworth` now 404s). Use this URL for every Simon Haworth cite on the page.
+
+## 4. Rooms: community and rooms
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| LI-LANDON | "FWIW, the BC + AI Ecosystem, of which I'm a member, is different than any other AI group I'm aware of — full of artists and creatives, filmmakers and indigenous voices, as well as deep tech experts and entrepreneurs. It holds space for both wonder and scepticism around AI without veering too far one way or the other." | Landon Steele. Steele Consulting Group. | T1 | https://www.linkedin.com/in/landonsteele |
+| LI-CARLY | "Kris Krüg has built something important for our community." | Carly Steiman. Founder, Workbee Home Services. | T1 | https://www.linkedin.com/in/carlysteiman/ |
+| LU30-SUZY | "The opening grounding … made the rest of the night feel that before anyone says 'agentic workflow,' remember whose land, whose water, whose stories, whose labour, and whose data we are standing on. … Rock on, Mr KK!" | Suzy Easton. Vancouver AI Meetup #30. | T1 | https://www.linkedin.com/in/suzyeaston |
+| MT-20 | "Kris Krüg, thank you for an outstanding event! Your clear, energetic hosting made it one of the most engaging, community-focused AI meetups I've ever attended. The interactive format and tight-knit atmosphere fostered real connections—and I even lucked into meeting the perfect collaborator for my AI project." | Jesse Benson. Vancouver AI Meetup #19, July 2025. | T1 | https://www.linkedin.com/in/jesse-robert-benson/ |
+| MT-25 | "Kris! This was my first time at the meet up and I had such a great time. I loved the community vibe and I love your energy …so fun to watch you in action! I will definitely be back and I'm looking into a membership" | Alex Samur. Vancouver AI Meetup #25. | T1 | https://www.linkedin.com/in/alexandrasamur |
+| MT-02 | "This must be the most enticing event I've been to in a long time. I was probably more impressed by the speakers who disturbed me than the ones I agreed with. This conversation is so important, and yet too limited in our everyday lives. I will be attending every single event I can." | Gus Santos. Vancouver AI Meetup #10. | T1 | plain text (no verified URL) |
+| SAT-01 | "I went to my first Vancouver AI community meetup event last month and it was buzzing with energy… Truly inspired." | Pete Young. Educator, Ed + AI thread. | T2 | https://www.linkedin.com/in/pete-young-8a7a89a5 |
+
+Note: LI-LANDON and MT-20 keep their source's own em dash, preserved verbatim (not house copy). LI-LANDON and LI-CARLY are the two v1 Featured picks not carried into Featured this pass (see judgment call 5); moved here since their inventory row proposes "Featured / Rooms" as the placement.
+
+## 5. Programs: Responsible AI Professional, Cohort 1
+
+RAP tier rows are consent-yes per the Notion consent tracker (11 of 13 in the cohort consented; the 2 decliners are the hard-block names in `consent-log.md`, excluded from this entire packet). LI-* rows are the same cohort members' own public LinkedIn posts, a separate and independent consent basis.
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| LI-DAVID | "So pleased to have completed this course, the guidance was amazing, and the final capstone was a chance to explore responsible AI. If you want to round out your understanding of ethics, and responsible AI, this is well worth the time." | David Gloyn-Cox. Enterprise Architect. | T1 | https://www.linkedin.com/in/dreffed |
+| LI-FIANN | "The course delivers very important insights into risks of large scale AI deployments. … Highly recommended for anyone who has a stake in the responsible use of PII data, environmental impact, and good governance of AI projects." | Fiann O'Hagan. Web analytics and performance. | T1 | https://www.linkedin.com/in/fiann/ |
+| LI-TAVIS | "Four weeks of asking the hard questions about deploying AI responsibly, applying real frameworks to real systems. Moving fast with AI without being reckless." | Tavis Yeung. Digital Marketing Innovation. | T1 | https://www.linkedin.com/in/tavisyeung/ |
+| RAP-02 | "It changed how I think about my work, and I left feeling proud of how I show up with AI." | Brittney Ashley. RAP Cohort 1, Creative Dynamics. | RAP | https://www.linkedin.com/in/brittneyashley |
+| RAP-03 | "RAP gives you a zoomable drone's-eye view of the entire AI ethics and governance landscape." | Daniel Bashaw. RAP Cohort 1. | RAP | https://www.linkedin.com/in/danbashaw |
+| RAP-05 | "This course revealed all of the critical elements of responsible AI use that are nowhere to be found in regular AI content." | Rachel Krayenhoff. RAP Cohort 1, AI practitioner. | RAP | https://www.linkedin.com/in/rachel-krayenhoff |
+
+Kerris is not repeated here (already Featured); keeps the same three Featured names from also carrying a second card elsewhere on the wall.
+
+## 6. Talks: keynotes and guest sessions
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| KB-JAI | "Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers." | Jai Djwa | T1 | https://www.linkedin.com/in/djwa/ |
+| KB-ED | "Kris's talk and event design felt like a masterclass in community organizing." | Ed Kennedy | T1 | https://www.linkedin.com/in/kennedy-ed/ |
+| REC-03 | "Kris is one of Vancouver's brightest lights at the intersection of culture and online technology. Visionary, creative, fearless and articulate, he electrifies audiences with the sense of humour, curiosity and possibility that he brings to his breathtaking range of creative endeavours." | Rob Cottingham, 2009. | T1 | https://www.linkedin.com/in/robcottingham |
+| REC-04 | "Kris is an adept speaker, facilitator and prophet who helps you to step into a future that is already here waiting for you--but you couldn't quite reach on your own. … Any community, any individual, any business will be better off once they've involved Kris. He's a force of nature." | Marty Avery, P.C.C. Executive and leadership coach. | T1 | https://www.linkedin.com/in/martyavery |
+| REC-05 | "He embraced the whole community. He brought his big heart, his boundless energy, his amazing mind and his unflagging generosity. … He has been asked back to PopTech for years now." | Kristen Hughes. PopTech. | T1 | https://www.linkedin.com/in/kristen-hughes-b403705 |
+| REC-06 | "Kris is an exceptional translator, facilitator, and activator, for the democratic power of social media and related technologies and community impact." | Joel Solomon. Renewal Funds. | T1 | https://www.linkedin.com/in/joel-solomon-a5a4b5 |
+
+Cottingham appears twice on the page (here, and again in Archive as LEG-ROB). Different quotes, 15 years apart, same long relationship; flagged in "Judgment calls," not an error.
+
+## 7. Training: workshops that use your real work
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| TR-01 | "This course was a game changer for me. I learned how to use multiple AI tools for content creation, PR, and marketing in a thoughtful, ethical, and practical way… If you are a busy professional who feels left behind by AI because you don't have time to understand it, this class is for you." | Jill Manuel. JCat Group. | T2 | https://www.linkedin.com/in/jillannmanuel/ |
+| TR-02 | "Peter and Kris are the dynamic duo that everyone dreams about collaborating with… My mind has been blown away at what I've been able to takeaway from this course and it's empowered me to go full time as my own boss for my own company." | Harrison Reed. Digital Marketing Specialist. | T2 | plain text (no verified URL) |
+| OH-02 | "Coaching calls were good. … Coach Kris was enthusiastic about my idea and helpful with showing me some next steps and pre-made tools." | Becky Pallack. AI for Creative Pros student. | T2 | plain text (no verified URL) |
+
+## 8. Threads (T2): said in the group chat
+
+Every card here has a `T2-shipped-logged` row in `consent-log.md` per the epic's ruling: ship good T2 lines now, log them, pull on request.
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| WA-01 | "Co Founders including James McKenzie who I only met thanks to Kris Krüg's amazing VanAI meetup almost a year ago!!!" | Darren Nicholls. BC + AI Members. | T2 | https://www.linkedin.com/in/darren-nicholls |
+| WA-09 | "Authentically demonstrating what it means to be human, nothing more, nothing less." | Sev Geraskin. BC + AI Members. | T2 | plain text (no verified URL) |
+| WA-10 | "So please keep this up everyone! Don't fucking stop, this work is so necessary and I'm so inspired by you all." | Peter Bowles. UpSpiral founder. | T2 | plain text (no verified URL) |
+
+**KK judgment call, Peter Bowles (WA-10):** included, unedited, per packet instruction to call this out rather than decide silently. Reasoning below in "Judgment calls." KK can pull it with one line removed from the payload plus a `pulled` status flip in the consent log.
+
+## 9. Film: Film Club nights
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| LI-STEVE | "The room was packed and the program was a blend of entertaining films, short technical tutorials, and thoughtful discussion about where the industry is heading. … The room last night was full of people re-inventing themselves and their industries and looking for ways to rebuild better." | Steve Jones, CFA. BC + AI Film Club. | T1 | https://www.linkedin.com/in/jonessteven |
+| MT-13 | "This was our first event and really enjoyed the film and the speakers. We will be back, thank you!" | Tanya Slingsby. The Thinking Game premiere. | T1 | plain text (no verified URL) |
+| MT-14 | "Really good. Great documentary. So glad I came. The panel afterwards was also amazing. Such a good conversation, great questions and fantastic answers. Would love to see more of these film sessions." | Yin Lau. The Thinking Game premiere. | T1 | plain text (no verified URL) |
+| SAT-03 | "Such an inspiring event! Can't wait to team up… The best is yet to come!" | Kaoru Yoshihira. BC + AI Film Club. | T2 | https://jp.linkedin.com/in/kaoruyoshihira |
+
+## 10. Archive: photography and connector years
+
+Unchanged from the v1 legacy set (already live, already reviewed) plus one epic-sanctioned addition (Butterfield, photography-only).
+
+| ID | Quote | Person and context | Tier | LinkedIn |
+|---|---|---|---|---|
+| LEG-ROB | "Anytime I see Kris at a conference, camera in hand, my heart lifts a little… Seeing the event through Kris' eyes is like doing it all over again… only better." | Rob Cottingham | T1 | https://www.linkedin.com/in/robcottingham |
+| LEG-JOSH | "A lesson in 'getting stuff done', kris is one of those people who seems to make the impossible possible – and manages to keep a few cards up his sleeve in the process." | Joshua Dunford. BURNKIT. | T1 | https://www.linkedin.com/in/joshdunford |
+| LEG-BEN | "Not pretentious but genuinely connected. Kris brings out the best in others and connects those around him." | Benjamin Random | T1 | plain text (no verified URL) |
+| LEG-COREY | "Kris is many things to many people. He gives good friend. He gives good birthday. He gives good debate, good gnomedex, good podcast, good video, good advice, good vancouver, good sxsw, and good revolution. Some say Canada is the new black. I say it's Kris." | Corey Dennis | T1 | plain text (no verified URL) |
+| LEG-CLAUDINE | "Kris takes breathtaking, lyrical and gorgeous pictures." | Claudine Co | T1 | plain text (no verified URL) |
+| LEG-STEPH | "Kris is unstoppable, except by large objects too heavy to move." | Stephanie Vacher | T1 | https://www.linkedin.com/in/stephanievacher |
+| LEG-DANIE | "A search for 'Flaming Lips' brought me to KK, his friends and one of the best ever photos of the band. … Continue to live big Kris… the next generation is watching." | Danie Peace | T1 | plain text (no verified URL) |
+| BF-2006 | "This kid can take photos - wow! - he's really good, and also a great person to be around. Thumbs up for Kris." | Stewart Butterfield. Co-founder, Flickr / Slack (2006 LinkedIn rec). | T1 | https://www.linkedin.com/in/butterfield/ |
+
+**Attribution lock, repeated on purpose:** LEG-ROB is Rob Cottingham, never Butterfield. BF-2006 is the only Butterfield line on the page, Archive-only, photography-context-only. The two must never be merged or swapped.
+
+## 11. CTA
+
+No quotes. CTA copy owned by `copy-v2.md` (#597).
+
+---
+
+## Ship tally
+
+| Section | IDs | Count |
+|---|---|---:|
+| Featured | LI-KERRIS-F, MT-01, MT-23 | 3 |
+| Rooms | LI-LANDON, LI-CARLY, LU30-SUZY, MT-20, MT-25, MT-02, SAT-01 | 7 |
+| Programs | LI-DAVID, LI-FIANN, LI-TAVIS, RAP-02, RAP-03, RAP-05 | 6 |
+| Talks | KB-JAI, KB-ED, REC-03, REC-04, REC-05, REC-06 | 6 |
+| Training | TR-01, TR-02, OH-02 | 3 |
+| Threads (T2) | WA-01, WA-09, WA-10 | 3 |
+| Film | LI-STEVE, MT-13, MT-14, SAT-03 | 4 |
+| Archive | LEG-ROB, LEG-JOSH, LEG-BEN, LEG-COREY, LEG-CLAUDINE, LEG-STEPH, LEG-DANIE, BF-2006 | 8 |
+| **Total testimonial cards** | | **40** |
+| Press band (separate, institutional) | Power 50, CreativeMornings, BC Studies | 3 |
+
+LinkedIn-linked: 28 of 40 (70%). Plain text: 12 of 40; every one of those 12 is `MISSING` in `linkedin-gaps.md` or was never researched there (the Bobby Motamed / Manny Minhas class). No slug was guessed for any of them.
+
+---
+
+## Judgment calls for KK
+
+1. **Featured three.** Shipped the packet's own recommendation (Simon Haworth via the Meetup #10 quote MT-01, Kerris via LI-KERRIS-F, Arno Apeldoorn via MT-23). All three are quality-5, named, T1. Swap freely; nothing else in the payload depends on which three are oversized.
+2. **Peter Bowles profanity (WA-10).** Shipped as-is, unedited ("Don't fucking stop…"). Call: the Threads section exists specifically to hold real group-chat voice that's rawer than LinkedIn copy, the line is enthusiastic and on-message (not an attack on anyone), and editing someone else's quote to sand off a swear word is its own kind of dishonesty about what they said. Recommend include. One-line pull if KK disagrees: flip `consent-log.md` status to `pulled` and drop the card from the payload.
+3. **Rob Cottingham, two placements.** REC-03 (Talks, 2009 LinkedIn rec about his stage presence) and LEG-ROB (Archive, the "camera in hand" quote already live and under the Butterfield attribution lock). Different quotes, different eras, same long relationship; not a duplication bug.
+4. **Simon Haworth, one placement not two.** He has two strong quotes in the inventory (MT-01 from Meetup #10, LU30-SIMON from Meetup #30). Only MT-01 is used (Featured) so the same name doesn't carry two cards; LU30-SIMON sits on the bench below if KK wants both.
+5. **Landon Steele and Carly Steiman moved from Featured to Rooms.** Both were 2 of v1's 3 Featured picks (already live, quality 5, FOUND LinkedIn). The #598 packet recommends Simon/Kerris/Arno for the new Featured three, so Landon and Carly moved to Rooms instead of dropping out of the curated set entirely; their inventory row lists "Featured / Rooms" as the proposed section, so this is a same-pass reassignment, not a demotion out of the page.
+
+## Bench: strong alternates not used this pass (no blocker, just not selected for the 40-card cap)
+
+- **Programs:** RAP-06 Allan Baedak, RAP-07 Bobby Motamed, RAP-08 Melisa DiPietro (LinkedIn FOUND: `https://ca.linkedin.com/in/meldip`), RAP-09 Manny Minhas. All RAP-consented, all usable.
+- **Talks:** REC-15 Len Edgerly, REC-16 Andrea Canadeo, KB-AUD1, KB-AUD2 (labeled audience feedback, already live).
+- **Training:** OH-01 Don Halcombe (T2, quality 3; trimmed well but bumped for a tighter section).
+- **Threads:** WA-02 Miranda Alldritt, WA-04 Kevin Friel, WA-05 carla ritchie (LinkedIn FOUND: `https://ca.linkedin.com/in/carla-ritchie-mba-8ba5851a3`), WA-06 David Griffith, WA-07 Manuj Aggarwal.
+- **Film:** WA-08 Matt Lambert.
+- **Rooms:** LU30-SIMON (see judgment call 4 above), MT-10 Sean Copeland (T1, quality 4; bumped to make room for Landon and Carly).
+
+## Excluded on consent grounds, not just "not picked": see `consent-log.md` for full detail
+
+- **MT-30 Aynsley Vogel.** Quality-5 quote, but she answered the original survey anonymously; a later cross-reference identified her. Publishing her name on a previously-anonymous line without asking her first is a real consent problem, not a quality one. Logged `requested`, left out.
+- **MT-24 Ishtar Beck.** The quote itself is a normal named T1 survey response (no consent issue). The LinkedIn URL #595 found for her carries an explicit "confirm logged-in before public use" flag (name and city match only, no role anchor). Left the URL out; the quote itself could ship plain-text if KK wants her in a future pass.
+- **All T3-tier rows** (unresolved surnames, unverified identity, or "verify source" flags in the inventory: Armin, Quine, Talib Khan, David Weng, Claudia/Moren/Emily with unresolved surnames, OH-03/04/11/12, OH-13/14, Kuo Hsiung Cho pending name-order confirmation). Excluded as a class. Ambiguous identity is a different failure mode than ambiguous consent, but the effect is the same: not safe to publish yet.

--- a/content/source-packs/content-architecture-2026/wp-payloads/page-map.json
+++ b/content/source-packs/content-architecture-2026/wp-payloads/page-map.json
@@ -54,15 +54,15 @@
     "url": "https://kriskrug.co/testimonials/",
     "payload": "testimonials.html",
     "markers": [
-      "Proof from the rooms, stages, and cohorts",
-      "Responsible AI Professional — Cohort 1",
-      "Photography and connector years",
+      "Proof with names attached.",
+      "Responsible AI Professional, Cohort 1.",
+      "The photography and connector years.",
+      "aurora-tstm",
       "aurora-quote-card",
       "Kerris Hougardy",
       "Simon Haworth",
-      "Suzy Easton",
-      "landonsteele",
-      "joshdunford"
+      "Said in the group chat.",
+      "kaoruyoshihira"
     ]
   }
 }

--- a/content/source-packs/content-architecture-2026/wp-payloads/testimonials.html
+++ b/content/source-packs/content-architecture-2026/wp-payloads/testimonials.html
@@ -1,153 +1,320 @@
 <!-- wp:html -->
-<!-- content-architecture-2026:testimonials -->
-<div class="aurora-testimonials-page">
-  <section class="aurora-speaking-hero" aria-labelledby="aurora-testimonials-title">
+<!-- content-architecture-2026:testimonials-v2 (#599, TSTM-6) -->
+<div class="aurora-testimonials-page aurora-tstm">
+
+  <section class="aurora-tstm-hero aurora-speaking-hero" aria-labelledby="aurora-testimonials-title">
     <div class="aurora-speaking-hero-copy">
       <p class="aurora-kicker">What people say</p>
-      <h2 id="aurora-testimonials-title">Proof from the rooms, stages, and cohorts.</h2>
-      <p>From Responsible AI classrooms and Vancouver meetups back through the photography and connector years — these are lines people put their names on. AI-era voices first; the archive stays honest about the path that got here.</p>
+      <h2 id="aurora-testimonials-title">Proof with names attached.</h2>
+      <p>What people say after the meetups, the cohorts, and the keynotes, plus the photography years that got me here. Real names, linked sources, nothing invented.</p>
       <div class="aurora-action-row">
         <a class="aurora-button aurora-button-primary" href="/contact/">Book a conversation</a>
         <a class="aurora-button aurora-button-secondary" href="/speaking/">Speaking</a>
       </div>
     </div>
+    <div class="aurora-tstm-stats" aria-label="BC + AI Ecosystem, by the numbers">
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">300</p>
+        <p class="aurora-tstm-stat-label">paid members, BC + AI Ecosystem Association</p>
+      </div>
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">3,000+</p>
+        <p class="aurora-tstm-stat-label">participants across the ecosystem</p>
+      </div>
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">94+</p>
+        <p class="aurora-tstm-stat-label">documented events</p>
+      </div>
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">31</p>
+        <p class="aurora-tstm-stat-label">monthly Vancouver AI meetups and counting</p>
+      </div>
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">9.5/10</p>
+        <p class="aurora-tstm-stat-label">Responsible AI Professional course rating, Cohort 1</p>
+      </div>
+      <div class="aurora-tstm-stat aurora-card">
+        <p class="aurora-tstm-stat-number">~2,400</p>
+        <p class="aurora-tstm-stat-label">attendees across 2024 events</p>
+      </div>
+    </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-featured">
+  <section class="aurora-tstm-press aurora-proof-section" aria-label="On the record">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">On the record</p>
+      <p>Not every receipt is a pull quote. Some of it is recognition, a stage, or peer review.</p>
+    </div>
+    <ul class="aurora-tstm-press-list">
+      <li class="aurora-tstm-press-item aurora-card">
+        <p><strong>Vancouver Magazine Power 50</strong></p>
+        <p>Named to Vancouver Magazine's 2026 Power 50 list.</p>
+        <p><a href="https://vanmag.com/city/power-50/introducing-vancouver-magazines-2026-power-50-list/" target="_blank" rel="noopener noreferrer">Read the list</a></p>
+      </li>
+      <li class="aurora-tstm-press-item aurora-card">
+        <p><strong>CreativeMornings</strong></p>
+        <p>Delivered the Punk Rock AI keynote at CreativeMornings Vancouver, Vancouver Art Gallery, May 2026. Official recording published by CreativeMornings HQ.</p>
+        <p><a href="https://creativemornings.com/talks/kris-krug" target="_blank" rel="noopener noreferrer">Watch the talk</a></p>
+      </li>
+      <li class="aurora-tstm-press-item aurora-card">
+        <p><strong>BC Studies</strong></p>
+        <p>Co-authored the peer-reviewed article "Building a Grass Roots AI Community of Practice: A Vancouver-Centered Use Case," BC Studies No. 224, Winter 2024/25.</p>
+        <p><a href="https://ojs.library.ubc.ca/index.php/bcstudies/article/view/199875" target="_blank" rel="noopener noreferrer">Read the article</a></p>
+      </li>
+    </ul>
+  </section>
+
+  <section class="aurora-tstm-featured aurora-proof-section" aria-labelledby="aurora-testimonials-featured">
     <div class="aurora-section-heading">
       <p class="aurora-kicker">Featured</p>
-      <h2 id="aurora-testimonials-featured">The lines that carry the current era.</h2>
-      <p>Recent voices from the Responsible AI Professional cohort and the BC + AI community — human-first adoption, rooms that hold wonder and scepticism, and a community people credit as real.</p>
+      <h2 id="aurora-testimonials-featured">Start with three.</h2>
+      <p>Three voices from the current era, quoted at full strength. The rest of the page backs them up.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three" aria-label="Featured testimonials">
-      <blockquote class="aurora-quote-card">
+    <div class="aurora-tstm-wall aurora-quote-grid aurora-quote-grid-three" aria-label="Featured testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Two things can be true at once. AI is here and I'm going to keep enabling it across our teams. And it can be done responsibly, with humans first, by people who treat that as the actual job rather than a disclaimer at the bottom of a deck.”</p>
-        <cite><a href="https://www.linkedin.com/in/kerrishougardy/" target="_blank" rel="noopener noreferrer">Kerris Hougardy, MBA</a> · Responsible AI Professional, Cohort 1</cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/kerrishougardy/" target="_blank" rel="noopener noreferrer">Kerris Hougardy, MBA</a> · <span class="aurora-tstm-chip">Responsible AI Professional, Cohort 1</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“The BC + AI Ecosystem … is different than any other AI group I'm aware of — full of artists and creatives, filmmakers and indigenous voices, as well as deep tech experts and entrepreneurs. It holds space for both wonder and scepticism around AI without veering too far one way or the other.”</p>
-        <cite><a href="https://www.linkedin.com/in/landonsteele" target="_blank" rel="noopener noreferrer">Landon Steele</a> · Steele Consulting Group</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“I am stumped. I arrive in Vancouver and stumble upon this strange and colourful community that has done more for my BC network than any conference. Am baffled to think: is there ANY other event where I can let my hair down, bring my music-loving wife, my media manic elder daughter, my business buddies innovating biotech and deep, deep science plus my youngest, the TikTok addict? I can't think of anything quite like it. Come and find out for yourself.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://ca.linkedin.com/in/simon-haworth-uk-us-prc" target="_blank" rel="noopener noreferrer">Simon Haworth</a> · <span class="aurora-tstm-chip">Vancouver AI Meetup #10</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“Kris Krüg has built something important for our community.”</p>
-        <cite><a href="https://www.linkedin.com/in/carlysteiman/" target="_blank" rel="noopener noreferrer">Carly Steiman</a> · Founder, Workbee Home Services</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Something is happening here. The energetic dialogue at these events is hard to describe. It feels like we are witnessing the creation of something special, here in Vancouver, as the whole world figures out how to embrace AI.”</p>
+        <cite class="aurora-tstm-cite">Arno Apeldoorn · <span class="aurora-tstm-chip">Vancouver AI Meetup #25</span></cite>
       </blockquote>
     </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-talks">
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-rooms">
     <div class="aurora-section-heading">
-      <p class="aurora-kicker">Talks &amp; teaching</p>
-      <h2 id="aurora-testimonials-talks">Stages, classrooms, and design rooms.</h2>
-      <p>What happens when a keynote or guest session leaves people with language and moves they can use — not just a temporary spark.</p>
+      <p class="aurora-kicker">Community and rooms</p>
+      <h2 id="aurora-testimonials-rooms">The monthly rooms.</h2>
+      <p>Vancouver AI at the Space Centre, office hours, and the regulars who keep showing up. Written by people who were in the seats, not by me.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three" aria-label="Talks and teaching testimonials">
-      <blockquote class="aurora-quote-card">
-        <p>“Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers.”</p>
-        <cite><a href="https://www.linkedin.com/in/djwa/" target="_blank" rel="noopener noreferrer">Jai Djwa</a></cite>
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Rooms testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“FWIW, the BC + AI Ecosystem, of which I'm a member, is different than any other AI group I'm aware of — full of artists and creatives, filmmakers and indigenous voices, as well as deep tech experts and entrepreneurs. It holds space for both wonder and scepticism around AI without veering too far one way or the other.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/landonsteele" target="_blank" rel="noopener noreferrer">Landon Steele</a> · <span class="aurora-tstm-chip">Steele Consulting Group</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“Kris's talk and event design felt like a masterclass in community organizing.”</p>
-        <cite><a href="https://www.linkedin.com/in/kennedy-ed/" target="_blank" rel="noopener noreferrer">Ed Kennedy</a></cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris Krüg has built something important for our community.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/carlysteiman/" target="_blank" rel="noopener noreferrer">Carly Steiman</a> · <span class="aurora-tstm-chip">Founder, Workbee Home Services</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“Visceral, real, and incredibly current. Truly authentic and up to date.”</p>
-        <cite>Audience feedback</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“The opening grounding … made the rest of the night feel that before anyone says 'agentic workflow,' remember whose land, whose water, whose stories, whose labour, and whose data we are standing on. … Rock on, Mr KK!”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/suzyeaston" target="_blank" rel="noopener noreferrer">Suzy Easton</a> · <span class="aurora-tstm-chip">Vancouver AI Meetup #30</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris Krüg, thank you for an outstanding event! Your clear, energetic hosting made it one of the most engaging, community-focused AI meetups I've ever attended. The interactive format and tight-knit atmosphere fostered real connections—and I even lucked into meeting the perfect collaborator for my AI project.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/jesse-robert-benson/" target="_blank" rel="noopener noreferrer">Jesse Benson</a> · <span class="aurora-tstm-chip">Vancouver AI Meetup #19</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris! This was my first time at the meet up and I had such a great time. I loved the community vibe and I love your energy …so fun to watch you in action! I will definitely be back and I'm looking into a membership”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/alexandrasamur" target="_blank" rel="noopener noreferrer">Alex Samur</a> · <span class="aurora-tstm-chip">Vancouver AI Meetup #25</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“This must be the most enticing event I've been to in a long time. I was probably more impressed by the speakers who disturbed me than the ones I agreed with. This conversation is so important, and yet too limited in our everyday lives. I will be attending every single event I can.”</p>
+        <cite class="aurora-tstm-cite">Gus Santos · <span class="aurora-tstm-chip">Vancouver AI Meetup #10</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“I went to my first Vancouver AI community meetup event last month and it was buzzing with energy… Truly inspired.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/pete-young-8a7a89a5" target="_blank" rel="noopener noreferrer">Pete Young</a> · <span class="aurora-tstm-chip">Educator, Ed + AI thread</span></cite>
       </blockquote>
     </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-programs">
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-programs">
     <div class="aurora-section-heading">
       <p class="aurora-kicker">Programs</p>
-      <h2 id="aurora-testimonials-programs">Responsible AI Professional — Cohort 1.</h2>
-      <p>Four weeks of frameworks, hard questions, and a hands-on capstone. Graduates speaking in their own words about ethics, governance, and shipping without being reckless.</p>
+      <h2 id="aurora-testimonials-programs">Responsible AI Professional, Cohort 1.</h2>
+      <p>Four weeks of frameworks, hard questions, and a capstone with your name on it. Graduates on what actually stuck.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three" aria-label="Responsible AI Professional testimonials">
-      <blockquote class="aurora-quote-card">
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Programs testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“So pleased to have completed this course, the guidance was amazing, and the final capstone was a chance to explore responsible AI. If you want to round out your understanding of ethics, and responsible AI, this is well worth the time.”</p>
-        <cite><a href="https://www.linkedin.com/in/dreffed" target="_blank" rel="noopener noreferrer">David Gloyn-Cox</a> · Enterprise Architect</cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/dreffed" target="_blank" rel="noopener noreferrer">David Gloyn-Cox</a> · <span class="aurora-tstm-chip">Enterprise Architect</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“The course delivers very important insights into risks of large scale AI deployments. … Highly recommended for anyone who has a stake in the responsible use of PII data, environmental impact, and good governance of AI projects.”</p>
-        <cite><a href="https://www.linkedin.com/in/fiann/" target="_blank" rel="noopener noreferrer">Fiann O'Hagan</a> · Web analytics &amp; performance</cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/fiann/" target="_blank" rel="noopener noreferrer">Fiann O'Hagan</a> · <span class="aurora-tstm-chip">Web analytics and performance</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Four weeks of asking the hard questions about deploying AI responsibly, applying real frameworks to real systems. Moving fast with AI without being reckless.”</p>
-        <cite><a href="https://www.linkedin.com/in/tavisyeung/" target="_blank" rel="noopener noreferrer">Tavis Yeung</a> · Digital Marketing Innovation</cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/tavisyeung/" target="_blank" rel="noopener noreferrer">Tavis Yeung</a> · <span class="aurora-tstm-chip">Digital Marketing Innovation</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“It changed how I think about my work, and I left feeling proud of how I show up with AI.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/brittneyashley" target="_blank" rel="noopener noreferrer">Brittney Ashley</a> · <span class="aurora-tstm-chip">RAP Cohort 1, Creative Dynamics</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“RAP gives you a zoomable drone's-eye view of the entire AI ethics and governance landscape.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/danbashaw" target="_blank" rel="noopener noreferrer">Daniel Bashaw</a> · <span class="aurora-tstm-chip">RAP Cohort 1</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“This course revealed all of the critical elements of responsible AI use that are nowhere to be found in regular AI content.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/rachel-krayenhoff" target="_blank" rel="noopener noreferrer">Rachel Krayenhoff</a> · <span class="aurora-tstm-chip">RAP Cohort 1, AI practitioner</span></cite>
       </blockquote>
     </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-rooms">
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-talks">
     <div class="aurora-section-heading">
-      <p class="aurora-kicker">Community &amp; rooms</p>
-      <h2 id="aurora-testimonials-rooms">Meetups, film club, and the people who show up.</h2>
-      <p>The recurring rooms — Film Club denseness, ecosystem texture, monthly Vancouver energy — described by people who were in the seats.</p>
+      <p class="aurora-kicker">Talks</p>
+      <h2 id="aurora-testimonials-talks">Keynotes and guest sessions.</h2>
+      <p>What hosts and audiences say when a talk lands: language they can reuse and moves they can make the next day.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three" aria-label="Community and rooms testimonials">
-      <blockquote class="aurora-quote-card">
-        <p>“The room was packed and the program was a blend of entertaining films, short technical tutorials, and thoughtful discussion about where the industry is heading. … The room last night was full of people re-inventing themselves and their industries and looking for ways to rebuild better.”</p>
-        <cite><a href="https://www.linkedin.com/in/jonessteven" target="_blank" rel="noopener noreferrer">Steve Jones, CFA</a> · BC + AI Film Club</cite>
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Talks testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/djwa/" target="_blank" rel="noopener noreferrer">Jai Djwa</a></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“Honestly Kris, if you are still uncertain about whether you have created something that matters — a movement, a community, a force in BC — then you need your eyes, ears, and all other senses tested.”</p>
-        <cite><a href="https://www.linkedin.com/in/simon-haworth/" target="_blank" rel="noopener noreferrer">Simon Haworth</a> · Vancouver AI Meetup #30</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris's talk and event design felt like a masterclass in community organizing.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/kennedy-ed/" target="_blank" rel="noopener noreferrer">Ed Kennedy</a></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“The opening grounding … made the rest of the night feel that before anyone says 'agentic workflow,' remember whose land, whose water, whose stories, whose labour, and whose data we are standing on. … Rock on, Mr KK!”</p>
-        <cite><a href="https://www.linkedin.com/in/suzyeaston" target="_blank" rel="noopener noreferrer">Suzy Easton</a> · Vancouver AI Meetup #30</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris is one of Vancouver's brightest lights at the intersection of culture and online technology. Visionary, creative, fearless and articulate, he electrifies audiences with the sense of humour, curiosity and possibility that he brings to his breathtaking range of creative endeavours.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/robcottingham" target="_blank" rel="noopener noreferrer">Rob Cottingham</a> · <span class="aurora-tstm-chip">2009</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris is an adept speaker, facilitator and prophet who helps you to step into a future that is already here waiting for you--but you couldn't quite reach on your own. … Any community, any individual, any business will be better off once they've involved Kris. He's a force of nature.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/martyavery" target="_blank" rel="noopener noreferrer">Marty Avery, P.C.C.</a> · <span class="aurora-tstm-chip">Executive and leadership coach</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“He embraced the whole community. He brought his big heart, his boundless energy, his amazing mind and his unflagging generosity. … He has been asked back to PopTech for years now.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/kristen-hughes-b403705" target="_blank" rel="noopener noreferrer">Kristen Hughes</a> · <span class="aurora-tstm-chip">PopTech</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Kris is an exceptional translator, facilitator, and activator, for the democratic power of social media and related technologies and community impact.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/joel-solomon-a5a4b5" target="_blank" rel="noopener noreferrer">Joel Solomon</a> · <span class="aurora-tstm-chip">Renewal Funds</span></cite>
       </blockquote>
     </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-archive">
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-training">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Training</p>
+      <h2 id="aurora-testimonials-training">Workshops that use your real work.</h2>
+      <p>Sessions built on the crew's own tools, data, and deadlines. Less inspiration, more reps.</p>
+    </div>
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Training testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“This course was a game changer for me. I learned how to use multiple AI tools for content creation, PR, and marketing in a thoughtful, ethical, and practical way… If you are a busy professional who feels left behind by AI because you don't have time to understand it, this class is for you.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/jillannmanuel/" target="_blank" rel="noopener noreferrer">Jill Manuel</a> · <span class="aurora-tstm-chip">JCat Group</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Peter and Kris are the dynamic duo that everyone dreams about collaborating with… My mind has been blown away at what I've been able to takeaway from this course and it's empowered me to go full time as my own boss for my own company.”</p>
+        <cite class="aurora-tstm-cite">Harrison Reed · <span class="aurora-tstm-chip">Digital Marketing Specialist</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Coaching calls were good. … Coach Kris was enthusiastic about my idea and helpful with showing me some next steps and pre-made tools.”</p>
+        <cite class="aurora-tstm-cite">Becky Pallack · <span class="aurora-tstm-chip">AI for Creative Pros student</span></cite>
+      </blockquote>
+    </div>
+  </section>
+
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-threads">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">From the threads</p>
+      <h2 id="aurora-testimonials-threads">Said in the group chat.</h2>
+      <p>Some of the best lines never hit LinkedIn. These came from message threads and DMs, published with permission from the people who wrote them.</p>
+    </div>
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Threads testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Co Founders including James McKenzie who I only met thanks to Kris Krüg's amazing VanAI meetup almost a year ago!!!”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/darren-nicholls" target="_blank" rel="noopener noreferrer">Darren Nicholls</a> · <span class="aurora-tstm-chip">BC + AI Members</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Authentically demonstrating what it means to be human, nothing more, nothing less.”</p>
+        <cite class="aurora-tstm-cite">Sev Geraskin · <span class="aurora-tstm-chip">BC + AI Members</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“So please keep this up everyone! Don't fucking stop, this work is so necessary and I'm so inspired by you all.”</p>
+        <cite class="aurora-tstm-cite">Peter Bowles · <span class="aurora-tstm-chip">UpSpiral founder</span></cite>
+      </blockquote>
+    </div>
+  </section>
+
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-film">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Film</p>
+      <h2 id="aurora-testimonials-film">Film Club nights.</h2>
+      <p>Screenings, short technical breakdowns, and a packed room arguing about where the industry goes next.</p>
+    </div>
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Film testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“The room was packed and the program was a blend of entertaining films, short technical tutorials, and thoughtful discussion about where the industry is heading. … The room last night was full of people re-inventing themselves and their industries and looking for ways to rebuild better.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/jonessteven" target="_blank" rel="noopener noreferrer">Steve Jones, CFA</a> · <span class="aurora-tstm-chip">BC + AI Film Club</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“This was our first event and really enjoyed the film and the speakers. We will be back, thank you!”</p>
+        <cite class="aurora-tstm-cite">Tanya Slingsby · <span class="aurora-tstm-chip">The Thinking Game premiere</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Really good. Great documentary. So glad I came. The panel afterwards was also amazing. Such a good conversation, great questions and fantastic answers. Would love to see more of these film sessions.”</p>
+        <cite class="aurora-tstm-cite">Yin Lau · <span class="aurora-tstm-chip">The Thinking Game premiere</span></cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“Such an inspiring event! Can't wait to team up… The best is yet to come!”</p>
+        <cite class="aurora-tstm-cite"><a href="https://jp.linkedin.com/in/kaoruyoshihira" target="_blank" rel="noopener noreferrer">Kaoru Yoshihira</a> · <span class="aurora-tstm-chip">BC + AI Film Club</span></cite>
+      </blockquote>
+    </div>
+  </section>
+
+  <section class="aurora-tstm-section aurora-proof-section" aria-labelledby="aurora-testimonials-archive">
     <div class="aurora-section-heading">
       <p class="aurora-kicker">Archive</p>
-      <h2 id="aurora-testimonials-archive">Photography and connector years.</h2>
-      <p>Older public lines from the camera-at-conferences and community-connector era. Kept as history, not as the lead proof for AI work today.</p>
+      <h2 id="aurora-testimonials-archive">The photography and connector years.</h2>
+      <p>Older public lines from the conference-camera era. Kept because the path matters, not as the lead proof for the AI work.</p>
     </div>
-    <div class="aurora-quote-grid aurora-quote-grid-three" aria-label="Archive testimonials">
-      <blockquote class="aurora-quote-card">
+    <div class="aurora-tstm-wall aurora-quote-grid" aria-label="Archive testimonials">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Anytime I see Kris at a conference, camera in hand, my heart lifts a little… Seeing the event through Kris' eyes is like doing it all over again… only better.”</p>
-        <cite><a href="https://www.linkedin.com/in/robcottingham" target="_blank" rel="noopener noreferrer">Rob Cottingham</a></cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/robcottingham" target="_blank" rel="noopener noreferrer">Rob Cottingham</a></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“A lesson in 'getting stuff done', kris is one of those people who seems to make the impossible possible – and manages to keep a few cards up his sleeve in the process.”</p>
-        <cite><a href="https://www.linkedin.com/in/joshdunford" target="_blank" rel="noopener noreferrer">Joshua Dunford</a> · BURNKIT</cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/joshdunford" target="_blank" rel="noopener noreferrer">Joshua Dunford</a> · <span class="aurora-tstm-chip">BURNKIT</span></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Not pretentious but genuinely connected. Kris brings out the best in others and connects those around him.”</p>
-        <cite>Benjamin Random</cite>
+        <cite class="aurora-tstm-cite">Benjamin Random</cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Kris is many things to many people. He gives good friend. He gives good birthday. He gives good debate, good gnomedex, good podcast, good video, good advice, good vancouver, good sxsw, and good revolution. Some say Canada is the new black. I say it's Kris.”</p>
-        <cite>Corey Dennis</cite>
+        <cite class="aurora-tstm-cite">Corey Dennis</cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Kris takes breathtaking, lyrical and gorgeous pictures.”</p>
-        <cite>Claudine Co</cite>
+        <cite class="aurora-tstm-cite">Claudine Co</cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
+      <blockquote class="aurora-tstm-card aurora-quote-card">
         <p>“Kris is unstoppable, except by large objects too heavy to move.”</p>
-        <cite><a href="https://www.linkedin.com/in/stephanievacher" target="_blank" rel="noopener noreferrer">Stephanie Vacher</a></cite>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/stephanievacher" target="_blank" rel="noopener noreferrer">Stephanie Vacher</a></cite>
       </blockquote>
-      <blockquote class="aurora-quote-card">
-        <p>“A search for “Flaming Lips” brought me to KK, his friends and one of the best ever photos of the band. … Continue to live big Kris… the next generation is watching.”</p>
-        <cite>Danie Peace</cite>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“A search for 'Flaming Lips' brought me to KK, his friends and one of the best ever photos of the band. … Continue to live big Kris… the next generation is watching.”</p>
+        <cite class="aurora-tstm-cite">Danie Peace</cite>
+      </blockquote>
+      <blockquote class="aurora-tstm-card aurora-quote-card">
+        <p>“This kid can take photos - wow! - he's really good, and also a great person to be around. Thumbs up for Kris.”</p>
+        <cite class="aurora-tstm-cite"><a href="https://www.linkedin.com/in/butterfield/" target="_blank" rel="noopener noreferrer">Stewart Butterfield</a> · <span class="aurora-tstm-chip">Co-founder, Flickr / Slack · 2006 LinkedIn rec</span></cite>
       </blockquote>
     </div>
   </section>
 
-  <section class="aurora-proof-section" aria-labelledby="aurora-testimonials-cta">
+  <section class="aurora-tstm-cta aurora-proof-section" aria-labelledby="aurora-testimonials-cta">
     <div class="aurora-card">
       <h2 id="aurora-testimonials-cta">Want a room like these?</h2>
       <p>Keynotes, workshops, briefings, and community design. Tell me the audience, the date, and the question the room is trying to answer.</p>
       <div class="aurora-action-row">
         <a class="aurora-button aurora-button-primary" href="/contact/">Start a booking conversation</a>
         <a class="aurora-button aurora-button-secondary" href="/speaking/">See speaking topics</a>
+        <a class="aurora-button aurora-button-tertiary" href="https://bc-ai.ca/" target="_blank" rel="noopener noreferrer">BC + AI</a>
       </div>
     </div>
   </section>
+
 </div>
 <!-- /wp:html -->


### PR DESCRIPTION
## Summary

Wave 2 to Wave 3 handoff for the testimonials showpiece v2 epic (#593): curates the 35 to 40 quote set with a consent log (#598), then rebuilds the page payload from that curated set (#599). No live WordPress writes, no theme edits; deploy stays gated behind #601/#602.

**Deviation from the packets:** each sub-issue's own packet names a separate branch (`codex/593-tstm-5-curate-consent`, `codex/593-tstm-6-testimonials-payload`). The orchestrating prompt for this session explicitly assigned both issues to one chained lane and one branch/PR with two commits, since #599 directly depends on #598's output and both were worked in the same session. Commits are still one per issue for a clean history: `097542c` for #598, `d257ffe` for #599.

## #598: curate + consent log

- `content/drafts/2026-08-01-testimonials-overhaul/curated-set-v2.md`: 40 testimonial cards across the locked section order (Featured 3, Rooms 7, Programs 6, Talks 6, Training 3, Threads 3, Film 4, Archive 8), plus 3 press-band institutional lines kept separate from that count.
- `content/drafts/2026-08-01-testimonials-overhaul/consent-log.md`: hard-block list up top, one row per shipped quote (tier, source, consent status, DM key for T2), plus a "requested / excluded" section for picks left out on consent or identity grounds.
- Hard blocks (William Jordan, Stephanie McKay, tilde/unresolved names, the Butterfield conference/camera mis-attribution) are excluded from the curated set entirely, not just flagged.
- T2 (WhatsApp/DM-sourced) quotes are shipped and logged per the epic's own ruling: "ship good quotes now including T2 private-source praise; maintain consent log; pull on request." Status `T2-shipped-logged`.

## #599: rebuild the payload

- `content/source-packs/content-architecture-2026/wp-payloads/testimonials.html` rebuilt in the #593 locked order: hero+stats, press band, featured, rooms, programs, talks, training, threads, film, archive, CTA.
- Uses the exact `.aurora-tstm-*` class contract from #593/#596's own packet (`.aurora-tstm`, `.aurora-tstm-hero`, `.aurora-tstm-stats`, `.aurora-tstm-stat`, `.aurora-tstm-press`, `.aurora-tstm-featured`, `.aurora-tstm-section`, `.aurora-tstm-wall`, `.aurora-tstm-card`, `.aurora-tstm-cite`, `.aurora-tstm-chip`, `.aurora-tstm-cta`). No invented alternates. #596 (the CSS) is still open and unmerged as of this PR, so every card is dual-classed `aurora-tstm-card aurora-quote-card` (and sections dual-classed with `aurora-proof-section` / `aurora-speaking-hero`) so the page still looks acceptable on the live CSS today and picks up the richer treatment the moment #596 ships.
- Simon Haworth's cite uses the corrected `https://ca.linkedin.com/in/simon-haworth-uk-us-prc` slug (old slug 404s, already hotfixed live per commit `a83e810`).
- `page-map.json`'s `testimonials` entry markers updated to match the new headings; verified every marker is a literal substring of the new payload, and the file still parses as valid JSON.
- No live WP PATCH. No SFTP. No `--execute` deploy run. That's #602, human-gated.

## Judgment calls for KK (PR marked `needs-human-review`)

1. **Featured three:** Simon Haworth (Meetup #10 quote), Kerris Hougardy, Arno Apeldoorn: the #598 packet's own recommendation. Swappable; nothing else depends on which three are oversized.
2. **Peter Bowles profanity, shipped unedited** ("Don't fucking stop, this work is so necessary..."). Reasoning in `curated-set-v2.md` under "Judgment calls." One-line pull if you disagree.
3. **Rob Cottingham appears twice**: Talks (a 2009 LinkedIn rec about his stage presence) and Archive (the "camera in hand" quote already live under the Butterfield attribution lock). Different quotes, 15 years apart, not a duplication bug.
4. **Landon Steele and Carly Steiman moved from Featured to Rooms.** Both were 2 of v1's 3 Featured picks (already live, quality 5, verified LinkedIn). Since the #598 packet recommends Simon/Kerris/Arno for the new Featured three, Landon and Carly moved to Rooms instead of dropping off the page entirely; their inventory row proposes "Featured / Rooms" as the placement either way.
5. **Two quotes marked `requested` and left out of the curated set:** Aynsley Vogel (quality-5 quote, but she answered the original survey anonymously and was identified afterward by cross-reference; needs her confirmation before naming her publicly) and Ishtar Beck (the quote itself is a normal named survey response, but the LinkedIn URL #595 found for her carries an explicit "confirm logged-in before public use" flag). Full reasoning in `consent-log.md`.

## Closeout verification run

- `rg -n 'William Jordan|Stephanie McKay' curated-set-v2.md`: no matches.
- `rg -c 'T2-shipped-logged|RAP-consented|T1-shipped|PRESS-public' consent-log.md`: 46 (non-zero).
- `rg -n 'aurora-tstm-' testimonials.html`: 122 matches; all 12 contract selectors present and used with a clear, consistent purpose (documented in the #599 commit message).
- `rg -n 'William Jordan|Stephanie McKay|user-infos' testimonials.html`: no matches. No body `<h1>`.
- `python3 -c "import json; json.load(open('page-map.json'))"`: valid JSON.
- Every `href` in the payload cross-checked programmatically: every LinkedIn URL is an exact substring match in `linkedin-gaps.md`'s FOUND rows; every non-LinkedIn URL is a source already cited in `copy-v2.md`. No invented slugs.
- `~/Code/kk-voice/scripts/voicecheck.py` run on `curated-set-v2.md` and `testimonials.html`: 4 flags in each file, all four inside verbatim third-party testimonial quotes (Landon Steele's own em dash, Jesse Benson's own em dash, Jill Manuel's own "game changer," Kaoru Yoshihira's own "team up"). Zero flags in any authored prose: headers, notes, section copy. Not edited: altering someone else's exact words to pass a style checker would violate the explicit "no invented paraphrases, never invent quotes" rule this whole packet runs on. A full em-dash scan confirms zero em dashes anywhere in this repo's new files outside those two quoted instances.

## Out of scope here

- #600 (consent outreach shortlist plus packet README): separate TSTM-7 lane, not touched.
- #601 (theme pixel deploy) and #602 (content body deploy): human-gated, not touched. No live WordPress writes of any kind in this PR.
- #596 (aurora-tstm CSS): still open; this payload consumes its exact class contract from #596's own packet text, not from merged CSS, since there isn't any yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyYEKKupvdbKGCY74uAvhT
