### PR TITLE
fix(#661): detect silent SEO meta drop + re-register Jetpack keys

### DIFF
--- a/scripts/notion-to-wp/kk_notion_to_wp.py
+++ b/scripts/notion-to-wp/kk_notion_to_wp.py
@@ -135,7 +135,8 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
         slug_override: str | None = None,
         date_override: str | None = None,
         category_override: str | None = None,
-        diff_update: bool = False) -> int:
+        diff_update: bool = False,
+        allow_seo_drop: bool = False) -> int:
     cfg = load_config()
     nclient = Notion(cfg.notion_token)
     page_id = parse_page_id(notion_url)
@@ -380,6 +381,26 @@ def run(notion_url: str, dry_run: bool, force_publish: bool,
             f"link={verified.get('link')!r}")
     except Exception as e:
         log(f"WARNING: post-write verification GET failed: {e}")
+        verified = None
+
+    seo_expected = (payload.get("meta") or {})
+    from publish_common import verify_seo_meta_landed  # lazy: avoids circular import
+    seo_dropped = verify_seo_meta_landed(
+        (verified or result).get("meta"), seo_expected
+    )
+    if seo_dropped:
+        msg = (
+            f"[ABORT] SEO meta silently dropped by WordPress REST: {seo_dropped}. "
+            "jetpack_seo_html_title / advanced_seo_description are no longer "
+            "registered (Jetpack deactivated). The POST returned 200 but the "
+            "values were not stored. Re-register the keys (see #661 option 1) "
+            "or re-run with --allow-seo-drop to publish without SEO meta."
+        )
+        if allow_seo_drop:
+            log(f"WARNING: {msg}")
+        else:
+            log(msg)
+            return 4
     return 0
 
 
@@ -411,6 +432,13 @@ def main():
         default=None,
         help="Override Notion Type → WP category routing. Required for Feature posts when tags are ambiguous.",
     )
+    p.add_argument(
+        "--allow-seo-drop",
+        action="store_true",
+        help="Publish even if WordPress REST silently drops jetpack_seo_html_title / "
+             "advanced_seo_description (Jetpack deactivated, keys unregistered). "
+             "Without this flag the connector aborts when SEO meta does not land. See #661.",
+    )
     args = p.parse_args()
     sys.exit(run(
         args.notion_url,
@@ -422,6 +450,7 @@ def main():
         date_override=args.date,
         category_override=args.category,
         diff_update=args.diff,
+        allow_seo_drop=args.allow_seo_drop,
     ))
 
 

--- a/scripts/notion-to-wp/prepare_review_draft.py
+++ b/scripts/notion-to-wp/prepare_review_draft.py
@@ -19,6 +19,7 @@ from typing import Iterable
 import yaml
 
 from kk_notion_to_wp import WordPress, load_config, update_title_guard
+from publish_common import verify_seo_meta_landed
 
 
 MIN_WORDS = 900
@@ -277,7 +278,7 @@ def ensure_terms(wp: WordPress, taxonomy: str, values: Iterable[str]) -> list[in
     return ids
 
 
-def update_wp_draft(pkg: DraftPackage, html_body: str, wp_id: int) -> dict:
+def update_wp_draft(pkg: DraftPackage, html_body: str, wp_id: int, *, fail_on_warning: bool = False) -> dict:
     cfg = load_config()
     wp = WordPress(cfg.wp_base_url, cfg.wp_user, cfg.wp_app_password)
     existing = wp.get_post(wp_id)
@@ -317,6 +318,15 @@ def update_wp_draft(pkg: DraftPackage, html_body: str, wp_id: int) -> dict:
         }
 
     result = wp.update_post(wp_id, payload)
+    seo_dropped = verify_seo_meta_landed(result.get("meta"), payload.get("meta"))
+    if seo_dropped:
+        print(
+            f"WARNING: SEO meta silently dropped by WordPress REST: {seo_dropped}. "
+            "jetpack_seo_html_title / advanced_seo_description are no longer "
+            "registered (Jetpack deactivated). See #661."
+        )
+        if fail_on_warning:
+            raise RuntimeError(f"SEO meta dropped: {seo_dropped}")
     return result
 
 
@@ -343,7 +353,13 @@ def main() -> int:
         f"images={count_images(pkg.body)} blocks={html_body.count('<!-- wp:')}"
     )
     if args.wp_id is not None:
-        result = update_wp_draft(pkg, html_body, args.wp_id)
+        try:
+            result = update_wp_draft(
+                pkg, html_body, args.wp_id, fail_on_warning=args.fail_on_warning
+            )
+        except RuntimeError as e:
+            print(f"ERROR: {e}")
+            return 4
         print(f"UPDATED: WP draft {result['id']} {result.get('link')}")
     return 0
 

--- a/scripts/notion-to-wp/publish_common.py
+++ b/scripts/notion-to-wp/publish_common.py
@@ -495,6 +495,38 @@ def build_seo_meta(meta_title: str, meta_description: str) -> dict[str, str]:
     }
 
 
+SEO_META_KEYS = ("jetpack_seo_html_title", "advanced_seo_description")
+
+
+def verify_seo_meta_landed(
+    response_meta: dict[str, Any] | None,
+    expected_meta: dict[str, str] | None,
+) -> list[str]:
+    """Return SEO meta keys that were sent but did not land in the REST response.
+
+    WordPress silently drops unregistered meta keys on write — the POST returns
+    200 and the value is never stored. Since Jetpack was deactivated on
+    kriskrug.co, ``jetpack_seo_html_title`` and ``advanced_seo_description`` are
+    no longer registered, so every connector publish silently loses them.
+
+    Pass the ``meta`` dict from the post-write readback (or the create/update
+    response) and the ``meta`` sub-dict from the payload. Any key that was sent
+    with a non-empty value but is absent or mismatched in the response is
+    listed. An empty list means everything landed (or nothing was sent).
+    """
+    if not expected_meta:
+        return []
+    response_meta = response_meta or {}
+    dropped: list[str] = []
+    for key in SEO_META_KEYS:
+        sent = expected_meta.get(key)
+        if not sent:
+            continue
+        if response_meta.get(key) != sent:
+            dropped.append(key)
+    return dropped
+
+
 def parse_int_arg(argv: list[str], flag: str, default: int | None = None) -> int | None:
     """Parse `--flag N` from argv; return default when absent."""
     if flag in argv:

--- a/scripts/notion-to-wp/tests/test_publish_common.py
+++ b/scripts/notion-to-wp/tests/test_publish_common.py
@@ -84,6 +84,51 @@ class PublishCommonTests(unittest.TestCase):
             any(__import__("unicodedata").combining(c) for c in meta["jetpack_seo_html_title"])
         )
 
+    def test_verify_seo_meta_landed_all_present(self):
+        dropped = publish_common.verify_seo_meta_landed(
+            {"jetpack_seo_html_title": "T", "advanced_seo_description": "D", "footnotes": ""},
+            {"jetpack_seo_html_title": "T", "advanced_seo_description": "D"},
+        )
+        self.assertEqual(dropped, [])
+
+    def test_verify_seo_meta_landed_detects_silent_drop(self):
+        dropped = publish_common.verify_seo_meta_landed(
+            {"footnotes": ""},
+            {"jetpack_seo_html_title": "T", "advanced_seo_description": "D"},
+        )
+        self.assertEqual(
+            sorted(dropped),
+            ["advanced_seo_description", "jetpack_seo_html_title"],
+        )
+
+    def test_verify_seo_meta_landed_detects_value_mismatch(self):
+        dropped = publish_common.verify_seo_meta_landed(
+            {"jetpack_seo_html_title": "OLD", "advanced_seo_description": "D"},
+            {"jetpack_seo_html_title": "NEW", "advanced_seo_description": "D"},
+        )
+        self.assertEqual(dropped, ["jetpack_seo_html_title"])
+
+    def test_verify_seo_meta_landed_empty_expected_returns_empty(self):
+        self.assertEqual(publish_common.verify_seo_meta_landed({"footnotes": ""}, {}), [])
+        self.assertEqual(publish_common.verify_seo_meta_landed({"footnotes": ""}, None), [])
+
+    def test_verify_seo_meta_landed_skips_empty_sent_values(self):
+        dropped = publish_common.verify_seo_meta_landed(
+            {"footnotes": ""},
+            {"jetpack_seo_html_title": "", "advanced_seo_description": ""},
+        )
+        self.assertEqual(dropped, [])
+
+    def test_verify_seo_meta_landed_handles_none_response_meta(self):
+        dropped = publish_common.verify_seo_meta_landed(
+            None,
+            {"jetpack_seo_html_title": "T", "advanced_seo_description": "D"},
+        )
+        self.assertEqual(
+            sorted(dropped),
+            ["advanced_seo_description", "jetpack_seo_html_title"],
+        )
+
     def test_parse_publish_argv(self):
         flags = publish_common.parse_publish_argv(["--execute", "--update"])
         self.assertTrue(flags.execute)

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -21,6 +21,7 @@ if (!defined('ABSPATH')) {
 define('KK_AURORA_VERSION', '1.5.8');
 
 require_once get_template_directory() . '/inc/seo-title.php';
+require_once get_template_directory() . '/inc/seo-meta-rest.php';
 
 /**
  * Suppress the core block-template skip link.

--- a/theme/kk-aurora/inc/seo-meta-rest.php
+++ b/theme/kk-aurora/inc/seo-meta-rest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Register Jetpack SEO meta keys for REST read/write.
+ *
+ * Jetpack registered `jetpack_seo_html_title` and `advanced_seo_description`
+ * with `show_in_rest = true`. When Jetpack was deactivated on kriskrug.co,
+ * those keys became unregistered, so WordPress silently drops them on REST
+ * write (the POST returns 200 but the value is never stored) and omits them
+ * from REST read responses.
+ *
+ * The theme already reads `jetpack_seo_html_title` via `get_post_meta()` in
+ * `inc/seo-title.php` (PHP, never REST), so existing values still render.
+ * This file restores the REST round-trip so the Notion → WP connector and
+ * `verify_wp_draft.py` can write and read both keys again.
+ *
+ * See https://github.com/WalksWithASwagger/kriskrug-wp/issues/661
+ *
+ * @package KK_Aurora
+ * @since 1.5.10
+ */
+
+declare(strict_types=1);
+
+namespace KK_Aurora;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action(
+    'init',
+    function (): void {
+        register_post_meta(
+            'post',
+            'jetpack_seo_html_title',
+            [
+                'type' => 'string',
+                'single' => true,
+                'show_in_rest' => true,
+                'default' => '',
+                'sanitize_callback' => 'sanitize_text_field',
+                'auth_callback' => function (): bool {
+                    return current_user_can('edit_posts');
+                },
+            ]
+        );
+
+        register_post_meta(
+            'post',
+            'advanced_seo_description',
+            [
+                'type' => 'string',
+                'single' => true,
+                'show_in_rest' => true,
+                'default' => '',
+                'sanitize_callback' => 'sanitize_textarea_field',
+                'auth_callback' => function (): bool {
+                    return current_user_can('edit_posts');
+                },
+            ]
+        );
+    }
+);


### PR DESCRIPTION
## Summary

Fixes #661. Two parts, one per the issue's recommended options 1 + 2:

### Option 2 — Connector hardening (safe, no prod change)

- New `verify_seo_meta_landed()` in `publish_common.py` compares the `meta` dict sent in the payload against the `meta` dict returned in the REST response. Returns the list of SEO keys that were sent with a non-empty value but are absent or mismatched in the response.
- `kk_notion_to_wp.py` calls it after the existing post-write readback. If keys were dropped, the connector **aborts (exit 4)** with a clear message unless `--allow-seo-drop` is passed.
- `prepare_review_draft.py` calls it after `update_post()`. Warns always; aborts (exit 4) when `--fail-on-warning` is set.
- This catches the silent drop that has been losing SEO title + meta description on every connector publish since Jetpack was deactivated.

### Option 1 — Restore the REST capability (needs KK approval + rollback)

- New `theme/kk-aurora/inc/seo-meta-rest.php` registers `jetpack_seo_html_title` and `advanced_seo_description` with `register_post_meta()` + `show_in_rest => true`, restoring both REST write and read.
- Wired into `functions.php` via `require_once`.
- **This touches prod-rendering PHP** (loaded on every page via `functions.php`). Per AGENTS.md it needs KK approval and a rollback path before deploy. The patch is included here for review but should not be SFTP-deployed until approved.
- Rollback: revert the one `require_once` line in `functions.php` (or delete `inc/seo-meta-rest.php`) and re-SFTP. No data migration needed — the keys already exist in `wp_postmeta` from the Jetpack era; this only re-registers them for REST.

## Why

WordPress silently drops unregistered meta keys on REST write — the POST returns 200 and the value is never stored. Jetpack registered these keys; with Jetpack deactivated, they're unregistered. The connector was sending them on every publish, getting a 200, and moving on. No error, no warning. Existing values still render because `inc/seo-title.php` reads them via `get_post_meta()` (PHP, not REST), but new publishes and updates were silently losing SEO meta.

## Test plan

- [x] 6 new unit tests for `verify_seo_meta_landed` (all-present, silent drop, value mismatch, empty expected, empty sent, None response)
- [x] All 148 connector tests pass (`make python-test`)
- [x] `php -l` passes on `inc/seo-meta-rest.php` and `functions.php`
- [ ] `phpcs` (needs `composer install` — not available in this env)
- [ ] After KK approval: SFTP deploy, verify `GET /wp-json/wp/v2/posts/<id>?context=edit` returns both meta keys
- [ ] After deploy: connector publish round-trip confirms SEO meta lands

## Safety

- **Connector changes:** Python-only, no prod-rendering code. Safe to merge without deploy.
- **Theme PHP:** Gated on KK approval + rollback. Do not SFTP-deploy until approved. The connector hardening (option 2) works independently — even without the PHP patch, the connector will now fail loudly instead of silently dropping SEO meta.

Generated with [Devin](https://devin.ai)
