### PR TITLE
content(#603): rewrite all 26 em dashes on AI Lands post 12653

### DIFF
--- a/content/drafts/2026-08-02-emdash-remediation/README.md
+++ b/content/drafts/2026-08-02-emdash-remediation/README.md
@@ -1,0 +1,101 @@
+# Em dash remediation: post 12653, AI Lands Inside Every Profession
+
+**Issue:** #603 (voice sweep epic). The live-apply child for this post is VOICE-5, [#609](https://github.com/WalksWithASwagger/kriskrug-wp/issues/609).
+**Lane:** Track A, repo-only. Nothing here touched the live site. No REST writes, no deploys, no connector runs.
+**Date:** 2026-08-02.
+
+## Which post, and why this one
+
+**Post 12653**, `ai-lands-inside-every-profession`, published **2026-07-31T17:40:55**.
+
+It is the newest post in the sweep window (2026-06-18 through 2026-07-31) per `content/drafts/voice-audit-blog-sweep-2026-08-01/manifest.json`, and it is the post the audit calls the em dash blowout. Three independent confirmations that it is the right target:
+
+1. `00-summary.md`, P1 item 1: "AI Lands: 26 prose em dashes (rank 1 offender)... Post ID 12653."
+2. The tally table in the same file: "em dash (32 of 44; **26 prose in ai-lands** + 6 table syntax in god-skills)."
+3. Direct count on the stored snapshot: `snapshots/2026-07-31-ai-lands-inside-every-profession.txt` contains exactly **26** U+2014 characters, and `voicecheck.py` on that file returns 27 flags (26 em dash, 1 soft `team`).
+
+**It is not post 12034.** Zero to One (`zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey`, 2026-06-30) is the third-person rewrite job, VOICE-8 / [#612](https://github.com/WalksWithASwagger/kriskrug-wp/issues/612), and it is owned by another lane running right now. Its audit finding is 6 mechanical flags and a person-shift problem, not a dash blowout, and its date is a month earlier than 12653. Nothing in this directory touches 12034. The one place it comes up is the `origin arc separately` link inside 12653, which is left exactly as it is.
+
+## Before and after
+
+| Metric | Before | After |
+|---|---|---|
+| Em dashes (U+2014) in body | **26** | **0** |
+| `voicecheck.py` flags | 27 (26 em dash, 1 soft `team`) | 1 (the same soft `team`) |
+| `voicecheck.py` exit | 1 | 1, on the documented keep only |
+| En dashes (U+2013) | 2, both date ranges | 2, unchanged |
+| Redefinition-reveal instances | ~8 | 5, with the two flagship instances intact |
+
+The one remaining flag is `judgment is a team sport`. Both audit phases ruled it a keep: it is an idiomatic set phrase, not a reference to his own crew, and "crew sport" is not a thing. Left alone deliberately.
+
+Every dash is rewritten, never swapped. No hyphens, no en dashes, no spaced hyphens standing in for the old dash. Twelve became colons, eight became a period plus a new sentence, three became commas, one became a comma with the clause inverted, and one matched pair became parentheses around a link aside. The full site-by-site record is in `dash-ledger.md`.
+
+## What else got fixed
+
+**The redefinition-reveal house tic.** The audit flagged this as the post's real voice risk after the dashes, and specifically because it dodges the checker: `voicecheck.py` anchors on the contraction `it's not just`, so a decontracted split like "The failure mode is not departure. The failure mode is a province with no serious pathway home." sails straight through with zero flags. Eight of them in 2,247 words turns a cadence into a template.
+
+Three were varied, per the audit's instruction to keep the two named flagship instances and vary two or three of the rest:
+
+- L60 "That is not a romance about grit, it is a design choice" became "That is a design choice, not a romance about grit." This one does double duty since it was also dash site 8.
+- L103 "The failure mode is not departure. The failure mode is a province with no serious pathway home." became "What kills a region is having no serious pathway home."
+- L135 "The point is not to cheerlead AI. The point is to build enough shared practice..." became "I am not asking you to cheer for AI. I am asking you to help build enough shared practice..."
+
+Kept on purpose: the Space Centre venue-rental line (L38) and "Ecosystem is not a vibe. It is repeated contact with consequences." (L99), both named keeps in the audit; the origin thesis at L36; the researchers' finding at L97; the fragment ladder at L115; and the pull quote at L14, which is quoted as printed in Business in Vancouver. Rationale per instance is in the ledger.
+
+**Typography matched to the stored post.** `remediated-body.md` uses the same curly apostrophes and paired curly quotes the live post already stores, so the applying agent can swap whole paragraphs without introducing an encoding diff. Relevant given the latin1 database behaviour documented for this site.
+
+## What was deliberately left alone
+
+| Thing | Why |
+|---|---|
+| Festival spelling ("Futureproof" x3) | VOICE-10 / [#614](https://github.com/WalksWithASwagger/kriskrug-wp/issues/614) owns that decision. Glossary says FUTURE PROOF, the July 28 sibling says Future Proof, this post says Futureproof. Not mine to pick. |
+| `judgment is a team sport` | Documented keep in both audit phases. |
+| The "no X, no Y, just Z" ladder at L30 to L32 | Works locally, and "A drumbeat" pays off again at L129. The audit flagged it only as a cross-post template watch item. |
+| Images, alt text, links, embed IDs, headings, block order | Out of scope. The lane is dashes plus reveal density. |
+| Post 12034, and every other post in the sweep | Other lanes own them. |
+
+## One thing I could not resolve, flagged not fixed
+
+L115 reads: "We took the community **a platform built from those rooms**, and then I read all thirty-two expert reports." That sentence looks like it is missing a word or a preposition (took the community *to Ottawa*? took *to* the Task Force?). It is preserved verbatim in `remediated-body.md` because fixing it is a content decision, not a punctuation one, and it is outside this lane. Worth a look from whoever applies #609, or from KK directly.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `README.md` | this |
+| `remediated-body.md` | full corrected body, block markers included, ready for a snapshot-first apply |
+| `dash-ledger.md` | all 26 sites with original phrasing, rewrite, and the move used |
+
+## How to verify
+
+Zero em dashes in every file in this directory:
+
+```
+python3 -c "import pathlib;[print(p.name, p.read_text(encoding='utf-8').count(chr(0x2014))) for p in sorted(pathlib.Path('content/drafts/2026-08-02-emdash-remediation').glob('*.md'))]"
+```
+
+Expect `0` for all three. The check is written with `chr(0x2014)` rather than a literal `grep` pattern so that running the verification does not reintroduce the character into this file. `dash-ledger.md` writes the original character as the literal token `{EMDASH}` precisely so the ledger can quote the originals without carrying them.
+
+Mechanical voice check on the corrected body:
+
+```
+python3 ~/Code/kk-voice/scripts/voicecheck.py content/drafts/2026-08-02-emdash-remediation/remediated-body.md
+```
+
+Expect exactly 1 flag, the soft `team` at the "team sport" line, and nothing else.
+
+Baseline for comparison:
+
+```
+python3 ~/Code/kk-voice/scripts/voicecheck.py \
+  content/drafts/voice-audit-blog-sweep-2026-08-01/snapshots/2026-07-31-ai-lands-inside-every-profession.txt
+```
+
+Expect 27 flags.
+
+## Still open
+
+- Live apply against 12653 has not happened and is not authorized from this lane. #609 owns it: snapshot first, slug and ID check, cache-bypass curl after.
+- Festival naming decision is blocked on #614.
+- The checker gap that let this density through is #616's work in `~/Code/kk-voice/anti-glossary.md`. The candidate regex from the audit is `\b(is|are|was) not (just|only|simply) [^.]{3,80}\. (It|That|They|These) (is|are)\b`, soft flag, judged on density rather than per instance. Not touched here, different repo.
+- The L115 missing-word question above.

--- a/content/drafts/2026-08-02-emdash-remediation/dash-ledger.md
+++ b/content/drafts/2026-08-02-emdash-remediation/dash-ledger.md
@@ -1,0 +1,83 @@
+# Dash ledger: all 26 em dash sites, post 12653
+
+Post: **AI Lands Inside Every Profession** (`ai-lands-inside-every-profession`, ID 12653, published 2026-07-31)
+Source: `content/drafts/voice-audit-blog-sweep-2026-08-01/snapshots/2026-07-31-ai-lands-inside-every-profession.txt`
+Line numbers are that snapshot's line numbers.
+
+**Notation:** this file is itself under the no-em-dash rule, so the original character U+2014 is written as the token `{EMDASH}` in the Original column. Substitute a literal U+2014 when diffing against the live post. Everything else in the Original column is verbatim.
+
+**Edit IDs** (`D1`..`D23`) match the fix table in `content/drafts/voice-audit-blog-sweep-2026-08-01/readings/2026-07-31-ai-lands-inside-every-profession.md`. Three edits cover a matched pair of dashes, so 26 dashes resolve into 23 edits.
+
+## The 26 sites
+
+| # | L | Edit | Move | Original (dash = `{EMDASH}`) | Rewrite |
+|---|---|---|---|---|---|
+| 1 | 18 | D1 | colon | Here is the rest of the story `{EMDASH}` the part that does not fit in a news brief. | Here is the rest of the story: the part that does not fit in a news brief. |
+| 2 | 28 | D13 | period | …since the very first weeks of this project `{EMDASH}` the entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement. | …since the very first weeks of this project. The entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement. |
+| 3 | 36 | D19 | comma | I had spent a year deep in the machine `{EMDASH}` testing tools, talking to labs, watching the ground move | I had spent a year deep in the machine, testing tools, talking to labs, watching the ground move |
+| 4 | 36 | D19 | period | …watching the ground move `{EMDASH}` and the conclusion kept getting louder: | …watching the ground move. And the conclusion kept getting louder: |
+| 5 | 44 | D2 | colon | 11 community subgroups `{EMDASH}` an AI Film Club run by Kevin Friel… | 11 community subgroups: an AI Film Club run by Kevin Friel… |
+| 6 | 46 | D14 | period | weekly programming, not just a monthly flagship `{EMDASH}` the events calendar does not take weeks off | weekly programming, not just a monthly flagship. The events calendar does not take weeks off |
+| 7 | 54 | D15 | period | …at the Space Centre `{EMDASH}` the long-dreamed homegrown annual gathering, now with dates and a speaker lineup | …at the Space Centre. The long-dreamed homegrown annual gathering, now with dates and a speaker lineup |
+| 8 | 60 | D22 | comma, inverted | That is not a romance about grit `{EMDASH}` it is a design choice. | That is a design choice, not a romance about grit. |
+| 9 | 62 | D3 | colon | *Vancouver AI Turns One* `{EMDASH}` the room, one year in. | *Vancouver AI Turns One*: the room, one year in. |
+| 10 | 64 | D4 | colon | Futureproof Festival `{EMDASH}` October 28–30, 2026 · Space Centre. | Futureproof Festival: October 28–30, 2026 · Space Centre. |
+| 11 | 70 | D5 | colon | …started feeling like civic infrastructure `{EMDASH}` a room people can come back to, where… | …started feeling like civic infrastructure: a room people can come back to, where… |
+| 12 | 72 | D16 | period | AI Ethical Futures Lab at Parker Street Studios, July 2026 `{EMDASH}` the room got real. | AI Ethical Futures Lab at Parker Street Studios, July 2026. The room got real. |
+| 13 | 74 | D6 | colon | now he calls this the orchestration era `{EMDASH}` not one model, but a pipeline you conduct | now he calls this the orchestration era: not one model, but a pipeline you conduct |
+| 14 | 74 | D6 | period | …a pipeline you conduct `{EMDASH}` and gives away every shortcut he knows on a Wednesday night. | …a pipeline you conduct. And he gives away every shortcut he knows on a Wednesday night. |
+| 15 | 74 | D17 | period | …made for about a hundred dollars `{EMDASH}` work that would have carried a six-figure budget at his old studio. | …made for about a hundred dollars. Work that would have carried a six-figure budget at his old studio. |
+| 16 | 76 | D7 | colon | About sixty-five showed up `{EMDASH}` farmers, teachers, local government folks, software people, artists, retirees. | About sixty-five showed up: farmers, teachers, local government folks, software people, artists, retirees. |
+| 17 | 78 | D8 | colon | Comox Valley AI in Courtenay `{EMDASH}` becoming its own thing. | Comox Valley AI in Courtenay: becoming its own thing. |
+| 18 | 82 | D20 | comma | …trustworthy enough for patient outcomes `{EMDASH}` for the responsibility that used to live entirely in the hands of doctors? | …trustworthy enough for patient outcomes, for the responsibility that used to live entirely in the hands of doctors? |
+| 19 | 84 | D9 | colon | …the Responsible AI Professional certification `{EMDASH}` because in every room, hands go up for deployment and down for governance… | …the Responsible AI Professional certification: in every room, hands go up for deployment and down for governance… |
+| 20 | 86 | D23 | parenthesis | AI amplifies whatever process it lands in `{EMDASH}` I watched this play out in city halls and wrote about it in AI Won’t Fix Your Broken Permit Process | AI amplifies whatever process it lands in (I watched this play out in city halls and wrote about it in AI Won’t Fix Your Broken Permit Process) |
+| 21 | 86 | D23 | parenthesis | …AI Won’t Fix Your Broken Permit Process `{EMDASH}` and “ask the chatbot” is not a governance plan. | …AI Won’t Fix Your Broken Permit Process), and “ask the chatbot” is not a governance plan. |
+| 22 | 97 | D10 | colon | …peer-reviewed case study in *BC Studies* `{EMDASH}` “Building a Grass Roots AI Community of Practice” (No. 224, April 2025). | …peer-reviewed case study in *BC Studies*: “Building a Grass Roots AI Community of Practice” (No. 224, April 2025). |
+| 23 | 115 | D11 | colon | 645 British Columbians answered `{EMDASH}` a fifth of every response in the country, second only to Ontario. | 645 British Columbians answered: a fifth of every response in the country, second only to Ontario. |
+| 24 | 117 | D21 | comma | …as a counterpoint to extractive defaults `{EMDASH}` if communities help write the terms instead of rubber-stamping blank cheques | …as a counterpoint to extractive defaults, if communities help write the terms instead of rubber-stamping blank cheques |
+| 25 | 123 | D12 | colon | Then she did the thing good journalists do `{EMDASH}` she put an industry association, a grassroots community, and an ethics-and-measurement foundation on the same page… | Then she did the thing good journalists do: she put an industry association, a grassroots community, and an ethics-and-measurement foundation on the same page… |
+| 26 | 127 | D18 | period | …research pipelines, capital `{EMDASH}` a healthy region needs all of those layers, run by people with different mandates who talk to each other. | Advocacy work, recurring community, ethics and measurement, research pipelines, capital. A healthy region needs all of those layers, run by people with different mandates who talk to each other. |
+
+## Move tally
+
+| Move | Count | Sites |
+|---|---|---|
+| Colon | 12 | 1, 5, 9, 10, 11, 13, 16, 17, 19, 22, 23, 25 |
+| Period plus new sentence | 8 | 2, 4, 6, 7, 12, 14, 15, 26 |
+| Comma | 3 | 3, 18, 24 |
+| Comma with the clause inverted | 1 | 8 |
+| Parentheses around the aside | 2 | 20, 21 |
+| **Total** | **26** | |
+
+No dash was swapped for a hyphen or an en dash. Every site is a real punctuation or sentence change.
+
+## En dashes left alone (correct typography, not em dash work)
+
+| L | Text | Why kept |
+|---|---|---|
+| 54 | October 28–30, 2026 | date range |
+| 64 | October 28–30, 2026 | date range |
+
+The audit made the same call. The `voicecheck.py` ban list covers U+2014 only.
+
+## Reveal-density edits made in the same pass
+
+Not dash work, but the audit tied them to this edit session. Three of the roughly eight "X is not A. It is B." instances were varied so the two flagship instances stay loud.
+
+| L | Original | Rewrite | Why |
+|---|---|---|---|
+| 60 | That is not a romance about grit `{EMDASH}` it is a design choice. | That is a design choice, not a romance about grit. | Doubles as dash site 8. Inverting the clause kills the template and the dash at once. |
+| 103 | The failure mode is not departure. The failure mode is a province with no serious pathway home. | What kills a region is having no serious pathway home. | Drops the antithesis frame, keeps "pathway home" so "Return pathways are policy" four lines later still lands. |
+| 135 | The point is not to cheerlead AI. The point is to build enough shared practice that this province can compete, govern, and create on purpose. | I am not asking you to cheer for AI. I am asking you to help build enough shared practice that this province can compete, govern, and create on purpose. | Puts a person on both sides of the sentence. It is a CTA paragraph, so second person is the natural read anyway. |
+
+Kept on purpose, per the audit's named keeps and one judgment call:
+
+| L | Instance | Call |
+|---|---|---|
+| 36 | the world did not need another AI content company. It needed an AI community company. | Keep. Origin thesis, and the two halves carry different content. |
+| 38 | That is not a venue rental. That is a city deciding to take its own future seriously. | Keep. Named keep in the audit. |
+| 99 | Ecosystem is not a vibe. It is repeated contact with consequences. | Keep. Named keep, and the thesis line of the post. |
+| 97 | not a platform, not a growth hack | Keep. Reporting the researchers' finding, not his own reveal. |
+| 115 | Not vague nods to "regional representation." Specific proposals about specific capability. | Keep. Fragment ladder, not the copula shape, and it is reporting what was in the expert reports. |
+| 14 | not just inside an AI sector | Keep. Quoted as printed in Business in Vancouver. |

--- a/content/drafts/2026-08-02-emdash-remediation/remediated-body.md
+++ b/content/drafts/2026-08-02-emdash-remediation/remediated-body.md
@@ -1,0 +1,184 @@
+# AI Lands Inside Every Profession
+
+Remediated body for live post **12653** (`ai-lands-inside-every-profession`, published 2026-07-31).
+Source of truth: `content/drafts/voice-audit-blog-sweep-2026-08-01/snapshots/2026-07-31-ai-lands-inside-every-profession.html`.
+
+**Status: repo-only. Nothing here has been written to the live site.** The apply step belongs to VOICE-5 (#609), snapshot-first.
+
+Block conventions used below so the applying agent can map back to WP blocks:
+
+- `##` = `wp-block-heading` (h2)
+- `> PULLQUOTE` = `wp-block-pullquote`
+- `> FIGURE` = `wp-block-image` (src, alt, caption reproduced verbatim unless the caption held a dash)
+- `> GALLERY` = `wp-block-gallery` (two nested images)
+- `> EMBED` = `wp-block-embed` (YouTube oEmbed)
+- Line breaks inside a paragraph that were `<br />` are marked `[BR]`
+
+Images, alt text, links, and embed IDs are unchanged. Only prose changed.
+
+---
+
+Daisy Xiong asked me a clean question for [Business in Vancouver](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298): why does B.C. need a stronger AI community?
+
+I gave her the most honest answer I had.
+
+Because artificial intelligence does not stay inside an AI sector.
+
+It lands inside healthcare systems deciding what clinicians can trust. Inside government offices writing procurement rules for tools nobody fully understands yet. Inside game studios and film pipelines rewriting how production work gets done. Inside HR teams drowning in synthetic job applications. Inside schools, law firms, credit unions, unions, and nonprofits trying to adopt without getting played.
+
+If your map of “the AI ecosystem” only includes companies with AI in the pitch deck, you are missing most of the people who will live with the consequences.
+
+> PULLQUOTE
+> Artificial intelligence lands inside every single profession; not just inside an AI sector.
+>
+> cite: as printed in [Business in Vancouver](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298), July 31, 2026
+
+That is the line Daisy put in the paper. Here is the rest of the story: the part that does not fit in a news brief.
+
+> FIGURE
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/michelle-diamond-meetup30-room-115.webp?ssl=1`
+> alt: Crowded Vancouver AI Meetup gathering in the H.R. MacMillan Space Centre planetarium, June 2026. Photo by Michelle Diamond.
+> caption: [Vancouver AI Meetup 30](https://bc-ai.ca/news/vancouver-ai-meetup-30-space-centre) at the H.R. MacMillan Space Centre, June 2026. Photo by Michelle Diamond.
+
+## We do not lack talent. We lack connective tissue.
+
+B.C. already has researchers, studios, startups, adopters, investors, and public servants doing serious work. Rob Goehring at AInBC is right that the province’s applied AI base is large, diverse, and still young. Sev Geraskin at the [Economy of Wisdom Foundation](https://economyofwisdom.org/) is right that we need better measurement and clearer power-capacity decisions. Three groups, one shared problem, honest differences in approach. Good.
+
+What we have underbuilt is the boring, recurring infrastructure that turns scattered excellence into a region that can learn together, hire across silos, form companies, and show up in policy conversations with a shared memory.
+
+And here is the thing: B.C. has done this before. Our interactive and digital media economy did not happen by accident. People sat down, built the tax credits, built the industry associations, and stitched studios, schools, and government into a cluster on purpose. Ask anyone who was in those rooms in the 2000s. I have been making the case that AI deserves the same deliberate treatment since [the very first weeks of this project](https://bc-ai.ca/news/why-we-need-to-double-down). The entry-level jobs that built those talent pipelines are exactly what AI is dissolving first, and nobody had started building the replacement.
+
+Not another isolated lab.[BR]
+Not another one-off summit.[BR]
+A drumbeat.
+
+## The room came before the plan
+
+The [Vancouver AI](https://vancouver.ai/) meetup started in my studio in January 2024 because I needed a room before I could figure out anything else. I had spent a year deep in the machine, testing tools, talking to labs, watching the ground move. And the conclusion kept getting louder: the world did not need another AI content company. It needed an AI community company.
+
+Eighty-five people crammed into that studio by the end. We were bursting. Then Lorraine Lowe came to me with an offer I still think about: the H.R. MacMillan [Space Centre](https://spacecentre.ca/) was reimagining itself as an innovation hub, and she wanted the AI meetups there. A fifty-year-old cultural institution looked at a scrappy community of builders and artists and said: you belong under the planetarium dome. That is not a venue rental. That is a city deciding to take its own future seriously.
+
+A year later we made it official as the [BC + AI Ecosystem Association](https://bc-ai.ca/about), a member-funded nonprofit. I wrote the [origin arc separately](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/). The short version of where that stands today:
+
+- about 300 paid annual members who actually know each other
+- 11 community subgroups: an [AI Film Club](https://bc-ai.ca/news/launching-the-bc-ai-film-club) run by Kevin Friel on a philosophy of “every human in every loop,” an AI Ethical Futures Lab, education circles, and regional rooms in Surrey, Squamish, and the Comox Valley (first Thursday of the month, if you’re on the Island)
+- weekly programming, not just a monthly flagship. The [events calendar](https://lu.ma/vancouver-ai) does not take weeks off
+- more than 3,000 people through the door since launch
+- [Responsible AI Professional](https://bc-ai.ca/certification/responsible-ai-professional) training in active use
+- hackathons that put real money into builders’ hands
+- [Futureproof Festival](https://futureproof.website/), October 28–30, 2026, at the Space Centre. The [long-dreamed](https://kriskrug.co/2026/06/01/long-road-to-futureproof/) homegrown annual gathering, now with dates and a speaker lineup
+
+> GALLERY (2 columns)
+>
+> FIGURE
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/michelle-diamond-meetup30-crowd-327.webp?ssl=1`
+> alt: Audience filling seats under the Space Centre dome at Vancouver AI Meetup 30, June 2026. Photo by Michelle Diamond.
+> caption: Meetup 30 crowd. Photo by Michelle Diamond.
+>
+> FIGURE
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/vancouver-ai-meetup-2026-06-room.webp?ssl=1`
+> alt: Wide view of Vancouver AI Meetup 30 at the H.R. MacMillan Space Centre, June 2026.
+> caption: Same night, wider room. BC + AI event archive.
+
+We are bootstrapped on memberships, tickets, certifications, and sponsorship. That is a design choice, not a romance about grit. Community infrastructure that only exists when a grant arrives is not infrastructure. Most funding in this space flows to research institutes, large companies, and intermediaries, and community gets treated like a nice-to-have layered on top. We flipped that. We are not waiting for someone to fund us to do these ideas.
+
+> EMBED (YouTube `MB3YnobJcEU`)
+> caption: *Vancouver AI Turns One*: the room, one year in.
+
+> FIGURE (linked to `https://futureproof.website/`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/futureproof-salmon-starfield.jpg?ssl=1`
+> alt: Futureproof Festival key art: coral salmon swimming toward a bright portal under aurora and stars. October 28-30, 2026, presented by BC + AI.
+> caption: [Futureproof Festival](https://futureproof.website/): October 28–30, 2026 · Space Centre. Key art: Futureproof / BC + AI.
+
+## The rooms multiplied
+
+“Eleven subgroups” is an org-chart fact. Here is what it feels like from inside.
+
+The AI Ethical Futures Lab meets at Parker Street Studios, and somewhere around its fifth session it [stopped feeling like an event series and started feeling like civic infrastructure](https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap): a room people can come back to, where somebody can raise disability access and somebody else can raise data-centre heat and both threads belong to the same conversation. Public AI discourse keeps getting flattened into the shiny demo or the red-alert siren. The Lab is where we stop pretending that contradiction is a branding problem.
+
+> FIGURE (linked to `https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/aefl-parker-street-room.jpg?ssl=1`
+> alt: AI Ethical Futures Lab session at Parker Street Studios: about twenty people seated in a loose circle in an art-filled studio, mid-discussion.
+> caption: AI Ethical Futures Lab at Parker Street Studios, July 2026. [The room got real](https://bc-ai.ca/news/ai-ethical-futures-lab-5-july-recap). Photo: BC + AI.
+
+The Film Club is where the professions argument gets cinematic. Kevin Friel spent twenty-five years at DNEG, BRON, and MPC; now he calls this the orchestration era: not one model, but a pipeline you conduct. And he gives away every shortcut he knows on a Wednesday night. When we ran the [first AI Animation Accelerator](https://bc-ai.ca/news/what-we-learned-running-the-first-ai-animation-accelerator), one of our filmmakers showed a thirty-second commercial he had made for about a hundred dollars. Work that would have carried a six-figure budget at his old studio. Two hundred and fifty people packed the Space Centre for our first film festival to watch six AI-made shorts. That is a profession renegotiating itself in public, in real time, in our rooms.
+
+And it is not a Vancouver story anymore. When we took the meetup to Courtenay, I called the first one Meetup #0 because I did not want to show up from the city pretending to know what the Island needed. We expected a dozen people. [About sixty-five showed up](https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing): farmers, teachers, local government folks, software people, artists, retirees. The valley was already having the conversation. You just have to give it a room.
+
+> FIGURE (linked to `https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/comox-valley-meetup-room.jpg?ssl=1`
+> alt: Comox Valley AI meetup in a Courtenay community hall: rows of seated attendees facing a presentation screen.
+> caption: Comox Valley AI in Courtenay: [becoming its own thing](https://bc-ai.ca/news/comox-valley-ai-is-becoming-its-own-thing). Photo: BC + AI.
+
+## What it looks like up close
+
+A health-tech CEO cornered me at one of our gatherings with a question that has stayed with me: when is this technology trustworthy enough for patient outcomes, for the responsibility that used to live entirely in the hands of doctors?
+
+You do not answer that question with a keynote. You answer it with practice: rooms where people deploying AI in consequential settings can compare notes, pressure-test vendors, and learn from each other’s near-misses. That is [why we built the Responsible AI Professional certification](https://kriskrug.co/2026/06/18/why-we-built-the-responsible-ai-professional-certification/): in every room, hands go up for deployment and down for governance, and that gap is where the damage happens.
+
+It is also why I keep saying [adoption is not the goal](https://bc-ai.ca/news/adoption-is-not-the-goal). AI amplifies whatever process it lands in (I watched this play out in city halls and wrote about it in [AI Won’t Fix Your Broken Permit Process](https://kriskrug.co/2026/06/24/ai-wont-fix-your-broken-permit-process/)), and “ask the chatbot” is [not a governance plan](https://kriskrug.co/2026/06/28/what-would-chat-do-and-why-thats-the-wrong-question/). Professions adopting AI need judgment, and judgment is a team sport.
+
+## The product is interconnectedness
+
+Three hundred people who do not know each other are a labour market.[BR]
+Three hundred people who share context, trust, and practice are a capability.
+
+The people in these rooms have each other’s numbers in their phones. That sounds small. It is not. A region gets smarter when ideas can travel between a life-sciences operator, a procurement officer, a creative technologist, and a founder without waiting for a conference badge or a ministerial panel.
+
+> FIGURE (linked to `https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/vanai-conversation-pair.jpg?ssl=1`
+> alt: Two attendees in animated one-on-one conversation at a Vancouver AI gathering, hands mid-gesture.
+> caption: The actual product. [From one room to province-wide infrastructure](https://bc-ai.ca/news/from-one-room-to-province-wide-infrastructure). Photo: BC + AI.
+
+Do not take my word for it. UBC researchers Patrick Pennefather and David Gaertner studied this community and published the result with me as a peer-reviewed case study in *BC Studies*: [“Building a Grass Roots AI Community of Practice”](https://bc-ai.ca/news/documenting-the-bc-ai-ecosystem-movement) (No. 224, April 2025). Their finding on what makes a local technology community hold together: not a platform, not a growth hack. Regular gatherings, porous participation, continuous documentation, and room for both formal and informal learning. In other words: the boring, recurring infrastructure. The stuff nobody funds.
+
+Ecosystem is not a vibe. It is repeated contact with consequences.
+
+## Brain circulation, not brain drain
+
+Young people will leave for larger hubs. Some should. What kills a region is having no serious pathway home.
+
+I want sea turtles: people who go get scars, capital, networks, and taste elsewhere, then return because B.C. has rooms worth rejoining, companies worth building in, and public institutions that know how to work with them.
+
+Retention slogans are cheap. Return pathways are policy.
+
+## A B.C. lane, not a Silicon Valley cosplay
+
+Vancouver is a ninety-minute flight from Silicon Valley, in the same time zone, with completely different defaults available to us. That proximity is an advantage. Copying the hyperscaler playbook and calling it strategy is not.
+
+B.C. can combine applied AI, creative technology, university research, clean electricity, Indigenous ownership and data-sovereignty principles, and a livable Pacific coast into something distinct. I have made the long version of this argument in [Sovereign AI for Whom?](https://kriskrug.co/2026/06/16/sovereign-ai-for-whom/) and [Canada Doesn’t Need a Bigger AI Machine. It Needs a Better One.](https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/)
+
+Ottawa is starting to notice. When Canada’s AI Task Force ran its national consultation, [645 British Columbians answered](https://bc-ai.ca/news/bcs-response-to-the-canada-s-ai-task-force): a fifth of every response in the country, second only to Ontario. We took the community [a platform built from those rooms](https://bc-ai.ca/news/bc-ai-s-platform-for-canada-s-ai-task-force), and then I read all thirty-two expert reports, because somebody should. Buried in them: three different Task Force experts, independently, naming Vancouver as a strategic location for federal AI investment. Not vague nods to “regional representation.” Specific proposals about specific capability. The ground truth we have been building is starting to show up in the national paperwork.
+
+That includes compute. We have a chance to build clean, green, Indigenous-owned, hydropower data centres as a counterpoint to extractive defaults, if communities help write the terms instead of rubber-stamping blank cheques ([You Can’t Drink Data](https://kriskrug.co/2026/05/23/you-cant-drink-data/)). [The Tyee carried a piece of that argument on July 24](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/). The point is simpler than the policy detail: infrastructure without public agency is just someone else’s factory on our grid.
+
+> FIGURE (linked to `https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/tyee-ai-adoption-headline.jpg?ssl=1`
+> alt: Screenshot of The Tyee headline: Who Gets a Say in AI Adoption?
+> caption: Related press: [Who Gets a Say in AI Adoption?](https://thetyee.ca/News/2026/07/24/Who-Gets-Say-AI-Adoption/) · The Tyee · July 24, 2026.
+
+## Three groups, one page
+
+Here is what I appreciated most about Daisy’s reporting. She came to this story after moderating AI panels around the city, where the same theme kept surfacing from every direction: the ecosystem question. Then she did the thing good journalists do: she put an industry association, a grassroots community, and an ethics-and-measurement foundation on the same page and let each be what it actually is.
+
+> FIGURE (linked to `https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298`)
+> src: `https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/biv-headline-clean.jpg?ssl=1`
+> alt: Business in Vancouver headline: B.C. groups push to build a stronger AI ecosystem, by Daisy Xiong.
+> caption: [B.C. groups push to build a stronger AI ecosystem](https://www.biv.com/news/technology/bc-groups-push-to-build-a-stronger-ai-ecosystem-12601298) · Business in Vancouver · Daisy Xiong · July 31, 2026.
+
+Advocacy work, recurring community, ethics and measurement, research pipelines, capital. A healthy region needs all of those layers, run by people with different mandates who talk to each other. The job is to stitch them together without flattening them into one logo. Nobody owns “the ecosystem.” That is the point of the word.
+
+I have been telling this story since before it had institutions attached, and writing it down the whole way. The 2024 sketch is still up: [Future Proof: Inside Vancouver’s Thriving AI Ecosystem](https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/). Then the [BC + AI Report 2024](https://bc-ai.ca/news/bc-ai-report-2024) and a [field map of the provincial AI economy](https://bc-ai.ca/news/state-of-the-bc-ai-economy) that December. Then [a province-wide listening exercise](https://bc-ai.ca/news/what-does-the-bc-ai-ecosystem-need) asking British Columbians what the ecosystem actually needs, because the people living inside an ecosystem should shape it before decisions get announced. Watching a business paper treat community infrastructure as economic news two years into that paper trail? That is the drumbeat working.
+
+## If you want in
+
+If AI is landing in your profession and you do not have a room yet, that is the product.
+
+[Join BC + AI](https://bc-ai.ca/membership). Come to a meetup. Bring the people from your sector who are making decisions in the dark. I am not asking you to cheer for AI. I am asking you to help build enough shared practice that this province can compete, govern, and create on purpose. (If you want the long version first, my Whistler Institute talk [Inside Vancouver’s AI Boom](https://www.youtube.com/watch?v=-XEsqsEbpoo) is on YouTube.)
+
+> EMBED (YouTube `T5ANAthZewE`)
+> caption: On stage at Vancouver AI, March 2026: *We Trained AI on Stolen Work… And I’m More Creative Than Ever*.
+
+Daisy got the thesis right.
+
+Now we keep building the rooms that make it true.


### PR DESCRIPTION
## What changed

Remediation package for the em-dash blowout the 2026-08-01 voice sweep flagged as its rank 1 offender. Three new files under `content/drafts/2026-08-02-emdash-remediation/`. Nothing else in the repo is touched.

**Target: post 12653**, `ai-lands-inside-every-profession`, published 2026-07-31. It is the newest post in the 2026-06-18 to 2026-07-31 sweep window per `manifest.json`, and the audit names it directly: "AI Lands: 26 prose em dashes (rank 1 offender)". Direct count on the stored snapshot confirms exactly 26 U+2014 characters.

**It is not post 12034.** Zero to One is the third-person rewrite job, VOICE-8 / #612, owned by a lane running concurrently. Different date, different finding, not touched here.

| File | What it is |
|---|---|
| `README.md` | which post, why it was picked, before and after counts, what else was fixed, what was left alone |
| `remediated-body.md` | the full corrected body with block markers, ready for a snapshot-first apply |
| `dash-ledger.md` | all 26 sites: original phrasing, rewrite, and the move used |

## Why

Em dashes are a standing hard rule. This one post carried more of them than the other 14 posts in the sweep combined.

Every dash is rewritten, never swapped. No hyphens, no en dashes, no spaced hyphens standing in. Twelve became colons, eight became a period plus a new sentence, three became commas, one became a comma with the clause inverted, and one matched pair became parentheses around a link aside. Twenty six dashes resolve into 23 edits because three edits close a matched pair.

Also addressed the redefinition-reveal house tic the audit called the post's real voice risk after the dashes. That pattern dodges `voicecheck.py` entirely, because the checker anchors on the contraction `it's not just` and the decontracted split form ("The failure mode is not departure. The failure mode is...") returns zero flags. Roughly eight instances in 2,247 words reads as a template. Three were varied, the two flagship instances the audit named were kept loud, and the rationale for every keep is in the ledger.

## How to verify

Zero em dashes across all three files:

```
python3 -c "import pathlib;[print(p.name, p.read_text(encoding='utf-8').count(chr(0x2014))) for p in sorted(pathlib.Path('content/drafts/2026-08-02-emdash-remediation').glob('*.md'))]"
```

Returns `0` for each. `dash-ledger.md` writes the original character as the token `{EMDASH}` so it can quote originals without carrying them.

Mechanical voice check, corrected body:

```
python3 ~/Code/kk-voice/scripts/voicecheck.py content/drafts/2026-08-02-emdash-remediation/remediated-body.md
```

**1 flag**, the soft `team` on "judgment is a team sport", which both audit phases ruled a keep.

Baseline on the live snapshot for comparison:

```
python3 ~/Code/kk-voice/scripts/voicecheck.py content/drafts/voice-audit-blog-sweep-2026-08-01/snapshots/2026-07-31-ai-lands-inside-every-profession.txt
```

**27 flags** (26 em dash, 1 soft `team`).

Repo gate: `make python-test` exits **0**. 339 tests OK, 3 tests OK, 68 passed.

## Scope discipline

- Track A, repo-only. No REST writes, no deploy, no connector runs, no media uploads. Live post 12653 is unchanged.
- Only files under `content/drafts/2026-08-02-emdash-remediation/` were added. No other lane's files were edited.
- Images, alt text, links, embed IDs, headings, and block order are preserved exactly.
- Typography in `remediated-body.md` matches the curly apostrophes and quotes the live post already stores, so an apply is a clean paragraph swap with no encoding diff. Relevant given this site's latin1 database behaviour.

## Still open

- **Live apply is not authorized from this lane.** VOICE-5 / #609 owns it: snapshot first, slug and ID check, cache-bypass curl after.
- **Festival naming** ("Futureproof" appears 3 times) is blocked on #614. Left as found.
- **Checker gap** that let the reveal density through belongs to #616 in `~/Code/kk-voice/anti-glossary.md`, a different repo. The candidate regex from the audit is noted in the README, not implemented here.
- **Possible missing word, flagged not fixed.** L115 reads "We took the community a platform built from those rooms, and then I read all thirty-two expert reports." That looks like a dropped preposition. Preserved verbatim because it is a content decision, not a punctuation one, and outside this lane. Worth a look from #609 or from KK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6zuqQbkT3ypd8qZyN9hxf
