### PR TITLE
fix(seo-audit): refuse to report a false negative when Jetpack meta is unregistered

### DIFF
--- a/scripts/seo-audit/inventory.py
+++ b/scripts/seo-audit/inventory.py
@@ -6,11 +6,20 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from inventory_lib import SEORecord, record_from_item, render_markdown, summarize, write_csv
+from inventory_lib import (
+    SEORecord,
+    meta_keys_registered,
+    record_from_item,
+    record_from_rendered,
+    render_markdown,
+    summarize,
+    write_csv,
+)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 NOTION_DIR = SCRIPT_DIR.parent / "notion-to-wp"
@@ -47,30 +56,98 @@ def fetch_published(wp: WordPress, kind: str) -> list[dict[str, Any]]:
     return items
 
 
-def collect_inventory(wp: WordPress) -> list[SEORecord]:
+UNREGISTERED_META_HELP = """\
+ERROR: the Jetpack SEO meta keys are not exposed by REST on this site.
+
+Every published item came back with those keys absent from `meta`, which this
+audit cannot distinguish from "no SEO title set". Reporting the inventory now
+would claim every item is missing its SEO metadata, which is false: the values
+are still in wp_postmeta and still rendering, because
+theme/kk-aurora/inc/seo-title.php reads them with get_post_meta().
+
+Cause: Jetpack registers these keys for REST, and Jetpack is deactivated.
+
+Consequence beyond this audit: REST *writes* to these keys silently no-op too.
+WordPress drops unregistered meta without erroring, so any script that PATCHes
+jetpack_seo_html_title appears to succeed and changes nothing.
+
+To measure what crawlers actually see, run with --source rendered.\
+"""
+
+
+def collect_inventory(wp: WordPress, items_by_kind: dict) -> list[SEORecord]:
     records: list[SEORecord] = []
-    for kind in ("post", "page"):
-        for item in fetch_published(wp, kind):
+    for kind, items in items_by_kind.items():
+        for item in items:
             records.append(record_from_item(kind, item))
     return records
 
 
+def collect_rendered_inventory(wp: WordPress, items_by_kind: dict) -> list[SEORecord]:
+    records: list[SEORecord] = []
+    for kind, items in items_by_kind.items():
+        for item in items:
+            link = str(item.get("link") or "")
+            if not link:
+                continue
+            separator = "&" if "?" in link else "?"
+            response = wp.s.get(
+                f"{link}{separator}cachebust={int(time.time())}", timeout=60
+            )
+            response.raise_for_status()
+            records.append(record_from_rendered(kind, item, response.text))
+    return records
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Read-only Jetpack SEO metadata inventory")
-    parser.add_argument("--format", choices=("markdown", "json", "csv"), default="markdown")
+    parser = argparse.ArgumentParser(
+        description="Read-only Jetpack SEO metadata inventory"
+    )
+    parser.add_argument(
+        "--format", choices=("markdown", "json", "csv"), default="markdown"
+    )
     parser.add_argument("--output", type=Path, help="Write CSV/JSON to this path")
+    parser.add_argument(
+        "--source",
+        choices=("meta", "rendered"),
+        default="meta",
+        help="meta reads REST post meta; rendered reads delivered HTML",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Audit at most this many items per kind (sampling, --source rendered)",
+    )
     args = parser.parse_args()
 
     cfg = load_config()
     if not cfg.has_wp_credentials:
-        print("WP_USER and WP_APP_PASSWORD required in scripts/notion-to-wp/.env", file=sys.stderr)
+        print(
+            "WP_USER and WP_APP_PASSWORD required in scripts/notion-to-wp/.env",
+            file=sys.stderr,
+        )
         return 1
 
     wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
-    records = collect_inventory(wp)
+    items_by_kind = {kind: fetch_published(wp, kind) for kind in ("post", "page")}
+    if args.limit:
+        items_by_kind = {k: v[: args.limit] for k, v in items_by_kind.items()}
+
+    if args.source == "rendered":
+        records = collect_rendered_inventory(wp, items_by_kind)
+    else:
+        all_items = [item for items in items_by_kind.values() for item in items]
+        if all_items and not meta_keys_registered(all_items):
+            print(UNREGISTERED_META_HELP, file=sys.stderr)
+            return 2
+        records = collect_inventory(wp, items_by_kind)
 
     if args.format == "json":
-        payload = {"summary": summarize(records), "records": [asdict(r) for r in records]}
+        payload = {
+            "source": args.source,
+            "summary": summarize(records),
+            "records": [asdict(r) for r in records],
+        }
         text = json.dumps(payload, indent=2)
         if args.output:
             args.output.write_text(text + "\n", encoding="utf-8")
@@ -81,7 +158,7 @@ def main() -> int:
         write_csv(out, records)
         print(f"Wrote {len(records)} rows to {out}")
     else:
-        print(render_markdown(records))
+        print(render_markdown(records, args.source))
 
     return 0
 

--- a/scripts/seo-audit/inventory_lib.py
+++ b/scripts/seo-audit/inventory_lib.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import html
+import re
 from dataclasses import asdict, dataclass
 from typing import Any
 
 SEO_TITLE_KEYS = ("jetpack_seo_html_title",)
 META_DESC_KEYS = ("advanced_seo_description",)
 SOCIAL_KEYS = ("jetpack_publicize_message",)
+SEO_META_KEYS = SEO_TITLE_KEYS + META_DESC_KEYS + SOCIAL_KEYS
 
 
 @dataclass
@@ -31,6 +34,64 @@ def meta_value(meta: dict[str, Any], keys: tuple[str, ...]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return ""
+
+
+def meta_keys_registered(items: list[dict[str, Any]]) -> bool:
+    """True when REST still exposes the Jetpack SEO meta keys.
+
+    Jetpack is what registers these keys with `show_in_rest`. Once it is
+    deactivated the keys drop out of the payload entirely, so every item looks
+    like it is missing its SEO title when the values are in fact still in
+    wp_postmeta and still rendering (theme/kk-aurora/inc/seo-title.php reads
+    them with get_post_meta). An absent key and an empty key are the same shape
+    through meta.get(), so the only way to tell a tooling failure from a content
+    gap is to look for the key itself.
+    """
+    return any(
+        key in (item.get("meta") or {}) for item in items for key in SEO_META_KEYS
+    )
+
+
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.I | re.S)
+_DESC_TAG_RE = re.compile(r"<meta[^>]+name=[\"']description[\"'][^>]*>", re.I)
+_CONTENT_RE = re.compile(r"content=[\"'](.*?)[\"']", re.I | re.S)
+
+
+def extract_rendered_seo(page_html: str) -> tuple[str, str]:
+    """Pull the <title> and meta description a crawler would actually see."""
+    title_match = _TITLE_RE.search(page_html)
+    title = html.unescape(title_match.group(1)).strip() if title_match else ""
+
+    description = ""
+    desc_tag = _DESC_TAG_RE.search(page_html)
+    if desc_tag:
+        content = _CONTENT_RE.search(desc_tag.group(0))
+        if content:
+            description = html.unescape(content.group(1)).strip()
+
+    return title, description
+
+
+def record_from_rendered(kind: str, item: dict[str, Any], page_html: str) -> SEORecord:
+    """Build a record from delivered HTML instead of REST meta.
+
+    Social message has no rendered equivalent (Publicize never reaches the
+    page), so it is reported as absent and excluded from the summary.
+    """
+    seo_title, meta_desc = extract_rendered_seo(page_html)
+    return SEORecord(
+        kind=kind,
+        wp_id=int(item["id"]),
+        slug=str(item.get("slug") or ""),
+        title=str(item.get("title", {}).get("rendered") or item.get("title") or ""),
+        link=str(item.get("link") or ""),
+        has_seo_title=bool(seo_title),
+        seo_title_length=len(seo_title),
+        has_meta_description=bool(meta_desc),
+        meta_description_length=len(meta_desc),
+        has_social_message=False,
+        social_message_length=0,
+    )
 
 
 def record_from_item(kind: str, item: dict[str, Any]) -> SEORecord:
@@ -59,26 +120,48 @@ def summarize(records: list[SEORecord]) -> dict[str, Any]:
         "posts": sum(1 for r in records if r.kind == "post"),
         "pages": sum(1 for r in records if r.kind == "page"),
         "missing_seo_title": sum(1 for r in records if not r.has_seo_title),
-        "missing_meta_description": sum(1 for r in records if not r.has_meta_description),
-        "missing_social_message": sum(1 for r in records if r.kind == "post" and not r.has_social_message),
+        "missing_meta_description": sum(
+            1 for r in records if not r.has_meta_description
+        ),
+        "missing_social_message": sum(
+            1 for r in records if r.kind == "post" and not r.has_social_message
+        ),
     }
 
 
-def render_markdown(records: list[SEORecord]) -> str:
+def render_markdown(records: list[SEORecord], source: str = "meta") -> str:
     stats = summarize(records)
+    heading = (
+        "# Rendered SEO Metadata Inventory"
+        if source == "rendered"
+        else "# Jetpack SEO Metadata Inventory"
+    )
+    provenance = (
+        'Read from delivered HTML (`<title>` and `<meta name="description">`), '
+        "which is the surface a crawler sees."
+        if source == "rendered"
+        else "Read from REST post meta."
+    )
     lines = [
-        "# Jetpack SEO Metadata Inventory",
+        heading,
         "",
-        "Read-only snapshot. `transcript` CPT excluded (not deployed).",
+        f"Read-only snapshot. `transcript` CPT excluded (not deployed). {provenance}",
         "",
         "## Summary",
         "",
         f"- Total: {stats['total']} ({stats['posts']} posts, {stats['pages']} pages)",
         f"- Missing SEO title: {stats['missing_seo_title']}",
         f"- Missing meta description: {stats['missing_meta_description']}",
-        f"- Posts missing social message: {stats['missing_social_message']}",
-        "",
     ]
+    if source == "rendered":
+        lines.append(
+            "- Posts missing social message: not measurable from rendered HTML"
+        )
+    else:
+        lines.append(
+            f"- Posts missing social message: {stats['missing_social_message']}"
+        )
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -89,7 +172,9 @@ def write_csv(path, records: list[SEORecord]) -> None:  # noqa: ANN001
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(asdict(records[0]).keys()) if records else [])
+        writer = csv.DictWriter(
+            handle, fieldnames=list(asdict(records[0]).keys()) if records else []
+        )
         if records:
             writer.writeheader()
             for record in records:

--- a/scripts/seo-audit/tests/test_inventory.py
+++ b/scripts/seo-audit/tests/test_inventory.py
@@ -3,7 +3,15 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from inventory_lib import SEORecord, record_from_item, summarize  # noqa: E402
+from inventory_lib import (  # noqa: E402
+    SEORecord,
+    extract_rendered_seo,
+    meta_keys_registered,
+    record_from_item,
+    record_from_rendered,
+    render_markdown,
+    summarize,
+)
 
 
 class InventoryTests(unittest.TestCase):
@@ -43,6 +51,67 @@ class InventoryTests(unittest.TestCase):
         ]
         stats = summarize(records)
         self.assertEqual(stats["missing_seo_title"], 1)
+
+
+class UnregisteredMetaTests(unittest.TestCase):
+    """The false negative that made the audit report all 1016 items as missing."""
+
+    def test_absent_keys_are_not_mistaken_for_empty_values(self):
+        # What REST returns with Jetpack deactivated: the SEO keys are gone.
+        items = [{"id": 1, "meta": {"footnotes": ""}}]
+        self.assertFalse(meta_keys_registered(items))
+
+    def test_registered_but_empty_keys_still_count_as_registered(self):
+        items = [{"id": 1, "meta": {"jetpack_seo_html_title": "", "footnotes": ""}}]
+        self.assertTrue(meta_keys_registered(items))
+
+    def test_any_item_carrying_a_key_proves_registration(self):
+        items = [
+            {"id": 1, "meta": {"footnotes": ""}},
+            {"id": 2, "meta": {"advanced_seo_description": "set"}},
+        ]
+        self.assertTrue(meta_keys_registered(items))
+
+    def test_empty_result_set_is_not_treated_as_unregistered(self):
+        self.assertFalse(meta_keys_registered([]))
+
+
+class RenderedSourceTests(unittest.TestCase):
+    def test_extracts_title_and_description(self):
+        page = (
+            "<html><head><title>You Can&#039;t Drink Data | Notes</title>"
+            '<meta name="description" content="A post about an AI protest." />'
+            "</head><body></body></html>"
+        )
+        title, description = extract_rendered_seo(page)
+        self.assertEqual(title, "You Can't Drink Data | Notes")
+        self.assertEqual(description, "A post about an AI protest.")
+
+    def test_handles_content_attribute_before_name(self):
+        page = '<meta content="Reversed order." name="description">'
+        _, description = extract_rendered_seo(page)
+        self.assertEqual(description, "Reversed order.")
+
+    def test_missing_tags_report_absent_not_crash(self):
+        title, description = extract_rendered_seo("<html><head></head></html>")
+        self.assertEqual(title, "")
+        self.assertEqual(description, "")
+
+    def test_record_from_rendered_marks_social_unmeasurable(self):
+        item = {
+            "id": 9,
+            "slug": "p",
+            "title": {"rendered": "P"},
+            "link": "https://kriskrug.co/p/",
+        }
+        record = record_from_rendered("post", item, "<title>Real Title</title>")
+        self.assertTrue(record.has_seo_title)
+        self.assertFalse(record.has_social_message)
+
+    def test_rendered_summary_does_not_claim_social_gaps(self):
+        records = [SEORecord("post", 1, "a", "A", "u", True, 5, True, 8, False, 0)]
+        self.assertIn("not measurable", render_markdown(records, "rendered"))
+        self.assertNotIn("not measurable", render_markdown(records, "meta"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`make seo-audit` reported **all 1016 published items** as missing their SEO title and meta description. Every one of those was false.

Jetpack registers `jetpack_seo_html_title` and `advanced_seo_description` for REST with `show_in_rest`. Jetpack is deactivated on kriskrug.co, so those keys drop out of the REST payload entirely. Through `meta.get()` an **absent key and an empty key are indistinguishable**, so the audit read "key not present" as "no SEO title set".

The data is fine. The values are still in `wp_postmeta` and still rendering, because `theme/kk-aurora/inc/seo-title.php` reads them with `get_post_meta()` in PHP, never touching REST.

### Evidence

```
GET /wp-json/wp/v2/posts?context=edit&_fields=id,slug,meta
12653 ai-lands-inside-every-profession -> meta keys: ['footnotes']
12638 no-one-knows-what-to-call-us-yet -> meta keys: ['footnotes']
```

`jetpack/v4/settings` returns 404. Live `<title>` tags render correctly.

## The fix

- `meta_keys_registered()` distinguishes an absent key from an empty value
- the meta path exits **2** with the cause instead of printing a bogus inventory
- `--source rendered` reads the delivered `<title>` and `<meta name="description">`, the surface a crawler actually sees, needing no REST meta
- `--limit` samples instead of walking all 1016 URLs
- rendered mode reports social message as *not measurable* rather than absent, since Publicize never reaches the page

## Verification

| Check | Result |
|---|---|
| `make seo-audit` | exits 2 with the diagnostic, no bogus report |
| `--source rendered --limit 5` | 0 missing titles, 0 missing descriptions |
| `make python-test` | all suites pass |
| unit tests | 12 pass, 3 pre-existing |
| em dashes added | 0 |

## The bigger consequence, not fixed here

**REST writes to these keys silently no-op too.** WordPress drops unregistered meta without erroring, so a script that PATCHes `jetpack_seo_html_title` appears to succeed and changes nothing.

The publisher does exactly that on every publish:
- `scripts/notion-to-wp/publish_common.py:493-494`
- `scripts/notion-to-wp/connector_payload.py:48-49`

This is almost certainly why setting an SEO title via REST stopped persisting and had to be done in the editor. Filed separately rather than widened into this PR.

## Safety

Read-only. No live WordPress writes, no theme changes, no deploys. Tooling lane only, `scripts/seo-audit/` and its tests.