### PR TITLE
Refresh Futureproof WordPress draft package

### DIFF
--- a/content/drafts/2026-07-26-futureproof-festival-announcement/VERIFY.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/VERIFY.md
@@ -1,182 +1,86 @@
-# VERIFY — Futureproof Festival announcement (#500 / FP-4)
+# VERIFY — Futureproof Festival announcement (#500)
 
-**Package:** `content/drafts/2026-07-26-futureproof-festival-announcement/`  
-**Slug:** `futureproof-festival-announcement`  
-**Target status:** WordPress `draft` only. Never `--publish`. Never `--update` / PATCH.  
-**Verified:** 2026-07-26 (cloud swarm agent, credential-free path); body rewritten 2026-08-02 for #645 (see note below); this file's own checklists below are **not yet re-run against the #645 body** and remain #500's job to re-verify before any draft create.
+**Package:** `content/drafts/2026-07-26-futureproof-festival-announcement/`
+**Slug:** `futureproof-festival-announcement`
+**Target:** WordPress draft only. No public publish.
+**Refreshed:** 2026-08-11
 
-## #645 rewrite note (2026-08-02) — re-verify before #500 acts
+## Current result
 
-`post.md` and `post.html` were substantially rewritten under #645 (new title "The Bat Signal," new lead image, conference-lineage receipts section, no hard-coded speaker list). The completeness table, em-dash count, speaker-embargo check, fact table, and link count below describe the **July 26 / early-August small-fix body**, not this new one. Before #500 runs any dry-run or draft-create command, re-run this file's checks against the current `post.md`/`post.html`. As a head start, the #645 rewrite pass already confirmed:
+The repository package is refreshed and the guarded create-only WordPress run succeeded.
 
-- Em dashes: 0 in both `post.md` and `post.html` (re-checked 2026-08-02, same method as below).
-- Links: 17 unique URLs in the new body (down from 34; the hard-coded speaker/org list and FATALE links were removed, see `internal-links.md`), all HTTP 200 on 2026-08-02.
-- Speaker embargo: no individual speaker names appear in body copy at all now; the roster is linked, not listed, so the FP-2 embargo table in `speakers.md` is no longer a publish-blocking dependency for this piece (see `speakers.md`'s #645 addendum).
-- Facts: dates, venue, Earlyworm CA$650/August 15, Call for Talks August 15, and 300/3,000+/94+ receipts are all current in the new body as of 2026-08-02 (sourced live from futureproof.website and KK's 2026-08-01 membership ruling).
-- New dependency for #500: the two Meetup #31 photos used as lead + supporting images are staged locally but are **unresolved hotlinks with no written cross-site reuse release** (see `asset-manifest.md`). #500 should not treat them as upload-ready without Kris's explicit sign-off, same as every other image in this package.
-
-### Dry-run executed 2026-08-02 (offline, no credentials, no WP writes)
-
-```
-scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/create_local_wp_draft.py \
-  content/drafts/2026-07-26-futureproof-festival-announcement/post.md
-```
-
-**First run FAILED**, and the failure was real, not environmental:
-
-```
-ERROR: while parsing a block mapping
-expected <block end>, but found '<scalar>'
-```
-
-Two alt values contained `Meetup #31`. In YAML a whitespace-preceded `#` opens a comment, so the alt scalar truncated mid-sentence and the folded continuation line broke the block mapping. `post.md` would not load at all, meaning #500 could not have dry-run or created anything. Fixed by single-quoting both values (commit `91ab3f1`); the `#31` text and line folding are preserved.
-
-**Re-run PASSES.** Result:
-
-| Field | Value |
+| Field | Readback |
 |---|---|
-| `dry_run` | `true` |
-| `title` | The Bat Signal |
-| `slug` | `futureproof-festival-announcement` |
-| categories | Vancouver AI Ecosystem |
-| tags | Futureproof, BC + AI, Vancouver AI, Festival, Space Centre, Build What Lasts |
-| images resolved | 7 (all local files exist; wordmark correctly absent) |
-| `slug_check` | `skipped_offline` |
+| WordPress post ID | `12732` |
+| Status | `draft` |
+| Slug | `futureproof-festival-announcement` |
+| Featured media | `12725` |
+| Private preview | `https://kriskrug.co/?p=12732` |
+| Edit URL | `https://kriskrug.co/wp-admin/post.php?post=12732&action=edit` |
 
-**What this does and does not prove.** It proves the quality gate passes, the frontmatter parses, the payload shape is valid, and every referenced image resolves to a real local file. It does **not** prove the slug is free: the dry-run path is deliberately offline (`dry_run_wp_config()`, no authenticated probe), so `slug_check` is `skipped_offline`. The create-only slug collision check (`assert_slug_available`) runs only on the `--execute` path. #500 still owns that check, and must still abort on collision rather than PATCH.
+No public publish occurred. No existing WordPress post was updated.
 
-## Verdict
+## 2026-08-11 release refresh
 
-Package is **complete and verification-ready**.  
-**WP draft was NOT created** in this session: `WP_USER` / `WP_APP_PASSWORD` are unset, and `create_local_wp_draft.py` hard-exits without credentials even in dry-run (per AGENTS.md / connector README).
+### Copy and voice
 
-Hand to KK (or a secrets-attached session) for dry-run → `--execute` create-only, **after** re-running this file's checklists against the #645 body.
+- Visible title: **The Bat Signal: Why I'm Building Futureproof Festival in Vancouver**
+- SEO title: **Building Futureproof Festival in Vancouver | Kris Krüg** (54 characters)
+- `post.md` and `post.html` contain zero em dashes.
+- `voicecheck.py` returned 0 flags across both files.
+- Manual Host/Anti-Hero facet review passed; see `voice-audit/`.
 
----
+### Current public facts
 
-## Package completeness (#500 acceptance)
+Verified from the official public festival pages on 2026-08-11:
 
-| Artifact | Status |
-|---|---|
-| `post.md` frontmatter (title, slug, status=draft, categories, tags, excerpt, seo, images[]) | PASS |
-| `post.html` Gutenberg `<!-- wp:* -->` body (40 block markers) | PASS |
-| `seo-meta.md` | PASS |
-| `alt-text.md` | PASS |
-| `internal-links.md` | PASS |
-| `speakers.md` (FP-2 cleared 8) | PASS |
-| `asset-manifest.md` + `images/` (6 binaries, hero designated) | PASS |
-| `VOICE-NOTES.md` | PASS (from #499) |
+- October 28–30, 2026
+- H.R. MacMillan Space Centre, Vancouver
+- Earlyworm CA$650 through August 15; standard CA$950; student CA$250; supporter CA$1,650
+- Active BC + AI members receive 25% off
+- Call for Talks is open through August 15
+- Public speaker directory contains 13 profiles; the article links the live directory instead of freezing a roster in body copy
+- BC + AI proof points retained from the approved source package: 300 members, 3,000+ attendees, 94+ documented events since 2023
 
-Sources assembled on branch `cursor/500-futureproof-wp-draft-prep-f196`:
+The article sends volatile prices and deadlines to the official festival pages. Recheck those pages again if publication occurs after August 15.
 
-- Story / SEO / HTML: `origin/cursor/499-futureproof-story-f196`
-- Images + asset-manifest: `origin/cursor/497-futureproof-assets-f196`
-- Speakers: `origin/cursor/498-futureproof-speakers-f196`
+### Links and media
 
----
+- All 24 unique `http(s)` URLs in `post.md` and `post.html` returned HTTP 200 on 2026-08-11.
+- Seven selected local image files resolved and passed the publisher quality gate.
+- Lead image: Vancouver AI Meetup #31 stage photograph, Michael Caswell photography and Kris Krüg editing.
+- Supporting audience photograph: Michael Caswell.
+- Kris approved the copy and visual sequence in the issue flow before the create-only run.
 
-## Issue #500 step checklist
+### Publisher verification
 
-### 1. Voice / em dashes
-
-- [x] Em dash count: `grep -c '—' post.md post.html` → **0 / 0**
-- [x] Light slop banlist scan (delve / tapestry / realm / seamless / game-changer / utilize / harness / "it's not just"): **none**
-- [ ] Full `voice-slop-audit` skill: **not present in this repo** (no SKILL.md / script found). Mechanical checks above + `VOICE-NOTES.md` stand in; KK should still do a human voice pass before public publish.
-
-### 2. Speaker embargo re-check
-
-- [x] Body names match FP-2 cleared list in `speakers.md`: Amber Case, Ana Serrano, Lynda Brown-Ganzert, Zaro, Mayumi Rollings, Anthonia Ogundele, Kaoru Yoshihira, Peter Bittner
-- [x] Display name **Zaro** (not Gabriel) in announce copy
-- [x] No HOLD names announced
-- [x] Each `/speakers/<slug>/` URL returned HTTP 200 on re-curl (see link table)
-
-### 3. Fact check
-
-| Fact | In package? |
-|---|---|
-| Dates Oct 28-30, 2026 | YES (`October 28-30, 2026`) |
-| Venue H.R. MacMillan Space Centre | YES (link: `hrmacmillanspacecentre.com`) |
-| Earlyworm CA$650 | YES |
-| Earlyworm priority ends August 15 | YES |
-| Receipts 300 / 3,000+ / 94+ | YES |
-| Call for Talks closes August 15 | YES (package) |
-
-**Note (updated 2026-08-02):** two facts were corrected after the 2026-07-26 check.
-
-1. **Call for Talks is August 15, not July 31.** KK extended it. The July 31 date was a *priority* window; the deadline is now a hard close. Canonical source is `~/Code/futureproof-festival/lib/pricing.ts:345` (`CALL_FOR_TALKS_CLOSE_DEADLINE = 2026-08-15T23:59:00-07:00`), confirmed by public readback of `futureproof.website/call-for-talks/` rendering "August 15, 2026". This resolves the old `Sept 31` ambiguity in the issue text; there is no September 31 and no September cutoff.
-2. **Membership is 300, not 250+.** Per KK's 2026-08-01 ruling: 300 paid members at $340/year. The 250+ figure predates it.
-
-Both Earlyworm and the Call for Talks now close on **August 15, 2026**. If this draft is created after that date, both lines need another pass.
-
-### 4. Links live
-
-All **34** unique `http(s)` URLs in `post.md` + `post.html` returned **HTTP 200** via `curl -I -L` (2026-07-26). Includes festival, speakers, orgs, internal kriskrug.co posts, and remote image asset URLs used in `post.html`.
-
-### 5–6. Dry-run + create draft
-
-- [x] Documented exact commands below
-- [ ] Dry-run executed — **BLOCKED ON CREDS**
-- [ ] `--execute` create-only — **NOT RUN** (no draft)
-- [ ] `status==draft` readback / WP id / preview URL in `publish.log` — **N/A until secrets session**
-
----
-
-## Exact publisher commands (from `scripts/notion-to-wp/README.md`)
-
-Working directory: repo root. Prefer Varlock when secrets are resolved.
-
-### Dry-run (validate quality gate + slug create-only; no WP writes)
-
-```bash
-# Preferred when Varlock resolves WP_USER + WP_APP_PASSWORD:
-make varlock-run CMD="scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/create_local_wp_draft.py content/drafts/2026-07-26-futureproof-festival-announcement/post.md"
-
-# Or with process env already injected:
-scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/create_local_wp_draft.py content/drafts/2026-07-26-futureproof-festival-announcement/post.md
+```text
+dry_run: true
+quality gate: pass
+images resolved: 7
+slug before create: available
+create: id 12732
+authenticated readback: status=draft, slug=futureproof-festival-announcement, featured_media=12725
 ```
 
-Expect: quality gate clean; slug `futureproof-festival-announcement` available (create-only). If slug already exists → **abort**, do not PATCH.
+The connector test suite passed: **148 tests**.
 
-### Create WordPress draft only (`status=draft`)
+## WordPress media receipt
 
-```bash
-make varlock-run CMD="scripts/notion-to-wp/.venv/bin/python scripts/notion-to-wp/create_local_wp_draft.py content/drafts/2026-07-26-futureproof-festival-announcement/post.md --execute"
-```
+| File | Media ID |
+|---|---:|
+| `vanai-meetup31-stage-kris-futureproof-slide.webp` | 12725 |
+| `vanai-meetup31-audience-wide-shot.webp` | 12726 |
+| `futureproof-honest-conversation-poster.png` | 12727 |
+| `manifesto-01-future-cultural-question.webp` | 12728 |
+| `manifesto-06-who-shapes-us.webp` | 12729 |
+| `manifesto-14-places-to-think.webp` | 12730 |
+| `futureproof-salmon-starfield-share-20260527.jpg` | 12731 |
 
-After success:
+The full redacted execution receipt remains in the gitignored local `publish.log` beside this file.
 
-1. Confirm `publish.log` records WP post id + edit/preview URL.
-2. Authenticated readback: `status == draft`, slug match, featured media set from uploaded hero.
-3. **Do not** pass `--publish`. Public publish / `--update` needs explicit KK sign-off + `--diff` review (out of scope for #500).
+## Remaining gate
 
-### Safety gates (2026-05-15)
+The repository copy received three final voice refinements after the create-only call: “three decades” replaced an older year count, a generic conference-bio phrase was tightened, and the excerpt was aligned. The private WordPress draft therefore needs one guarded, human-approved in-place update before publication. The dry-run target guard passed for post `12732`; no update was executed because issue #500 explicitly forbids updates.
 
-- Create-only. Slug collision → abort.
-- Never PATCH without verified slug-match target and KK-approved update path.
-- Draft only; no live publish from this issue.
-
----
-
-## This session: credential block
-
-```
-WP_USER present: False
-WP_APP_PASSWORD present: False
-NOTION_TOKEN present: False
-scripts/notion-to-wp/.venv: absent in cloud pod
-scripts/notion-to-wp/.env: absent
-```
-
-Per AGENTS.md: connector / `create_local_wp_draft.py` **hard-exits requiring creds even in dry-run**. Credential-free prep (this package + VERIFY) is the correct ship for this environment.
-
-**WP draft created: no.**
-
----
-
-## Hand-off for secrets-attached follow-up
-
-1. Ensure `scripts/notion-to-wp/.venv` exists (`pip install -r scripts/notion-to-wp/requirements.txt`).
-2. Inject `WP_USER` + `WP_APP_PASSWORD` (Cursor Cloud secrets or `make varlock-run`).
-3. Run dry-run command above; paste redacted success lines into `publish.log`.
-4. Run `--execute`; assert draft readback; leave post private for KK review.
-5. Close #500 acceptance boxes only after draft id + preview URL exist.
+After that exact sync, review the private preview and authorize publication separately. Publishing is outside issue #500.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/VOICE-NOTES.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/VOICE-NOTES.md
@@ -1,10 +1,10 @@
-# VOICE-NOTES: The Bat Signal (#645 rewrite)
+# VOICE-NOTES: The Bat Signal: Why I'm Building Futureproof Festival in Vancouver
 
-Rewritten 2026-08-02. The July 26 "Baby Is Here" notes below are preserved for history since that draft's structure is gone; new notes follow for the current body.
+Refreshed 2026-08-11 for #500. The July 26 "Baby Is Here" notes below are preserved for history since that draft's structure is gone; current notes follow.
 
 ## Kept on purpose
 
-- **New title "The Bat Signal"** replaces "The Baby Is Here." The birth metaphor was right for a launch announcement; this piece's central action is an invitation, so the title names that directly, per #645's editorial brief.
+- **The title keeps "The Bat Signal" and adds the subject.** "Why I'm Building Futureproof Festival in Vancouver" answers the user's request for a more descriptive title without flattening the hook.
 - **Opens on the Meetup #31 stage photo**, not the festival poster. "That's not a metaphor for Futureproof. That's the rehearsal." does the work of connecting the current room to the festival without over-explaining it.
 - **One link to *The Long Road to Futureproof*, early, then dropped.** States plainly this isn't that story again, so the piece doesn't accidentally retell the FATALE arc.
 - **"International badass man of mystery"** appears exactly once, self-deprecating, immediately undercut by "What I actually am is a guy who kept showing up." Per the issue brief: internal tuning fork or a single knowing line, never a repeated title.
@@ -17,9 +17,9 @@ Rewritten 2026-08-02. The July 26 "Baby Is Here" notes below are preserved for h
 
 ## Places KK should rewrite if the voice is off
 
-1. **"The Bat Signal" title**: on-the-nose by design, matching the issue's own working name for this piece. Swap if he wants something less literal once he's seen it in context.
+1. **Descriptive title:** the hook remains, but the new subtitle names Futureproof Festival and Vancouver plainly.
 2. **Kevin Friel / AI Film Club mention**: added because he's publicly on the speakers page and it supports "built by community, not solo-hero." Cut if Kris wants fewer named individuals in this piece.
-3. **"Twenty-eight years on the internet" callback at the close**: mirrors the July 26 draft's number; confirm it's still accurate at time of publish.
+3. **"Three decades on the internet" callback at the close:** grounded in the current KK source record that dates his web/community work to 1995 without pretending to know the exact anniversary.
 4. **Historical photo**: deliberately absent from this draft (see `asset-manifest.md`'s flagged/unresolved historical-photo section). If Kris wants one, it slots naturally into the receipts section.
 5. **Venue link** uses `hrmacmillanspacecentre.com` (live 200), unchanged from the original package.
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/asset-manifest.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/asset-manifest.md
@@ -1,5 +1,21 @@
 # Asset Manifest — Futureproof Festival announcement (#497)
 
+## #500 WordPress receipt (2026-08-11)
+
+Kris approved the current visual sequence and cross-site reuse in the issue flow. The guarded create-only run uploaded the seven images referenced by `post.md` and created private WordPress draft `12732`. No public publish occurred.
+
+| File | Role | WordPress media ID |
+|---|---|---:|
+| `vanai-meetup31-stage-kris-futureproof-slide.webp` | lead / featured | 12725 |
+| `vanai-meetup31-audience-wide-shot.webp` | community-room | 12726 |
+| `futureproof-honest-conversation-poster.png` | official-graphic | 12727 |
+| `manifesto-01-future-cultural-question.webp` | gallery-1 | 12728 |
+| `manifesto-06-who-shapes-us.webp` | gallery-2 | 12729 |
+| `manifesto-14-places-to-think.webp` | gallery-3 | 12730 |
+| `futureproof-salmon-starfield-share-20260527.jpg` | gallery-4 | 12731 |
+
+The preferred lead is the current Vancouver AI stage photograph, not a portrait of someone who was absent. Photography: Michael Caswell. Editing: Kris Krüg. The supporting audience photograph is also by Michael Caswell.
+
 Wave 1 / FP-1. Design assets only. No post body, no WP API calls.
 
 Staged under `images/` from public production URLs on [futureproof.website](https://www.futureproof.website/). Festival-repo local paths (`~/Code/futureproof-festival/public/...`) were not available in this cloud VM; public equivalents of those production files were used instead. Binaries copied as-is (no open/edit).

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/internal-links.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/internal-links.md
@@ -1,5 +1,11 @@
 # Link audit: The Bat Signal (Futureproof network follow-up, #645)
 
+## #500 refresh (2026-08-11)
+
+All 24 unique `http(s)` URLs across `post.md` and `post.html` returned HTTP 200. This count includes the 17 editorial destinations below plus the seven public image sources embedded in the Gutenberg body.
+
+The private WordPress draft is `https://kriskrug.co/?p=12732`; it remains `status=draft` and is not a public publication receipt.
+
 Rewritten 2026-08-02 for #645. Supersedes the July 26 FP-4 link audit below the original speaker-list and FATALE links, which are no longer in the body copy (see `speakers.md` and `alt-text.md` addenda for why).
 
 All links re-curled with `curl -sL -o /dev/null -w "%{http_code}"` on 2026-08-02. **17 unique URLs, all HTTP 200.**

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/post.html
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/post.html
@@ -3,7 +3,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Behind me: a slide painted with salmon and ravens and northern lights, the type reading <strong>VANCOUVER, WE NEED TO TALK ABOUT AI.</strong> In front of me: the Vancouver AI community, meetup number thirty-one, still showing up three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.</p>
+<p>Behind me: a slide painted with salmon and ravens and northern lights, the type reading <strong>VANCOUVER, WE NEED TO TALK ABOUT AI.</strong> In front of me: the Vancouver AI community, meetup number thirty-one, still showing up almost three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
@@ -19,7 +19,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>Twenty-eight years on the internet. This is my bat signal.</p></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>Three decades on the internet. This is my bat signal.</p></blockquote></figure>
 <!-- /wp:pullquote -->
 
 <!-- wp:heading -->
@@ -27,7 +27,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>I don't love talking about myself in the third-person conference-bio voice, all "award-winning" this and "thought leader" that. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.</p>
+<p>I don't love talking about myself in the third-person conference-bio voice, all shiny awards and self-importance. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
@@ -145,7 +145,7 @@
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p>I've been building toward this room since before I knew its name. Twenty-eight years on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.</p>
+<p>I've been building toward this room since before I knew its name. Three decades on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/post.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/post.md
@@ -1,7 +1,7 @@
 ---
-title: The Bat Signal
+title: "The Bat Signal: Why I'm Building Futureproof Festival in Vancouver"
 slug: futureproof-festival-announcement
-post_date: '2026-08-02'
+post_date: '2026-08-11'
 status: draft
 post_type: post
 author_wp_id: 1
@@ -16,11 +16,11 @@ tags:
 - Build What Lasts
 featured: true
 featured_media_id: 0
-excerpt: Twenty-eight years of photographing other people's rooms taught me what
+excerpt: Decades of photographing other people's rooms taught me what
   makes one worth building. Futureproof is the room. This is the invitation to
   everyone who ever let me stand in theirs.
 seo:
-  meta_title: The Bat Signal | Futureproof Festival
+  meta_title: Building Futureproof Festival in Vancouver | Kris Krüg
   meta_description: Kris Krüg's network bat signal for Futureproof Festival, Oct
     28-30 2026 in Vancouver. Receipts from PopTech to DENT. The invitation is the point.
 images:
@@ -68,7 +68,7 @@ images:
 
 Last month I stood on a stage in front of a room that shouldn't have been full on a Wednesday night, and it was full anyway.
 
-Behind me: a slide painted with salmon and ravens and northern lights, the type reading **VANCOUVER, WE NEED TO TALK ABOUT AI.** In front of me: the Vancouver AI community, meetup number thirty-one, still showing up three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.
+Behind me: a slide painted with salmon and ravens and northern lights, the type reading **VANCOUVER, WE NEED TO TALK ABOUT AI.** In front of me: the Vancouver AI community, meetup number thirty-one, still showing up almost three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.
 
 ![Kris Krüg speaks on stage at Vancouver AI Meetup #31, in front of a Futureproof slide reading Vancouver, we need to talk about AI, with salmon and skyline artwork behind him.](images/vanai-meetup31-stage-kris-futureproof-slide.webp)
 
@@ -76,11 +76,11 @@ That's not a metaphor for Futureproof. That's the rehearsal. The room already ex
 
 I told the fuller origin story, FATALE and all, in [*The Long Road to Futureproof*](https://kriskrug.co/2026/06/01/long-road-to-futureproof/). This one isn't that story again. This one is about who's invited.
 
->>> Twenty-eight years on the internet. This is my bat signal.
+>>> Three decades on the internet. This is my bat signal.
 
 ## The receipts, not the résumé
 
-I don't love talking about myself in the third-person conference-bio voice, all "award-winning" this and "thought leader" that. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.
+I don't love talking about myself in the third-person conference-bio voice, all shiny awards and self-importance. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.
 
 Before any of this was AI, it was:
 
@@ -135,6 +135,6 @@ Everything below lives on the festival's own site, because prices and deadlines 
 - **[Call for Talks](https://www.futureproof.website/call-for-talks/)**, open through August 15. First-time speakers and rough first drafts genuinely welcome.
 - **Sponsor or exhibit?** Start on the [tickets](https://www.futureproof.website/tickets/) page and find the rest of us through [BC + AI](https://bc-ai.ca/) and the [events calendar](https://bc-ai.ca/events).
 
-I've been building toward this room since before I knew its name. Twenty-eight years on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.
+I've been building toward this room since before I knew its name. Three decades on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.
 
 **[Build what lasts.](https://futureproof.website/)**

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/seo-meta.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/seo-meta.md
@@ -1,16 +1,16 @@
-# SEO snapshot: The Bat Signal (Futureproof Festival network follow-up)
+# SEO snapshot: The Bat Signal: Why I'm Building Futureproof Festival in Vancouver
 
-Updated 2026-08-02 for #645. This file was rewritten in place to match the new title and hero image; see git history for the July 26 "The Baby Is Here" snapshot if needed.
+Updated 2026-08-11 for #500. The visible title now keeps the bat-signal hook while making the subject explicit.
 
 | Field | Value |
 |---|---|
-| Visible title (H1) | The Bat Signal |
-| SEO title (`<title>`) | The Bat Signal \| Futureproof Festival |
-| Slug | `futureproof-festival-announcement` (unchanged; permalink `/2026/08/02/futureproof-festival-announcement/` once dated) |
+| Visible title (H1) | The Bat Signal: Why I'm Building Futureproof Festival in Vancouver |
+| SEO title (`<title>`) | Building Futureproof Festival in Vancouver \| Kris Krüg |
+| Slug | `futureproof-festival-announcement` (unchanged; permalink `/2026/08/11/futureproof-festival-announcement/` once dated) |
 | Meta description | Kris Krüg's network bat signal for Futureproof Festival, Oct 28-30 2026 in Vancouver. Receipts from PopTech to DENT. The invitation is the point. |
 | Category | Vancouver AI Ecosystem |
 | Tags | Futureproof, BC + AI, Vancouver AI, Festival, Space Centre, Build What Lasts |
-| Excerpt | Twenty-eight years of photographing other people's rooms taught me what makes one worth building. Futureproof is the room. This is the invitation to everyone who ever let me stand in theirs. |
+| Excerpt | Decades of photographing other people's rooms taught me what makes one worth building. Futureproof is the room. This is the invitation to everyone who ever let me stand in theirs. |
 | Featured | YES (hero: `images/vanai-meetup31-stage-kris-futureproof-slide.webp`, per #644's preferred lead; `featured_media_id` assigned at #500 upload) |
 | Schema | Article (auto via kk-schema mu-plugin if deployed) |
 | OG image | Meetup #31 stage photo (2400x1600 landscape, safe OG crop). Landscape alternate if needed: `images/futureproof-salmon-starfield-share-20260527.jpg` (1200x630) |
@@ -20,12 +20,12 @@ Updated 2026-08-02 for #645. This file was rewritten in place to match the new t
 
 | Field | Chars | Target |
 |---|---|---|
-| SEO title | 30 | ≤60 |
+| SEO title | 54 | ≤60 |
 | Meta description | 130 | 140-160 (slightly short; OK for voice, matches prior package's tolerance) |
 
 ## What changed from the July 26 snapshot
 
-- **Title:** "The Baby Is Here" → "The Bat Signal". The birth metaphor was right for a launch announcement; this piece's job is an invitation to Kris's network, so the title now names that action directly.
+- **Title:** "The Bat Signal" → "The Bat Signal: Why I'm Building Futureproof Festival in Vancouver." The hook stays, but a reader no longer has to guess what the post is about.
 - **Featured image:** switched from the honest-conversation poster to the Meetup #31 stage photo, per #644's curation. The poster is now an official-graphic supporting image in the body, not the hero.
 - **Meta description:** no longer states ticket price or dates (those live on futureproof.website and move independently); instead names the two things this specific article does that the live origin post and the July 26 draft don't: the conference-lineage receipts and the direct invitation.
 
@@ -33,7 +33,7 @@ Updated 2026-08-02 for #645. This file was rewritten in place to match the new t
 
 - Prefer the Meetup #31 stage photo as featured. It is landscape (2400×1600), which is safer for OG/card crops than the July 26 poster's portrait 1200×1800.
 - If a landscape alternate is still wanted, the salmon-starfield share JPEG remains the fallback (already used as kriskrug.co homepage Futureproof pillar art).
-- Share copy cue (not published here): "Twenty-eight years on the internet. This is my bat signal. Futureproof, Oct 28-30, Vancouver."
+- Share copy cue (not published here): "Three decades on the internet. This is my bat signal. Futureproof, Oct 28-30, Vancouver."
 - Do not invent speakers beyond what's linked to the live public roster; this draft intentionally does not hard-code names (see `speakers.md` #645 addendum).
 - Do not resurrect "The baby is here" language in social captions drawn from this piece; it belongs to the prior draft's framing, not this one's.
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
@@ -2,7 +2,9 @@
 
 ## #500 public roster refresh (2026-08-11)
 
-The official public directory currently lists 13 speakers: Amber Case, Ana Serrano, Lynda Brown-Ganzert, Zaro, Kris Krüg, Mayumi Rollings, Anthonia Ogundele, Kaoru Yoshihira, Peter Bittner, Kevin Friel, Brewster Kahle, Sara Blenkhorn, and Brett Gaylor.
+The official public directory currently lists 13 speakers: Amber Case, Ana Serrano, Anthonia Ogundele, Brett Gaylor, Brewster Kahle, Zaro, Jos Duncan-Ase, Kevin Friel, Kris Krüg, Lynda Brown-Ganzert, Mayumi Rollings, Peter Bittner, and Sara Blenkhorn.
+
+This was refreshed again immediately before merge. Jos Duncan-Ase is on the current directory; Kaoru Yoshihira appears only in the dated July 26 snapshot preserved below and is no longer in the current public roster.
 
 The article does not reproduce this volatile roster. It names Kevin Friel in a specific community-credit sentence and links his live public profile; otherwise it links the canonical speaker directory. Recheck the directory immediately before public publication.
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
@@ -1,5 +1,11 @@
 # Futureproof Festival — public speaker lineup (#498 / FP-2)
 
+## #500 public roster refresh (2026-08-11)
+
+The official public directory currently lists 13 speakers: Amber Case, Ana Serrano, Lynda Brown-Ganzert, Zaro, Kris Krüg, Mayumi Rollings, Anthonia Ogundele, Kaoru Yoshihira, Peter Bittner, Kevin Friel, Brewster Kahle, Sara Blenkhorn, and Brett Gaylor.
+
+The article does not reproduce this volatile roster. It names Kevin Friel in a specific community-credit sentence and links his live public profile; otherwise it links the canonical speaker directory. Recheck the directory immediately before public publication.
+
 Verified **2026-07-26T19:47Z** against public web only.
 
 **Safety gate:** active speaker embargo. Local festival allowlist / pipeline files were **not** available on this VM (`~/Code/futureproof-festival/...`). Clearance below is based solely on live public pages at [futureproof.website](https://www.futureproof.website/). No allowlist JSON was read or edited.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/00-summary.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/00-summary.md
@@ -1,0 +1,14 @@
+# Voice audit summary
+
+## Verdict
+
+**Pass.** The descriptive title names Futureproof Festival and Vancouver while preserving “The Bat Signal” hook. Mechanical scan: 0 flags across `post.md` and `post.html`. Manual read: strong Host voice with Anti-Hero edge, real receipts, distributed credit, and an earned invitation.
+
+## Fix first
+
+None in the repository copy.
+
+## Optional
+
+- Kris can still swap the “international badass man of mystery” line if he wants less self-mythology, but it is immediately undercut and works in context.
+- A historical conference photograph could add another visual beat, but the current stage, audience, official poster, and manifesto sequence already makes the argument without it.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/slop-check-findings.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/slop-check-findings.md
@@ -1,0 +1,12 @@
+# Mechanical voice check
+
+Checked 2026-08-11 with `~/Code/kk-voice/scripts/voicecheck.py` against both `post.md` and `post.html`.
+
+Result: **0 flags across 2 files**. No banned terms, em dashes, canned contrast formulas, or glossary spelling problems were detected.
+
+Word counts:
+
+- `post.md`: 1,579 words including frontmatter
+- `post.html`: 1,659 words including Gutenberg comments
+
+This article has no stated word cap.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/slop-check-raw.json
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/slop-check-raw.json
@@ -1,0 +1,7 @@
+{
+  "total": 0,
+  "files": {
+    "content/drafts/2026-07-26-futureproof-festival-announcement/post.md": [],
+    "content/drafts/2026-07-26-futureproof-festival-announcement/post.html": []
+  }
+}

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/voice-alignment-report.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit/voice-alignment-report.md
@@ -1,0 +1,38 @@
+# Voice alignment report
+
+## Facet
+
+**The Host**, with an **Anti-Hero** edge in the receipts section and closing invitation. The audience is Kris's existing creative, technology, and conference network; the article's job is to welcome people into a room, credit the people already building it, and show enough receipts to earn the invitation.
+
+## Section read
+
+### Opening
+
+Works. The Meetup #31 photograph and the line “That's the rehearsal” give the piece a current, specific scene. Michael Caswell is credited in the prose and image metadata. The opening does not pretend Futureproof appeared from nowhere.
+
+### The receipts, not the résumé
+
+Works. Named conferences, dates, collaborators, and first-person memories replace generic bio claims. “Cute.” and the folding-chair language keep the register human. The section has swagger without turning the festival into a solo-founder story.
+
+### What twenty years behind the lens actually teaches you
+
+Works. The four bold openings are purposeful lessons tied to concrete earlier examples, not filler headings. The section uses plain copulas and avoids artificial uplift.
+
+### Why Futureproof, why now, why Vancouver
+
+Works. Vancouver AI and BC + AI are presented as accumulated community work. Kevin Friel, Michael Caswell, and Tristan Brand receive specific credit. The Space Centre choice is grounded in place rather than venue marketing.
+
+### The bat signal and invitation
+
+Works. The invitation names the actual people Kris wants in the room, includes skeptics and unclassifiable people, and keeps the both/and stance on AI: neither hype nor panic. The close adds a direct call to participate instead of merely restating the premise.
+
+## Manual blind-spot scan
+
+- No reworded “not only X, but Y” reveal cadence.
+- The long invitation list is genre-appropriate and concrete, not list-stacking for padding.
+- No filler “landscape,” throat-clearing, manufactured vulnerability, or forced upbeat close.
+- No semantic-hollow prestige language.
+
+## Verdict
+
+Voice-aligned and ready for editorial review. No required rewrite remains in the repository copy.


### PR DESCRIPTION
## Summary

- makes the title descriptive while keeping the Bat Signal hook
- refreshes current Futureproof dates, prices, roster notes, links, and media receipts
- records the guarded WordPress draft creation and seven uploaded media IDs
- adds a full KK voice/slop audit with zero mechanical flags
- keeps the WordPress post private and identifies the one remaining guarded draft-sync step

## Verification

- `voicecheck.py`: 0 flags across `post.md` and `post.html`
- connector tests: 148 passed
- package dry-run: passed, 7 images resolved
- 24 unique external URLs: HTTP 200 on 2026-08-11
- authenticated WordPress readback: post 12732, `status=draft`, expected slug, featured media 12725
- `git diff --check`: clean

Refs #500. This PR does not publish or update WordPress.
