### PR TITLE
fix(#686): add ABSPATH guard to digital-composting.php

### DIFF
--- a/inc/digital-composting.php
+++ b/inc/digital-composting.php
@@ -3,6 +3,9 @@
  * Digital Composting Module
  * Registers Custom Post Type for Transcripts and Topics Taxonomy
  */
+if (!defined('ABSPATH')) {
+    exit;
+}
 function kk_register_transcript_assets() {
     register_post_type('transcript', [
         'labels' => [


### PR DESCRIPTION
## What

Fixes #686: `inc/digital-composting.php` had no `defined('ABSPATH')` check, allowing direct URL access to the file.

## Change

Added the standard WordPress direct-access guard:

```php
if (!defined('ABSPATH')) {
    exit;
}
```

## Verification

- `php -l inc/digital-composting.php` — pass
- Pattern matches every other PHP file in the theme (`functions.php:14-16`)

## Note

This file is listed in AGENTS.md as custom repo-side WP code that should deploy only with an explicit rollback path and KK approval.

Part of the 2026-08-05 repo audit swarm (#682–#690)