### PR TITLE
fix(#685): replace dark-theme header scrolled color with cream/ink tokens

### DIFF
--- a/theme/kk-aurora/assets/js/micro-interactions.js
+++ b/theme/kk-aurora/assets/js/micro-interactions.js
@@ -225,10 +225,10 @@
       }
       
       .aurora-header.is-scrolled {
-        background-color: rgba(13, 13, 18, 0.9);
+        background-color: rgba(239, 230, 210, 0.92);
         backdrop-filter: blur(12px);
         -webkit-backdrop-filter: blur(12px);
-        box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+        box-shadow: 0 1px 0 rgba(23, 19, 16, 0.08);
       }
       
       .aurora-header.is-hidden {


### PR DESCRIPTION
## What

Fixes #685: `micro-interactions.js` `initHeaderTransform()` injected `rgba(13, 13, 18, 0.9)` (dark-theme leftover) for `.aurora-header.is-scrolled`. On the cream/ink Revive port this produced a dark header bar on scroll.

## Change

```diff
- background-color: rgba(13, 13, 18, 0.9);
+ background-color: rgba(239, 230, 210, 0.92);
```
```diff
- box-shadow: 0 1px 0 rgba(255, 255, 255, 0.05);
+ box-shadow: 0 1px 0 rgba(23, 19, 16, 0.08);
```

## Verification

- `node --check theme/kk-aurora/assets/js/micro-interactions.js` — pass
- Cream surface `rgba(239,230,210,0.92)` matches `--revive-surface` (#efe6d2)
- Shadow border `rgba(23,19,16,0.08)` uses ink color at low opacity

## Related

- #682 and #683 were also filed in this audit but are regressions in PR #681, not pre-existing bugs. Closed with pointer to PR #681 comment.
- Part of the 2026-08-05 repo audit swarm (#682–#690)