### PR TITLE
content(#612): rewrite Zero to One body into first person

### DIFF
--- a/content/drafts/2026-08-01-zero-to-one-voice-rewrite/README.md
+++ b/content/drafts/2026-08-01-zero-to-one-voice-rewrite/README.md
@@ -1,0 +1,189 @@
+# Zero to One first-person rewrite (issue #612, WP post 12034)
+
+**Status: draft only. Nothing has been written to WordPress. Live apply is gated on KK approval.**
+
+Live target: WP post **12034**,
+https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/
+
+## Files in this directory
+
+| File | What it is |
+|---|---|
+| `rewritten-body.md` | The full new post body in readable markdown. **Read this one.** |
+| `proposed-content-raw.html` | The same body as WordPress block markup. This is what would ship as `content.raw`. |
+| `diff-notes.md` | Paragraph-by-paragraph person shift, plus the mechanical, tense, and date tables. |
+| `rewrite-notes.md` | Longer section-by-section rationale from the first pass on this draft. |
+| `live-content-raw-2026-08-01.html` | Snapshot of live `content.raw`, unchanged. The rollback reference. |
+| `README.md` | This file. |
+
+`rewritten-body.md` and `proposed-content-raw.html` are kept in lockstep. Verified programmatically:
+after stripping markup from both, the text is line-for-line identical (110 blocks each). If one
+changes, change the other.
+
+## The problem this fixes
+
+The live post is a third-person case study about "Krüg" published under Kris's own byline. It reads
+like a research report someone else wrote. On top of that it narrates from a November 2025 vantage
+point while carrying a June 30, 2026 publish date, so it uses future tense about things that already
+happened, and it contradicts itself on when the nonprofit registered.
+
+The receipts underneath are excellent. The frame was the thing that was wrong. So this is a person
+shift and a fact pass, not a rewrite of the reporting.
+
+## What changed
+
+1. **Frame: third person to first person, throughout.** "When Kris Krüg opened the doors" becomes
+   "when I opened the doors." "As Krüg stated" becomes Kris saying the thing directly. "Hilton's work
+   with Krüg (who serves as CTO of Indigenomics Institute)" becomes "as CTO of the Indigenomics
+   Institute I worked with her on." Full map in `diff-notes.md`.
+2. **Tense: stale future tense removed.** "The founding member period runs through December 31, 2025"
+   becomes "ran through." "December's BC AI Awards will recognize" becomes "We aimed the December BC
+   AI Awards at recognizing." "Spring 2026 brings the Creative AI Jam" becomes "lined up the Creative
+   AI Jam for spring 2026."
+3. **Dates: the August 2024 / August 2025 contradiction resolved.** See the next section for which
+   date won and why.
+4. **Six mechanical hard-rule hits fixed:** `seamless`, `cutting-edge`, `pivotal`, the
+   "no X, no Y, just Z" cadence, the dangling first-name "Tyler," and the "Team BC home base" quote.
+5. **Two arithmetic and internal-consistency fixes** the voice audit did not catch. Both flagged
+   below rather than buried.
+6. **Three broken inline lists rebuilt as real `wp:list` blocks.** The live HTML runs the
+   nonprofit-rationale items, the board-member items, and the membership tiers together in single
+   paragraphs with no separators, which renders as a wall of text. Item text is unchanged. This is a
+   rendering fix.
+7. **Redefinition-reveal tics thinned.** The audit counted roughly eight "this wasn't X but Y"
+   constructions and five "proved X" instances. Both are now at zero.
+
+## The date contradiction, and which date I treated as correct
+
+The live post says three incompatible things about when BC + AI registered as a nonprofit:
+
+- Section heading and body: **August 2024** ("By mid-August 2024, the decision was made")
+- Lede: nonprofit status **by August 2025**
+- Launch section: registration happened "approximately one week prior" to the August 27, **2025**
+  launch, and then gives that week-earlier date as "around August 20, **2024**"
+
+That last sentence contradicts itself inside its own parentheses. One week before August 27, 2025 is
+August 20, 2025, not August 20, 2024.
+
+**I treated August 2025 as correct.** The evidence is the post's own meetup numbering, which is
+internally consistent everywhere it appears:
+
+- `#VAI01` = January 25, 2024 (stated twice)
+- `#VAI13` = January 2025 (inside Matthew Schwartzman's direct quote)
+- `#VAI20` = August 27, 2025 (stated four separate times as the launch date)
+- Meetups are monthly, "the last Thursday of each month" (stated explicitly)
+
+`#VAI01` to `#VAI20` is nineteen monthly meetups, which is nineteen months. January 2024 plus
+nineteen months is August 2025. That lands exactly on `#VAI20`'s own stated date, and `#VAI13` in
+January 2025 falls exactly where it should on the same line. The numbering is self-consistent and it
+only works with an August 2025 registration. The "2024" is a year typo that propagated through one
+section.
+
+Corrected in four places: the section heading, "By mid-August 2025 we made the call," the
+registration-timing sentence, and the "nonprofit registration (August 2025)" turning point.
+
+Two companion date problems in the same section:
+
+- **"By spring 2024, after roughly 20 months of grassroots organizing."** Wrong on both halves. The
+  community launched January 2024, so spring 2024 is about four months in, not twenty. Moved to
+  spring 2025 (correct year, consistent with a summer 2025 decision and an August 2025 registration)
+  and softened "roughly 20 months" to "more than a year," which is what a January 2024 start actually
+  supports. I did not invent a replacement month count. Flagged for KK below.
+- **"Twenty times the first gathering eighteen months earlier."** 250 people is roughly three times
+  80, not twenty times. Corrected to "three times the crowd from the first studio night a year and a
+  half earlier." Both numbers were already stated elsewhere in the same post. This one was not in the
+  voice audit, so it is called out rather than slipped in.
+
+## Facts preserved
+
+Verified programmatically against the live snapshot: **zero numbers, zero named people or
+organizations, and zero calendar dates were dropped.** The only date that changed is
+`August 20, 2024`, which is the contradiction above.
+
+Every name the audit praised is intact and still carries its specific contribution: Gabriel George Sr.
+(Tsleil-Waututh Nation, Eagle Song, grandson of Chief Dan George), Carol Ann Hilton (Indigenomics
+Institute, board), Lorraine Lowe (H.R. MacMillan Space Centre, board), Matthew Schwartzman (19, Maple
+Ridge, Surrey AI), Ryv Valiquette (White Rock), Sev Geraskin ("Hot Dogma"), Peter Bittner (The Upgrade
+AI, Seattle), Jos Duncan-Asé (Philadelphia), Mark Busse (Creative Mornings Vancouver), Mike Klassen
+(Vancouver City Councillor), and Tyler Westover (Invest Surrey).
+
+Numbers intact: 80 people at 290 W. 3rd Avenue, 135+ by #VAI05, 250 at the launch, 34 signups the
+first night, 130 paid members in 2.5 months, 50 members/month, $2,500 hackathon prizes, $10,000 from
+Rival Technologies, $15,000+ from MetaCreation Lab, 1,000+ trained, 50+ workshops, 92% / 88% / 95% /
+40%, 40% underrepresented participants, 30% RISE co-funding, 15,000+ contacts, $450 legacy ticket,
+$200 transition offer, 480 organizations, 200+ funding programs, 1,001 survey respondents, the
+35/25/20/10 demographic split, all five membership tier prices, and the three BC women on the national
+AI Task Force.
+
+**KK's 2026-08-01 membership rulings from #615 are preserved byte-exact:** Individual `$340/year`, the
+`300 paid members` arc sentence, and both `130 paid members` / 2.5-month milestone sentences, which
+stay as time-stamped history per that ruling's instruction 3.
+
+## The one change I made on top of the earlier pass
+
+The lede said "130 founding members" with no date attached, while the closing paragraph says "300 paid
+members." A reader hits both and asks which it is. Rather than overwrite either figure, I time-stamped
+the lede: "130 founding members **by that November**." That is KK's own instruction 3 from #615
+(time-stamp the historical figure) applied to the one place it had not been. It keeps the receipt,
+resolves the apparent contradiction, and invents nothing.
+
+One-line revert if KK disagrees: drop "by that November" from the lede paragraph in both
+`rewritten-body.md` and `proposed-content-raw.html`.
+
+## Gate results
+
+```
+python3 ~/Code/kk-voice/scripts/voicecheck.py rewritten-body.md
+  -> OK: sounds like Kris (0 flags), exit 0
+
+python3 ~/Code/kk-voice/scripts/voicecheck.py <stripped proposed-content-raw.html>
+  -> OK: sounds like Kris (0 flags), exit 0
+```
+
+Also verified by direct search against `proposed-content-raw.html`:
+
+| Check | Result |
+|---|---|
+| Em dashes | 0 |
+| `Krüg stated` / `As Krüg` / `serves as CTO` | 0 |
+| `proved <word>` tic | 0 |
+| `seamless` / `cutting-edge` / `pivotal` / `empower*` / `foster*` / `landscape` / `unprecedented` | 0 |
+| `not just X but Y` / `wasn't just` / `not only` | 0 |
+| Numbers, names, dates dropped vs live | 0 (except the corrected `August 20, 2024`) |
+| Markdown body vs block markup text | identical, 110 blocks each |
+
+## Open items for KK
+
+1. **"Team BC home base."** The audit says keep it as a quoted brand phrase. But the word "Team" sits
+   inside the quote and trips the checker's soft `team` rule, and the acceptance criteria ask for a
+   clean run. It is currently paraphrased to "a chance to make it BC + AI's home base." Say the word
+   and it goes back to the literal quote with one accepted contextual flag.
+2. **"Roughly 20 months of grassroots organizing"** is softened to "more than a year" rather than
+   replaced with a guessed figure. If you know which moment that count was anchored to, it can be made
+   precise.
+3. **The lede's time-stamped "130 founding members by that November."** Confirm, or say you would
+   rather the lede lead with the current 300.
+4. **The `$240` "new membership cost" sentence** in the behind-the-scenes section still sits in the
+   same post as the `$340` Individual tier. That is a historical transition-era figure, it was not one
+   of the four figures ruled on in #615, and it is left untouched. Flagged, not fixed. That is a
+   numbers question, not a voice question.
+5. **"Twenty times" to "three times."** Arithmetic fix found outside the audit. Confirm the phrasing.
+
+## What was not touched
+
+- Post title, slug, excerpt, featured image, categories, tags. Only `content.raw` is in scope.
+- Cert post **12257**. Explicitly out of scope.
+- The live site. No REST writes were made or attempted from this lane.
+
+## If KK approves, the apply path
+
+Not executed here. For whoever runs it:
+
+1. Re-pull `GET /wp-json/wp/v2/posts/12034?context=edit` and diff against
+   `live-content-raw-2026-08-01.html`. If it drifted, stop and re-reconcile.
+2. Write that fresh pull to a rollback file before any PATCH.
+3. PATCH `content` with `proposed-content-raw.html`, verifying the ID is 12034 and the slug matches
+   before the write.
+4. Purge Pagely page cache, then verify logged out with a cache-bypass query string. First rendered
+   paragraph should open in first person.
+5. Post the live opening paragraph back on issue #612.

--- a/content/drafts/2026-08-01-zero-to-one-voice-rewrite/diff-notes.md
+++ b/content/drafts/2026-08-01-zero-to-one-voice-rewrite/diff-notes.md
@@ -1,30 +1,187 @@
-# Diff notes: notable line-level before/after (live -> proposed)
+# Diff notes: live post 12034 to proposed first-person draft
 
-Companion to `rewrite-notes.md`. Live = `live-content-raw-2026-08-01.html`
-(re-verified byte-identical to a fresh 2026-08-02 API pull). Proposed =
-`proposed-content-raw.html`.
+Live = `live-content-raw-2026-08-01.html` (includes KK's #615 membership edits).
+Proposed = `proposed-content-raw.html` / `rewritten-body.md`.
 
-## Person shift (representative sample; applies throughout)
+Part 1 is the paragraph-by-paragraph person shift, which is the point of issue #612.
+Parts 2 through 6 are the mechanical, judgment, tense, date, and structural fixes.
 
-- Live: `when Kris Krüg opened the doors of MØTLEYKRÜG Media headquarters`
-  Proposed: `when I opened the doors of MØTLEYKRÜG Media`
+---
 
-- Live: `As Krüg stated: "Our ethos is simple yet profound: to welcome
-  everyone intrigued by AI's potential. From seasoned researchers to budding
-  artists, from tech enthusiasts to curious students."`
-  Proposed: `My ethos was simple: welcome everyone intrigued by AI's
-  potential, from seasoned researchers to budding artists, from tech
-  enthusiasts to curious students.`
+## Part 1: paragraph-by-paragraph person shift
 
-- Live: `Hilton's work with Krüg (who serves as CTO of Indigenomics
-  Institute) produced the indigenomics.ai platform`
-  Proposed: `Carol Ann and I also built together: as CTO of the Indigenomics
-  Institute I worked with her on the indigenomics.ai platform`
+`3rd -> 1st` means the paragraph named Kris in third person and now has him speaking.
+`impersonal -> 1st` means the paragraph had no narrator at all ("the community did X",
+"BC + AI developed Y") and now has one. `no shift` means the paragraph was already
+narrator-neutral reporting and only took a mechanical or tense fix, if anything.
 
-- Live: `Kris Krüg - founder and community organizer` (board list)
-  Proposed: `Kris Krüg (me): founder and community organizer` (list item)
+### Lede
 
-## Mechanical (hard-rule) fixes
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 1 | "BC + AI transformed from an 80-person studio gathering into British Columbia's largest grassroots AI ecosystem" | "In January 2024 I opened my studio doors for a meetup and 80 people showed up." | impersonal -> 1st. Also drops "unprecedented in Canada's AI landscape" and time-stamps the 130 figure. |
+
+### The spark
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 2 | H2 "The spark: January 2024 ignites Vancouver's AI scene" | H2 "The spark: 80 people in my studio" | heading, 3rd -> 1st possessive |
+| 3 | "when Kris Krüg opened the doors of MØTLEYKRÜG Media headquarters" | "when I opened the doors of MØTLEYKRÜG Media" | 3rd -> 1st. "80 people packed into a studio space" -> "into my studio". Comma splice becomes a colon. |
+| 4 | "As Krüg stated: 'Our ethos is simple yet profound...'" | "My ethos was simple: welcome everyone intrigued by AI's potential" | 3rd -> 1st. The quote-of-self becomes a direct statement, which keeps the specific words and kills the press-clip frame in one move. |
+| 5 | "The timing proved perfect." | "The timing helped." | no shift. "proved" tic removed. |
+
+### Outgrowing the room
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 6 | H2 "Explosive growth forces venue upgrade within four months" | H2 "Four months in, we outgrew the room" | heading, impersonal -> 1st plural |
+| 7 | "By May 30, 2024 (#VAI05), attendance had surged" | "By May 30, 2024 (#VAI05), attendance passed 135 people" | no shift, reporting stays reporting |
+| 8 | "This wasn't typical tech networking." | "Gabriel George's Eagle Song opened every gathering" | reveal construction cut; closes with Kris's own read ("You hear that at enough meetups and it changes how you think") |
+| 9 | "Krüg had negotiated a partnership with the H.R. MacMillan Space Centre" | "By mid-2024 I had worked out a partnership with the H.R. MacMillan Space Centre" | 3rd -> 1st. "This partnership would prove crucial, Lowe would later join" splice -> "The partnership stuck: Lorraine later joined the nonprofit board." |
+
+### Indigenous wisdom
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 10 | H2 "Indigenous wisdom becomes operational framework, not decoration" | H2 "Indigenous wisdom as the operating system" | heading, X-not-Y removed |
+| 11 | "While many tech events include perfunctory land acknowledgments, BC + AI embedded" | "Plenty of tech events open with a land acknowledgment and move on. We built it differently" | impersonal -> 1st plural. Also removes "Gabriel George wasn't performing ceremony as a courtesy." |
+| 12 | "Gabriel's great-great grandmother had lived" | same facts, tightened | no shift |
+| 13 | "The community learned that Indigenous elders had predicted" | "From Gabriel we learned that Indigenous elders described" | impersonal -> 1st plural, and credits the teacher |
+| 14 | "These weren't just inspiring stories." | "Those teachings did operational work." | reveal construction cut. "The community adopted Gabriel's teaching" -> "we adopted". impersonal -> 1st plural. |
+
+### Education
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 15 | H2 "Education initiatives democratize AI access across BC" | H2 "Teaching AI without the gatekeeping" | heading, brochure verb removed |
+| 16 | "The Upgrade AI (co-founded by Krüg and Peter Bittner in late 2023)" | "The Upgrade AI, which Peter Bittner and I co-founded in late 2023" | 3rd -> 1st |
+| 17 | "The education model proved remarkably successful... fostered 40% average productivity gains" | "The numbers tell you it worked... graduates reported average productivity gains of 40%" | no shift. "proved" tic and "foster" both removed. |
+| 18 | "Crucially, The Upgrade maintained accessibility." | "Access stayed the design constraint." | no shift |
+| 19 | "As the community stated: 'Education should not be an afterthought...'" | "The principle we wrote down for it still holds: 'Education should not be an afterthought...'" | impersonal -> 1st plural, quote kept intact |
+
+### Surrey
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 20 | H2 "Surrey expansion proves the decentralized model works" | H2 "Surrey AI: the model leaves Vancouver" | heading, "proves" removed |
+| 21 | "the grueling commute to Vancouver meetups" | "the grueling commute to our Vancouver meetups" | impersonal -> 1st plural possessive |
+| 22 | "Schwartzman and Ryv Valiquette" | "Matthew and Ryv Valiquette" | no person shift; surname-only reference softened to how Kris would actually refer to him |
+| 23 | "The response validated the model, nine consecutive monthly meetups ran" | "The response answered any doubts: nine consecutive monthly meetups" | no shift. Comma splice becomes a colon. |
+| 24 | "Tyler and his team saw Surrey AI as essential infrastructure" | "Tyler Westover, who leads Invest Surrey as the City of Surrey's Director of Business and Government Relations, saw Surrey AI as essential infrastructure" | no shift. Dangling first name given a full identity. |
+| 25 | "Surrey AI proved the concept... empowering young leaders" | "Surrey AI made the case... Young leaders ran it, local needs shaped it" | no shift. "proved" and "empower" both removed. |
+
+### Carol Ann Hilton
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 26 | H2 "Carol Ann Hilton's five minutes that changed everything" | unchanged | no shift, the heading was already right |
+| 27 | "While Gabriel George provided ceremonial grounding, Carol Ann Hilton brought" | "Gabriel gave us ceremonial grounding. Carol Ann Hilton brought" | impersonal -> 1st plural ("gave us") |
+| 28 | "what community members describe as '5 minutes...'" | "what members still describe as '5 minutes...'" | no shift, tense corrected |
+| 29 | "She didn't offer platitudes" | "No platitudes about the chaotic state of the world." | no shift |
+| 30 | "Most radical was her teaching" | "The most radical part was her teaching" | no shift. Attributes the argument to Carol Ann explicitly rather than stating it as narrator fact. |
+| 31 | "This wasn't poetry but protocol, love as organizing principle." | "She meant it as protocol, love as an organizing principle." | reveal construction cut, attribution added |
+| 32 | "Hilton's work with Krüg (who serves as CTO of Indigenomics Institute) produced the indigenomics.ai platform" | "Carol Ann and I also built together: as CTO of the Indigenomics Institute I worked with her on the indigenomics.ai platform" | 3rd -> 1st. This is the single worst line in the live post and the copula avoidance ("serves as") goes with it. Also removes "weren't symbolic additions but foundational." |
+
+### Formalizing
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 33 | H2 "nonprofit status in August 2024" | H2 "nonprofit status in August 2025" | year corrected, see Part 5 |
+| 34 | "the community faced a critical decision. Could they remain an informal network" | "we faced a real decision. Stay an informal network, or build formal structure" | impersonal -> 1st plural. "they" was the loudest outsider tell in the section. |
+| 35 | "The debate played out in planning meetings through early summer 2024." | "The debate ran through planning meetings into early summer 2025." | no shift, year corrected |
+| 36 | run-together inline list of four rationales | real `wp:list`, item text unchanged | structural |
+| 37 | "The community was determined this would NOT become 'Silicon Valley 2.0'" | "We were determined this would NOT become 'Silicon Valley 2.0'" | impersonal -> 1st plural |
+| 38 | "By mid-August 2024, the decision was made." | "By mid-August 2025 we made the call." | impersonal passive -> 1st plural active, year corrected |
+| 39 | board list, "Kris Krüg - founder and community organizer" | list item, "Kris Krüg (me): founder and community organizer" | 3rd -> 1st. Kris naming himself in a list of three is fine; the "(me)" is what stops it reading like a press release. |
+| 40 | "Indigenous perspectives weren't advisory but governing... This was structural, not symbolic." | "made Indigenous leadership a governing position, not an advisory one" | two reveal constructions collapsed into one plain sentence |
+
+### Launch party
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 41 | H2 "August 27, 2025: 250 people witness the official launch" | H2 "August 27, 2025: the launch party" | heading, newsy framing removed |
+| 42 | "twenty times the first gathering eighteen months earlier" | "three times the crowd from the first studio night a year and a half earlier" | no shift, arithmetic corrected (Part 6) |
+| 43-49 | program bullets, 6:00 PM through 8:20 PM | unchanged except Bittner's line tightened | no shift |
+| 50 | "The timing was strategic. Registration had occurred approximately one week prior (around August 20, 2024), but the community waited" | "The timing was deliberate. Registration had gone through about a week earlier, around August 20, 2025, but we held the public celebration" | impersonal -> 1st plural, year corrected |
+| 51 | "Thirty-four members signed up that first night." | unchanged | no shift. KK-ruled figures untouched. |
+
+### Membership
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 52 | H2 "Membership model balances access with sustainability" | H2 "How we priced membership" | heading, impersonal -> 1st plural |
+| 53 | "The founding member drive (running through December 31, 2025)" | "(which ran through December 31, 2025)" | no shift, tense corrected |
+| 54 | run-together inline list of five tiers | real `wp:list`, prices unchanged incl. `$340/year` | structural |
+| 55 | "The first 100 members would lock 'Founder '25' badges" | "The first 100 members locked in 'Founder '25' badges" | no shift, tense corrected |
+| 56 | "A critical debate occurred in the August 25, 2025 onboarding meeting... The decision went for time-based" | "One debate from the August 25, 2025 onboarding meeting stuck with me... We went time-based" | impersonal -> 1st, and it is the one place the narrator admits an argument happened |
+
+### Behind the scenes
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 57 | H2 "challenges turned into design features" | H2 "Behind the scenes: duct tape and vibes" | heading, spin removed, uses the community's own phrase |
+| 58 | "The nonprofit formation wasn't seamless." | "The nonprofit formation wasn't smooth." | no shift, banned word removed |
+| 59 | "Through transparent voice messages to existing supporters, the community offered" | "We sent voice messages to those early supporters laying out the change, offered" | impersonal -> 1st plural |
+| 60 | "The community's philosophy: 'Small, real dollars...'" | "The philosophy: 'Small, real dollars...'" | no shift, the quote was already the strongest line in the post |
+| 61 | "The solution involved comprehensive recording systems... turned ephemeral gatherings into permanent community assets" | "We built recording systems... a talk from a year ago is still findable, quotable, and useful" | impersonal -> 1st plural, hollow closer replaced with what the thing actually does |
+
+### Ecosystem programs
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 62 | H2 "Tech ecosystem activities build connective tissue" | H2 "The connective tissue: hackathons, Office Hours, partnerships" | heading, names the actual contents |
+| 63 | "BC + AI developed multiple programs" | "we ran programs" | impersonal -> 1st plural |
+| 64 | "Data Storytelling Hackathon" | unchanged facts, "committed $10,000" -> "put up $10,000" | no shift |
+| 65 | "Office Hours... became the 'operational backbone'" | same, scare quotes dropped | no shift |
+| 66 | "BC + AI partnered with Creative Mornings Vancouver" | "we linked up with Creative Mornings Vancouver" | impersonal -> 1st plural |
+| 67 | "ensured BC + AI remained connected to cutting-edge research" | "kept BC + AI connected to the research frontier" | no shift, banned word removed |
+| 68 | "The community prepared briefings for provincial ministers" | "we prepared briefings for provincial ministers" | impersonal -> 1st plural |
+
+### Culture
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 69 | H2 "Community culture: stoked and careful at the same time" | unchanged | no shift |
+| 70 | "BC + AI had developed a distinctive culture captured in phrases" | "the culture had its own vocabulary" | no shift, padding removed |
+| 71-76 | six touchstones, each restating its bold phrase in prose | same six quotes, restatement trimmed | no shift. "Not techno-utopianism or techno-pessimism but critical optimism" -> "critical optimism instead of." |
+| 77 | "The community's attendance metrics told the growth story" | "The attendance numbers carried the growth story" | no shift |
+| 78 | "Documentation captured explosive growth." | "Other people started writing it down too." | no shift |
+
+### Turning points
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 79 | H2 "Critical turning points that shaped the journey" | H2 "The turning points" | heading trimmed |
+| 80 | "Certain moments proved pivotal in BC + AI's evolution:" | "Certain moments changed BC + AI's trajectory:" | no shift, banned word removed |
+| 81-87 | seven turning points | facts unchanged; "The nonprofit registration (August 2024)" -> "(August 2025)"; "worthy of collaboration with" -> "wanted to build with us" | last one, impersonal -> 1st plural |
+
+### Ecosystem map
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 88 | H2 "The ecosystem map: 480 organizations and counting" | unchanged | no shift |
+| 89 | "This wasn't passive directory maintenance but active network weaving" | "The map was a working tool. We used it to introduce organizations that should have known each other already" | reveal construction cut, impersonal -> 1st plural |
+| 90 | "The community developed extensive funding resources" | "We also built out funding resources" | impersonal -> 1st plural |
+| 91 | "When BC + AI spoke to government, they came with actual data" | "When we walked into a government meeting, we came with actual data" | 3rd plural -> 1st plural. "they" for his own organization was the tell. |
+
+### Close
+
+| # | Live opens | Proposed opens | Shift |
+|---|---|---|---|
+| 92 | H2 "Looking forward: the movement is just beginning" | H2 "Where that left us" | heading. The old one promised a future the post no longer stands in. |
+| 93 | "BC + AI stood as proof" | "BC + AI was proof" | no shift, copula avoidance removed |
+| 94 | "The founding member period runs through... December's BC AI Awards will recognize... Spring 2026 brings..." | "ran through... We aimed the December BC AI Awards at... lined up the Creative AI Jam for spring 2026" | impersonal -> 1st plural, full tense pass |
+| 95 | "But the numbers tell only part of the story. More significant is the culture BC + AI established" | "The numbers tell part of the story. The culture is the part I care about most" | impersonal -> 1st singular. The only place the narrator says what he values, which is what a byline is for. |
+| 96 | "This is BC + AI's story... proving that another way... is not just possible but already happening" | "That's our story... Another way of building AI's future is already happening in British Columbia." | impersonal -> 1st plural, reveal construction cut, "Not through venture capital or corporate sponsorship but through" -> "No venture capital. No corporate sponsor steering it." |
+| 97 | Related list | unchanged | no shift |
+
+**Person-shift tally:** 12 paragraphs moved third person to first, 24 moved impersonal to first,
+9 headings rewritten. Every explicit "Krüg" self-reference is gone. Confirmed:
+`rg "Krüg stated|As Krüg|serves as CTO" proposed-content-raw.html` returns 0.
+
+---
+
+## Part 2: mechanical hard-rule fixes
 
 | # | Live | Proposed |
 |---|---|---|
@@ -33,68 +190,70 @@ Companion to `rewrite-notes.md`. Live = `live-content-raw-2026-08-01.html`
 | 3 | `Certain moments proved pivotal in BC + AI's evolution:` | `Certain moments changed BC + AI's trajectory:` |
 | 4 | `No pitches, no pyramid schemes, just genuine peer-to-peer learning.` | `Nobody pitched. Nobody recruited. People taught each other.` |
 | 5 | `Tyler and his team saw Surrey AI as essential infrastructure` | `Tyler Westover, who leads Invest Surrey as the City of Surrey's Director of Business and Government Relations, saw Surrey AI as essential infrastructure` |
-| 6 | `offers opportunity for BC + AI to be "Team BC home base"` | `saw Web Summit Vancouver as a chance to make it BC + AI's home base` (quote dropped — see rewrite-notes.md "flagged trade-off") |
+| 6 | `offers opportunity for BC + AI to be "Team BC home base"` | `saw Web Summit Vancouver as a chance to make it BC + AI's home base` (quote dropped, see README open item 1) |
 
-## Judgment-call fixes (checker-verified in the reading)
+## Part 3: judgment fixes (checker-verified in the audit reading)
 
 | Live | Proposed |
 |---|---|
 | `built something unprecedented in Canada's AI landscape` | `built something Canada had not seen before` |
-| `By November 2025, BC + AI stood as proof that grassroots organizing could build...` | `By November 2025, BC + AI was proof that grassroots organizing could build...` |
-| `proving that another way of building AI's future is not just possible but already happening in British Columbia` | `Another way of building AI's future is already happening in British Columbia.` |
+| `By November 2025, BC + AI stood as proof` | `By November 2025, BC + AI was proof` |
+| `proving that another way of building AI's future is not just possible but already happening` | `Another way of building AI's future is already happening in British Columbia.` |
 | `The event sold out immediately, 80 people packed into a studio space...` | `The event sold out immediately: 80 people packed into my studio at 290 W. 3rd Avenue...` |
 | `This partnership would prove crucial, Lowe would later join the nonprofit board, cementing the institutional relationship.` | `The partnership stuck: Lorraine later joined the nonprofit board.` |
 | `empowering young leaders` / `fostered 40% average productivity gains` | `Young leaders ran it, local needs shaped it...` / `graduates reported average productivity gains of 40%` |
 
-## Tense pass (all stale future tense -> past)
+The em-dash-ghost comma splices (dashes mechanically swapped to commas at publish time, leaving
+splices) are restored to colons and periods throughout, not only in the two rows above.
+
+## Part 4: tense pass
 
 | Live | Proposed |
 |---|---|
 | `The founding member period runs through December 31, 2025` | `The founding member period ran through December 31, 2025` |
 | `December's BC AI Awards will recognize British Columbia's AI innovators...` | `We aimed the December BC AI Awards at recognizing British Columbia's AI innovators...` |
 | `Spring 2026 brings the Creative AI Jam with Creative Mornings Vancouver.` | `lined up the Creative AI Jam with Creative Mornings for spring 2026` |
+| `with plans for a Spring 2026 "Creative AI Jam" event` | `with a "Creative AI Jam" planned for spring 2026` |
+| `The first 100 members would lock "Founder '25" badges` | `The first 100 members locked in "Founder '25" badges` |
+| `The founding member drive (running through December 31, 2025)` | `The founding member drive (which ran through December 31, 2025)` |
 
-## Date-contradiction fix (Aug 2024 -> Aug 2025), with source
+## Part 5: date-contradiction fix, August 2024 to August 2025
 
-Source for the correction: the post's own `#VAI` meetup numbering.
-`#VAI01` = Jan 25, 2024. `#VAI13` = January 2025 (Schwartzman's direct
-quote). `#VAI20` = August 27, 2025 (stated 4x in the post). Meetups are
-monthly. `#VAI01` -> `#VAI20` = 19 months = August 2025, matching `#VAI20`'s
-own stated date. Registration is described as "approximately one week
-prior" to `#VAI20`, so registration is ~August 20, 2025, not 2024.
+Reasoning and evidence in README.md. Source is the post's own `#VAI` numbering:
+`#VAI01` January 25 2024, `#VAI13` January 2025, `#VAI20` August 27 2025, monthly cadence.
+Nineteen meetups from `#VAI01` is nineteen months, landing on August 2025.
 
 | Live | Proposed |
 |---|---|
-| Heading: `The decision to formalize: nonprofit status in August 2024` | `The decision to formalize: nonprofit status in August 2025` |
-| `By spring 2024, after roughly 20 months of grassroots organizing...` | `By spring 2025, after more than a year of grassroots organizing...` (see rewrite-notes.md for why "20 months" was softened rather than corrected to a specific number) |
+| Heading `nonprofit status in August 2024` | `nonprofit status in August 2025` |
+| `By spring 2024, after roughly 20 months of grassroots organizing` | `By spring 2025, after more than a year of grassroots organizing` |
 | `The debate played out in planning meetings through early summer 2024.` | `The debate ran through planning meetings into early summer 2025.` |
 | `By mid-August 2024, the decision was made.` | `By mid-August 2025 we made the call.` |
 | `Registration had occurred approximately one week prior (around August 20, 2024)` | `Registration had gone through about a week earlier, around August 20, 2025` |
-| `The nonprofit registration (August 2024) enabled sustainable operations...` | `The nonprofit registration (August 2025) opened up sustainable operations...` |
+| `The nonprofit registration (August 2024) enabled sustainable operations` | `The nonprofit registration (August 2025) opened up sustainable operations` |
 
-## Arithmetic fix (not in the SSOT reading; found independently)
+`August 20, 2024` is the only calendar date in the live post that does not survive into the draft.
+Verified: no other number, name, or date was dropped.
 
-| Live | Proposed |
-|---|---|
-| `Approximately 250 people filled the Space Centre planetarium on August 27, 2025, twenty times the first gathering eighteen months earlier.` | `Approximately 250 people filled the Space Centre planetarium on August 27, 2025, three times the crowd from the first studio night a year and a half earlier.` |
+## Part 6: arithmetic and internal consistency (found outside the audit)
 
-250 / 80 ≈ 3.1x, not 20x. "A year and a half" (18 months) matches the live
-post's own figure and is unchanged.
+| Live | Proposed | Why |
+|---|---|---|
+| `twenty times the first gathering eighteen months earlier` | `three times the crowd from the first studio night a year and a half earlier` | 250 / 80 is about 3.1, not 20. Both figures already appear in the post. |
+| lede `130 founding members` (undated), closer `300 paid members` | lede `130 founding members by that November` | Time-stamps the historical figure per KK's #615 instruction 3, so the lede stops appearing to contradict the closer. See README. |
 
-## Protected figures — confirmed byte-exact (KK's 2026-08-01 rulings)
+## Part 7: KK's #615 figures, confirmed byte-exact
 
-Verified with direct string search against both files; all four present
-verbatim in the proposed draft:
+Direct string match against `proposed-content-raw.html`, all four present verbatim:
 
 1. `Individual</strong>: $340/year (1 seat for freelancers and independent practitioners)`
 2. `From 80 people in a studio to 300 paid members of a nonprofit with regional chapters, Indigenous board leadership, and national recognition`
 3. `by early November 2025), the association had enrolled <strong>130 paid members</strong>, an average of 50 members per month`
 4. `Reaching 130 paid members</strong> within 2.5 months validated the membership model`
 
-## Structural fix: broken inline lists -> real wp:list blocks
+## Part 8: structural, broken inline lists to real blocks
 
-Live has three places where multiple bolded items run together in a single
-`<p>` with no separators (renders as an unreadable wall of text), e.g.:
+Live has three places where bolded items run together in one `<p>` with no separators:
 
 ```
 <p><strong>Credibility for funding</strong>: Government grants and corporate
@@ -103,39 +262,39 @@ Aggregate community power for policy advocacy<strong>Sustainable
 operations</strong>: Move beyond "duct tape and vibes"...</p>
 ```
 
-Proposed converts these to `wp:list` / `wp:list-item` blocks (rationale-for-
-nonprofit list, board-member list, membership-tier list). Text of every item
-is unchanged; only the markup structure changed, matching the "keep valid
-WordPress block markup" requirement.
+Converted to `wp:list` / `wp:list-item` for the nonprofit-rationale list, the board list, and the
+membership-tier list. Item text unchanged, markup only.
 
-## Fact-check performed (not a text change, a verification)
+## Part 9: fact-check performed
 
-"Tyler" (live, no surname/title) -> confirmed as Tyler Westover against
-`kk-kb/content/people/tyler-westover/profile.md`: Director, Business and
-Government Relations, City of Surrey / Invest Surrey. His founding-member
-record (`kk-kb/content/people/tyler-westover/sources/founding-member.md`)
-shows `Created: 2025-11-12T10:15:00`, which matches the live post's own
-"By November 12, 2025, Invest Surrey... had committed to joining BC + AI"
-sentence exactly — confirms this is the same person and event, not a guess.
+"Tyler" appears in the live post with no surname and no role, first and only mention. Confirmed as
+Tyler Westover against `kk-kb/content/people/tyler-westover/profile.md`: Director, Business and
+Government Relations, City of Surrey, leads Invest Surrey. His founding-member record
+(`sources/founding-member.md`) carries `Created: 2025-11-12`, which matches the live post's own
+"By November 12, 2025, Invest Surrey... had committed to joining BC + AI" sentence. Same person,
+same event, not an inference.
 
-## Verification commands run
+## Part 10: verification commands run
 
-```
-# WP block markup balance (open/close tag pairing)
-python3 -c "... parses <!-- wp:X --> / <!-- /wp:X --> pairs, confirms empty stack"
+```bash
+# text parity between the two draft formats
+python3 - <<'PY'   # strips markup from both, compares line by line
+# -> IDENTICAL, 110 blocks each
+PY
 
-# Third-person tells
-rg -n "Krüg stated|As Krüg|serves as CTO" proposed-content-raw.html   # 0 matches
+# voice gate
+python3 ~/Code/kk-voice/scripts/voicecheck.py rewritten-body.md
+# -> OK: sounds like Kris (0 flags), exit 0
+python3 ~/Code/kk-voice/scripts/voicecheck.py <stripped proposed-content-raw.html>
+# -> OK: sounds like Kris (0 flags), exit 0
 
-# Em dashes
-rg -n "—" proposed-content-raw.html   # 0 matches
+# hard rules
+python3 -c "print(open('proposed-content-raw.html').read().count(chr(8212)))"  # 0  (em dashes)
+grep -nE "Krüg stated|As Krüg|serves as CTO" proposed-content-raw.html   # 0
+grep -noE "prove[ds]? [a-z]+" proposed-content-raw.html                  # 0
+grep -noiE "seamless|cutting-edge|pivotal|empower|foster|landscape|unprecedented" proposed-content-raw.html  # 0
+grep -noiE "not just [a-z]+ but|isn't just|wasn't just|weren't just|not only" proposed-content-raw.html      # 0
 
-# Full anti-glossary sweep (landscape, testament, tapestry, delve, realm,
-# robust, myriad, plethora, boasts, utilize, harness, garner, glean, "not
-# just X but Y", "no X no Y just Z", soft-flag "team", "when it comes to",
-# "cannot be overstated", "studies show")   # all 0 matches
-
-# voicecheck.py on stripped text (WP block comments + HTML tags removed)
-python3 ~/Code/kk-voice/scripts/voicecheck.py stripped.txt
-# -> OK: sounds like Kris (0 flags), exit code 0
+# fact preservation, live vs proposed
+# numbers dropped: 0   names dropped: 0   dates dropped: 1 (August 20, 2024, the corrected one)
 ```

--- a/content/drafts/2026-08-01-zero-to-one-voice-rewrite/proposed-content-raw.html
+++ b/content/drafts/2026-08-01-zero-to-one-voice-rewrite/proposed-content-raw.html
@@ -1,5 +1,5 @@
 <!-- wp:paragraph -->
-<p><strong>In January 2024 I opened my studio doors for a meetup and 80 people showed up.</strong> Less than two years later, BC + AI was British Columbia's largest grassroots AI ecosystem: a registered nonprofit with Indigenous board leadership, 130 founding members, and regional chapters across the province. This is the story of how we built something Canada had not seen before. Receipts included.</p>
+<p><strong>In January 2024 I opened my studio doors for a meetup and 80 people showed up.</strong> Less than two years later, BC + AI was British Columbia's largest grassroots AI ecosystem: a registered nonprofit with Indigenous board leadership, 130 founding members by that November, and regional chapters across the province. This is the story of how we built something Canada had not seen before. Receipts included.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->

--- a/content/drafts/2026-08-01-zero-to-one-voice-rewrite/rewritten-body.md
+++ b/content/drafts/2026-08-01-zero-to-one-voice-rewrite/rewritten-body.md
@@ -1,0 +1,217 @@
+# Zero to One: From Meetup to Movement
+
+Draft body for WP post 12034, first person. Markdown reading copy of
+`proposed-content-raw.html`, which is the file that would actually ship as
+`content.raw`. The two are kept in lockstep: if one changes, change both.
+
+Status: **draft, awaiting KK approval. Nothing written to WordPress.**
+
+---
+
+**In January 2024 I opened my studio doors for a meetup and 80 people showed up.** Less than two years later, BC + AI was British Columbia's largest grassroots AI ecosystem: a registered nonprofit with Indigenous board leadership, 130 founding members by that November, and regional chapters across the province. This is the story of how we built something Canada had not seen before. Receipts included.
+
+## The spark: 80 people in my studio
+
+Vancouver's AI community didn't exist as an organized force until **January 25, 2024, when I opened the doors of MØTLEYKRÜG Media** for the first Vancouver AI Community Meetup (#VAI01). The event sold out immediately: 80 people packed into my studio at 290 W. 3rd Avenue, tucked inside the Vancouver Biennale Art Warehouse. We put **Indigenous ceremony at the centre from day one**. Gabriel George Sr. of the Tsleil-Waututh Nation opened with traditional songs, and that set the pattern that never changed: ceremony before innovation, relationships before transactions.
+
+That first night featured Vancouver City Councillor Mike Klassen, researchers from SFU and Emily Carr University, and AI artists showing interactive installations. My ethos was simple: **welcome everyone intrigued by AI's potential**, from seasoned researchers to budding artists, from tech enthusiasts to curious students. Nobody pitched. Nobody recruited. People taught each other.
+
+The timing helped. ChatGPT had exploded into public consciousness just months earlier, and Vancouver's creative and tech communities were hungry for a room to process the implications together. **Word of mouth alone drove consistent sellouts** for the next several months.
+
+## Four months in, we outgrew the room
+
+By **May 30, 2024 (#VAI05), attendance passed 135 people**, nearly double what my studio could hold. Monthly meetups on the last Thursday of each month had become the AI event in Vancouver, and the mix in the room was the point: developers next to photographers, Indigenous knowledge keepers talking data sovereignty with machine learning researchers, performance artists running generative music through their sets.
+
+**Gabriel George's Eagle Song opened every gathering**, creating what members started calling a "sacred container" for technical discussions. His teaching that "our people saw it coming, they said one day our world would be connected by a web" tied ancient Indigenous prophecy to modern AI development. You hear that at enough meetups and it changes how you think about what a network is for.
+
+We needed a bigger room. By mid-2024 I had worked out a **partnership with the H.R. MacMillan Space Centre**, whose Executive Director Lorraine Lowe saw the fit between space exploration and AI's frontier territory right away. The planetarium holds 200+ people and comes with professional AV. The partnership stuck: Lorraine later joined the nonprofit board.
+
+## Indigenous wisdom as the operating system
+
+Plenty of tech events open with a land acknowledgment and move on. We built it differently: **Indigenous perspectives became BC + AI's philosophical operating system**. Gabriel's teachings shaped how the community understood networks, data, relationships, and collective responsibility.
+
+Gabriel's great-great grandmother lived in the village where the Space Centre now stands, before colonial authorities forcibly relocated her family. That made every gathering there an act of return and reclamation. His grandfather was **Chief Dan George**, the Oscar-nominated actor and cultural icon, and Gabriel carries that legacy of bridging Indigenous wisdom with contemporary society.
+
+From Gabriel we learned that Indigenous elders described the internet centuries before its invention: "a web covering the world," "longhouses reaching to the sky." They prophesied that "when the eagle landed on the moon," Indigenous communities would begin their revival. In 1969, NASA transmitted "the eagle has landed." Gabriel connected those prophecies to AI: **technology is the latest iteration of the planetary web the ancestors foresaw**.
+
+Those teachings did operational work. **OCAP protocols** (Ownership, Control, Access, Possession) became non-negotiable for data governance. The Indigenomics framework, relationship over transaction, long-term thinking over extraction, guided partnership decisions. And we adopted Gabriel's teaching that attendees are "human recorders responsible for sharing what they learn." Show up, learn something, carry it out the door to someone else.
+
+## Teaching AI without the gatekeeping
+
+While the meetups built community, **[The Upgrade AI](https://www.theupgrade.ai/)**, which Peter Bittner and I co-founded in late 2023, handled structured professional education. The **first cohort for creative professionals launched March 11, 2024**: a 6-week certification program built on treating AI as a "force multiplier for human expertise, not a replacement."
+
+The numbers tell you it worked. By November 2025, The Upgrade had trained **over 1,000 professionals through 50+ workshops**. **92% wanted sector-specific training** next, **88% of graduates were using AI tools in their work**, satisfaction ran at **95%**, and graduates reported **average productivity gains of 40%**.
+
+Access stayed the design constraint. **40% of participants came from underrepresented groups**: women, Indigenous peoples, visible minorities. A partnership with Circle Innovation's RISE in BC program covered **30% co-funding for eligible British Columbia SMEs** so cost didn't decide who got to learn. Through 2024-2025 the program grew to serve journalists (with Google News Initiative), PR professionals, sales leaders, and healthcare workers.
+
+In parallel, the **ED + AI initiative** launched in 2024-2025 to bring educators in. The second ED + AI meetup in October 2025 drew a packed house of K-12 teachers, post-secondary instructors, parents, students, and EdTech builders. Working groups formed around Human-Centered AI in Education guidelines: assessment redesign, youth data consent, access gaps between districts. The principle we wrote down for it still holds: **"Education should not be an afterthought in the AI conversation. It should be a central force shaping how AI is imagined, designed, and applied."**
+
+## Surrey AI: the model leaves Vancouver
+
+The first real test of the distributed vision was **Surrey AI's launch on March 11, 2025**. Matthew Schwartzman, just 19 years old and based in Maple Ridge, had been making the grueling commute to our Vancouver meetups. As he told the room at #VAI13 in January 2025: "After sitting on Highway 1 for an hour, I'm pretty sure I saw my life flash before my eyes."
+
+Matthew and Ryv Valiquette (from White Rock) announced a "Surrey style version in Surrey": **half the price of Vancouver events, lighter programming, better parking, and accessible to people working until 5 PM**. The timing was smart. Surrey has serious AI activity in logistics, transportation, mechatronics, and agritech, and Fraser Valley folks often couldn't justify the Vancouver commute.
+
+**Surrey AI #1 launched at Royal Canadian Legion Branch #8** on a second-Tuesday schedule that wouldn't collide with Vancouver's last-Thursday rhythm. The response answered any doubts: **nine consecutive monthly meetups through November 2025**, professional photography, steady attendance, growing institutional support.
+
+By **November 12, 2025, Invest Surrey** (the city's economic development agency) had committed to joining BC + AI and partnering on a December Innovation Boulevard-themed meetup. Tyler Westover, who leads Invest Surrey as the City of Surrey's Director of Business and Government Relations, saw Surrey AI as essential infrastructure for positioning a fast-growing city as an innovation hub. Plans took shape for a quantum computing event at SFU Surrey in February 2026.
+
+Surrey AI made the case: **community-led AI education can thrive outside the big tech hubs**. Young leaders ran it, local needs shaped it, and it paid its own way with grassroots and institutional support. That success sparked more regional nodes: Victoria, Squamish, and conversations in Kelowna, all following the same blueprint of ceremony, inclusivity, and radical localism.
+
+## Carol Ann Hilton's five minutes that changed everything
+
+Gabriel gave us ceremonial grounding. **Carol Ann Hilton brought the economic and philosophical framework**. As CEO of the Indigenomics Institute and a board member of the emerging nonprofit, Carol Ann had spent years building Indigenomics, a movement toward a **$100 billion Indigenous economy** in Canada that reframes economic relationships through Indigenous values.
+
+At the **August 27, 2025 nonprofit launch (#VAI20)**, right after Gabriel's Eagle Song, Carol Ann delivered what members still describe as "5 minutes that laid the philosophical foundation for everything that followed." She opened with the Indigenomics Institute's guiding question: **"How are you showing up tonight?"** That question now sits inside how the AI community governs itself.
+
+Her framework asked: "What are we responding to? Why are we here?" No platitudes about the chaotic state of the world. She reframed chaos through the Chinese symbol: **"Chaos = creative potential. AI transformation is opportunity for conscious creation, not fear."**
+
+The most radical part was her teaching on **decolonizing prescribed meaning**: "As much as meaning has been prescribed to us and each one of our heritage and legacies... there was a prescription of meaning applied onto our humanity." Colonial systems imposed meanings and limits on all peoples. Carol Ann's argument: **AI gives us a chance to rewrite meaning around real values**, because once you can see the imposed prescription, you can choose differently.
+
+Then she challenged the room: **"What does it feel like to put love in the code? Love in the land? Love in the culture?"** She meant it as protocol, love as an organizing principle. That speech locked in what the BC AI Ecosystem Association would be: ceremonial practice as governance structure, technology grounded in traditional wisdom, relationships over networking, and AI connected to economic justice and decolonization.
+
+Carol Ann and I also built together: as CTO of the Indigenomics Institute I worked with her on the **[indigenomics.ai](https://indigenomics.ai/) platform**, AI tools that carry Indigenous values and support economic sovereignty. That collaboration put Indigenous perspectives at the foundation of the build.
+
+## The decision to formalize: nonprofit status in August 2025
+
+By spring 2025, after more than a year of grassroots organizing, we faced a real decision. **Stay an informal network, or build formal structure so the thing could sustain itself?**
+
+The debate ran through planning meetings into early summer 2025. The case for nonprofit status was strong:
+
+- **Credibility for funding**: government grants and corporate sponsorships require formal entities
+- **Collective voice**: aggregate community power for policy advocacy
+- **Sustainable operations**: move beyond "duct tape and vibes" to professional infrastructure
+- **Resource circulation**: province-wide learning and knowledge sharing
+
+The worry was losing the grassroots spirit. We were determined this would **NOT become "Silicon Valley 2.0"** or another corporate-controlled industry association. Whatever structure we chose had to preserve ceremony, radical inclusivity, Indigenous leadership, and community-first decision making.
+
+By mid-August 2025 we made the call. **BC + AI registered as the BC AI Ecosystem Association nonprofit society** under the BC Societies Act, with three founding board members:
+
+- **Carol Ann Hilton** (Indigenomics Institute): Indigenous leadership and the philosophical framework
+- **Lorraine Lowe** (H.R. MacMillan Space Centre): institutional partnership and venue support
+- **Kris Krüg** (me): founder and community organizer
+
+That composition made Indigenous leadership a governing position, not an advisory one: Carol Ann's seat meant every major decision would filter through Indigenomics principles and protocols.
+
+## August 27, 2025: the launch party
+
+**Vancouver AI Community Meetup #20 doubled as the nonprofit launch party**. Approximately 250 people filled the Space Centre planetarium on August 27, 2025, three times the crowd from the first studio night a year and a half earlier. The program held everything BC + AI had become:
+
+**6:00 PM**: Doors opened to networking and food
+
+**Indigenous Ceremony**: Gabriel George's Eagle Song filled the planetarium dome
+
+**Carol Ann Hilton**: Five-minute philosophical framework address
+
+**Jos Duncan-Asé** (flying in from Philadelphia): "Love + AI" ethics framework
+
+**Peter Bittner** (flying in from Seattle): "The Future of Work" and the urgency of upskilling
+
+**Hackathon winners**: $2,500 prizes for data storytelling projects
+
+**8:20 PM**: **Official nonprofit announcement and founding member roll call**
+
+The timing was deliberate. **Registration had gone through about a week earlier, around August 20, 2025**, but we held the public celebration for the milestone 20th meetup. Commemoration and declaration of intent in one night.
+
+**Thirty-four members signed up that first night**. Within the first 2.5 months (by early November 2025), the association had enrolled **130 paid members**, an average of 50 members per month. This exceeded expectations and validated the hybrid model: free or low-cost events for accessibility, paid membership for committed participants seeking deeper benefits.
+
+## How we priced membership
+
+The founding member drive (which ran through December 31, 2025) offered five tiers for different corners of the community:
+
+- **Student**: $80/year (1 seat, proof of enrollment required)
+- **Individual**: $340/year (1 seat for freelancers and independent practitioners)
+- **Micro Pack**: $600/year (5 seats for small teams)
+- **Growth Pack**: $1,400/year (12 seats for growing organizations)
+- **Enterprise Patron**: $3,000/year (30 seats for large organizations)
+
+The **first 100 members locked in "Founder '25" badges and the right to shape bylaws**: governance by the people who showed up early. Benefits stacked: 25% off Vancouver AI meetups, training discounts, coworking access, weekly Office Hours, the Discord, the member directory, and a voice in policy decisions.
+
+One debate from the August 25, 2025 onboarding meeting stuck with me: should the founding period be time-limited (December 31) or capped at the first 100 people? We went **time-based with no numeric cap**, leaving room for Prince George, Kelowna, and Vancouver Island to join before the founding period closed. The logic: **a network of 250 founders beats an exclusive club of 25**.
+
+## Behind the scenes: duct tape and vibes
+
+The nonprofit formation wasn't smooth. **Website payment integration got finished in a rush** right before the August 27 launch. The membership model meant wiring Stripe to a brand-new bank account, building a member database with sequential numbering, and automating email sequences for 15,000+ contacts.
+
+The most delicate move involved **existing Vancouver Core AI annual ticket holders** who had paid $450 for year-long event access. The new membership cost just $240 annually and came with more benefits. We sent voice messages to those early supporters laying out the change, offered BC + AI membership at approximately $200 (a small extra discount), and moved the Core AI channel to a members-only space. **Transparency over perfection** kept the trust intact through the switch.
+
+Geographic equity took creative work. Surrey AI ran **half-price tickets** and better parking than downtown Vancouver. The BC + AI Youth Access Fund covered **scholarships for participants under 20 or over 80**, plus bus rides to hackathons and certification costs. The philosophy: **"Small, real dollars to the exact places that open doors."**
+
+Documentation was its own problem. 23+ monthly meetups had generated hours of video, transcripts, and photos. We built recording systems, Notion databases, and custom AI tools trained on our own transcripts, and kept professional photography at every event. The result is a **searchable knowledge commons**: a talk from a year ago is still findable, quotable, and useful.
+
+## The connective tissue: hackathons, Office Hours, partnerships
+
+Beyond the monthly meetups, we ran programs to build out British Columbia's AI ecosystem:
+
+**Data Storytelling Hackathon** (launched February 26, 2025): Rival Technologies put up $10,000 across four rounds for stories told with data and AI. The first winner, Sev Geraskin, built "Hot Dogma", a data-driven philosophical analysis with 3D visualization answering "Is a hotdog a sandwich?" Later rounds took on Canadian identity, BC's AI story, and the soundtrack of human experience.
+
+**Office Hours** (launched September 2025): weekly Thursday sessions that became the operational backbone of BC + AI programming. Equal parts creative jam, civic briefing, and peer mentoring: project collaborations, funding conversations, GitHub tutorials, member connections. By November 2025 Office Hours were on fire, with founders meeting investors and new collaborations launching weekly.
+
+**Creative Mornings partnership** (announced August 2025): we linked up with Creative Mornings Vancouver, Mark Busse's decade-old tradition of free creative gatherings, billed as uniting "two of Vancouver's most generative creative forces," with a "Creative AI Jam" planned for spring 2026. Both organizations center creativity, ethics, and the Commons while refusing Silicon Valley monoculture.
+
+**Academic partnerships**: MetaCreation Lab at SFU donated $15,000+ in equipment. UBC's Emerging Media Lab collaborated on research. Northeastern University plugged in industry programs. These partnerships kept BC + AI connected to the research frontier without giving up its community-first approach.
+
+**Government relations**: we prepared briefings for provincial ministers, took part in federal AI Task Force consultations, and positioned the community as a grassroots counterweight to corporate AI advocacy. **Three BC women sat on Canada's national AI Task Force**, keeping provincial and Indigenous voices in federal AI strategy.
+
+## Community culture: stoked and careful at the same time
+
+By November 2025 the culture had its own vocabulary. The touchstones:
+
+**"Stoked + careful at the same time"**: critical optimism instead of techno-utopianism or techno-pessimism.
+
+**"In this canoe together"**: Carol Ann's metaphor for the collective journey, adopted community-wide.
+
+**"Ceremony first, then innovation"**: Indigenous protocols as prerequisite. Every event, policy discussion, and partnership started from values.
+
+**"Amplifying creativity, not replacing humans"**: The Upgrade's core philosophy.
+
+**"Multi-modal, multi-cultural, radically local, and future-facing"**: the community's self-description.
+
+**"No gatekeeping"**: radical inclusivity we inherited from Creative Mornings Vancouver, all skill levels and backgrounds welcome.
+
+The attendance numbers carried the growth story: **80 people in a studio (January 2024), 135+ in an overcrowded venue (May 2024), 250+ at the Space Centre (August 2025 on)**, selling out along the way. The demographic mix stayed rare for AI gatherings: **35% technology workers, 25% creative industries, 20% academia, 10% public policy**.
+
+Other people started writing it down too. **UBC's BC Studies Journal published a case study** on the Vancouver AI Community Meetups, noting that early successes "offer valuable lessons for emerging AI communities worldwide." The community picked up recognition as **"British Columbia's largest grassroots AI network"** and **"Canada's premier monthly gathering focused on ethical, community-driven AI development."**
+
+## The turning points
+
+Certain moments changed BC + AI's trajectory:
+
+**The first sellout** (January 25, 2024) validated the appetite and set the format that stuck: ceremony, speakers, demos, performances, networking, all in service of collective learning rather than individual gain.
+
+**135+ attendees** (May 30, 2024) forced the move to the Space Centre, which opened up 3x growth and made the last-Thursday meetup the AI gathering in Vancouver.
+
+**Surrey AI's launch** (March 11, 2025) showed the distributed model worked: 19-year-old Matthew Schwartzman leading a regional chapter without top-down control.
+
+**Carol Ann Hilton's board appointment and August 27 speech** embedded Indigenomics principles in the nonprofit's DNA.
+
+**The nonprofit registration** (August 2025) opened up sustainable operations, grant access, and collective advocacy, while the board composition and governance design protected the grassroots values.
+
+**Reaching 130 paid members** within 2.5 months validated the membership model and created financial runway for 2026 programming expansion.
+
+**The Creative Mornings partnership** was the coming-of-age signal: one of Vancouver's most respected creative institutions wanted to build with us.
+
+## The ecosystem map: 480 organizations and counting
+
+Behind the scenes we maintained an **ecosystem map tracking 480 British Columbia AI organizations**: startups, research labs, nonprofits, government agencies, educational institutions. The map was a working tool. We used it to introduce organizations that should have known each other already, spot collaboration openings, and map the province's AI capabilities.
+
+We also built out **funding resources covering 200+ grants, loans, and investment programs** for nonprofits, startups, and researchers working with AI in BC. Updated monthly, tested by the community, and credited with helping dozens of members land funding. Information that usually sits siloed, made open. That's the values statement in practice.
+
+**Three rounds of public opinion research** (with Angus Reid and Rival Technologies) surveyed 1,001 British Columbia residents about AI attitudes, concerns, and priorities. That data shaped programming and armed the policy work. When we walked into a government meeting, we came with **actual data about what British Columbians wanted from AI development**.
+
+## Where that left us
+
+By November 2025, BC + AI was proof that **grassroots organizing could build significant AI infrastructure** outside corporate control. Monthly Vancouver meetups kept rolling (#VAI23 in November, #VAI24 set for December with the BC AI Awards). Surrey AI ran its ninth consecutive meetup. ED + AI working groups drafted Human-Centered AI in Education frameworks. The Upgrade ran multiple certification cohorts at once across professions.
+
+The **founding member period ran through December 31, 2025**, with expansion pointed at Prince George, Kelowna, and Vancouver Island. We aimed the **December BC AI Awards** at recognizing British Columbia's AI innovators, builders, and ethical leaders, lined up the **Creative AI Jam** with Creative Mornings for spring 2026, and saw **[Web Summit Vancouver](https://vancouver.websummit.com/)** as a chance to make it BC + AI's home base, with community activations and hackathon sprints.
+
+The numbers tell part of the story. The culture is the part I care about most: **ceremony before innovation, Indigenous wisdom guiding technical decisions, education without gatekeeping, communities outside Vancouver counting for something, love as a technical specification, AI amplifying human creativity instead of replacing it**.
+
+**From 80 people in a studio to 300 paid members of a nonprofit with regional chapters, Indigenous board leadership, and national recognition**, all in under two years. No venture capital. No corporate sponsor steering it. Ceremony, community, and careful optimism. That's our story: the grassroots journey from meetup to movement. Another way of building AI's future is already happening in British Columbia.
+
+## Related
+
+- [BC + AI](https://bc-ai.ca/)
+- [BC + AI member profile](https://bc-ai.ca/blog/bc_ai_member/kris-krug/)
+- [Vancouver AI community origin story](https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/)
+- [The Upgrade AI](https://www.theupgrade.ai/)


### PR DESCRIPTION
Closes nothing yet. Draft for KK review on issue #612. **No WordPress writes were made or attempted.**

Live target: WP post **12034**, https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/

## What changed

All files are under `content/drafts/2026-08-01-zero-to-one-voice-rewrite/`.

| File | State | What it is |
|---|---|---|
| `rewritten-body.md` | new | The full first-person body in readable markdown. This is the review artifact. |
| `README.md` | new | What changed, facts preserved, how the date contradiction was resolved, open items for KK. |
| `diff-notes.md` | rewritten | Paragraph-by-paragraph person shift, plus mechanical, judgment, tense, date, arithmetic and structural tables. |
| `proposed-content-raw.html` | 1-line edit | The same body as WP block markup. Would ship as `content.raw`. |
| `live-content-raw-2026-08-01.html` | untouched | Live snapshot, the rollback reference. |
| `rewrite-notes.md` | untouched | Prior-pass rationale, still accurate. |

A partial draft was already on `main` from an earlier pass (`03975a9`). This lane built on it rather
than restarting: it audited that work, added the two deliverables it was missing (a readable body and
a lane README), rewrote `diff-notes.md` to lead with the paragraph-by-paragraph person map, and made
one content change.

`rewritten-body.md` and `proposed-content-raw.html` are kept in lockstep. Verified: strip markup from
both and the text is line-for-line identical, 110 blocks each.

## Why

The live post is a third-person case study about "Krüg" published under Kris's own byline, narrating
from a November 2025 vantage on a June 2026 publish date, with future tense about things that already
happened and three incompatible claims about when the nonprofit registered. The receipts and names
underneath are good. The frame was the problem, so this is a person shift and a fact pass.

## The date contradiction, and which date won

Live says all three of these: registration in **August 2024** (heading and body), nonprofit status by
**August 2025** (lede), and registration "approximately one week prior" to the August 27 **2025**
launch given as "around August 20, **2024**" (self-contradictory inside its own parentheses).

**Treated August 2025 as correct**, on the post's own meetup numbering: `#VAI01` = January 25 2024,
`#VAI13` = January 2025 (inside a direct quote), `#VAI20` = August 27 2025 (stated four times),
cadence is "the last Thursday of each month." Nineteen meetups from `#VAI01` is nineteen months, which
lands on August 2025 and puts `#VAI13` exactly where it belongs. The numbering is self-consistent and
only works with an August 2025 registration. Corrected in four places.

Two companion problems in the same section, both documented rather than silently patched:
- `"By spring 2024, after roughly 20 months of grassroots organizing"` is wrong on both halves from a
  January 2024 start. Moved to spring 2025 and softened to "more than a year." No replacement month
  count was invented. Flagged for KK.
- `"twenty times the first gathering"` is arithmetically wrong: 250 people is about three times 80.
  Corrected to "three times." Both figures were already in the post. Not in the voice audit, so it is
  called out explicitly.

## One content change on top of the prior pass

The lede carried an undated `130 founding members` while the closer carries KK's ruled `300 paid
members`. Time-stamped the lede to `130 founding members by that November`, which is KK's own
instruction 3 from #615 applied to the one spot that had not been. Keeps the receipt, removes the
apparent contradiction, invents nothing. One-line revert if KK disagrees.

## How to verify

```bash
# voice gate
python3 ~/Code/kk-voice/scripts/voicecheck.py content/drafts/2026-08-01-zero-to-one-voice-rewrite/rewritten-body.md
# -> OK: sounds like Kris (0 flags), exit 0
```

| Check | Result |
|---|---|
| `make python-test` | **PASS**, 339 + 3 tests OK, 68 passed |
| `voicecheck.py` on `rewritten-body.md` | **0 flags, exit 0** |
| `voicecheck.py` on stripped `proposed-content-raw.html` | **0 flags, exit 0** |
| Em dashes across all four lane files | **0** |
| `Krüg stated` / `As Krüg` / `serves as CTO` | **0** |
| `proved <word>` tic (5 in live) | **0** |
| `seamless` / `cutting-edge` / `pivotal` / `empower*` / `foster*` / `landscape` / `unprecedented` | **0** |
| `not just X but Y` / `wasn't just` / `not only` | **0** |
| Numbers dropped vs live | **0** |
| Named people and organizations dropped vs live | **0** |
| Calendar dates dropped vs live | **1**, `August 20, 2024`, the corrected one |
| KK's four #615 figures byte-exact | **4/4** |
| WP block open/close balance | **balanced**, 114 blocks |
| Markdown body vs block markup text | **identical**, 110 blocks each |

Issue acceptance criteria met: first-person draft covering the full post, all six mechanical fixes,
Tyler given a full identity (Tyler Westover, Invest Surrey, cross-checked against `kk-kb` where his
founding-member record's `Created: 2025-11-12` matches the post's own November 12 2025 sentence),
tense and date pass with the source cited in the README, and `voicecheck.py` clean.

## Still open

Five judgment calls are listed at the bottom of the README for KK, not decided here:

1. `"Team BC home base"` is currently paraphrased. The audit says keep it as a quoted phrase, but the
   word "Team" inside the quote trips the checker's soft rule and the AC asks for a clean run. Revert
   is one line if KK wants the literal quote plus one accepted contextual flag.
2. `"roughly 20 months"` softened rather than replaced with a guess.
3. The time-stamped lede figure.
4. The `$240` "new membership cost" sentence still sits in the same post as the `$340` Individual
   tier. It was not one of the four figures ruled on in #615, so it is flagged and untouched. Numbers
   question, not a voice question.
5. The `"twenty times"` to `"three times"` arithmetic fix.

## Out of scope, not touched

Post title, slug, excerpt, featured image, taxonomies. Cert post 12257. The live site.
Per the packet, live apply happens only after a KK approval comment on issue #612, with snapshot,
rollback and cache-bypass verify. The apply steps are written down at the bottom of the README but
were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6zuqQbkT3ypd8qZyN9hxf