### PR TITLE
content(#420): rethink Services language, layout, and scroll depth

### DIFF
--- a/content/drafts/2026-08-02-services-page/README.md
+++ b/content/drafts/2026-08-02-services-page/README.md
@@ -1,0 +1,162 @@
+# Services page rethink, issue #420
+
+**Status:** draft only. No live write, no deploy, no CSS change proposed.
+**Measured:** 2026-08-02
+**Live URL:** `GET /services/` returns 301 to `/generative-ai-services/` (200). WP page ID 2666.
+**Evidence:** `evidence/height-before-after-2026-08-02.json`, `pack-proposed.html`
+
+KK's teardown verdict, 2026-07-17:
+
+> The language is weak and the boxes are weak. There's a lot of scroll. The stylesheet's fucked up. This page needs a rethinking from the ground up.
+
+## First: nothing has shipped since the last audit
+
+The live page body and its inline stylesheet are byte-identical to the snapshot taken on 2026-07-26 for the earlier #420 package (`content/drafts/2026-07-26-services-page/`). Same 4,418 byte inline `<style>`, same 237 words of copy. That package was correct and it was never applied. This one supersedes it with a measured before/after and an apply-ready HTML payload.
+
+## What is on the page right now
+
+Four sections inside one custom HTML block (`.kk-services-2026`), under the theme's own H1 block:
+
+| # | Section | Words | Height at 1440 |
+|---|---|---:|---:|
+| 1 | Hero (kicker, display H2, two lead paragraphs) | 67 | 449 |
+| 2 | How I can help (4 ribbon cards) | 89 | 426 |
+| 3 | Proof in motion (2 photo cards) | 40 | 532 |
+| 4 | Start here (CTA card) | 41 | 297 |
+| | **Total pack** | **237** | **1819** |
+
+Seven boxed surfaces total: 4 offer cards, 2 proof cards, 1 CTA card. Two images. Three links in the whole page.
+
+## Problem 1: the page is the site's money page and it is the weakest one
+
+`/services/` is linked three times from site chrome: the nav item **Services**, the header's primary CTA **Work with me** (that CTA was pointed here by #422), and a **Work with me** link in the footer. Every route into "hire this person" lands here.
+
+## Problem 2: it repeats three other pages and adds nothing
+
+Compared against the live text of `/speaking/`, `/work/`, and `/contact/`:
+
+| Services offer | Already covered, better, on |
+|---|---|
+| AI strategy | `/speaking/` "Executive briefings", `/contact/` "Plan strategy or training" |
+| Training and workshops | `/speaking/` "Workshops", `/contact/` "Book a talk or workshop" |
+| Community systems | `/work/` "BC + AI Ecosystem", `/contact/` "Community collaborations" |
+| Keynotes and briefings | `/speaking/` "Keynotes", `/work/` "AI keynotes" |
+
+Four of four. The Services page does not describe a single offer that another page does not already describe in more concrete language. `/speaking/` says "rooms with too many acronyms" and "without hype theatre". `/contact/` says "A short brief beats a vague hello". Services says "sensemaking" and "creative courage".
+
+Four pages also end with four differently worded versions of the same instruction:
+
+- `/services/`: "Book an AI strategy session" then "Start a conversation"
+- `/speaking/`: "Book Kris for a keynote" then "Start a booking conversation"
+- `/work/`: "Bring this work into your room" then "Talk about a project"
+- `/contact/`: "Email Kris" then "Send the note"
+
+## Problem 3: it repeats itself inside its own first screen
+
+Three titles stack before any content: the theme H1 "Generative AI Creative Services & Strategy", the kicker "AI services", and the display H2 "AI strategy for people who still care about culture". Three ways to say "services" in the first 180 vertical pixels.
+
+Then the hero lead says the work is "part strategy, part training, part sensemaking, and part creative courage". The four cards 30 pixels below it are AI strategy, Training and workshops, Community systems, Keynotes and briefings. The lead paragraph is a table of contents for the grid directly underneath it.
+
+"AI" appears 11 times in 237 words, 4.6 percent of every word on the page.
+
+## Problem 4: the boxes fail the issue's own acceptance test
+
+Acceptance says every service block must state what it is, who it is for, and what to do next.
+
+| Card | What | Who | Next |
+|---|---|---|---|
+| I. AI strategy | yes | no | no |
+| II. Training and workshops | yes | no | no |
+| III. Community systems | yes | no | no |
+| IV. Keynotes and briefings | yes | no | no |
+
+Zero of four offer cards contain a link. The card's top slot, which is already styled and already costs vertical space, holds a roman numeral. `I.` `II.` `III.` `IV.` carry no information. That slot is the fix, and it is free.
+
+## Problem 5: the scroll, measured
+
+Playwright Chromium headless, logged out, light scheme, reduced motion, scroll-settle pass, 2026-08-02.
+
+| Viewport | Document | Entry content | `.kk-services-2026` | Theme footer |
+|---|---:|---:|---:|---:|
+| 1440 x 900 | 3737 | 1860 | 1819 | 1384 |
+| 768 x 900 | 4812 | 2758 | 2716 | 1651 |
+| 375 x 812 | 5326 | 2644 | 2602 | 2344 |
+
+Two things fall out of this.
+
+**The offers are below the fold.** At 1440 x 900 the first offer card starts at y=935. The viewport ends at 900. On the page the whole site points at, you cannot see a single thing you can hire him for without scrolling. At 375 the first card starts at y=941 against an 812 tall viewport.
+
+**A third of the scroll is not this page's.** The theme footer is 1384px at 1440 and 2344px at 375, for 105 words. That is 37 percent of the desktop document and 44 percent of the mobile document. The page body cannot be held responsible for it and this lane cannot fix it. See "Where the acceptance criterion needs a ruling" below.
+
+## Problem 6: the stylesheet, specifically
+
+Not fixed here. #423 owns it and has an open draft PR. Recorded so that lane has the receipts:
+
+1. **Proof cards render bold by accident.** The whole proof card is an `<a>`, and `.kk-services-2026 a:not(.kk-services-button) { font-weight: 700 }` therefore applies to the card's `h3` and `p`. Both proof blurbs render at weight 700. Visible in the 1440 before capture.
+2. **Two stacked horizontal rules under "START HERE".** The previous section's 1px bottom border sits directly above `.kk-services-cta`'s own 2px accent `border-top`, which is clipped to `max-width: 40rem`. The result is a full-width hairline, a gap, then a short orange line.
+3. **Eight `!important` declarations to undo the theme.** `.kk-services-2026 :where(p, li)::first-letter` overrides `initial-letter`, `font-size`, `font-weight`, `float`, `margin`, `line-height`, `color`, and `background`, all `!important`, purely to cancel a drop cap the theme applies to prose. Plus `max-width: 72rem` to escape the `aurora-prose` measure. This block is the page fighting the theme, which is the exact condition #423 exists to end.
+
+`AURORA-STYLESHEET-REBUILD-PLAN.md` already lists this inline block for step 7 deletion. Nothing in this package adds CSS, so it survives that deletion as long as the class names get theme-side homes.
+
+## The structural fix
+
+**Services stops competing with `/speaking/` and `/work/` and becomes the routing layer.**
+
+It is the page every CTA points at, so it should do what a front door does: name the four things you can buy, say who each is for, and send you one click deeper. The detail already exists elsewhere and is better written there. Restating it here is what produced both the filler language and the extra scroll.
+
+That single decision does most of the work:
+
+- The "Proof in motion" section disappears, because proof becomes the link target of each offer card. That is 532px at 1440 and 1175px at 768.
+- The offer cards gain "who" and "next" by putting the audience in the slot currently holding a roman numeral and putting the link inline at the end of the blurb. Zero new CSS, zero added height.
+- The hero drops to one lead and pulls the CTA button up, because it no longer has to summarize what the cards below already say.
+
+## Result, measured the same way
+
+Prototyped by replacing `.kk-services-2026` innerHTML on the live page with `pack-proposed.html` and re-measuring. Same stylesheet, same fonts, same theme chrome, same run conditions.
+
+| Viewport | Scope | Before | After | Change |
+|---|---|---:|---:|---:|
+| 1440 | entry content | 1860 | 1184 | **-36.3%** |
+| 1440 | pack | 1819 | 1143 | **-37.2%** |
+| 1440 | full document | 3737 | 3061 | -18.1% |
+| 768 | pack | 2716 | 1293 | **-52.4%** |
+| 768 | full document | 4812 | 3389 | -29.6% |
+| 375 | pack | 2602 | 1716 | **-34.1%** |
+| 375 | full document | 5326 | 4440 | -16.6% |
+
+The first offer card moves from y=935 to y=799 at 1440, which puts it above the 900px fold. At 375 it moves from y=941 to y=700, above the 812px fold.
+
+Word count barely moves, 237 to 223. The height comes out of stacked blocks and an image plane, not out of deleted sentences. That matters: the page did not get thinner, it got denser.
+
+## Where the acceptance criterion needs a ruling
+
+The issue says "Total page height reduced by at least a third at 1440". Measured against the whole document that is 3737 down to 2491, a cut of 1246px. The entire page body is 1819px and the footer alone is 1384px. Hitting it would mean deleting 68 percent of everything this page owns, footer untouched.
+
+Recommendation: score acceptance on **entry content at 1440**, where this proposal delivers 36.3 percent. Then file the footer separately. 1384px of chrome at 1440 and 2344px at 375, for 105 words, is a site-wide problem that shows up on every page, and it is theme territory, not Track A. I have not touched it.
+
+## Decision gates for KK
+
+1. **Pricing.** There is no published price anywhere on kriskrug.co. The only pricing language on the site is `/contact/` asking for a "budget range if you have one", and `docs/current-state/marketing/community-advocate-program-v1-2026-06-17.md` explicitly forbids pricing promises without your approval. So the draft states how quoting works and asks for a range. It invents no numbers. If you want a floor published instead, say the number and I will swap the paragraph.
+2. **Receipts.** The draft names only BC + AI and Futureproof, both already public in the site footer and on `/work/`. Venue names exist in repo drafts (Web Summit Vancouver, ChannelNEXT, LaSalle College, Bass Coast, SFU SIAT, Whistler Institute) but I could not confirm they are publicly claimed on the live site, so I left them out. Adding two or three would make the cards stronger. Your call which.
+3. **The two photos get deleted.** The BC + AI network graph and the Both Hands Full stage shot come off this page. Both still live on `/work/` and `/speaking/`, which is where the cards now point. Confirm you are fine losing the image plane here, since it is the single largest scroll item.
+4. **H1 and the title tag.** Proposed H1 is "AI keynotes, training, and strategy" in place of "Generative AI Creative Services & Strategy". Separately, the live `<title>` is `Generative AI Creative Services & Strategy &mdash; Kris Krug | AI Keynote Speaker & Creative Technologist`. That contains an em dash. It comes from the site-wide title pattern, not this page's body, so I did not touch it, but it is a standing-rule violation on a public string and somebody should own it.
+
+## What this package does not do
+
+No CSS. No theme files. No live write. No deploy. The layout depends on three existing class behaviours that #423 must preserve or rehome: `.kk-services-kicker` (now carries the audience line), `.kk-services-ribbon-card::before` (the colour ribbon), and `.kk-services-button`. Details in `layout-proposal.md`.
+
+## Files
+
+- `copy-draft.md`: the rewritten copy, block by block, with the voice notes
+- `layout-proposal.md`: section order, the four height mechanisms, before/after counts, the #423 handoff
+- `pack-proposed.html`: apply-ready replacement for the `.kk-services-2026` inner HTML
+- `evidence/height-before-after-2026-08-02.json`: raw measurements, both variants, three viewports
+
+## Apply gates, when KK approves
+
+1. Snapshot page 2666 before any write, slug-verified.
+2. Dry run first. `/services/` must still 301 to `/generative-ai-services/`.
+3. Non-ASCII goes in as numeric character references. The DB is latin1 and REST writes corrupt raw codepoints, so "Krüg" must be written as an entity. See the latin1 note in repo memory.
+4. Purge Pagely page cache and confirm the render logged out. REST edits do not auto-purge.
+5. Capture 375, 768, 1440 after the purge and record the real document heights against this file's numbers.
+6. Confirm the six links return 200 logged out: `/speaking/`, `/work/`, `/contact/` (x2 buttons, x2 card links).

--- a/content/drafts/2026-08-02-services-page/copy-draft.md
+++ b/content/drafts/2026-08-02-services-page/copy-draft.md
@@ -1,0 +1,153 @@
+# Services page copy draft, issue #420
+
+**Status:** draft for KK approval. Not applied.
+**Date:** 2026-08-02
+**Target:** WP page 2666, `/generative-ai-services/`, served at `/services/`
+**Em dashes:** 0. Verified by character scan of this file and of `pack-proposed.html`.
+
+Rendered form is `pack-proposed.html`. This file is the copy plus the reasoning, so you can rule on wording without reading markup.
+
+---
+
+## Page title
+
+**H1:** AI keynotes, training, and strategy
+
+Replaces "Generative AI Creative Services & Strategy". Same keywords, no word salad, and it stops being the third thing on the screen that says "services".
+
+Note: the `<title>` tag is separate and currently reads `Generative AI Creative Services & Strategy &mdash; Kris Krug | AI Keynote Speaker & Creative Technologist`. It has an em dash in it. It comes from the site-wide title pattern, not this page body, so it is flagged in the README rather than changed here.
+
+---
+
+## 1. Open
+
+> # I get hired for four things.
+>
+> Talks, team training, strategy work, and building AI communities that actually meet. Pick the one you need, or send me the room and I will tell you what fits.
+>
+> **[ EMAIL KRIS ]** → `/contact/`
+
+**Why this and not the current version.**
+
+The live headline is "AI strategy for people who still care about culture." It is a mood. It does not tell a conference organizer with a budget and a date that they are on the right page. "I get hired for four things" does, and it sets up the grid directly below it so the lead paragraph no longer has to.
+
+Killed from the live hero, with the reason:
+
+| Phrase now live | Why it goes |
+|---|---|
+| still care about culture | vibe, not an offer |
+| move from AI pressure to practical fluency | nobody has ever said "practical fluency" out loud |
+| part strategy, part training, part sensemaking, and part creative courage | a table of contents for the four cards 30px below it |
+| This is not generic prompt-hacking | defining yourself by what you are not |
+| hands-on capacity building | NGO grant language |
+| without surrendering judgment, taste, responsibility, or trust | four abstract nouns in a row |
+| I help organizations, creative teams, schools, civic groups, and community builders | five audiences in one breath means none of them |
+
+The audiences did not disappear. They moved into the cards, where each one sits next to the specific thing that audience buys.
+
+---
+
+## 2. The four offers
+
+Each card is audience line, name, what it is, and where to go next. The audience line goes in the slot that currently holds a roman numeral.
+
+### Card 1
+
+> `CONFERENCES, FESTIVALS, OFFSITES`
+>
+> ### Keynote talks
+>
+> A 30 to 60 minute talk built for your room, with live demos and work from this month, not a stock deck from last year. [Topics and formats](/speaking/)
+
+### Card 2
+
+> `NEWSROOMS, STUDIOS, FACULTY, PUBLIC SECTOR`
+>
+> ### Team training
+>
+> Your people build real workflows in their own tools and leave with something they use the next day. Half day, full day, or a cohort. [Book a workshop](/contact/)
+
+### Card 3
+
+> `LEADERSHIP TEAMS, BOARDS, FUNDERS`
+>
+> ### Strategy and briefings
+>
+> I read how your team actually works, then tell you where AI helps, where it will embarrass you, and what to do first. Written down, so somebody can act on it. [Start a briefing](/contact/)
+
+### Card 4
+
+> `CITIES, ASSOCIATIONS, FESTIVALS`
+>
+> ### Community and ecosystem work
+>
+> The rooms, programs, and publishing loops that turn scattered people into a working AI community. BC + AI and Futureproof are this. [See the ecosystem work](/work/)
+
+**Why these four and in this order.**
+
+Same four offers as today, renamed to what a buyer would type into an email. Ordered by how often each one is the reason somebody arrives: talks first, training second, strategy third, ecosystem work fourth. The live order leads with "AI strategy", which is the hardest one to buy cold.
+
+Two deliberate word choices worth defending:
+
+- "where it will embarrass you" in card 3. It is the only line on the page that says something a consultant would not say, and it is the reason card 3 sounds like a person. If it goes, card 3 goes back to being beige.
+- "not a stock deck from last year" in card 1. Every keynote buyer has been burned by one. Naming it does more work than any adjective would.
+
+Card 4 names BC + AI and Futureproof because both are already public in the site footer and on `/work/`. No unverified receipts. See README decision gate 2 if you want venue names added.
+
+---
+
+## 3. How to start
+
+> ## How to start
+>
+> Send the audience, the date, the format, and a budget range if you have one. A short brief beats a vague hello. Everything is quoted: talks price on room size, travel, and prep, training on how many people and how many sessions.
+>
+> **[ EMAIL KRIS ]** → `/contact/`
+
+**Why this replaces "Book an AI strategy session".**
+
+The live CTA is "Book an AI strategy session", which is one of the four offers wearing the hat of all four. Somebody who wants a keynote reads that and wonders if they are in the wrong place. "How to start" covers everything above it.
+
+"A short brief beats a vague hello" is lifted verbatim from `/contact/`. It is already yours, it is the best line on that page, and repeating it here is deliberate: it is the one thing worth saying twice because it changes what lands in the inbox.
+
+**On pricing.** No number is published anywhere on kriskrug.co today. The only pricing-adjacent language on the live site is `/contact/` asking for a "budget range if you have one", and the marketing docs forbid pricing promises without your sign-off. So this paragraph says how quoting works and invents nothing. It gives a buyer the two variables that actually move the number, which is more than "start a conversation" gives them.
+
+If you want a floor published instead, the swap is one sentence:
+
+> Everything is quoted. Talks start at $X, training at $Y per day. Tell me your range and I will tell you straight away whether it works.
+
+Your number, your call.
+
+---
+
+## What got deleted
+
+| Section | Reason |
+|---|---|
+| "AI services" kicker | The H1 directly above it already says services |
+| Second hero paragraph | Defined the work by what it is not |
+| Roman numerals I, II, III, IV | Zero information in a slot that costs vertical space |
+| "Proof in motion" section, both photo cards | Proof moved into the cards as links to `/work/` and `/speaking/`, where the same images already live |
+| "Book an AI strategy session" heading | One offer standing in for four |
+
+## Counts, before and after
+
+| | Live | Draft |
+|---|---:|---:|
+| Words in the block | 237 | 223 |
+| Sections | 4 | 3 |
+| Boxed surfaces | 7 | 5 |
+| Images | 2 | 0 |
+| Links | 3 | 6 |
+| Offer cards with an audience | 0 of 4 | 4 of 4 |
+| Offer cards with a next step | 0 of 4 | 4 of 4 |
+| Uses of "AI" | 11 | 4 |
+| Em dashes | 0 | 0 |
+
+Roughly the same word count, 37 percent less height at 1440. The page did not get shorter by saying less. It got shorter by stopping the repetition and dropping the image plane.
+
+## Voice check
+
+Scanned and absent: unlock, delve, leverage, empower, journey, landscape, robust, seamless, holistic, synergy, elevate, fluency, sensemaking, capacity, courage. No "it's not just X, it's Y". No three-adjective stacks. The noun lists that remain are audiences and variables, which are load bearing.
+
+Run `voice-slop-audit` against `pack-proposed.html` before apply.

--- a/content/drafts/2026-08-02-services-page/evidence/height-before-after-2026-08-02.json
+++ b/content/drafts/2026-08-02-services-page/evidence/height-before-after-2026-08-02.json
@@ -1,0 +1,270 @@
+{
+  "measured_at": "2026-08-02",
+  "tool": "playwright chromium headless, logged out, colorScheme light, reducedMotion reduce, scroll-settle pass",
+  "url": "https://kriskrug.co/generative-ai-services/",
+  "note": "after variant = the live page with .kk-services-2026 innerHTML replaced by pack-proposed.html. Zero CSS change: same inline stylesheet, same fonts, same theme header and footer.",
+  "before": {
+    "375": {
+      "iw": 375,
+      "ih": 812,
+      "doc": 5326,
+      "post": 2644,
+      "header": 105,
+      "pageTitleBlock": 93,
+      "footer": 2344,
+      "pack": 2602,
+      "hero": 563,
+      "sections": [
+        {
+          "cls": "kk-services-hero",
+          "h": 563
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 762
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 868
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 294
+        }
+      ],
+      "ribbonGrid": 680,
+      "proofGrid": 785,
+      "cta": 265,
+      "proofImg": 213,
+      "displayFontPx": "32px",
+      "firstOfferTop": 941,
+      "ctaTop": 2633
+    },
+    "768": {
+      "iw": 768,
+      "ih": 900,
+      "doc": 4812,
+      "post": 2758,
+      "header": 93,
+      "pageTitleBlock": 134,
+      "footer": 1651,
+      "pack": 2716,
+      "hero": 403,
+      "sections": [
+        {
+          "cls": "kk-services-hero",
+          "h": 403
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 662
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 1258
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 277
+        }
+      ],
+      "ribbonGrid": 579,
+      "proofGrid": 1175,
+      "cta": 249,
+      "proofImg": 459,
+      "displayFontPx": "34.56px",
+      "firstOfferTop": 831,
+      "ctaTop": 2813
+    },
+    "1440": {
+      "iw": 1440,
+      "ih": 900,
+      "doc": 3737,
+      "post": 1860,
+      "header": 76,
+      "pageTitleBlock": 179,
+      "footer": 1384,
+      "pack": 1819,
+      "hero": 449,
+      "sections": [
+        {
+          "cls": "kk-services-hero",
+          "h": 449
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 426
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 532
+        },
+        {
+          "cls": "kk-services-section",
+          "h": 297
+        }
+      ],
+      "ribbonGrid": 343,
+      "proofGrid": 449,
+      "cta": 268,
+      "proofImg": 299,
+      "displayFontPx": "48px",
+      "firstOfferTop": 935,
+      "ctaTop": 1954
+    }
+  },
+  "after": {
+    "375": {
+      "iw": 375,
+      "ih": 812,
+      "doc": 4440,
+      "post": 1758,
+      "footer": 2344,
+      "pack": 1716,
+      "hero": 365,
+      "offers": 915,
+      "cta": 319,
+      "sections": [
+        365,
+        955,
+        319
+      ],
+      "firstOfferTop": 700,
+      "offersFullyAboveFold": false,
+      "cardHeights": [
+        176,
+        220,
+        203,
+        233
+      ]
+    },
+    "768": {
+      "iw": 768,
+      "ih": 900,
+      "doc": 3389,
+      "post": 1335,
+      "footer": 1651,
+      "pack": 1293,
+      "hero": 321,
+      "offers": 607,
+      "cta": 249,
+      "sections": [
+        321,
+        647,
+        249
+      ],
+      "firstOfferTop": 705,
+      "offersFullyAboveFold": false,
+      "cardHeights": [
+        124,
+        124,
+        152,
+        124
+      ]
+    },
+    "1440": {
+      "iw": 1440,
+      "ih": 900,
+      "doc": 3061,
+      "post": 1184,
+      "footer": 1384,
+      "pack": 1143,
+      "hero": 356,
+      "offers": 373,
+      "cta": 297,
+      "sections": [
+        356,
+        412,
+        297
+      ],
+      "firstOfferTop": 799,
+      "offersFullyAboveFold": false,
+      "cardHeights": [
+        156,
+        156,
+        185,
+        185
+      ]
+    }
+  },
+  "deltas": {
+    "1440": {
+      "doc": {
+        "before": 3737,
+        "after": 3061,
+        "delta_px": -676,
+        "pct": -18.1
+      },
+      "post": {
+        "before": 1860,
+        "after": 1184,
+        "delta_px": -676,
+        "pct": -36.3
+      },
+      "pack": {
+        "before": 1819,
+        "after": 1143,
+        "delta_px": -676,
+        "pct": -37.2
+      },
+      "footer": {
+        "before": 1384,
+        "after": 1384,
+        "delta_px": 0,
+        "pct": 0.0
+      }
+    },
+    "768": {
+      "doc": {
+        "before": 4812,
+        "after": 3389,
+        "delta_px": -1423,
+        "pct": -29.6
+      },
+      "post": {
+        "before": 2758,
+        "after": 1335,
+        "delta_px": -1423,
+        "pct": -51.6
+      },
+      "pack": {
+        "before": 2716,
+        "after": 1293,
+        "delta_px": -1423,
+        "pct": -52.4
+      },
+      "footer": {
+        "before": 1651,
+        "after": 1651,
+        "delta_px": 0,
+        "pct": 0.0
+      }
+    },
+    "375": {
+      "doc": {
+        "before": 5326,
+        "after": 4440,
+        "delta_px": -886,
+        "pct": -16.6
+      },
+      "post": {
+        "before": 2644,
+        "after": 1758,
+        "delta_px": -886,
+        "pct": -33.5
+      },
+      "pack": {
+        "before": 2602,
+        "after": 1716,
+        "delta_px": -886,
+        "pct": -34.1
+      },
+      "footer": {
+        "before": 2344,
+        "after": 2344,
+        "delta_px": 0,
+        "pct": 0.0
+      }
+    }
+  }
+}

--- a/content/drafts/2026-08-02-services-page/layout-proposal.md
+++ b/content/drafts/2026-08-02-services-page/layout-proposal.md
@@ -1,0 +1,165 @@
+# Services page layout proposal, issue #420
+
+**Status:** draft. No CSS proposed, no theme files touched.
+**Measured:** 2026-08-02, Playwright Chromium headless, logged out, light scheme, reduced motion, scroll-settle pass.
+**Prototype:** `pack-proposed.html` injected into the live page, then re-measured under identical conditions.
+
+## The constraint that shaped this
+
+The stylesheet decision is #423 and it is open. So this proposal is built to a hard rule: **the height cut must come from HTML structure and copy only, with the existing stylesheet untouched.** Every number below was measured with the live 4,418 byte inline block exactly as it is today. Nothing here needs a CSS change to work, and nothing here blocks #423 from deleting that block later.
+
+That rule turned out to be a feature. It forced the design into the space the current CSS already provides, which is why the biggest win is free.
+
+## Section order, before and after
+
+**Before, 4 sections:**
+
+1. Hero: kicker, display H2, two lead paragraphs
+2. How I can help: 4 ribbon cards, 2 x 2
+3. Proof in motion: 2 photo cards, 2 x 1
+4. Start here: CTA card
+
+**After, 3 sections:**
+
+1. Open: display H2, one lead, primary button
+2. Offers: 4 ribbon cards, 2 x 2, each carrying audience, offer, and next step
+3. How to start: CTA card
+
+**Section count 4 to 3. Boxed surfaces 7 to 5. Images 2 to 0. Links 3 to 6.**
+
+Why this order. The page is the destination of the site's primary "Work with me" CTA, so its only job is to name what you can buy and route you one click deeper. Open states the four things exist. Offers lets you self-select. How to start tells you what to put in the email. There is nothing else a front door needs.
+
+## The four mechanisms
+
+### M1. Delete "Proof in motion", move proof into the cards
+
+The largest single item on the page. Two `<a>` cards each wrapping a 16:10 image, linking `/work/` and `/speaking/`.
+
+Those are the same two destinations the offer cards now link to. The section was a second, taller navigation to places the offers already had to point at. So it becomes the offer cards' link targets.
+
+| Viewport | Height removed |
+|---|---:|
+| 1440 | 532 |
+| 768 | 1258 |
+| 375 | 868 |
+
+The image plane is why 768 is the worst viewport on the live page: the grid drops to one column, so both 16:10 images render at full container width, 459px each. The proof section alone is 1258px there, larger than the entire proposed page body at that viewport.
+
+Side effect, free: this also removes the bold-text bug. The proof card is an `<a>`, so `.kk-services-2026 a:not(.kk-services-button) { font-weight: 700 }` currently forces both card headings and both blurbs to weight 700. Deleting the cards deletes the symptom. #423 should still fix the cause.
+
+### M2. Repurpose the wasted kicker slot for the audience line
+
+This is the important one and it costs nothing.
+
+Each offer card already renders three stacked elements: a `.kk-services-kicker`, an `h3`, and a `p`. The kicker currently holds `I.` `II.` `III.` `IV.` Roman numerals. They carry no information and they occupy a styled, spaced, already-paid-for row.
+
+Put the audience there.
+
+```
+BEFORE                          AFTER
+I.                              CONFERENCES, FESTIVALS, OFFSITES
+AI strategy                     Keynote talks
+Map where AI can actually       A 30 to 60 minute talk built for
+help, where it should stay      your room ... [Topics and formats]
+out, and how your team can
+move without chaos or
+vendor fog.
+```
+
+The "next step" goes inline at the end of the blurb, inside the existing `p`, which already has link styling (`a:not(.kk-services-button)`, accent colour, weight 700, underline on hover).
+
+Result: all four cards satisfy the issue's acceptance test (what it is, who it is for, what to do next) with **zero new CSS and zero added height**. The card grid is 343px before and 373px after at 1440. Thirty pixels for four audience lines and four links.
+
+This is the answer to "the boxes are weak". The boxes were not weak because they lacked a surface. They were weak because one of their three slots was a roman numeral.
+
+### M3. Collapse the hero
+
+Remove the "AI services" kicker, since the H1 immediately above it says the same word. Cut the two lead paragraphs to one, since the first was a table of contents for the grid below and the second defined the work by what it is not. Pull the primary CTA button up into the hero so there is a way to act above the fold.
+
+1440: 449 to 356. 768: 403 to 321. 375: 563 to 365.
+
+### M4. Tighten the closer
+
+`h2` plus two paragraphs plus a button becomes `h2` plus one paragraph plus a button, with the pricing mechanics folded into the same paragraph.
+
+1440: 297 section height retained but the CTA card itself carries more information in less space. 768: 277 to 249. 375: 294 to 319 (mobile grows slightly because the merged paragraph wraps to more lines at 375; net still strongly positive).
+
+## Measured result
+
+Same page, same stylesheet, same fonts, same theme header and footer. Only `.kk-services-2026` innerHTML differs.
+
+| Viewport | Scope | Before | After | Change |
+|---|---|---:|---:|---:|
+| **1440 x 900** | entry content | 1860 | 1184 | **-36.3%** |
+| | services block | 1819 | 1143 | **-37.2%** |
+| | full document | 3737 | 3061 | -18.1% |
+| **768 x 900** | entry content | 2758 | 1335 | **-51.6%** |
+| | services block | 2716 | 1293 | **-52.4%** |
+| | full document | 4812 | 3389 | -29.6% |
+| **375 x 812** | entry content | 2644 | 1758 | **-33.5%** |
+| | services block | 2602 | 1716 | **-34.1%** |
+| | full document | 5326 | 4440 | -16.6% |
+
+Section by section at 1440:
+
+| Section | Before | After |
+|---|---:|---:|
+| Hero / Open | 449 | 356 |
+| How I can help / Offers | 426 | 412 |
+| Proof in motion | 532 | removed |
+| Start here / How to start | 297 | 297 |
+| **Block total** | **1819** | **1143** |
+
+## Above the fold
+
+| Viewport | First offer card top, before | After | Fold |
+|---|---:|---:|---:|
+| 1440 x 900 | 935 | **799** | 900 |
+| 375 x 812 | 941 | **700** | 812 |
+
+Today, at both the desktop and the mobile reference viewport, you cannot see a single purchasable thing without scrolling. After, the first offer is on the first screen at both.
+
+## The acceptance criterion needs a ruling
+
+The issue says "Total page height reduced by at least a third at 1440". Against the full document that means 3737 to 2491, a 1246px cut.
+
+The page body is 1819px. The theme footer is 1384px. Hitting 1246px out of the document while the footer is fixed means removing 68 percent of everything this page owns.
+
+| At 1440 | px | Share of document |
+|---|---:|---:|
+| Theme header | 76 | 2% |
+| Theme H1 block | 179 | 5% |
+| Services block, before | 1819 | 49% |
+| Theme footer | 1384 | **37%** |
+
+At 375 the footer is 2344px, **44 percent** of the document, for 105 words.
+
+Recommendation: **score #420 on entry content at 1440**, where this delivers 36.3 percent, clear of the bar. Then file the footer as its own issue. It is 1384px of chrome on every page of the site, it is Track B, and this lane has not touched it.
+
+## Dependency on #423, and how it is contained
+
+Nothing here adds, edits, or deletes a CSS rule. The proposal is deliberately built inside the styling the page already has, so it lands cleanly whichever way #423 goes.
+
+`AURORA-STYLESHEET-REBUILD-PLAN.md` lists this page's inline block for step 7 deletion. When that happens, three existing behaviours must be preserved or rehomed or this layout degrades:
+
+| Class | What the layout needs from it | If it disappears |
+|---|---|---|
+| `.kk-services-kicker` | small mono uppercase label above the `h3` | the audience line reads as body copy and the card loses its scan hierarchy |
+| `.kk-services-ribbon-card::before` | the 8px colour ribbon on the left edge | the cards lose their only visual boundary, since they have no background or border |
+| `.kk-services-button` | inverted solid CTA button | the two CTAs render as plain accent links |
+
+Also for #423, observed on the live page and **not fixed here**:
+
+1. `a:not(.kk-services-button) { font-weight: 700 }` cascades into whole-card links, so the proof cards render entirely bold. Removed by M1, but the rule is still wrong.
+2. `.kk-services-cta { border-top: 2px solid accent; max-width: 40rem }` stacks directly under the previous section's full-width 1px bottom border, producing two horizontal rules with the section kicker floating between them. Still present in the proposed layout, because fixing it is a CSS change.
+3. Eight `!important` declarations on `:where(p, li)::first-letter` exist only to cancel a theme drop cap, plus `max-width: 72rem` to escape the `aurora-prose` measure. This is the page fighting the theme, which is the condition #423 is meant to end.
+
+**Order of operations:** this layout can land before or after #423. It does not need the stylesheet decision, and it does not pre-empt it. If #423 lands first, re-measure before applying, since the numbers above were taken against today's CSS.
+
+## Rejected alternatives
+
+**Tabs or an accordion over the four offers.** Would have got the block under 800px at 1440. Rejected: it hides every offer behind a click on the page the site's primary CTA points at, and it drops four offer names out of the initial HTML for search. Density beat disclosure here.
+
+**Four across in a single row at 1440.** Rejected: at 72rem max-width each card gets roughly 250px, the 1.65rem `h3` wraps to three lines, and the 2 x 2 grid it replaces is only 343px tall to begin with. It would have traded readability for about 150px.
+
+**Keeping one proof image.** Rejected: a single 16:10 image is still 299px at 1440 and 459px at 768, which is most of one mechanism's savings for one photograph that already appears on `/work/`.

--- a/content/drafts/2026-08-02-services-page/pack-proposed.html
+++ b/content/drafts/2026-08-02-services-page/pack-proposed.html
@@ -1,0 +1,36 @@
+<section class="kk-services-hero">
+<h2 class="kk-services-display">I get hired for four things.</h2>
+<p class="kk-services-lead">Talks, team training, strategy work, and building AI communities that actually meet. Pick the one you need, or send me the room and I will tell you what fits.</p>
+<p><a class="kk-services-button" href="/contact/">Email Kris</a></p>
+</section>
+<section class="kk-services-section">
+<div class="kk-services-ribbon-grid">
+<article class="kk-services-ribbon-card" style="--service-ribbon:linear-gradient(180deg,#d94a1f 0 25%,#e8b53a 25% 50%,#1f8a86 50% 75%,#2b57a6 75% 100%)">
+<p class="kk-services-kicker">Conferences, festivals, offsites</p>
+<h3>Keynote talks</h3>
+<p>A 30 to 60 minute talk built for your room, with live demos and work from this month, not a stock deck from last year. <a href="/speaking/">Topics and formats</a></p>
+</article>
+<article class="kk-services-ribbon-card" style="--service-ribbon:linear-gradient(180deg,#1f8a86 0 25%,#39a8d8 25% 50%,#6b3a97 50% 75%,#171310 75% 100%)">
+<p class="kk-services-kicker">Newsrooms, studios, faculty, public sector</p>
+<h3>Team training</h3>
+<p>Your people build real workflows in their own tools and leave with something they use the next day. Half day, full day, or a cohort. <a href="/contact/">Book a workshop</a></p>
+</article>
+<article class="kk-services-ribbon-card" style="--service-ribbon:linear-gradient(180deg,#e8b53a 0 25%,#d94a1f 25% 50%,#171310 50% 75%,#d6337a 75% 100%)">
+<p class="kk-services-kicker">Leadership teams, boards, funders</p>
+<h3>Strategy and briefings</h3>
+<p>I read how your team actually works, then tell you where AI helps, where it will embarrass you, and what to do first. Written down, so somebody can act on it. <a href="/contact/">Start a briefing</a></p>
+</article>
+<article class="kk-services-ribbon-card" style="--service-ribbon:linear-gradient(180deg,#171310 0 25%,#d94a1f 25% 50%,#e8b53a 50% 75%,#2b57a6 75% 100%)">
+<p class="kk-services-kicker">Cities, associations, festivals</p>
+<h3>Community and ecosystem work</h3>
+<p>The rooms, programs, and publishing loops that turn scattered people into a working AI community. BC + AI and Futureproof are this. <a href="/work/">See the ecosystem work</a></p>
+</article>
+</div>
+</section>
+<section class="kk-services-section">
+<div class="kk-services-cta">
+<h2>How to start</h2>
+<p>Send the audience, the date, the format, and a budget range if you have one. A short brief beats a vague hello. Everything is quoted: talks price on room size, travel, and prep, training on how many people and how many sessions.</p>
+<p><a class="kk-services-button" href="/contact/">Email Kris</a></p>
+</div>
+</section>


### PR DESCRIPTION
Draft package for issue #420. **Draft only: no live write, no deploy, no CSS change, no theme files.**

Files, all under `content/drafts/2026-08-02-services-page/`:

- `README.md` — what the page does wrong, measured
- `copy-draft.md` — rewritten copy in KK voice, with the reasoning per block
- `layout-proposal.md` — section order, the four height mechanisms, before/after counts, #423 handoff
- `pack-proposed.html` — apply-ready replacement for the `.kk-services-2026` inner HTML
- `evidence/height-before-after-2026-08-02.json` — raw measurements, both variants, three viewports

## Nothing shipped from the last pass

The live body and its 4,418 byte inline `<style>` are byte-identical to the 2026-07-26 snapshot in `content/drafts/2026-07-26-services-page/`. That package was right and never got applied. This one supersedes it with a measured before/after and an apply-ready payload.

## What is actually wrong, measured

**It is the site's money page and the weakest one.** `/services/` is the target of the nav item, the header "Work with me" CTA (pointed here by #422), and a footer link.

**It repeats three other pages.** All four of its offers are already described, in better language, on `/speaking/`, `/work/`, or `/contact/`. Services contributes zero offers the site does not already explain elsewhere. Four pages also end with four differently worded versions of "email me".

**It repeats itself in its own first screen.** Three titles stack before any content. The hero lead ("part strategy, part training, part sensemaking, and part creative courage") is a table of contents for the four cards 30px below it. "AI" is 11 of 237 words.

**The boxes fail the issue's own acceptance test.** 0 of 4 offer cards state who it is for. 0 of 4 contain a link. The card's top slot, already styled and already costing vertical space, holds a roman numeral.

**The offers are below the fold.** At 1440x900 the first offer card starts at y=935.

| Viewport | Document | Entry content | `.kk-services-2026` | Theme footer |
|---|---:|---:|---:|---:|
| 1440 x 900 | 3737 | 1860 | 1819 | 1384 |
| 768 x 900 | 4812 | 2758 | 2716 | 1651 |
| 375 x 812 | 5326 | 2644 | 2602 | 2344 |

## The fix

Services stops competing with `/speaking/` and `/work/` and becomes the routing layer: name the four things you can buy, say who each is for, send one click deeper.

The biggest structural win costs nothing. The offer card already renders kicker / h3 / p. Put the audience in the kicker slot instead of a roman numeral and the "next" link inline at the end of the blurb, and all four cards satisfy what / who / next with **zero new CSS and 30px of added grid height**.

Then delete "Proof in motion" entirely (532px at 1440, 1258px at 768), because proof becomes the link target of each card and both images already live on `/work/` and `/speaking/`.

## Result

Prototyped by replacing `.kk-services-2026` innerHTML on the live page and re-measuring under identical conditions. Same stylesheet, same fonts, same theme chrome.

| Viewport | Scope | Before | After | Change |
|---|---|---:|---:|---:|
| 1440 | entry content | 1860 | 1184 | **-36.3%** |
| 1440 | services block | 1819 | 1143 | **-37.2%** |
| 1440 | full document | 3737 | 3061 | -18.1% |
| 768 | services block | 2716 | 1293 | **-52.4%** |
| 375 | services block | 2602 | 1716 | **-34.1%** |

Section count 4 to 3. Boxes 7 to 5. Images 2 to 0. Links 3 to 6. First offer card moves from y=935 to y=799 at 1440 and y=941 to y=700 at 375, above the fold at both. Word count barely moves (237 to 223): the height comes out of stacked blocks and an image plane, not deleted sentences.

## The acceptance criterion needs a ruling

"Total page height reduced by at least a third at 1440" measured against the whole document means cutting 1246px. The page body is 1819px and the **theme footer is 1384px**, 37% of the desktop document and 44% of the mobile one, for 105 words. Hitting it would mean deleting 68% of everything this page owns.

Proposal: score #420 on **entry content at 1440**, where this delivers 36.3%, and file the footer separately as Track B. I have not touched it.

## Scope fence honoured (#423)

Zero CSS proposed. Every number was measured against the live inline stylesheet exactly as it is today, so this lands either before or after #423 without pre-empting it. Three existing behaviours the layout needs preserved or rehomed when that block is deleted at step 7: `.kk-services-kicker`, `.kk-services-ribbon-card::before`, `.kk-services-button`.

Three CSS defects observed and **deliberately not fixed**, handed to #423:
1. `a:not(.kk-services-button) { font-weight: 700 }` cascades into whole-card links, so both proof cards render entirely bold.
2. `.kk-services-cta` `border-top` stacks under the previous section's bottom border, giving two horizontal rules with a kicker floating between.
3. Eight `!important` declarations on `::first-letter` purely to cancel a theme drop cap, plus `max-width: 72rem` to escape `aurora-prose`.

## Open, needs KK

1. **Pricing.** No number is published anywhere on the site; `/contact/` asks for a "budget range", and the marketing docs forbid pricing promises without sign-off. The draft explains how quoting works and invents nothing. A one-sentence swap for a published floor is in `copy-draft.md` if you want it.
2. **Receipts.** Only BC + AI and Futureproof are named, both already public in the footer and on `/work/`. Venue names exist in repo drafts but I could not confirm they are publicly claimed live, so they are out. Adding two or three would strengthen the cards.
3. **Two photos get deleted** from this page. Both still live on `/work/` and `/speaking/`.
4. **The live `<title>` contains an em dash.** It comes from the site-wide title pattern, not this page body, so it is flagged rather than changed. Somebody should own it.

## Verification

- `make python-test`: **pass** (68 passed, plus 3 SEO inventory tests OK, plus connector suites OK)
- `make validate`: `php-syntax` **pass** (39 files), then **fails on missing `vendor/bin/phpcs`**. Pre-existing local environment gap, `vendor/` is not installed. This lane touches zero PHP.
- Em dash scan across the package: **0**
- Link smoke logged out: `/services/` 301 to `/generative-ai-services/` 200; `/speaking/`, `/work/`, `/contact/` all **200**
- Screenshots at 375 and 1440 captured to scratchpad for the render check (not committed; `reports/` PNGs are gitignored and the pixel gate is an apply-time step)

Apply gates (snapshot page 2666, dry run, latin1 NCR entities for "Krüg", Pagely purge, post-purge captures) are listed at the end of `README.md`.
