### PR TITLE
fix(morning-truth): report live-vs-repo Aurora drift instead of never checking

### DIFF
--- a/docs/current-state/reports/morning-truth-20260803-024628Z.md
+++ b/docs/current-state/reports/morning-truth-20260803-024628Z.md
@@ -1,0 +1,548 @@
+# Morning Truth Report - 2026-08-03 02:46:28 UTC
+
+Scope: Track A (`main`) read-only verification and repo-state stabilization.
+
+## Snapshot Summary
+
+- Open PRs: `9`
+- Open issues: `59`
+- WordPress version (smoke): `7.0.2`
+- Draft queue: future posts `0`, draft posts `67`, draft pages `4`
+- `/projects/` status: `HTTP/2 301`
+- `/recent-projects-include/` og:image: `(not found)`
+- Homepage reveal safety net detected: `no`
+- GSAP/ScrollTrigger CDN detected: `no`
+
+## Issue Label Signals
+
+- `priority:high`: `31`
+- `aurora-v2`: `2`
+- `track-b`: `17`
+- `swarm-ready`: `22`
+- `swarm-parked`: `0`
+- `needs-human-review`: `29`
+- `auto-implement`: `0`
+
+## Drift Check
+
+| Signal | Declared | Observed | Drift |
+|---|---:|---:|---|
+| Open PRs | 0 | 9 | YES |
+| Open Issues | 66 | 59 | YES |
+| WordPress Version | 7.0.2 | 7.0.2 | no |
+| Scheduled Posts | 0 | 0 | no |
+| Draft Posts | 67 | 67 | no |
+| Draft Pages | 4 | 4 | no |
+
+## WP Smoke Summary
+
+- Failures: `0`
+- Warnings: `0`
+
+## Data Availability
+
+- All startup truth data sources resolved.
+
+## Aurora Risk (Read-Only)
+
+- **Aurora live vs repo: DRIFT.** FAIL theme version drift detected: live (https://kriskrug.co/wp-content/themes/kk-aurora/style.css): 1.5.7 repo (theme/kk-aurora/style.css): 1.5.8
+- Local `aurora/v2` worktree not detected from porcelain list.
+
+## Startup Command Outputs
+
+### Git Fetch
+
+- Command: `git fetch --prune`
+- Exit code: `0`
+
+stderr:
+```text
+From https://github.com/WalksWithASwagger/kriskrug-wp
+ - [deleted]         (none)     -> origin/content/632-hero-ledger-2024-2025
+ - [deleted]         (none)     -> origin/content/633-hero-ledger-2026-meetup
+ - [deleted]         (none)     -> origin/content/634-events-internal-links
+ - [deleted]         (none)     -> origin/content/636-speaking-video-set
+ - [deleted]         (none)     -> origin/content/futureproof-network-followup
+ - [deleted]         (none)     -> origin/test/631-events-render-contract
+```
+
+### Git Status
+
+- Command: `git status --short --branch`
+- Exit code: `0`
+
+```text
+## fix/morning-truth-theme-parity
+ M scripts/morning_truth_report.py
+ M scripts/tests/test_morning_truth_report.py
+```
+
+### Recent Log
+
+- Command: `git log --oneline -n 20`
+- Exit code: `0`
+
+```text
+dd87d4a test(#631): pin the /events/ render contract, close the file:// path (#651)
+cbb83d0 content(#636): verify and finalize speaking-page talk video set (#650)
+3028fd7 content(#634): plan internal links for the /events/ archive (#649)
+d4b9fa2 content(#633): build hero source ledger for 2026 one-offs + meetup series (#648)
+8dfde38 content(#632): add hero source ledger for 2024/2025 one-off stages (#647)
+f9c47cc docs(#500): record dry-run evidence and the slug-check caveat
+91ab3f1 fix(#500): quote alt strings so YAML frontmatter parses
+d0f9b50 content: Futureproof network follow-up (#643, #644, #645) (#646)
+21afad2 docs: refresh CURRENT-STATE open-issue count to 66
+863341c content: correct Futureproof Call for Talks date and membership figure
+31a43f8 docs: refresh CURRENT-STATE declared counters to 2026-08-02 truth (#566)
+5e819a0 content(#600): consent outreach shortlist + packet README
+3a4864a docs: morning-truth report 2026-08-02
+b4e0fca docs: reconcile AGENTS.md Aurora version truth (live 1.5.7, repo 1.5.8)
+326fb0f content: curate testimonial set + rebuild payload (#598, #599) (#630)
+9151563 theme: aurora-tstm testimonials showpiece CSS (#596) (#629)
+03975a9 content(#612): stage Zero to One first-person rewrite for KK review
+9c77a08 chore(#618): waive CSS budget for merged aurora-hero-2026 hero
+7d6f86d ops(#592): events archive backfill snapshots + rollback
+af002f2 content(#592): strip em dashes from events copy, sync 6 heroes, render backfill
+```
+
+### Open PRs
+
+- Command: `gh pr list --state open --limit 50`
+- Exit code: `0`
+
+```text
+660	fix(seo-audit): refuse to report a false negative when Jetpack meta is unregistered	fix/seo-audit-false-negative	DRAFT	2026-08-03T02:43:17Z
+659	docs(#46): WCAG 2.1 AA audit of kriskrug.co, browser-measured	docs/46-wcag-audit	DRAFT	2026-08-03T02:04:24Z
+658	content(#4): alt text inventory across kriskrug.co with apply-ready proposed strings	content/4-alt-text-inventory	DRAFT	2026-08-03T01:39:58Z
+657	content(#637): stage-photography inventory and rights ledger for the Speaking rebuild	content/637-speaking-photo-rights	DRAFT	2026-08-03T01:39:57Z
+656	docs(#249): measure YCDD striking-distance after the #233 deploy	docs/249-striking-distance	DRAFT	2026-08-03T01:32:53Z
+655	docs(#423): stylesheet rebuild vs incremental repair decision memo	docs/423-stylesheet-decision	DRAFT	2026-08-03T01:31:14Z
+654	docs(#122): inventory and prioritize the 24 undesigned pages	docs/122-undesigned-pages	DRAFT	2026-08-03T01:30:21Z
+653	content(#638): reconcile keynote taxonomies into one recommendation	content/638-keynote-taxonomy	DRAFT	2026-08-03T01:25:35Z
+652	docs(#566, #549): refresh current-state front door + archive close-out	docs/566-front-door-refresh	DRAFT	2026-08-03T01:25:00Z
+```
+
+### Open Issues
+
+- Command: `gh issue list --state open --limit 200`
+- Exit code: `0`
+
+```text
+661	OPEN	[BUG] REST writes to Jetpack SEO meta silently no-op since Jetpack deactivation	bug, priority:high, tech-debt	2026-08-03T02:43:41Z
+642	OPEN	[SWARM DISPATCH] Command board — 2026-08-02 (four proof surfaces: events, testimonials, futureproof, speaking)	priority:high, swarm-ready, roadmap	2026-08-03T02:42:02Z
+641	OPEN	[SPEAKING] VideoObject schema + proof-triangle internal links (#419 W3)	priority:medium, content, seo, needs-human-review, swarm-wave-3, blocked	2026-08-03T02:39:20Z
+640	OPEN	[SPEAKING] Video embed hygiene + LCP contract tests (#419 W2)	priority:medium, accessibility, performance, swarm-wave-2, tests, blocked	2026-08-03T02:46:04Z
+639	OPEN	[SPEAKING] Page architecture + payload rebuild for WP 1887 (#419 W2)	priority:high, content, ux, swarm-wave-2, blocked	2026-08-03T02:39:17Z
+638	OPEN	[SPEAKING] Reconcile three conflicting keynote taxonomies into one (#419 W1)	priority:high, content, needs-human-review, swarm-wave-1, needs-decision	2026-08-03T01:26:00Z
+637	OPEN	[SPEAKING] Stage photography inventory + rights clearance (#419 W1)	priority:high, content, needs-human-review, swarm-ready, swarm-wave-1	2026-08-03T01:40:38Z
+635	OPEN	[DEPLOY] Events hero backfill ship (exclusive live apply, successor to #592)	priority:medium, content, needs-human-review, swarm-wave-2, deployment, blocked	2026-08-03T01:23:45Z
+612	OPEN	[swarm][voice-w2] Rewrite Zero to One into first person (12034)	enhancement, priority:high, content, needs-human-review, swarm-ready	2026-08-03T01:22:35Z
+603	OPEN	[EPIC] Voice sweep fixes — 15-post Dark Crystal audit (2026-08-01)	enhancement, priority:high, content, swarm-ready	2026-08-01T17:53:47Z
+602	OPEN	[DEPLOY] TSTM-9: Snapshot-gate deploy testimonials page body	priority:high, content, needs-human-review, deployment, blocked	2026-08-02T16:31:30Z
+601	OPEN	[DEPLOY] TSTM-8: Pixel-gate theme deploy for aurora-tstm	priority:high, needs-human-review, track-b, deployment, blocked	2026-08-02T16:31:29Z
+593	OPEN	[EPIC] Testimonials showpiece v2 — /testimonials/ (WP 2409)	priority:high, content, needs-human-review, roadmap, blocked	2026-08-02T17:04:50Z
+585	OPEN	[DESIGN] Kill leftover dark-neon page islands + cohesion audit (ghost stylesheet)	bug, priority:high, content, ux, needs-human-review, track-b, tech-debt	2026-08-01T17:01:32Z
+573	OPEN	[SWARM DISPATCH] Command board — 2026-07-31 (master workplan: merge queue, truth refresh, Futureproof, rebuild chain)	swarm-ready, roadmap	2026-08-02T17:29:35Z
+572	OPEN	[DECISION] Git history rewrite (filter-repo) after #369 working-tree reclaim	priority:low, tech-debt, needs-decision, blocked	2026-08-03T02:40:18Z
+571	OPEN	[DECISION] Parked plugins: deploy, keep parked, or archive kk-sidebar-promos + kk-marquee-board	priority:low, needs-human-review, deployment, needs-decision	2026-07-31T22:34:48Z
+570	OPEN	[OPS] Issue label hygiene: retire stale swarm-wave and blocked labels	priority:low, needs-human-review, tech-debt	2026-08-03T02:46:19Z
+566	OPEN	[DOCS] Refresh front-door current-state docs past 2026-07-16	documentation, priority:high, tech-debt	2026-08-03T01:25:15Z
+549	OPEN	[OPS] Archive stale docs/current-state May–June plans into archive/	documentation, priority:low, needs-human-review, tech-debt	2026-08-03T01:25:31Z
+500	OPEN	[CONTENT] Futureproof post: verify + create WP draft (no publish)	priority:high, content, needs-human-review, deployment, blocked	2026-08-02T20:28:06Z
+496	OPEN	[EPIC] Futureproof Festival announcement post (Track A)	priority:high, content, swarm-ready	2026-08-02T18:12:27Z
+495	OPEN	[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)	swarm-ready, roadmap	2026-07-26T15:50:39Z
+481	OPEN	[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1	priority:medium, needs-human-review, track-b, refactor, blocked	2026-08-03T02:39:49Z
+480	OPEN	[CONTENT] Retire Track A page-content CSS blocks (six live routes)	priority:medium, content, needs-human-review, tech-debt, blocked	2026-08-03T02:45:29Z
+479	OPEN	[THEME] Consolidate 12 breakpoints into a 3-step scale	priority:medium, mobile, track-b, swarm-ready, refactor, blocked	2026-08-03T01:23:42Z
+478	OPEN	[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0	priority:medium, track-b, swarm-ready, tech-debt, blocked	2026-08-03T01:23:40Z
+477	OPEN	[EPIC] Component migration: one component per PR — Aurora 1.5.3+	priority:medium, track-b, swarm-ready, roadmap, refactor, blocked	2026-08-03T02:39:47Z
+476	OPEN	[THEME] Primitives layer + block-editor parity — Aurora 1.5.2	priority:high, track-b, swarm-ready, refactor, blocked	2026-08-03T01:23:38Z
+475	OPEN	[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1	priority:medium, track-b, swarm-ready, refactor	2026-07-27T18:25:43Z
+424	OPEN	[QA] Site-wide hover, focus, and interactivity pass	priority:medium, accessibility, ux, track-b, swarm-ready, blocked	2026-08-03T01:23:35Z
+423	OPEN	[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair	priority:high, track-b, tech-debt, refactor	2026-08-03T01:31:49Z
+420	OPEN	[PAGE] Services page: rethink language, layout, and scroll depth	priority:medium, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:24Z
+419	OPEN	[PAGE] Speaking page: multimedia rebuild that sells keynotes	priority:high, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:22Z
+418	OPEN	[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'	priority:high, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:20Z
+416	OPEN	[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA	priority:high, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:18Z
+415	OPEN	[HOME] 'What People Say' redesign + network diagram spike	priority:high, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:15Z
+414	OPEN	[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity	priority:high, content, ux, needs-human-review, track-b, swarm-ready	2026-08-03T01:22:13Z
+413	OPEN	[HOME] Bring back the client logo soup: monochromatic and interactive	priority:high, content, ux, needs-human-review, swarm-ready	2026-08-03T01:22:11Z
+412	OPEN	[HOME] Creative Labs section redesign: layout, image crops, clarity	priority:high, content, ux, needs-human-review, track-b, swarm-ready	2026-08-03T01:22:08Z
+411	OPEN	[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states	priority:high, content, ux, needs-human-review, track-b, swarm-ready	2026-08-03T01:22:06Z
+403	OPEN	[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown	priority:high, ux, track-b, roadmap	2026-07-17T14:44:46Z
+402	OPEN	[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs	enhancement, help wanted	2026-07-17T04:25:24Z
+385	OPEN	Normalize the WordPress workflow skill without breaking automation		2026-07-17T01:12:49Z
+369	OPEN	[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)		2026-07-25T18:53:36Z
+339	OPEN	[SEO] Run the measured July Kris publisher batch	priority:high, seo, needs-human-review	2026-07-14T07:28:42Z
+331	OPEN	[SEO] Shrink taxonomy sitemap bloat and define archive indexability	priority:high, seo, needs-human-review, roadmap	2026-07-24T22:41:40Z
+318	OPEN	[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history	priority:medium, tech-debt	2026-07-12T05:46:59Z
+277	OPEN	[FORMS] Decide whether the lightweight contact CTA is enough	priority:medium, platform, content, needs-human-review	2026-07-01T21:18:37Z
+276	OPEN	[OPS] Delete inactive Jetpack after rollback window	priority:medium, platform, needs-human-review, deployment, tech-debt	2026-07-01T21:18:35Z
+274	OPEN	[SEO] Submit canonical sitemap in Search Console and monitor indexing	priority:high, seo, needs-human-review, roadmap	2026-07-16T14:43:11Z
+249	OPEN	[SEO] Measure 'you can't drink data' striking-distance after #233 deploy	content, seo	2026-08-03T02:43:18Z
+127	OPEN	[AURORA P2] Dedicated mobile / responsive QA pass	bug, priority:medium, mobile, accessibility, track-b, aurora-v2, blocked	2026-08-03T01:23:33Z
+125	OPEN	[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup	priority:medium, performance, track-b, tech-debt	2026-07-02T21:01:24Z
+122	OPEN	[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)	enhancement, priority:medium, content, aurora-v2	2026-08-03T02:44:55Z
+86	OPEN	[QA] Post-Jetpack real-site performance, accessibility, and tracking QA	priority:high, mobile, accessibility, performance, track-b	2026-07-02T21:01:25Z
+46	OPEN	[A11Y] Full WCAG 2.1 AA Accessibility Audit	enhancement, priority:high, accessibility	2026-08-03T02:04:45Z
+22	OPEN	[CONTENT] Add Indigenous Land Acknowledgment	enhancement, priority:medium, mobile, content	2026-06-09T23:05:53Z
+4	OPEN	[BUG] Add Alt Text to All Images	bug, enhancement, priority:high, accessibility, seo	2026-08-03T02:45:57Z
+```
+
+### Worktrees
+
+- Command: `git worktree list --porcelain`
+- Exit code: `0`
+
+```text
+worktree /Users/kk/Code/kriskrug-wp
+HEAD dd87d4a42ef67cd78647fec7c68abdcafbf5bc97
+branch refs/heads/fix/morning-truth-theme-parity
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-1
+HEAD 07050c2370d16efdac5ffd0092d8b9065830d4bd
+branch refs/heads/content/637-speaking-photo-rights
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-2
+HEAD f215aff12b37b4bcaf2429eb88fb5e1fbbca339b
+branch refs/heads/content/638-keynote-taxonomy
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-3
+HEAD 015822833aa3712b145028151f115da52faea61b
+branch refs/heads/docs/423-stylesheet-decision
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-4
+HEAD 4308ff883a79e8815cd7a91246a1d80461c2ace7
+branch refs/heads/docs/566-front-door-refresh
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-6
+HEAD 8bfaf46d7fd6ee9cc78978b920be6873d1789439
+branch refs/heads/docs/46-wcag-audit
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-7
+HEAD 2a8388948b41d4dbc2b4197ec5c978c88506689e
+branch refs/heads/content/4-alt-text-inventory
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-8
+HEAD 002ab2e248d8d02c4402b344196a4e7f8b4d33da
+branch refs/heads/docs/249-striking-distance
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_2b664e20-3ae-9
+HEAD 7ca01190c731ca2735992217c72eaa2a0d1c2454
+branch refs/heads/docs/122-undesigned-pages
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-1
+HEAD 07050c2370d16efdac5ffd0092d8b9065830d4bd
+detached
+locked claude agent wf_d3299f01-624-1 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-2
+HEAD 3aee2ac04f28ebe8a0b2a61eeffb5d67eca880ca
+detached
+locked claude agent wf_d3299f01-624-2 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-3
+HEAD 015822833aa3712b145028151f115da52faea61b
+branch refs/heads/docs/423-stylesheet-decision
+locked claude agent wf_d3299f01-624-3 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-4
+HEAD 26306e6d27e9c08131e0251efe8195462726cf48
+detached
+locked claude agent wf_d3299f01-624-4 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-6
+HEAD 8bfaf46d7fd6ee9cc78978b920be6873d1789439
+detached
+locked claude agent wf_d3299f01-624-6 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-7
+HEAD 130be35b2eb6d9e2a8f51aafee70ecac66ff78a3
+detached
+locked claude agent wf_d3299f01-624-7 (pid 34419 start Mon Aug  3 01:08:44 2026)
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-8
+HEAD 002ab2e248d8d02c4402b344196a4e7f8b4d33da
+branch refs/heads/docs/249-striking-distance
+
+worktree /Users/kk/Code/kriskrug-wp/.claude/worktrees/wf_d3299f01-624-9
+HEAD 60313cdf91aeec951490f2f5fc1544aea2b44f43
+branch refs/heads/worktree-wf_d3299f01-624-9
+```
+
+### Main Divergence
+
+- Command: `git rev-list --left-right --count origin/main...main`
+- Exit code: `0`
+
+```text
+0	0
+```
+
+### Aurora vs Main Divergence
+
+- Command: `git rev-list --left-right --count origin/aurora/v2...origin/main`
+- Exit code: `128`
+
+stderr:
+```text
+fatal: ambiguous argument 'origin/aurora/v2...origin/main': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+```
+
+## Supporting Command Outputs
+
+### Issue JSON
+
+- Command: `gh issue list --state open --limit 200 --json number,title,labels,updatedAt`
+- Exit code: `0`
+
+```text
+[{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":661,"title":"[BUG] REST writes to Jetpack SEO meta silently no-op since Jetpack deactivation","updatedAt":"2026-08-03T02:43:41Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":642,"title":"[SWARM DISPATCH] Command board — 2026-08-02 (four proof surfaces: events, testimonials, futureproof, speaking)","updatedAt":"2026-08-03T02:42:02Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEkQ","name":"swarm-wave-3","description":"Final hardening and QA wave","color":"B60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":641,"title":"[SPEAKING] VideoObject schema + proof-triangle internal links (#419 W3)","updatedAt":"2026-08-03T02:39:20Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxqUg","name":"tests","description":"Automated test work","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":640,"title":"[SPEAKING] Video embed hygiene + LCP contract tests (#419 W2)","updatedAt":"2026-08-03T02:46:04Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":639,"title":"[SPEAKING] Page architecture + payload rebuild for WP 1887 (#419 W2)","updatedAt":"2026-08-03T02:39:17Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"}],"number":638,"title":"[SPEAKING] Reconcile three conflicting keynote taxonomies into one (#419 W1)","updatedAt":"2026-08-03T01:26:00Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjQ","name":"swarm-wave-1","description":"First active swarm wave","color":"1D76DB"}],"number":637,"title":"[SPEAKING] Stage photography inventory + rights clearance (#419 W1)","updatedAt":"2026-08-03T01:40:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEjw","name":"swarm-wave-2","description":"Second swarm wave","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":635,"title":"[DEPLOY] Events hero backfill ship (exclusive live apply, successor to #592)","updatedAt":"2026-08-03T01:23:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":612,"title":"[swarm][voice-w2] Rewrite Zero to One into first person (12034)","updatedAt":"2026-08-03T01:22:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":603,"title":"[EPIC] Voice sweep fixes — 15-post Dark Crystal audit (2026-08-01)","updatedAt":"2026-08-01T17:53:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":602,"title":"[DEPLOY] TSTM-9: Snapshot-gate deploy testimonials page body","updatedAt":"2026-08-02T16:31:30Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":601,"title":"[DEPLOY] TSTM-8: Pixel-gate theme deploy for aurora-tstm","updatedAt":"2026-08-02T16:31:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":593,"title":"[EPIC] Testimonials showpiece v2 — /testimonials/ (WP 2409)","updatedAt":"2026-08-02T17:04:50Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":585,"title":"[DESIGN] Kill leftover dark-neon page islands + cohesion audit (ghost stylesheet)","updatedAt":"2026-08-01T17:01:32Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":573,"title":"[SWARM DISPATCH] Command board — 2026-07-31 (master workplan: merge queue, truth refresh, Futureproof, rebuild chain)","updatedAt":"2026-08-02T17:29:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":572,"title":"[DECISION] Git history rewrite (filter-repo) after #369 working-tree reclaim","updatedAt":"2026-08-03T02:40:18Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrtg","name":"needs-decision","description":"Blocked on a human decision","color":"b60205"}],"number":571,"title":"[DECISION] Parked plugins: deploy, keep parked, or archive kk-sidebar-promos + kk-marquee-board","updatedAt":"2026-07-31T22:34:48Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":570,"title":"[OPS] Issue label hygiene: retire stale swarm-wave and blocked labels","updatedAt":"2026-08-03T02:46:19Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":566,"title":"[DOCS] Refresh front-door current-state docs past 2026-07-16","updatedAt":"2026-08-03T01:25:15Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPCw","name":"documentation","description":"Improvements or additions to documentation","color":"0075ca"},{"id":"LA_kwDOQyPlNc8AAAACT1ur2g","name":"priority:low","description":"Nice to have","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":549,"title":"[OPS] Archive stale docs/current-state May–June plans into archive/","updatedAt":"2026-08-03T01:25:31Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":500,"title":"[CONTENT] Futureproof post: verify + create WP draft (no publish)","updatedAt":"2026-08-02T20:28:06Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":496,"title":"[EPIC] Futureproof Festival announcement post (Track A)","updatedAt":"2026-08-02T18:12:27Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":495,"title":"[SWARM DISPATCH] Command board — 2026-07-26 (rebuild chain, content wave, ops)","updatedAt":"2026-07-26T15:50:39Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":481,"title":"[THEME] Rename aurora-/revive-/kkm- classes to a single kk- convention — Aurora 1.6.1","updatedAt":"2026-08-03T02:39:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":480,"title":"[CONTENT] Retire Track A page-content CSS blocks (six live routes)","updatedAt":"2026-08-03T02:45:29Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":479,"title":"[THEME] Consolidate 12 breakpoints into a 3-step scale","updatedAt":"2026-08-03T01:23:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":478,"title":"[THEME] Delete dead CSS; fold animations + bleeding-edge into the layer stack — Aurora 1.6.0","updatedAt":"2026-08-03T01:23:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":477,"title":"[EPIC] Component migration: one component per PR — Aurora 1.5.3+","updatedAt":"2026-08-03T02:39:47Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":476,"title":"[THEME] Primitives layer + block-editor parity — Aurora 1.5.2","updatedAt":"2026-08-03T01:23:38Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":475,"title":"[THEME] Reset + base layer; retire or opt-in the drop cap — Aurora 1.5.1","updatedAt":"2026-07-27T18:25:43Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":424,"title":"[QA] Site-wide hover, focus, and interactivity pass","updatedAt":"2026-08-03T01:23:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"},{"id":"LA_kwDOQyPlNc8AAAACmtxrfg","name":"refactor","description":"Code refactor, no behavior change","color":"5319E7"}],"number":423,"title":"[DECISION] Stylesheet hierarchy: rebuild from the ground up vs incremental repair","updatedAt":"2026-08-03T01:31:49Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":420,"title":"[PAGE] Services page: rethink language, layout, and scroll depth","updatedAt":"2026-08-03T01:22:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":419,"title":"[PAGE] Speaking page: multimedia rebuild that sells keynotes","updatedAt":"2026-08-03T01:22:22Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":418,"title":"[PAGE] About page: unify backgrounds, column widths, and kill the double 'public trail'","updatedAt":"2026-08-03T01:22:20Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":416,"title":"[HOME] Newsletter section: rename, kill the dispatch/field-notes cliche, add thumbnails, one clear CTA","updatedAt":"2026-08-03T01:22:18Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":415,"title":"[HOME] 'What People Say' redesign + network diagram spike","updatedAt":"2026-08-03T01:22:15Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":414,"title":"[HOME] Speaking stages section: ground-up redesign with links, visuals, interactivity","updatedAt":"2026-08-03T01:22:13Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":413,"title":"[HOME] Bring back the client logo soup: monochromatic and interactive","updatedAt":"2026-08-03T01:22:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":412,"title":"[HOME] Creative Labs section redesign: layout, image crops, clarity","updatedAt":"2026-08-03T01:22:08Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACj6hEgw","name":"swarm-ready","description":"Bounded and safe for autonomous swarm execution now","color":"0E8A16"}],"number":411,"title":"[HOME] 'Join BC / Future Proof' section: rewrite copy, fix alignment, drop cap, and hover states","updatedAt":"2026-08-03T01:22:06Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvHg","name":"ux","description":"User experience","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":403,"title":"[EPIC] Site redesign 2026-07: polish/UI layer overhaul from KK teardown","updatedAt":"2026-07-17T14:44:46Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEw","name":"help wanted","description":"Extra attention is needed","color":"008672"}],"number":402,"title":"[swarm][seo-content] Double down on surprising KrisKrug.co search wins and authority hubs","updatedAt":"2026-07-17T04:25:24Z"},{"labels":[],"number":385,"title":"Normalize the WordPress workflow skill without breaking automation","updatedAt":"2026-07-17T01:12:49Z"},{"labels":[],"number":369,"title":"[OPS] Execute KK-approved #318 reclaim list (drafts images / report PNGs / old backups)","updatedAt":"2026-07-25T18:53:36Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":339,"title":"[SEO] Run the measured July Kris publisher batch","updatedAt":"2026-07-14T07:28:42Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":331,"title":"[SEO] Shrink taxonomy sitemap bloat and define archive indexability","updatedAt":"2026-07-24T22:41:40Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":318,"title":"[OPS] Repo bloat reduction — reports/backup captures, content/drafts images, .git history","updatedAt":"2026-07-12T05:46:59Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"}],"number":277,"title":"[FORMS] Decide whether the lightweight contact CTA is enough","updatedAt":"2026-07-01T21:18:37Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1usAQ","name":"platform","description":"Platform improvements","color":"D4C5F9"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxrGw","name":"deployment","description":"Production deploy / live-ops change","color":"1D76DB"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":276,"title":"[OPS] Delete inactive Jetpack after rollback window","updatedAt":"2026-07-01T21:18:35Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"},{"id":"LA_kwDOQyPlNc8AAAACT6dlXQ","name":"needs-human-review","description":"Requires manual review","color":"ff4444"},{"id":"LA_kwDOQyPlNc8AAAACmtxqlw","name":"roadmap","description":"Derived from roadmap research","color":"fbca04"}],"number":274,"title":"[SEO] Submit canonical sitemap in Search Console and monitor indexing","updatedAt":"2026-07-16T14:43:11Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":249,"title":"[SEO] Measure 'you can't drink data' striking-distance after #233 deploy","updatedAt":"2026-08-03T02:43:18Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"},{"id":"LA_kwDOQyPlNc8AAAACmtxr2w","name":"blocked","description":"Blocked by a dependency or decision","color":"000000"}],"number":127,"title":"[AURORA P2] Dedicated mobile / responsive QA pass","updatedAt":"2026-08-03T01:23:33Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"},{"id":"LA_kwDOQyPlNc8AAAACmtxrTw","name":"tech-debt","description":"Tech debt / hygiene","color":"6E7781"}],"number":125,"title":"[PERF] Post-Jetpack performance stabilization + Boost Critical CSS cleanup","updatedAt":"2026-07-02T21:01:24Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"},{"id":"LA_kwDOQyPlNc8AAAACjzk4vg","name":"aurora-v2","description":"Aurora v2 redesign work","color":"0E8A16"}],"number":122,"title":"[AURORA P1] ~25 generic content pages are undesigned (bare title + legacy content)","updatedAt":"2026-08-03T02:44:55Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLg","name":"performance","description":"Speed and optimization","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACjzk3kw","name":"track-b","description":"Track B Aurora/theme work","color":"5319E7"}],"number":86,"title":"[QA] Post-Jetpack real-site performance, accessibility, and tracking QA","updatedAt":"2026-07-02T21:01:25Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"}],"number":46,"title":"[A11Y] Full WCAG 2.1 AA Accessibility Audit","updatedAt":"2026-08-03T02:04:45Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urxA","name":"priority:medium","description":"Important but not urgent","color":"fbca04"},{"id":"LA_kwDOQyPlNc8AAAACT1uuSQ","name":"mobile","description":"","color":"ededed"},{"id":"LA_kwDOQyPlNc8AAAACT1uu-g","name":"content","description":"Content updates and UX","color":"d876e3"}],"number":22,"title":"[CONTENT] Add Indigenous Land Acknowledgment","updatedAt":"2026-06-09T23:05:53Z"},{"labels":[{"id":"LA_kwDOQyPlNc8AAAACT1GPBw","name":"bug","description":"Something isn't working","color":"d73a4a"},{"id":"LA_kwDOQyPlNc8AAAACT1GPEQ","name":"enhancement","description":"New feature or request","color":"a2eeef"},{"id":"LA_kwDOQyPlNc8AAAACT1urnw","name":"priority:high","description":"Urgent issue","color":"b60205"},{"id":"LA_kwDOQyPlNc8AAAACT1uvFg","name":"accessibility","description":"WCAG compliance","color":"7057ff"},{"id":"LA_kwDOQyPlNc8AAAACT1uvLA","name":"seo","description":"SEO optimization","color":"0e8a16"}],"number":4,"title":"[BUG] Add Alt Text to All Images","updatedAt":"2026-08-03T02:45:57Z"}]
+```
+
+### PR JSON
+
+- Command: `gh pr list --state open --limit 50 --json number,title,updatedAt`
+- Exit code: `0`
+
+```text
+[{"number":660,"title":"fix(seo-audit): refuse to report a false negative when Jetpack meta is unregistered","updatedAt":"2026-08-03T02:44:04Z"},{"number":659,"title":"docs(#46): WCAG 2.1 AA audit of kriskrug.co, browser-measured","updatedAt":"2026-08-03T02:05:09Z"},{"number":658,"title":"content(#4): alt text inventory across kriskrug.co with apply-ready proposed strings","updatedAt":"2026-08-03T02:45:27Z"},{"number":657,"title":"content(#637): stage-photography inventory and rights ledger for the Speaking rebuild","updatedAt":"2026-08-03T01:40:41Z"},{"number":656,"title":"docs(#249): measure YCDD striking-distance after the #233 deploy","updatedAt":"2026-08-03T02:43:51Z"},{"number":655,"title":"docs(#423): stylesheet rebuild vs incremental repair decision memo","updatedAt":"2026-08-03T01:31:57Z"},{"number":654,"title":"docs(#122): inventory and prioritize the 24 undesigned pages","updatedAt":"2026-08-03T02:44:30Z"},{"number":653,"title":"content(#638): reconcile keynote taxonomies into one recommendation","updatedAt":"2026-08-03T02:46:31Z"},{"number":652,"title":"docs(#566, #549): refresh current-state front door + archive close-out","updatedAt":"2026-08-03T02:46:07Z"}]
+```
+
+### Draft Queue Counts (REST, read-only)
+
+- Command: `python3 scripts/morning_truth_report.py (internal queue fetch)`
+- Exit code: `0`
+
+```text
+future_posts=0, draft_posts=67, draft_pages=4
+```
+
+### WP7 Public Smoke (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/wp7-public-smoke.py --base-url https://kriskrug.co --expect-version 7.0.2 --timeout 20 --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/",
+        "plugins": {
+          "google-site-kit": "1.184.0"
+        },
+        "status": 200,
+        "theme": "kk-aurora",
+        "wordpress_version": "7.0.2"
+      },
+      "failures": [],
+      "path": "/",
+      "status": "pass",
+      "url": "https://kriskrug.co/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/blog/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/blog/",
+      "status": "pass",
+      "url": "https://kriskrug.co/blog/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/speaking/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/speaking/",
+      "status": "pass",
+      "url": "https://kriskrug.co/speaking/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/work/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/work/",
+      "status": "pass",
+      "url": "https://kriskrug.co/work/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/contact/",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/contact/",
+      "status": "pass",
+      "url": "https://kriskrug.co/contact/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "namespaces": [
+          "akismet/v1",
+          "code-snippets/v1",
+          "google-site-kit/v1",
+          "jetpack-boost-ds",
+          "jetpack-boost/v1",
+          "jetpack-protect/v1",
+          "jetpack/v4",
+          "jetpack/v4/explat",
+          "mcp",
+          "my-jetpack/v1",
+          "oembed/1.0",
+          "popup-maker/v1",
+          "popup-maker/v2",
+          "pum/v1",
+          "redirection/v1",
+          "wp-abilities/v1",
+          "wp-block-editor/v1",
+          "wp-site-health/v1",
+          "wp/v2",
+          "zbscrm/v1"
+        ],
+        "site_name": "Kris Kr\u00fcg | Generative AI Tools &amp; Techniques"
+      },
+      "failures": [],
+      "path": "/wp-json/",
+      "status": "pass",
+      "url": "https://kriskrug.co/wp-json/",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "application/xml; charset=UTF-8",
+        "final_url": "https://kriskrug.co/wp-sitemap.xml",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/sitemap.xml",
+      "status": "pass",
+      "url": "https://kriskrug.co/sitemap.xml",
+      "warnings": []
+    },
+    {
+      "details": {
+        "content_type": "text/html; charset=UTF-8",
+        "final_url": "https://kriskrug.co/?s=ai",
+        "status": 200
+      },
+      "failures": [],
+      "path": "/?s=ai",
+      "status": "pass",
+      "url": "https://kriskrug.co/?s=ai",
+      "warnings": []
+    }
+  ],
+  "observed_wordpress_version": "7.0.2",
+  "started_at": "2026-08-03T02:46:35Z"
+}
+```
+
+### Current-State Drift Check (JSON)
+
+- Command: `/opt/homebrew/opt/python@3.14/bin/python3.14 scripts/check_current_state_drift.py --base-url https://kriskrug.co --work-plan docs/current-state/CURRENT-STATE-2026-07-30.md --json`
+- Exit code: `0`
+
+```text
+{
+  "base_url": "https://kriskrug.co",
+  "checks": [
+    {
+      "declared": 0,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_prs",
+      "label": "Open PRs",
+      "observed": 9,
+      "status": "drift"
+    },
+    {
+      "declared": 66,
+      "drift": true,
+      "evaluated": true,
+      "key": "open_issues",
+      "label": "Open Issues",
+      "observed": 59,
+      "status": "drift"
+    },
+    {
+      "declared": "7.0.2",
+      "drift": false,
+      "evaluated": true,
+      "key": "wp_version",
+      "label": "WordPress Version",
+      "observed": "7.0.2",
+      "status": "no drift"
+    },
+    {
+      "declared": 0,
+      "drift": false,
+      "evaluated": true,
+      "key": "future_posts",
+      "label": "Scheduled Posts",
+      "observed": 0,
+      "status": "no drift"
+    },
+    {
+      "declared": 67,
+      "drift": false,
+      "evaluated": true,
+      "key": "draft_posts",
+      "label": "Draft Posts",
+      "observed": 67,
+      "status": "no drift"
+    },
+    {
+      "declared": 4,
+      "drift": false,
+      "evaluated": true,
+      "key": "draft_pages",
+      "label": "Draft Pages",
+      "observed": 4,
+      "status": "no drift"
+    }
+  ],
+  "errors": [],
+  "work_plan": "/Users/kk/Code/kriskrug-wp/docs/current-state/CURRENT-STATE-2026-07-30.md"
+}
+```
+
+### Projects URL Headers
+
+- Command: `curl -sI https://kriskrug.co/projects/`
+- Exit code: `0`
+
+```text
+HTTP/2 301 
+date: Mon, 03 Aug 2026 02:46:48 GMT
+content-type: text/html; charset=UTF-8
+content-length: 0
+server: Pagely-ARES/1.22.28
+x-gateway-request-id: 0bb6f1e7ada3507364dd675a403e7727
+x-jetpack-boost-cache: miss
+expires: Mon, 03 Aug 2026 03:34:03 GMT
+cache-control: max-age=3600
+x-redirect-by: redirection
+location: /work/
+x-gateway-cache-key: 1784933659.113|standard|https|kriskrug.co|||/projects/
+x-gateway-cache-status: HIT
+x-gateway-skip-cache: 0
+```

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -26,9 +26,13 @@ class CommandResult:
     stderr: str
 
 
-def run_command(title: str, command: list[str], cwd: Path, timeout: int = 120) -> CommandResult:
+def run_command(
+    title: str, command: list[str], cwd: Path, timeout: int = 120
+) -> CommandResult:
     try:
-        completed = subprocess.run(command, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+        completed = subprocess.run(
+            command, cwd=cwd, capture_output=True, text=True, timeout=timeout
+        )
     except subprocess.TimeoutExpired as exc:
         return CommandResult(
             title=title,
@@ -46,7 +50,9 @@ def run_command(title: str, command: list[str], cwd: Path, timeout: int = 120) -
     )
 
 
-def run_json_command(title: str, command: list[str], cwd: Path) -> tuple[CommandResult, Any | None]:
+def run_json_command(
+    title: str, command: list[str], cwd: Path
+) -> tuple[CommandResult, Any | None]:
     result = run_command(title, command, cwd)
     if result.returncode != 0 or not result.stdout:
         return result, None
@@ -64,7 +70,11 @@ def parse_status_line(headers: str) -> str:
 
 
 def parse_og_image(html: str) -> str:
-    match = re.search(r'<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)', html, flags=re.I)
+    match = re.search(
+        r'<meta\s+property=["\']og:image["\']\s+content=["\']([^"\']+)',
+        html,
+        flags=re.I,
+    )
     if not match:
         return "(not found)"
     return match.group(1)
@@ -108,7 +118,9 @@ def build_label_counts(issues_json: list[dict[str, Any]]) -> dict[str, int]:
 def fetch_wp_queue_counts(repo_root: Path) -> tuple[dict[str, int] | None, str | None]:
     env_path = repo_root / "scripts/notion-to-wp/.env"
     has_env_file = env_path.exists()
-    has_process_creds = bool(os.environ.get("WP_USER") and os.environ.get("WP_APP_PASSWORD"))
+    has_process_creds = bool(
+        os.environ.get("WP_USER") and os.environ.get("WP_APP_PASSWORD")
+    )
     if not has_env_file and not has_process_creds:
         return None, (
             f"WordPress credentials unavailable: missing env file: {env_path} "
@@ -130,7 +142,12 @@ def format_json_count(payload: Any) -> str:
 def summarize_smoke(smoke_json: Any) -> dict[str, Any]:
     """Summarize public smoke JSON; an unavailable result never reads as 0 failures."""
     if not isinstance(smoke_json, dict):
-        return {"available": False, "failures": None, "warnings": None, "observed_version": None}
+        return {
+            "available": False,
+            "failures": None,
+            "warnings": None,
+            "observed_version": None,
+        }
     failures = 0
     warnings = 0
     for check in smoke_json.get("checks", []):
@@ -146,6 +163,31 @@ def summarize_smoke(smoke_json: Any) -> dict[str, Any]:
     }
 
 
+def render_theme_parity_line(result: CommandResult) -> str:
+    """Summarize live-vs-repo Aurora drift for the Aurora Risk section.
+
+    AGENTS.md requires a public style.css readback before trusting the repo
+    version, and the drift has historically gone in both directions. The
+    detector already exists (#546); nothing was running it automatically.
+
+    Exit 0 covers both a genuine match and a soft skip when live is
+    unreachable, so those are reported differently here. A skip is not a pass.
+    """
+    stdout = result.stdout or ""
+    if result.returncode == 1:
+        detail = " ".join(stdout.split())
+        return f"- **Aurora live vs repo: DRIFT.** {detail}"
+    if result.returncode == 2:
+        return (
+            f"- **Aurora live vs repo: could not measure.** `{stdout or result.stderr}`"
+        )
+    if stdout.startswith("SKIP") or "unreachable" in stdout:
+        return f"- **Aurora live vs repo: not measured** (live unreachable). `{' '.join(stdout.split())}`"
+    if stdout.startswith("PASS"):
+        return f"- Aurora live vs repo: in sync. `{stdout}`"
+    return f"- **Aurora live vs repo: unexpected result** (exit {result.returncode}). `{stdout or result.stderr}`"
+
+
 def collect_truth_errors(
     prs_json: Any,
     issues_json: Any,
@@ -156,15 +198,23 @@ def collect_truth_errors(
     """List startup truth data sources that could not be evaluated."""
     errors: list[str] = []
     if not isinstance(prs_json, list):
-        errors.append("open PR list unavailable (gh pr list JSON failed or was unparsable)")
+        errors.append(
+            "open PR list unavailable (gh pr list JSON failed or was unparsable)"
+        )
     if not isinstance(issues_json, list):
-        errors.append("open issue list unavailable (gh issue list JSON failed or was unparsable)")
+        errors.append(
+            "open issue list unavailable (gh issue list JSON failed or was unparsable)"
+        )
     if queue_error:
         errors.append(f"draft queue counts unavailable: {queue_error}")
     if not smoke_available:
-        errors.append("public smoke result unavailable (missing or unparsable JSON); treat as degraded")
+        errors.append(
+            "public smoke result unavailable (missing or unparsable JSON); treat as degraded"
+        )
     if not isinstance(drift_json, dict):
-        errors.append("current-state drift report unavailable (command or parsing failure)")
+        errors.append(
+            "current-state drift report unavailable (command or parsing failure)"
+        )
     return errors
 
 
@@ -172,7 +222,7 @@ def render_command_block(result: CommandResult) -> str:
     lines = [
         f"### {result.title}",
         "",
-        f"- Command: `{ ' '.join(result.command) }`",
+        f"- Command: `{' '.join(result.command)}`",
         f"- Exit code: `{result.returncode}`",
     ]
     if result.stdout:
@@ -191,11 +241,29 @@ def main() -> int:
         default="docs/current-state/WORK-PLAN-2026-05-23.md",
         help="Declared state doc used for drift checks.",
     )
-    parser.add_argument("--command-timeout", type=int, default=120, help="Timeout for shell subcommands in seconds.")
-    parser.add_argument("--request-timeout", type=int, default=20, help="Timeout for each public smoke HTTP request.")
+    parser.add_argument(
+        "--command-timeout",
+        type=int,
+        default=120,
+        help="Timeout for shell subcommands in seconds.",
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=int,
+        default=20,
+        help="Timeout for each public smoke HTTP request.",
+    )
     parser.add_argument("--out", help="Write report to this path.")
-    parser.add_argument("--stdout", action="store_true", help="Print the report instead of writing a file.")
-    parser.add_argument("--skip-fetch", action="store_true", help="Skip git fetch for strictly non-mutating runs.")
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the report instead of writing a file.",
+    )
+    parser.add_argument(
+        "--skip-fetch",
+        action="store_true",
+        help="Skip git fetch for strictly non-mutating runs.",
+    )
     parser.add_argument(
         "--fail-on-error",
         action="store_true",
@@ -210,7 +278,11 @@ def main() -> int:
     stamp = now.strftime("%Y%m%d-%H%M%SZ")
     out_path = None
     if not args.stdout:
-        out_path = Path(args.out) if args.out else repo_root / "docs/current-state/reports" / f"morning-truth-{stamp}.md"
+        out_path = (
+            Path(args.out)
+            if args.out
+            else repo_root / "docs/current-state/reports" / f"morning-truth-{stamp}.md"
+        )
         if not out_path.is_absolute():
             out_path = (repo_root / out_path).resolve()
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -218,38 +290,105 @@ def main() -> int:
     startup_results = []
     if not args.skip_fetch:
         startup_results.append(
-            run_command("Git Fetch", ["git", "fetch", "--prune"], repo_root, timeout=args.command_timeout)
+            run_command(
+                "Git Fetch",
+                ["git", "fetch", "--prune"],
+                repo_root,
+                timeout=args.command_timeout,
+            )
         )
-    startup_results.extend([
-        run_command("Git Status", ["git", "status", "--short", "--branch"], repo_root, timeout=args.command_timeout),
-        run_command("Recent Log", ["git", "log", "--oneline", "-n", "20"], repo_root, timeout=args.command_timeout),
-        run_command("Open PRs", ["gh", "pr", "list", "--state", "open", "--limit", "50"], repo_root, timeout=args.command_timeout),
-        run_command("Open Issues", ["gh", "issue", "list", "--state", "open", "--limit", "200"], repo_root, timeout=args.command_timeout),
-        run_command("Worktrees", ["git", "worktree", "list", "--porcelain"], repo_root, timeout=args.command_timeout),
-        run_command("Main Divergence", ["git", "rev-list", "--left-right", "--count", "origin/main...main"], repo_root, timeout=args.command_timeout),
-        run_command(
-            "Aurora vs Main Divergence",
-            ["git", "rev-list", "--left-right", "--count", "origin/aurora/v2...origin/main"],
-            repo_root,
-            timeout=args.command_timeout,
-        ),
-    ])
+    startup_results.extend(
+        [
+            run_command(
+                "Git Status",
+                ["git", "status", "--short", "--branch"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Recent Log",
+                ["git", "log", "--oneline", "-n", "20"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Open PRs",
+                ["gh", "pr", "list", "--state", "open", "--limit", "50"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Open Issues",
+                ["gh", "issue", "list", "--state", "open", "--limit", "200"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Worktrees",
+                ["git", "worktree", "list", "--porcelain"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Main Divergence",
+                ["git", "rev-list", "--left-right", "--count", "origin/main...main"],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+            run_command(
+                "Aurora vs Main Divergence",
+                [
+                    "git",
+                    "rev-list",
+                    "--left-right",
+                    "--count",
+                    "origin/aurora/v2...origin/main",
+                ],
+                repo_root,
+                timeout=args.command_timeout,
+            ),
+        ]
+    )
 
     issues_json_result, issues_json = run_json_command(
         "Issue JSON",
-        ["gh", "issue", "list", "--state", "open", "--limit", "200", "--json", "number,title,labels,updatedAt"],
+        [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,labels,updatedAt",
+        ],
         repo_root,
     )
     prs_json_result, prs_json = run_json_command(
         "PR JSON",
-        ["gh", "pr", "list", "--state", "open", "--limit", "50", "--json", "number,title,updatedAt"],
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "50",
+            "--json",
+            "number,title,updatedAt",
+        ],
         repo_root,
     )
 
     queue_counts, queue_error = fetch_wp_queue_counts(repo_root)
     draft_result = CommandResult(
         title="Draft Queue Counts (REST, read-only)",
-        command=["python3", "scripts/morning_truth_report.py", "(internal queue fetch)"],
+        command=[
+            "python3",
+            "scripts/morning_truth_report.py",
+            "(internal queue fetch)",
+        ],
         returncode=0 if not queue_error else 1,
         stdout=(
             f"future_posts={queue_counts['future_posts']}, "
@@ -297,7 +436,11 @@ def main() -> int:
     )
     work_page_html = run_command(
         "Work Page HTML",
-        ["curl", "-sL", f"{args.base_url.rstrip('/')}/recent-projects-include/?cachebust={cache_bust}"],
+        [
+            "curl",
+            "-sL",
+            f"{args.base_url.rstrip('/')}/recent-projects-include/?cachebust={cache_bust}",
+        ],
         repo_root,
     )
     home_page_html = run_command(
@@ -305,8 +448,20 @@ def main() -> int:
         ["curl", "-sL", f"{args.base_url.rstrip('/')}/?cachebust={cache_bust}"],
         repo_root,
     )
+    theme_parity = run_command(
+        "Live vs Repo Aurora Version",
+        [
+            sys.executable,
+            "scripts/check_live_theme_parity.py",
+            "--base",
+            args.base_url.rstrip("/"),
+        ],
+        repo_root,
+    )
 
-    worktrees_output = next((item.stdout for item in startup_results if item.title == "Worktrees"), "")
+    worktrees_output = next(
+        (item.stdout for item in startup_results if item.title == "Worktrees"), ""
+    )
     aurora_branch_section = None
     for section in parse_worktree_sections(worktrees_output):
         if section.get("branch") == "refs/heads/aurora/v2":
@@ -319,7 +474,15 @@ def main() -> int:
         aurora_path = Path(aurora_branch_section["worktree"])
         aurora_local_divergence = run_command(
             "Aurora Local vs Origin Divergence",
-            ["git", "-C", str(aurora_path), "rev-list", "--left-right", "--count", "origin/aurora/v2...aurora/v2"],
+            [
+                "git",
+                "-C",
+                str(aurora_path),
+                "rev-list",
+                "--left-right",
+                "--count",
+                "origin/aurora/v2...aurora/v2",
+            ],
             repo_root,
         )
         aurora_local_status = run_command(
@@ -332,7 +495,9 @@ def main() -> int:
         label_counts = build_label_counts(issues_json)
         label_lines = [f"- `{key}`: `{count}`" for key, count in label_counts.items()]
     else:
-        label_lines = ["- Issue label counts: `unavailable` (open issue JSON query failed)"]
+        label_lines = [
+            "- Issue label counts: `unavailable` (open issue JSON query failed)"
+        ]
     draft_queue_summary = (
         f"future posts `{queue_counts['future_posts']}`, "
         f"draft posts `{queue_counts['draft_posts']}`, "
@@ -411,7 +576,9 @@ def main() -> int:
             "- Result: `unavailable` (public smoke output missing or unparsable; treat as degraded, not passing)",
         ]
 
-    truth_errors = collect_truth_errors(prs_json, issues_json, queue_error, smoke["available"], drift_json)
+    truth_errors = collect_truth_errors(
+        prs_json, issues_json, queue_error, smoke["available"], drift_json
+    )
     if truth_errors:
         availability_lines = [f"- `unavailable`: {error}" for error in truth_errors]
     else:
@@ -433,6 +600,8 @@ def main() -> int:
         ]
     )
 
+    lines.append(render_theme_parity_line(theme_parity))
+
     if aurora_local_divergence:
         lines.append(
             f"- Local `aurora/v2` vs `origin/aurora/v2`: `{aurora_local_divergence.stdout or '(no output)'}`"
@@ -440,7 +609,9 @@ def main() -> int:
     else:
         lines.append("- Local `aurora/v2` worktree not detected from porcelain list.")
     if aurora_local_status:
-        lines.append(f"- Local `aurora/v2` status: `{aurora_local_status.stdout or '(clean/no output)'}`")
+        lines.append(
+            f"- Local `aurora/v2` status: `{aurora_local_status.stdout or '(clean/no output)'}`"
+        )
 
     lines.extend(["", "## Startup Command Outputs", ""])
     for result in startup_results:

--- a/scripts/tests/test_morning_truth_report.py
+++ b/scripts/tests/test_morning_truth_report.py
@@ -168,3 +168,49 @@ class MorningTruthAvailabilityTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ThemeParityLineTests(unittest.TestCase):
+    """Live-vs-repo Aurora drift reporting (#546 detector, wired into the report)."""
+
+    @staticmethod
+    def _result(returncode, stdout="", stderr=""):
+        return morning_truth_report.CommandResult(
+            title="Live vs Repo Aurora Version",
+            command=["python3", "scripts/check_live_theme_parity.py"],
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    def test_drift_is_reported_as_drift(self):
+        line = morning_truth_report.render_theme_parity_line(
+            self._result(1, "FAIL theme version drift detected:\n  live: 1.5.7\n  repo: 1.5.8")
+        )
+        self.assertIn("DRIFT", line)
+        self.assertIn("1.5.7", line)
+        self.assertIn("1.5.8", line)
+
+    def test_match_is_reported_as_in_sync(self):
+        line = morning_truth_report.render_theme_parity_line(
+            self._result(0, "PASS live and repo agree on Version: 1.5.8")
+        )
+        self.assertIn("in sync", line)
+        self.assertNotIn("DRIFT", line)
+
+    def test_unreachable_live_is_not_reported_as_a_pass(self):
+        # The detector exits 0 for both a real match and a soft skip. A skip
+        # must not read as "in sync" or the report would launder a
+        # non-measurement into a green check.
+        line = morning_truth_report.render_theme_parity_line(
+            self._result(0, "WARN live theme unreachable (...)\nSKIP parity check (repo declares Version: 1.5.8)")
+        )
+        self.assertIn("not measured", line)
+        self.assertNotIn("in sync", line)
+
+    def test_repo_read_failure_is_reported_as_unmeasurable(self):
+        line = morning_truth_report.render_theme_parity_line(
+            self._result(2, "ERROR could not read repo Version from theme/kk-aurora/style.css")
+        )
+        self.assertIn("could not measure", line)
+        self.assertNotIn("in sync", line)


### PR DESCRIPTION
## The gap

`scripts/check_live_theme_parity.py` (issue #546) opens with:

> The repo's #1 risk is the live `kk-aurora` theme silently diverging from the version tracked in `main`.

It detects that correctly. **Nothing ran it automatically.** Not CI, not `make validate`, not `make morning-truth`. It only fired when someone typed `make check-live-parity` by hand.

Meanwhile the **Aurora Risk (Read-Only)** section of every morning-truth report covered only local `aurora/v2` worktree state and said nothing at all about the live theme version. So the repo's stated #1 risk had a working detector and no trigger.

There is real drift right now, and it was not showing up:

```
$ make check-live-parity
FAIL theme version drift detected:
  live (https://kriskrug.co/wp-content/themes/kk-aurora/style.css): 1.5.7
  repo (theme/kk-aurora/style.css): 1.5.8
```

## The change

Wires the existing detector into morning-truth. **No new drift logic** — this is one `run_command` call plus a render function.

### A skip is not a pass

The detector exits `0` both when versions match *and* when live is unreachable (a deliberate soft-skip so the check degrades gracefully offline). Collapsing those into one green line would launder a non-measurement into a pass, which is exactly what AGENTS.md warns about with *"readback, don't assume, in either direction."*

So the four states render distinctly:

| Detector state | Report line |
|---|---|
| exit 1, drift | **Aurora live vs repo: DRIFT.** + both versions |
| exit 0, `PASS` | Aurora live vs repo: in sync |
| exit 0, `SKIP` (unreachable) | **not measured** (live unreachable) |
| exit 2 | **could not measure** |

## Verification

Actual output from `make morning-truth` on this branch, in `morning-truth-20260803-024628Z.md`:

```
## Aurora Risk (Read-Only)

- **Aurora live vs repo: DRIFT.** FAIL theme version drift detected: live (...): 1.5.7 repo (theme/kk-aurora/style.css): 1.5.8
- Local `aurora/v2` worktree not detected from porcelain list.
```

| Check | Result |
|---|---|
| `make morning-truth` | emits the real current gap |
| unit tests | 15 pass, 4 new (drift / in-sync / unreachable / unreadable-repo) |
| `make python-test` | 0 failures across all suites |
| em dashes added | 0 |

## Note on the current drift

The 1.5.7 vs 1.5.8 gap is **expected and gated**, not a bug: it is the undeployed `aurora-tstm` CSS waiting on the #601 pixel gate. This PR surfaces it rather than gating on it, deliberately. Wiring the check into CI as a hard failure would block every PR until #601 ships.

## Related

Came out of the #566 front-door work. That lane added a hardcoded regex to `docs_truth_check.py` matching the exact string `Aurora 1.5.0 (live == repo`, which catches today's stale line but not tomorrow's. `docs_truth_check.py` is a regex blacklist by design and cannot catch novel staleness. This is the dynamic complement, and it lives where live checks already run.

## Safety

Read-only. One GET to the public `style.css`. No live WordPress writes, no theme changes, no deploys.