### PR TITLE
content(#496): deepen and publish the Futureproof Festival story

### DIFF
--- a/content/drafts/2026-07-26-futureproof-festival-announcement/VERIFY.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/VERIFY.md
@@ -1,102 +1,155 @@
-# VERIFY — Futureproof Festival announcement (#500)
+# VERIFY: Futureproof Festival announcement polish v2
 
 **Package:** `content/drafts/2026-07-26-futureproof-festival-announcement/`
 **Slug:** `futureproof-festival-announcement`
-**Target:** WordPress draft only. No public publish.
-**Refreshed:** 2026-08-11
+**Target:** existing WordPress post; guarded content sync was draft-only
+**Refreshed:** 2026-08-12
 
-## Current result
+## Result
 
-The repository package is refreshed, the guarded create-only WordPress run succeeded, and the separately authorized final-copy sync is complete.
+The deeper article, revised visual sequence, video, source-page screenshots, and SEO fields are live on WordPress post `12732`. The guarded sync left the post as a private draft; a later WordPress action outside that script changed it to `publish`. Production was re-audited after that state change.
 
-| Field | Readback |
+| Field | Current public readback |
 |---|---|
 | WordPress post ID | `12732` |
-| Status | `draft` |
+| Status | `publish` |
+| Published | `true` |
 | Slug | `futureproof-festival-announcement` |
-| Featured media | `12725` |
-| Private preview | `https://kriskrug.co/?p=12732` |
+| Authoring title (exact guarded write) | **Futureproof Festival of AI: A Bat Signal from Vancouver** |
+| Rendered title treatment | H1 **Futureproof Festival of AI** plus front-end-rendered subtitle **A Bat Signal from Vancouver** |
+| SEO title | **Futureproof Festival of AI in Vancouver \| Kris Krüg** |
+| Featured media | `12739` |
+| Canonical URL | `https://kriskrug.co/2026/08/11/futureproof-festival-announcement/` |
 | Edit URL | `https://kriskrug.co/wp-admin/post.php?post=12732&action=edit` |
 
-No public publish occurred. Issue #500 completed without updating an existing post; after it closed, a separately authorized sync updated only the private draft's `content` and `excerpt` fields.
+## Editorial and SEO checks
 
-## 2026-08-11 release refresh
+- Raw Markdown body token count: **1,964** (the verifier's deterministic package-size metric; live visible-text counts are lower because URLs and image markup are excluded by WordPress).
+- Editorial destinations: **25 unique URLs**, all returned HTTP 200 on 2026-08-12.
+- Internal KrisKrug.co links: **5**.
+- Body media: **9 images** and **1 YouTube embed**.
+- The full Vancouver AI Meetup #31 recording is embedded; the Futureproof segment is linked at **19:04**.
+- Meta description: **146 characters**.
+- `post.md` and `post.html` contain no em dashes, private filesystem paths, stale venue domain, disputed attendance totals, unresolved editorial markers, or the old TEDx location error. Canonical `post.html` intentionally retains local `images/...` plus `wp-image-TBD` tokens for the guarded publisher to rewrite; the production/readback body contains neither.
+- `voicecheck.py --json` returned **0 findings** across `post.md` and `post.html`.
+- Manual voice review passed; see `voice-audit-v2/`.
 
-### Copy and voice
+The article now distinguishes True North Media House from W2, identifies TEDxSummit as Doha, Qatar, and describes only program formats supported by the current festival pages.
 
-- Visible title: **The Bat Signal: Why I'm Building Futureproof Festival in Vancouver**
-- SEO title: **Building Futureproof Festival in Vancouver | Kris Krüg** (54 characters)
-- `post.md` and `post.html` contain zero em dashes.
-- `voicecheck.py` returned 0 flags across both files.
-- Manual Host/Anti-Hero facet review passed; see `voice-audit/`.
+## Visual sequence and rights
 
-### Current public facts
+| Use | File | WordPress media ID | Source / approval |
+|---|---|---:|---|
+| Lead story photograph | `vanai-meetup31-stage-kris-futureproof-slide.webp` | 12725 | Michael Caswell; edited by Kris Krüg |
+| Community proof | `vanai-meetup31-community-group-photo.webp` | 12733 | Michael Caswell |
+| True North source receipt | `receipt-true-north-media-house.png` | 12734 | Editorial screenshot with source link |
+| TEDx source receipt | `receipt-tedx-summit-kris-krug.png` | 12735 | Editorial screenshot with source link |
+| DENT source receipt | `receipt-dent-kris-krug.png` | 12736 | Editorial screenshot with source link |
+| Space Centre courtyard | `vanai-space-centre-courtyard-community.webp` | 12737 | Michelle Diamond; approved public promotional reuse |
+| Space Centre at night | `space-centre-community-night.webp` | 12738 | Michelle Diamond; approved public promotional reuse |
+| Honest-conversation poster | `futureproof-honest-conversation-poster.png` | 12727 | Futureproof brand-audit H02 approved |
+| Featured and closing key art | `futureproof-salmon-starfield-share-20260711.jpg` | 12739 | Futureproof brand-audit L04 approved |
 
-Verified from the official public festival pages on 2026-08-11:
+The previously selected May hero was rejected in the Futureproof brand audit and is no longer used. The three source screenshots render as standalone full-width figures rather than an unreadable three-column gallery. The old audience image carrying an expired promotion is no longer used.
 
-- October 28–30, 2026
-- H.R. MacMillan Space Centre, Vancouver
-- Earlyworm CA$650 through August 15; standard CA$950; student CA$250; supporter CA$1,650
-- Active BC + AI members receive 25% off
-- Call for Talks is open through August 15
-- Public speaker directory contains 13 profiles; the article links the live directory instead of freezing a roster in body copy
-- BC + AI proof points retained from the approved source package: 300 members, 3,000+ attendees, 94+ documented events since 2023
+## Guarded WordPress sync receipt
 
-The article sends volatile prices and deadlines to the official festival pages. Recheck those pages again if publication occurs after August 15.
-
-### Links and media
-
-- All 24 unique `http(s)` URLs in `post.md` and `post.html` returned HTTP 200 on 2026-08-11.
-- Seven selected local image files resolved and passed the publisher quality gate.
-- Lead image: Vancouver AI Meetup #31 stage photograph, Michael Caswell photography and Kris Krüg editing.
-- Supporting audience photograph: Michael Caswell.
-- Kris approved the copy and visual sequence in the issue flow before the create-only run.
-
-### Publisher verification
+The sync command defaults to an authenticated dry run. `--apply` wrote only these fields:
 
 ```text
-dry_run: true
-quality gate: pass
-images resolved: 7
-slug before create: available
-create: id 12732
-authenticated readback: status=draft, slug=futureproof-festival-announcement, featured_media=12725
-final-copy sync: content + excerpt only
-post-sync readback: status=draft, title unchanged, featured_media=12725
+title
+content
+excerpt
+featured_media
+meta
 ```
 
-The connector test suite passed: **148 tests**.
+Before any mutation it wrote a mode-600, gitignored REST snapshot:
 
-## WordPress media receipt
+`wp-snapshots/rest-post-12732-before-polish-v2-20260812T224659154754Z.json.tmp`
 
-| File | Media ID |
-|---|---:|
-| `vanai-meetup31-stage-kris-futureproof-slide.webp` | 12725 |
-| `vanai-meetup31-audience-wide-shot.webp` | 12726 |
-| `futureproof-honest-conversation-poster.png` | 12727 |
-| `manifesto-01-future-cultural-question.webp` | 12728 |
-| `manifesto-06-who-shapes-us.webp` | 12729 |
-| `manifesto-14-places-to-think.webp` | 12730 |
-| `futureproof-salmon-starfield-share-20260527.jpg` | 12731 |
+Readback hashes:
 
-Local operational evidence remains gitignored beside this package: `publish.log`, the pre-write REST snapshot, the rollback manifest, and the narrow restore helper.
+```text
+before body: 97d0c9042b5763f0917330b78845798f79327107c08c4c97799809ec39d1a4f7
+after body:  d8f8421b824754d64f021dde1da2c7ca9ddfa4a573695f937f90a6343f19cdf6
+```
 
-## Final-copy sync receipt
+The guarded readback confirmed all payload fields exactly and preserved:
 
-Kris separately authorized the post-issue private-draft sync on 2026-08-11. The dry-run proved the payload contained only `content` and `excerpt`, with exactly:
+```text
+status: draft
+slug: futureproof-festival-announcement
+categories: [1662]
+tags: [1628, 1801, 542, 1719, 1800, 1495]
+author: 1
+date: 2026-08-11T12:00:00
+date_gmt: 2026-08-11T20:00:00
+```
 
-- two “Twenty-eight years on the internet” → “Three decades on the internet” replacements;
-- one conference-bio phrase refinement;
-- the aligned excerpt.
+The rendered WordPress body contains all nine media IDs, one iframe, responsive `srcset`/`sizes`, lazy loading, and lightbox triggers. It contains no local paths or placeholder media markers.
 
-Authenticated post-write readback confirmed:
+## State transition and public smoke checks
 
-- `status=draft` and slug unchanged;
-- visible title unchanged;
-- featured media unchanged at `12725`;
-- old phrases absent and new phrases present at the expected counts;
-- body SHA-256 `97d0c9042b5763f0917330b78845798f79327107c08c4c97799809ec39d1a4f7`.
+Immediately after the guarded sync, the exact readback remained `draft` and public exposure was closed:
 
-Rollback snapshot: `wp-snapshots/rest-post-12732-before-final-copy-sync-20260811T232451Z.json.tmp` (gitignored local evidence).
+```text
+/?p=12732                                      -> 404
+/futureproof-festival-announcement/            -> 404
+/wp-json/wp/v2/posts/12732                      -> 401
+public REST slug search                         -> []
+```
 
-The repository and private WordPress draft are now copy-aligned. Review the private preview and authorize publication separately; publishing remains outside issue #500 and this sync.
+The live state changed later. Public REST now reports `status=publish` and `featured_media=12739`. A final snapshot-first, content-only review fix replaced the poster alt and unsupported sponsor wording; exact readback preserved every protected field and advanced `modified_gmt` to `2026-08-12T23:22:22`. Current public checks:
+
+```text
+canonical dated URL                             -> 200
+/futureproof-festival-announcement/             -> 301, then canonical 200
+/wp-json/wp/v2/posts/12732                      -> 200, status=publish
+public REST slug search                         -> one matching published post
+```
+
+The production page was checked at desktop and mobile widths:
+
+- desktop viewport: **1440 × 1000**, no horizontal overflow;
+- mobile viewport: **390 × 844**, no horizontal overflow;
+- featured image responsive at both widths;
+- all nine body images loaded at natural width;
+- source screenshots are readable at full article width;
+- YouTube iframe and all nine lightboxes are present;
+- title, subtitle, excerpt, August 11 date, author, reading time, captions, and visual sequence render coherently;
+- canonical URL, SEO title, 146-character meta description, approved Open Graph image, and `BlogPosting` structured data are present.
+- poster alt now says **gathered in a circle**, and the sponsor CTA describes only the packages shown on the linked page.
+
+## Test receipt
+
+```text
+verify_futureproof_polish_v2.py                 pass
+external URL checks                             25/25 HTTP 200
+voicecheck.py                                   0 findings
+targeted sync/verifier tests                    13 passed
+ruff                                            pass
+py_compile                                      pass
+make test publisher suite                       343 passed
+make test SEO inventory suite                   12 passed
+make test SEO backfill/link-safety suite         68 passed
+plugin and theme smoke checks                   pass
+```
+
+Final content-only production fix receipt:
+
+```text
+snapshot: rest-post-12732-before-two-review-fixes-20260812T232221806662Z.json (local, mode 600)
+before body: 68df6fb645b95e7d9414e27ebf9ac3d3bf61cfd2dd34fa9454f494a24f479d82
+after body:  addd40d6c0a3df6655c56f2f6d8828809a5c02061d90fab6c42ada98b9ee5f96
+payload: content only
+protected fields changed: none
+```
+
+## Remaining follow-ups
+
+1. Confirm Michael Caswell's cross-site reuse/credit line for the two Meetup photographs. The current captions credit him on-page.
+2. Recheck or remove the August 15 ticket and call-for-talks deadline after it passes.
+3. Keep the local mode-600 snapshot until the public page and repository closeout are accepted.
+
+This is a WordPress publication path, not a Vercel deployment. No Vercel project update is required for this post.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/VOICE-NOTES.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/VOICE-NOTES.md
@@ -1,4 +1,23 @@
-# VOICE-NOTES: The Bat Signal: Why I'm Building Futureproof Festival in Vancouver
+# VOICE-NOTES: Futureproof Festival of AI: A Bat Signal from Vancouver
+
+## V2 editorial decisions (2026-08-12)
+
+The working title is now **Futureproof Festival of AI: A Bat Signal from Vancouver**. It leads with the canonical event name for readers and search while preserving the personal hook.
+
+- **Facet:** Host with Anti-Hero edge. Kris is inviting people into a room, not pitching a product or writing a founder victory lap.
+- **Opening:** exact date, meetup number, video, event archive, and gallery replace the floating “last month” setup.
+- **Community before hero:** Vancouver AI and BC + AI get their own evidence section before the conference résumé.
+- **Receipts:** historical claims link the strongest available evidence and are paired with public-source screenshots.
+- **Distributed credit:** Michael Caswell, Michelle Diamond, Kevin Friel, Darren Barefoot, Boris Mann, and Brian Lamb are named where they did the work.
+- **Both hands full:** the festival is positioned as a room for critique and curiosity, with neither boosterism nor doom allowed to flatten the conversation.
+- **Specific CTA:** attend, speak, exhibit, sponsor, follow the roster, or follow the wider event archive.
+- **No generic wrap-up:** “This is the first Futureproof Festival. It is not the first room.” closes the proof arc before the final invitation.
+- **Zero authored em dashes:** retained as a hard voice rule.
+- **No exact unstable community totals:** disputed 250/300 member and attendance/event-count figures were replaced with conservative, defensible language.
+
+The remainder of this file is a frozen archive of the pre-v2 package. Its title, counts, venue, upload, and rights notes are superseded and must not be used as current release guidance.
+
+## Archived pre-v2 notes (superseded)
 
 Refreshed 2026-08-11 for #500. The July 26 "Baby Is Here" notes below are preserved for history since that draft's structure is gone; current notes follow.
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/alt-text.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/alt-text.md
@@ -1,24 +1,15 @@
-# Image alt text
+# Image alt text and captions: v2
 
-Source of truth for roles and source URLs: `asset-manifest.md` (#644 update). Alts below match frontmatter + in-body placement in `post.md` / `post.html`, rewritten 2026-08-02 for #645.
+| Asset | Role | Alt | Credit/caption |
+|---|---|---|---|
+| `futureproof-salmon-starfield-share-20260711.jpg` | featured + close | Futureproof Festival key art with coral salmon and ravens moving toward a bright portal under an aurora. Text reads Futureproof Festival, October 28-30, 2026, presented by BC+AI. | Futureproof Festival art layer. |
+| `vanai-meetup31-stage-kris-futureproof-slide.webp` | opening proof | Kris Krüg speaks on stage at Vancouver AI Meetup #31 in front of a Futureproof slide reading Vancouver, we need to talk about AI. | Photo: Michael Caswell. Edited: Kris Krüg. |
+| `vanai-meetup31-community-group-photo.webp` | room proof | Dozens of Vancouver AI Meetup #31 participants gather on and in front of the stage for a closing group photo. | Vancouver AI Meetup #31, together at the end of the night. Photo: Michael Caswell. |
+| `receipt-true-north-media-house.png` | historical receipt | MediaShift's 2010 article documenting True North Media House and the citizen media hub at the Vancouver Olympics. | Screenshot of MediaShift for editorial reference, captured August 12, 2026. |
+| `receipt-tedx-summit-kris-krug.png` | historical receipt | TED Blog's 2012 article naming Kris Krüg as a TEDxSummit photographer. | Screenshot of TED Blog for editorial reference, captured August 12, 2026. |
+| `receipt-dent-kris-krug.png` | historical receipt | Kris Krüg's 2023 DENT article with a group photograph from the conference. | Screenshot of KrisKrug.co, captured August 12, 2026. |
+| `vanai-space-centre-courtyard-community.webp` | participation | Vancouver AI attendees talk in small groups across the Space Centre courtyard. | Community between sessions at the Space Centre. Photo: Michelle Diamond. |
+| `space-centre-community-night.webp` | place | The H.R. MacMillan Space Centre glows pink and blue at night while people gather inside. | Photo: Michelle Diamond. |
+| `futureproof-honest-conversation-poster.png` | campaign pivot | Futureproof Festival poster showing people gathered in a circle beneath an aurora, rising salmon, and a raven. Text reads The most honest AI conversation happening this year, Vancouver, October 28-30, 2026. | Futureproof Festival art layer. |
 
-- **vanai-meetup31-stage-kris-futureproof-slide.webp** (lead / hero) — alt: "Kris Krüg speaks on stage at Vancouver AI Meetup #31, in front of a Futureproof slide reading Vancouver, we need to talk about AI, with salmon and skyline artwork behind him." Credit: Photo: Michael Caswell. Edited: Kris Krüg.
-- **vanai-meetup31-audience-wide-shot.webp** (community-room) — alt: "A wide shot from the back of the room, a full silhouetted audience facing the lit Futureproof stage and screen during Vancouver AI Meetup #31." Credit: Photo: Michael Caswell.
-- **futureproof-honest-conversation-poster.png** (official-graphic, was hero) — alt: "Futureproof Festival poster with silhouetted figures walking toward a golden-lit portal under ornate arches. White type reads The most honest AI conversation happening anywhere this year. Dates Vancouver Oct 28-30, 2026."
-- **manifesto-01-future-cultural-question.webp** (gallery) — alt: "Hand-painted Futureproof poster reading The Future Is a Cultural Question over an aurora above a forested shoreline with salmon and painted eyes."
-- **manifesto-06-who-shapes-us.webp** (gallery) — alt: "Hand-painted Futureproof poster reading Who Gets to Shape What Shapes Us over rivers running through open hands."
-- **manifesto-14-places-to-think.webp** (gallery) — alt: "Hand-painted Futureproof poster reading The Future Needs Places to Think over a quiet tidepool reflecting stars."
-- **futureproof-salmon-starfield-share-20260527.jpg** (gallery + optional OG landscape) — alt: "Futureproof launch key art with coral salmon swimming toward a bright portal under aurora and stars. Title type FUTUREPROOF FESTIVAL, October 28-30, 2026, presented by BC+AI."
-
-## Dropped from this rewrite
-
-- **futureproof-wordmark-white-transparent.png** — was inline after the FATALE/dream beat in the July 26 draft. That beat (the FATALE renaming saga) isn't in the #645 rewrite, since it's already told in full in *The Long Road to Futureproof* and repeating it would duplicate that post's section-level argument. The wordmark file is still staged in `images/` and listed in `asset-manifest.md`'s July 26 set if a later draft wants it back.
-
-## Placement (current, #645)
-
-1. Meetup #31 stage photo immediately after the opening two paragraphs (the "last month I stood on a stage" scene).
-2. Meetup #31 audience photo after "What twenty years behind the lens actually teaches you," closing that section before the "why Futureproof" heading.
-3. Official-graphic poster after "The H.R. MacMillan Space Centre... is home," closing the "why Futureproof, why now, why Vancouver" section.
-4. Four-image manifesto gallery after "I'm asking you to help hold a room that can stay honest," inside "The bat signal" section (`[[GALLERY-MANIFESTO]]` marker in `post.md`).
-
-Binaries for the two new meetup photos are staged locally under `images/` (see `asset-manifest.md`), matching the July 26 set's staging pattern. `post.html` still hotlinks the public R2 and futureproof.website URLs directly, same convention as the original package, so #500 can swap to uploaded media IDs without rewriting alts.
+The title text visible inside screenshots and posters is described only when it helps the reader understand why the image is present. Photographer credits remain captions, not duplicated into alt text.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/asset-manifest.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/asset-manifest.md
@@ -1,5 +1,67 @@
 # Asset Manifest — Futureproof Festival announcement (#497)
 
+## V2 visual package (2026-08-12)
+
+This section supersedes the earlier sequencing recommendations below. The older receipts remain for audit history.
+
+### Featured graphic
+
+The recommended WordPress featured/OG media is now **`futureproof-salmon-starfield-share-20260711.jpg`**, WordPress media ID `12739`.
+
+- Source: `https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260711.jpg`
+- Dimensions: 1200×630, exact 1.91:1 social-card ratio.
+- SHA-256: `68ecc3c42b32857916e5d62c7ac30efe5bfc387bb2614045abb42791121dfc08`
+- Provenance: official Futureproof Festival campaign art, approved as L04 in `data/brand-audit.json`. The earlier 20260527 file/media `12731` is rejected as L03 and is not reused.
+- Editorial reason: it clearly names the festival, carries the date and BC + AI attribution, and answers the request for a purpose-built graphic. The 3:2 stage photograph remains the opening editorial image.
+
+### Article sequence
+
+| File | Size | Role | Source / credit | SHA-256 |
+|---|---:|---|---|---|
+| `vanai-meetup31-stage-kris-futureproof-slide.webp` | 2400×1600 | opening proof | Michael Caswell photo; Kris Krüg edit; Meetup #31 R2 gallery | `4f2c77c776e54174b08b69a3e41cca4d954ffdb17149c59928ff04ab497e0647` |
+| Meetup #31 YouTube | 16:9 video | full-event embed, Futureproof at 19:04 | `https://www.youtube.com/watch?v=YitQ4fNEDW8` | n/a |
+| `vanai-meetup31-community-group-photo.webp` | 2400×1600 | room proof | Michael Caswell photo; Meetup #31 R2 gallery | `e3d58e4b17ebcd8e20d673ea5b21a0f2abc3afdeb202000f4c3617bb916a6360` |
+| `receipt-true-north-media-house.png` | 1440×900 | historical screenshot | MediaShift page, captured 2026-08-12 | `bd630687fd16a0d4ef4507f1087c8be7f5abcadfe803f20926ae4b40a152390b` |
+| `receipt-tedx-summit-kris-krug.png` | 1440×900 | historical screenshot | TED Blog page, captured 2026-08-12 | `a7c864d3b2f5369261abd320ed3c00eb1db9e3b7bfbf8024d07bf558d12969a6` |
+| `receipt-dent-kris-krug.png` | 1440×900 | historical screenshot | KrisKrug.co page, captured 2026-08-12 | `7d02497cfd2a4dc3ed82e6c2d5b04c5cc18fd1fd6b517bf9feb6945dedbe27c8` |
+| `vanai-space-centre-courtyard-community.webp` | 1800×1200 | participation proof | Michelle Diamond, approved public-reuse frame FPH-011 | `1bfe958b5ed5ad29a9f159032f5456fb1db18607d1d2e3a1e8252432bc9e7015` |
+| `space-centre-community-night.webp` | 1800×1200 | venue proof | Michelle Diamond, Futureproof photo library FPH-097 | `b611a54de56815613bee5823413b67a39a620c1217e74e6c9e0be1ba3049dc26` |
+| `futureproof-honest-conversation-poster.png` | 1024×1536 | one campaign-art pivot | official Futureproof art | `01fdaa144ff92bfa7a7cbd4155714c91a12c550194b3771438f790ef27258a7f` |
+| `futureproof-salmon-starfield-share-20260711.jpg` | 1200×630 | featured + closing invitation | approved official Futureproof art L04 | `68ecc3c42b32857916e5d62c7ac30efe5bfc387bb2614045abb42791121dfc08` |
+
+The three repetitive manifesto tiles were removed. The new sequence alternates real event photography, video, three full-width archival screenshots, place, and one campaign-art beat. The closing group photograph replaces an audience frame whose projected slide carried an expired one-night ticket offer.
+
+### Rights and release gate
+
+- The issue flow authorized using the existing Meetup #31 sequence and official campaign artwork for this update. The two Meetup frames are public BC + AI event photography and are credited to Michael Caswell on-page; the repository still lacks a separate written cross-site reuse release, so that confirmation remains a post-public follow-up.
+- FPH-011 and FPH-097 appear in `not-ai-publication-approval-2026-07-18.md`, which records Kris's public-promotional-reuse approval and Michelle Diamond's permission and credit.
+- The three page screenshots are full-width editorial receipts linked to their public sources. Do not detach them from captions/source links.
+- The page is now public. The live captions retain the named credits; direct cross-site reuse confirmation for the two Michael Caswell frames remains a follow-up.
+
+### Storage note
+
+`content/drafts/**/images/` is intentionally gitignored because shipped binaries live in WordPress media. The manifest, source URLs, dimensions, hashes, alt text, and media receipts are the tracked reconstruction record.
+
+### V2 WordPress media receipt
+
+The guarded draft-only sync completed on 2026-08-12. Exact media filename matching reused two attachments and uploaded seven missing assets:
+
+| File | WordPress media ID | Result |
+|---|---:|---|
+| `vanai-meetup31-stage-kris-futureproof-slide.webp` | 12725 | reused |
+| `futureproof-honest-conversation-poster.png` | 12727 | reused |
+| `vanai-meetup31-community-group-photo.webp` | 12733 | uploaded |
+| `receipt-true-north-media-house.png` | 12734 | uploaded |
+| `receipt-tedx-summit-kris-krug.png` | 12735 | uploaded |
+| `receipt-dent-kris-krug.png` | 12736 | uploaded |
+| `vanai-space-centre-courtyard-community.webp` | 12737 | uploaded |
+| `space-centre-community-night.webp` | 12738 | uploaded |
+| `futureproof-salmon-starfield-share-20260711.jpg` | 12739 | uploaded and featured |
+
+The prior media `12731` remains historical and is not used by v2 because its May artwork is rejected as L03 in the current Futureproof brand audit.
+
+A later WordPress action outside the guarded sync changed post `12732` to `publish`. Production readback now shows featured media `12739`, all nine body images, the video embed, and the expected captions.
+
 ## #500 WordPress receipt (2026-08-11)
 
 Kris approved the current visual sequence and cross-site reuse in the issue flow. The guarded create-only run uploaded the seven images referenced by `post.md` and created private WordPress draft `12732`. No public publish occurred.
@@ -108,7 +170,7 @@ The strongest already-vetted official campaign art remains `images/futureproof-h
 - **Source URL:** `https://www.futureproof.website/graphics/honest-conversation/futureproof-honest-conversation-poster.png`
 - **Festival-repo equivalent (for KK drop if re-export needed):** `public/graphics/honest-conversation/futureproof-honest-conversation-poster.png`
 - **Format:** PNG 1200×1800 (portrait)
-- **Alt:** Futureproof Festival poster: silhouetted figures walk toward a golden-lit portal between ornate arched windows marked with fish, trees, and eyes; teal and orange energy lines rise to a centered eye. White type reads "The most honest AI conversation happening anywhere this year." Teal line below: Vancouver · Oct 28-30, 2026 · Up to 600 people. BC+AI Ecosystem mark at lower left.
+- **Alt:** Futureproof Festival poster showing people gathered in a circle beneath an aurora, rising salmon, and a raven. Text reads "The most honest AI conversation happening this year," Vancouver, October 28-30, 2026, presented by BC + AI Ecosystem.
 
 ### 2. Wordmark
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/internal-links.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/internal-links.md
@@ -1,58 +1,31 @@
-# Link audit: The Bat Signal (Futureproof network follow-up, #645)
+# Link map: Futureproof Festival of AI v2
 
-## #500 refresh (2026-08-11)
+Updated 2026-08-12. The body contains 25 unique editorial destinations before image source URLs.
 
-All 24 unique `http(s)` URLs across `post.md` and `post.html` returned HTTP 200. This count includes the 17 editorial destinations below plus the seven public image sources embedded in the Gutenberg body.
+## KrisKrug.co internal links
 
-The private WordPress draft is `https://kriskrug.co/?p=12732`; it remains `status=draft` and is not a public publication receipt.
+1. `https://kriskrug.co/2026/06/01/long-road-to-futureproof/` — origin story.
+2. `https://kriskrug.co/vancouver-ai/` — Vancouver AI hub.
+3. `https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/` — meetup-to-nonprofit history.
+4. `https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/` — DENT receipt and related essay.
+5. `https://kriskrug.co/ai-events/` — events and recaps hub.
 
-Rewritten 2026-08-02 for #645. Supersedes the July 26 FP-4 link audit below the original speaker-list and FATALE links, which are no longer in the body copy (see `speakers.md` and `alt-text.md` addenda for why).
+## Community proof
 
-All links re-curled with `curl -sL -o /dev/null -w "%{http_code}"` on 2026-08-02. **17 unique URLs, all HTTP 200.**
+- Meetup #31 archive, full video at 19:04, and complete photo gallery.
+- BC + AI About page and companion Futureproof regional story.
 
-## Internal links (1)
+## Historical proof
 
-- https://kriskrug.co/2026/06/01/long-road-to-futureproof/ — the live origin post this piece follows up on; linked once, early, so this article doesn't retell it.
+- Northern Voice, MediaShift/True North Media House, PopTech's organization account, TED Blog, SXSW Flickr archive, and Kris's DENT essay.
 
-## External links
+## Festival pathways
 
-### Festival / RSVP / tickets
+- Festival overview, tickets, Luma registration, live speakers, Kevin Friel profile, venue, Call for Talks, startup exhibitors, and sponsors.
 
-- https://futureproof.website/
-- https://www.futureproof.website/speakers/
-- https://www.futureproof.website/speakers/kevin-friel/
-- https://www.futureproof.website/tickets/
-- https://www.futureproof.website/call-for-talks/
-- https://luma.com/futureproof-festival
+## Release rules
 
-The single named-speaker link (Kevin Friel) is the one exception to this piece's "link the roster, don't hard-code names" rule. It is there because the copy credits him by name for bringing the BC + AI Film Club into the festival, and a named credit should link to that person's own profile rather than a generic directory. He is publicly listed on the roster with a live profile (HTTP 200).
-
-### Orgs
-
-- https://bc-ai.ca/
-- https://bc-ai.ca/events
-- https://vancouver.ai/
-- https://www.hrmacmillanspacecentre.com/
-
-### Network-receipts lineage (#643 ledger, 6 of the recommended 6-link sequence used)
-
-- https://en.wikipedia.org/wiki/Northern_Voice
-- https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/
-- https://www.flickr.com/photos/kk/albums/72157608995273506/ (PopTech)
-- https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/ (TEDxSummit)
-- https://www.flickr.com/photos/kk/albums/72157649379627911/ (SXSW Interactive 2013)
-- https://www.flickr.com/photos/kk/collections/72157691620626391/ (DENT)
-
-The ledger's optional 7th link (kriskrug.co/about/) was not used in the body; the receipts section carries the "receipts over adjectives" framing in Kris's own words instead of linking out to it.
-
-## Dropped from the July 26 audit (and why)
-
-- **Individual speaker profile links (8 URLs)** — the FATALE/speaker-roster section that hard-coded these is gone. #645's acceptance criteria calls for linking the roster page rather than hard-coding volatile speaker lists; see `speakers.md`'s #645 addendum for the roster-growth reasoning.
-- **https://fatalefestival.com/** and the second kriskrug.co post (`.../future-proof-inside-vancouvers-thriving-ai-ecosystem/`) — both belonged to the FATALE-renaming retelling, which this piece deliberately does not repeat (already told in full in *The Long Road to Futureproof*, linked above).
-- **Org links for individual speakers** (calmtech.com, ocadu.ca, rxpx.health, zaro.me, tinyghoststudios.com, ethoslab.ca, byteplus.com, theupgrade.ai) — dropped along with the hard-coded speaker list.
-
-## Notes for #500
-
-- Re-curl every URL before draft create, same as the original package's guidance.
-- External links open in a new tab with `rel="noopener noreferrer"` in `post.html`, except the single kriskrug.co internal link (no target/rel needed, same-site).
-- After publish (KK-gated): click-check every internal and external link on the live post.
+- An HTTP 200 is not sufficient. Each destination must be checked for expected title/content; this caught the parked `hrmacmillanspacecentre.com` domain.
+- The canonical venue destination is `https://www.spacecentre.ca/`.
+- Deadline and roster destinations were checked on publication day and require another check after August 15.
+- The 25 rendered destinations passed the 2026-08-12 production check; repeat after any deadline-related edit.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/post.html
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/post.html
@@ -1,21 +1,31 @@
 <!-- wp:paragraph -->
-<p>Last month I stood on a stage in front of a room that shouldn't have been full on a Wednesday night, and it was full anyway.</p>
+<p>On July 29, I stood onstage at <a href="https://bc-ai.ca/events/vancouver-ai-meetup-2026-07">Vancouver AI Meetup #31</a> in front of a room that had no business being full on a Wednesday night. It was full anyway.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Behind me: a slide painted with salmon and ravens and northern lights, the type reading <strong>VANCOUVER, WE NEED TO TALK ABOUT AI.</strong> In front of me: the Vancouver AI community, meetup number thirty-one, still showing up almost three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.</p>
+<p>Behind me, salmon, ravens, northern lights, and seven words in very large type: <strong>VANCOUVER, WE NEED TO TALK ABOUT AI.</strong> In front of me, the crew that has kept showing up month after month to do exactly that. Michael Caswell caught the frame. I am mid-sentence, pointing at something I clearly believe.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
-<figure class="wp-block-image aligncenter size-large"><img src="https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/large/b4717426bf89.webp" alt="Kris Krüg speaks on stage at Vancouver AI Meetup #31, in front of a Futureproof slide reading Vancouver, we need to talk about AI, with salmon and skyline artwork behind him." class="wp-image-TBD"/><figcaption class="wp-element-caption">Photo: Michael Caswell. Edited: Kris Krüg.</figcaption></figure>
+<figure class="wp-block-image aligncenter size-large"><img src="images/vanai-meetup31-stage-kris-futureproof-slide.webp" alt="Kris Krüg speaks on stage at Vancouver AI Meetup #31 in front of a Futureproof slide reading Vancouver, we need to talk about AI." class="wp-image-TBD" width="2400" height="1600"/><figcaption class="wp-element-caption">Vancouver AI Meetup #31, July 29, 2026. Photo: Michael Caswell. Edited: Kris Krüg.</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->
-<p>That's not a metaphor for Futureproof. That's the rehearsal. The room already exists. I'm asking it to get bigger for three days in October.</p>
+<p>That night was not a metaphor for Futureproof. It was a rehearsal. The room already exists. I am asking it to get bigger for three days in October.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:embed {"url":"https://www.youtube.com/watch?v=YitQ4fNEDW8","type":"video","providerNameSlug":"youtube","responsive":true,"className":"wp-embed-aspect-16-9 wp-has-aspect-ratio"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=YitQ4fNEDW8
+</div><figcaption class="wp-element-caption">Vancouver AI Meetup #31 in full. The Futureproof segment begins at <a href="https://www.youtube.com/watch?v=YitQ4fNEDW8&amp;t=1144s">19:04</a>.</figcaption></figure>
+<!-- /wp:embed -->
+
+<!-- wp:paragraph -->
+<p>The <a href="https://www.youtube.com/watch?v=YitQ4fNEDW8&amp;t=1144s">full recording</a> starts the Futureproof part at 19:04. The <a href="https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/index.html">photo gallery</a> shows what the camera onstage cannot: the people, the side conversations, and the room doing its real work.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>I told the fuller origin story, FATALE and all, in <a href="https://kriskrug.co/2026/06/01/long-road-to-futureproof/"><em>The Long Road to Futureproof</em></a>. This one isn't that story again. This one is about who's invited.</p>
+<p>I told the origin story, including the FATALE name and the long road here, in <a href="https://kriskrug.co/2026/06/01/long-road-to-futureproof/"><em>The Long Road to Futureproof</em></a>. This is the next chapter. It is about the rooms that taught me what to build, the Vancouver community already proving the model, and who I want beside us when the doors open.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:pullquote -->
@@ -23,131 +33,207 @@
 <!-- /wp:pullquote -->
 
 <!-- wp:heading -->
+<h2 class="wp-block-heading">The room already exists</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><a href="https://kriskrug.co/vancouver-ai/">Vancouver AI</a> began in January 2024 as a monthly gathering in my studio. Eighty people squeezed into the first one. By July 2026 we were at meetup thirty-one, filling the Space Centre and producing an archive of talks, transcripts, photographs, demos, arguments, and very strange hallway conversations.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The deeper story is in <a href="https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/"><em>Zero to One: From Meetup to Movement</em></a>. The short version is that the meetup grew a spine. <a href="https://bc-ai.ca/about">BC + AI</a> gave the work a nonprofit home, regional relationships, member programs, weekly office hours, film nights, hackathons, education work, and hundreds of people willing to keep showing up. Thousands of seats have been filled since the first gathering. The exact count matters less than the repetition: this is not one lucky sold-out night.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/vanai-meetup31-community-group-photo.webp" alt="Dozens of Vancouver AI Meetup #31 participants gather on and in front of the stage for a closing group photo." class="wp-image-TBD" width="2400" height="1600"/><figcaption class="wp-element-caption">Vancouver AI Meetup #31, together at the end of the night. Photo: Michael Caswell.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>The community has been practising what Futureproof needs: ceremony before slides, relationships before transactions, artists beside engineers, skeptics beside builders, and enough trust to disagree without turning the room into a blood sport.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Futureproof did not arrive from a branding workshop. It grew out of those monthly rooms. <a href="https://bc-ai.ca/news/futureproof-festival-regional-story-national-invitation">BC + AI's companion story</a> carries the regional invitation. This essay carries mine.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
 <h2 class="wp-block-heading">The receipts, not the résumé</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>I don't love talking about myself in the third-person conference-bio voice, all shiny awards and self-importance. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.</p>
+<p>I do not love the third-person conference-bio voice, all polished credentials and suspiciously shiny adjectives. Someone once called me an international badass man of mystery. Cute. What I actually did was keep showing up with a camera until rooms started trusting me with more than the photographs.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Before any of this was AI, it was:</p>
+<p>Before the AI conversation swallowed the calendar, there were other rooms:</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
 <ul class="wp-block-list">
-<li><strong><a href="https://en.wikipedia.org/wiki/Northern_Voice" target="_blank" rel="noopener noreferrer">Northern Voice</a></strong>, 2005 to 2013. Vancouver's own blogging and social-software conference, and I was one of the people who organized it, alongside Darren Barefoot, Boris Mann, and a dozen other Vancouver internet weirdos. First time I turned a scene into a conference. Not the last.</li>
-<li>The <strong><a href="https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/" target="_blank" rel="noopener noreferrer">2010 Winter Olympics</a></strong>, right here in this city. I wasn't credentialed press. I helped build True North Media House, an independent media hub for bloggers and citizen journalists who had no other seat at the world's biggest media event. That's the actual precedent for "non-extractive." I've done it before, at a bigger scale than this festival, with worse funding.</li>
-<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157608995273506/" target="_blank" rel="noopener noreferrer">PopTech</a></strong>, Camden, Maine, on and off from 2008 through 2013. PopTech's own account still credits the photos. Years of watching scientists, artists, and activists get put in one room on purpose.</li>
-<li><strong><a href="https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/" target="_blank" rel="noopener noreferrer">TEDxSummit</a></strong>, Morocco, 2012, where TED's own blog called me "one of our photographers and a longtime friend of TEDx." Plus TEDxVancouver, TEDxOilSpill, and a few other cities. One format, endlessly local.</li>
-<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157649379627911/" target="_blank" rel="noopener noreferrer">SXSW Interactive</a></strong>, Austin, 2013. Eight hundred and one photos from one festival, because thirty thousand people in one convention center still has a hundred small rooms inside it if you look for them.</li>
-<li><strong><a href="https://www.flickr.com/photos/kk/collections/72157691620626391/" target="_blank" rel="noopener noreferrer">DENT</a></strong>, Sun Valley and beyond, official photographer since 2014. I've called DENT a family reunion in public before, and I meant it. Creativity meets community, ideas take flight, you learn to karate spar with people you'll see again next year.</li>
+<!-- wp:list-item -->
+<li><strong><a href="https://en.wikipedia.org/wiki/Northern_Voice">Northern Voice</a>, Vancouver, 2005 to 2013.</strong> Darren Barefoot, Boris Mann, Brian Lamb, and a crew of Vancouver internet weirdos turned a blogging and social-software scene into a conference. I helped organize it. It taught me that a community event can be scrappy and still become civic infrastructure.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/">True North Media House</a>, Vancouver, 2010.</strong> We helped build True North Media House, a virtual accreditation and coordination network outside the official Olympic press system, while W2 provided the physical workspace for independent media. That is the lineage behind Futureproof's insistence that the people affected by a system deserve a place in the conversation.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.flickr.com/photos/poptech/10468089914">PopTech</a>, Camden, Maine, 2008 to 2013.</strong> PopTech's own archive credits my photography. I watched scientists, artists, technologists, and activists get put in one room on purpose, years before "multidisciplinary" became conference wallpaper.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/">TEDxSummit</a>, Doha, Qatar, 2012.</strong> TED's blog called me "one of our photographers and a longtime friend of TEDx." The lesson was not the red carpet. It was how a common format can travel across cities while each local community keeps its own voice.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157649379627911/">SXSW Interactive</a>, Austin, 2013.</strong> I made 801 photographs while roughly thirty thousand people spread across downtown. Even at that scale, the memorable thing was still a human-sized room inside the machine.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/">DENT</a>, Sun Valley and beyond, since 2014.</strong> I have photographed DENT for years and called it a family reunion because that is how it feels. People return. Trust compounds. The conference becomes part of your life instead of a transaction that vanishes with the lanyard.</li>
+<!-- /wp:list-item -->
 </ul>
 <!-- /wp:list -->
 
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/receipt-true-north-media-house.png" alt="MediaShift's 2010 article documenting True North Media House and the citizen media hub at the Vancouver Olympics." class="wp-image-TBD" width="1440" height="900"/><figcaption class="wp-element-caption"><a href="https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/">True North Media House</a>, documented by MediaShift in 2010.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/receipt-tedx-summit-kris-krug.png" alt="TED Blog's 2012 article naming Kris Krüg as a TEDxSummit photographer." class="wp-image-TBD" width="1440" height="900"/><figcaption class="wp-element-caption"><a href="https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/">TED Blog</a>, 2012.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/receipt-dent-kris-krug.png" alt="Kris Krüg's 2023 DENT article with a group photograph from the conference." class="wp-image-TBD" width="1440" height="900"/><figcaption class="wp-element-caption"><a href="https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/">DENT the Future</a>, from Kris's own archive.</figcaption></figure>
+<!-- /wp:image -->
+
 <!-- wp:paragraph -->
-<p>None of that is a flex. It's a pattern. Every one of those rooms taught me the same four things, and I never got to build my own version of the room until now.</p>
+<p>Those screenshots are not decoration. They are public receipts. Links rot, bios inflate, and memory gets heroic when nobody checks it. I want this festival built on the opposite habit: name the people, show the source, keep the record.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">What twenty years behind the lens actually teaches you</h2>
+<h2 class="wp-block-heading">What twenty years behind the lens taught me</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><strong>The room is the product.</strong> Not the stage, not the swag, not the sponsor logos. The unglamorous folding chairs and the hallway where the real conversation happens after the panel ends.</p>
+<p>The room is the product. Stages, swag, and sponsor walls are furniture. The actual product is whether someone can walk in alone, find a conversation worth joining, and leave with a relationship that survives the closing slide.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Hallways matter more than keynotes.</strong> Every event I named above, the thing people remembered a year later happened between sessions, not during them.</p>
+<p>Hallways carry half the program. The talk gives people a shared object. The five minutes afterward, when two strangers compare notes beside a badly placed coffee urn, is where the object becomes useful.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Art and disagreement belong beside the technology, not after it.</strong> PopTech knew this in 2008. DENT knows it every year. Most AI conferences in 2026 still don't.</p>
+<p>Art and disagreement belong beside the technology. They are not garnish for the reception. Too many AI events I have attended put product demos at the centre and invite culture in later to make the program look human. Futureproof starts with the humans already in the room.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong>Audiences are participants, not tickets.</strong> True North Media House existed because the Olympics' official media system had no room for the people the Games actually affected. Futureproof exists for the same reason, aimed at AI instead of a sporting event.</p>
+<p>Audiences are participants. A good gathering gives people jobs to do: ask the sharper question, show the unfinished thing, challenge the premise, introduce two people, document what happened, or make the next room possible.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
-<figure class="wp-block-image aligncenter size-large"><img src="https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/large/639c78efe5d2.webp" alt="A wide shot from the back of the room, a full silhouetted audience facing the lit Futureproof stage and screen during Vancouver AI Meetup #31." class="wp-image-TBD"/><figcaption class="wp-element-caption">Photo: Michael Caswell.</figcaption></figure>
+<figure class="wp-block-image aligncenter size-large"><img src="images/vanai-space-centre-courtyard-community.webp" alt="Vancouver AI attendees talk in small groups across the Space Centre courtyard." class="wp-image-TBD" width="1800" height="1200"/><figcaption class="wp-element-caption">Community between sessions at the Space Centre. Photo: Michelle Diamond.</figcaption></figure>
 <!-- /wp:image -->
 
+<!-- wp:paragraph -->
+<p>That is why Futureproof brings talks, film, creative work, demos, live performance, and room for conversations that are not onstage. The format should create useful collisions without manufacturing them. If every minute is programmed, nobody has time to become part of the story.</p>
+<!-- /wp:paragraph -->
+
 <!-- wp:heading -->
-<h2 class="wp-block-heading">Why Futureproof, why now, why Vancouver</h2>
+<h2 class="wp-block-heading">Why Futureproof Festival of AI, why now, why Vancouver</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>I started <a href="https://vancouver.ai/" target="_blank" rel="noopener noreferrer">Vancouver AI</a> as Thursday nights, because you can't summon a founding festival out of a cold invite. You stack the small rooms until the scene can see itself. Then <a href="https://bc-ai.ca/" target="_blank" rel="noopener noreferrer">BC + AI</a> became the nonprofit skeleton, because paperwork is where good ideas either become real or die of neglect. As of this writing that's <strong>300 members</strong>, <strong>3,000+ people through the doors</strong>, and <strong>94+ documented events</strong> since 2023. That's not my achievement. That's what a community builds when you stay out of its way and bring folding chairs.</p>
+<p><a href="https://www.futureproof.website/">Futureproof Festival of AI</a> is an international AI culture and ideas festival in Vancouver, October 28 to 30, 2026. Opening night leads into two full program days at the <a href="https://www.spacecentre.ca/">H.R. MacMillan Space Centre</a>, with the film festival closing party carrying us out the other side.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><a href="https://futureproof.website/" target="_blank" rel="noopener noreferrer">Futureproof</a> is the next body growing out of that soil, built by BC + AI and this community, not by me alone. <a href="https://www.futureproof.website/speakers/kevin-friel/" target="_blank" rel="noopener noreferrer">Kevin Friel</a> brings the BC + AI Film Club with him. A <a href="https://www.futureproof.website/speakers/" target="_blank" rel="noopener noreferrer">growing public roster</a> of speakers is saying yes. Michael Caswell and Tristan Brand were the ones actually pointing cameras at the room the night this article opens on, because the guy who spent twenty years photographing other people's conferences finally gets to be caught in someone else's frame for a change.</p>
+<p>The editorial line is simple: critique in one hand, curiosity in the other. No hype. No panic. We need a place where an artist can question the training data, a founder can show a working tool, an educator can talk about what is happening in classrooms, an Indigenous leader can challenge the assumptions underneath the system, and a skeptic can stay in the room long enough to hear something unexpected.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Vancouver, specifically, because I've spent more than a decade photographing rooms where people arrive as one version of themselves and leave a little rewired. You learn fast which venues are rentals and which ones are home. The <a href="https://www.hrmacmillanspacecentre.com/" target="_blank" rel="noopener noreferrer">H.R. MacMillan Space Centre</a>, with the Pacific outside and a planetarium dome overhead, is home.</p>
+<p>The <a href="https://www.futureproof.website/speakers/">public speaker roster</a> is already bringing together people from archives, design, healthcare, film, research, public-interest work, startups, and community building. Kevin Friel is carrying the <a href="https://www.futureproof.website/speakers/kevin-friel/">BC + AI Film Club</a> thread into the festival. More of the program will become public as it is ready. I would rather publish a real name late than a fantasy schedule early.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
-<figure class="wp-block-image aligncenter size-large"><img src="https://www.futureproof.website/graphics/honest-conversation/futureproof-honest-conversation-poster.png" alt="Futureproof Festival poster with silhouetted figures walking toward a golden-lit portal under ornate arches. White type reads The most honest AI conversation happening anywhere this year. Dates Vancouver Oct 28-30, 2026." class="wp-image-TBD"/></figure>
+<figure class="wp-block-image aligncenter size-large"><img src="images/space-centre-community-night.webp" alt="The H.R. MacMillan Space Centre glows pink and blue at night while people gather inside." class="wp-image-TBD" width="1800" height="1200"/><figcaption class="wp-element-caption">The Space Centre alive at night. Photo: Michelle Diamond.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>Vancouver matters here. This city knows how to build strange combinations: technology and land, cinema and software, activism and design, ceremony and experimentation. It also knows how to sell itself a little too easily. Futureproof should be honest about both. The <a href="https://www.futureproof.website/venues/">official venue page</a> shows the Space Centre as it actually works, full of people, not as an empty rental brochure.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/futureproof-honest-conversation-poster.png" alt="Futureproof Festival poster showing people gathered in a circle beneath an aurora, rising salmon, and a raven. Text reads The most honest AI conversation happening this year, Vancouver, October 28-30, 2026." class="wp-image-TBD" width="1024" height="1536"/><figcaption class="wp-element-caption">Official Futureproof Festival campaign art.</figcaption></figure>
 <!-- /wp:image -->
 
 <!-- wp:heading -->
-<h2 class="wp-block-heading">The bat signal</h2>
+<h2 class="wp-block-heading">The bat signal: who belongs in the room</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>If you stacked chairs with me at Northern Voice. If you were in Camden, Sun Valley, Austin, or that room in Morocco. If you've sat in a Vancouver AI meetup, argued with me in a hallway, taught a workshop, opened with ceremony, photographed a room I was also photographing, or just kept showing up when the room was still half empty: this is the call.</p>
+<p>If you stacked chairs with me at Northern Voice, worked beside us during the Olympics, or crossed paths in Camden, Doha, Austin, or Sun Valley, this is the call.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>If you have sat in a Vancouver AI meetup, taught a workshop, opened with ceremony, screened a film, built a prototype, challenged me in a hallway, photographed the room, or helped clean it after everyone left, this is also the call.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>If we have never met but you are trying to build technology without surrendering culture, judgment, consent, or joy, there is a chair for you too.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:pullquote -->
-<figure class="wp-block-pullquote"><blockquote><p>Come make the room bigger. Bring your better questions, and bring the people you know who ask them too.</p></blockquote></figure>
+<figure class="wp-block-pullquote"><blockquote><p>Come make the room bigger. Bring your better questions, and bring the people who ask them.</p></blockquote></figure>
 <!-- /wp:pullquote -->
 
 <!-- wp:paragraph -->
-<p>Speakers, builders, artists, photographers, organizers, skeptics, founders, and the gloriously unclassifiable people every good conference collects by accident. Old network, new network, doesn't matter. I'm not asking you to attend a product launch with better lighting. I'm asking you to help hold a room that can stay honest without collapsing into hype or panic.</p>
+<p>I am not inviting you to a product launch with better lighting. I am asking you to help hold a room that can stay honest without collapsing into boosterism or doom. Speakers, builders, artists, photographers, organizers, educators, policymakers, researchers, founders, skeptics, students, and the gloriously unclassifiable people every useful conference collects by accident.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:gallery {"columns":2,"imageCrop":false} -->
-<figure class="wp-block-gallery has-nested-images columns-2">
-<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true}} -->
-<figure class="wp-block-image size-large"><img src="https://www.futureproof.website/graphics/manifesto/manifesto-01-future-cultural-question.webp" alt="Hand-painted Futureproof poster reading The Future Is a Cultural Question over an aurora above a forested shoreline with salmon and painted eyes." class="wp-image-TBD"/></figure>
-<!-- /wp:image -->
-<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true}} -->
-<figure class="wp-block-image size-large"><img src="https://www.futureproof.website/graphics/manifesto/manifesto-06-who-shapes-us.webp" alt="Hand-painted Futureproof poster reading Who Gets to Shape What Shapes Us over rivers running through open hands." class="wp-image-TBD"/></figure>
-<!-- /wp:image -->
-<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true}} -->
-<figure class="wp-block-image size-large"><img src="https://www.futureproof.website/graphics/manifesto/manifesto-14-places-to-think.webp" alt="Hand-painted Futureproof poster reading The Future Needs Places to Think over a quiet tidepool reflecting stars." class="wp-image-TBD"/></figure>
-<!-- /wp:image -->
-<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true}} -->
-<figure class="wp-block-image size-large"><img src="https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260527.jpg" alt="Futureproof launch key art with coral salmon swimming toward a bright portal under aurora and stars. Title type FUTUREPROOF FESTIVAL, October 28-30, 2026, presented by BC+AI." class="wp-image-TBD"/></figure>
-<!-- /wp:image -->
-</figure>
-<!-- /wp:gallery -->
-
 <!-- wp:heading -->
-<h2 class="wp-block-heading">Come make it real</h2>
+<h2 class="wp-block-heading">Futureproof dates, tickets, and ways to take part</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p>Everything below lives on the festival's own site, because prices and deadlines move faster than this post should try to track:</p>
+<p>Choose the door that fits:</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list -->
 <ul class="wp-block-list">
-<li><strong><a href="https://futureproof.website/" target="_blank" rel="noopener noreferrer">Futureproof Festival</a></strong>, October 28-30, 2026, H.R. MacMillan Space Centre, Vancouver.</li>
-<li><strong><a href="https://luma.com/futureproof-festival" target="_blank" rel="noopener noreferrer">RSVP on Luma</a></strong></li>
-<li><strong><a href="https://www.futureproof.website/tickets/" target="_blank" rel="noopener noreferrer">Tickets</a></strong>, Earlyworm pricing through August 15, standard pricing after.</li>
-<li><strong><a href="https://www.futureproof.website/call-for-talks/" target="_blank" rel="noopener noreferrer">Call for Talks</a></strong>, open through August 15. First-time speakers and rough first drafts genuinely welcome.</li>
-<li>Sponsor or exhibit? Start on the <a href="https://www.futureproof.website/tickets/" target="_blank" rel="noopener noreferrer">tickets</a> page and find the rest of us through <a href="https://bc-ai.ca/" target="_blank" rel="noopener noreferrer">BC + AI</a> and the <a href="https://bc-ai.ca/events" target="_blank" rel="noopener noreferrer">events calendar</a>.</li>
+<!-- wp:list-item -->
+<li><strong>Attend:</strong> <a href="https://www.futureproof.website/tickets/">compare the passes</a> on the festival site, then <a href="https://luma.com/futureproof-festival">register on Luma</a>, where current availability is kept.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.futureproof.website/call-for-talks/">Propose a talk</a>:</strong> first-time speakers and rough first drafts are welcome. If you are reading this before August 15, 2026, the current call is still open. Check the page for live status after that date.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.futureproof.website/startup-exhibitors/">Bring a working product</a>:</strong> the Startup Exhibitor path is for small crews who want people to try something real, not stare at a logo wall.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.futureproof.website/sponsors/">Support the room</a>:</strong> the sponsor page lays out the partnership options and what each package includes.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://www.futureproof.website/speakers/">Meet the speakers</a>:</strong> use the live roster rather than an old list copied into somebody else's article.</li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><strong><a href="https://kriskrug.co/ai-events/">Follow the wider scene</a>:</strong> my AI events archive has the recaps, talks, field notes, and other rooms feeding this one.</li>
+<!-- /wp:list-item -->
 </ul>
 <!-- /wp:list -->
 
 <!-- wp:paragraph -->
-<p>I've been building toward this room since before I knew its name. Three decades on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.</p>
+<p>The Earlyworm ticket window currently runs through August 15, 2026. After that, the official ticket and Luma pages remain the source of truth. Prices and deadlines move. The invitation does not.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"sizeSlug":"large","lightbox":{"enabled":true},"align":"center"} -->
+<figure class="wp-block-image aligncenter size-large"><img src="images/futureproof-salmon-starfield-share-20260711.jpg" alt="Futureproof Festival key art with coral salmon and ravens moving toward a bright portal under an aurora. Text reads Futureproof Festival, October 28-30, 2026, presented by BC+AI." class="wp-image-TBD" width="1200" height="630"/><figcaption class="wp-element-caption">Futureproof Festival of AI, October 28 to 30, 2026. Presented by BC + AI.</figcaption></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>This is the first Futureproof Festival. It is not the first room.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p><strong><a href="https://futureproof.website/" target="_blank" rel="noopener noreferrer">Build what lasts.</a></strong></p>
+<p>Three decades on the internet, most of them spent photographing gatherings like this, and the guest list is everyone who ever let me stand in theirs.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><strong><a href="https://www.futureproof.website/">Build what lasts.</a></strong></p>
 <!-- /wp:paragraph -->

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/post.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/post.md
@@ -1,8 +1,8 @@
 ---
-title: "The Bat Signal: Why I'm Building Futureproof Festival in Vancouver"
+title: "Futureproof Festival of AI: A Bat Signal from Vancouver"
 slug: futureproof-festival-announcement
 post_date: '2026-08-11'
-status: draft
+status: publish
 post_type: post
 author_wp_id: 1
 categories:
@@ -15,126 +15,171 @@ tags:
 - Space Centre
 - Build What Lasts
 featured: true
-featured_media_id: 0
-excerpt: Decades of photographing other people's rooms taught me what
-  makes one worth building. Futureproof is the room. This is the invitation to
-  everyone who ever let me stand in theirs.
+featured_media_id: 12739
+excerpt: Futureproof Festival of AI is the room Vancouver has been rehearsing for, three days of art, technology, argument, and better questions at the Space Centre.
 seo:
-  meta_title: Building Futureproof Festival in Vancouver | Kris Krüg
-  meta_description: Kris Krüg's network bat signal for Futureproof Festival, Oct
-    28-30 2026 in Vancouver. Receipts from PopTech to DENT. The invitation is the point.
+  meta_title: Futureproof Festival of AI in Vancouver | Kris Krüg
+  meta_description: "Kris Krüg's bat signal for Futureproof Festival of AI: three days of art, technology and honest AI conversation in Vancouver, October 28-30, 2026."
 images:
+- file: images/futureproof-salmon-starfield-share-20260711.jpg
+  alt: Futureproof Festival key art with coral salmon and ravens moving toward a bright portal under an aurora. Text reads Futureproof Festival, October 28-30, 2026, presented by BC+AI.
+  role: featured-graphic
+  source: https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260711.jpg
+  credit: Futureproof Festival art layer.
 - file: images/vanai-meetup31-stage-kris-futureproof-slide.webp
-  alt: 'Kris Krüg speaks on stage at Vancouver AI Meetup #31, in front of a Futureproof
-    slide reading Vancouver, we need to talk about AI, with salmon and skyline
-    artwork behind him.'
-  role: lead
+  alt: Kris Krüg speaks on stage at Vancouver AI Meetup #31 in front of a Futureproof slide reading Vancouver, we need to talk about AI.
+  role: opening-proof
   source: https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/large/b4717426bf89.webp
   credit: 'Photo: Michael Caswell. Edited: Kris Krüg.'
-- file: images/vanai-meetup31-audience-wide-shot.webp
-  alt: 'A wide shot from the back of the room, a full silhouetted audience facing
-    the lit Futureproof stage and screen during Vancouver AI Meetup #31.'
+- file: images/vanai-meetup31-community-group-photo.webp
+  alt: Dozens of Vancouver AI Meetup #31 participants gather on and in front of the stage for a closing group photo.
   role: community-room
-  source: https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/large/639c78efe5d2.webp
+  source: https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/large/7414cf190634.webp
   credit: 'Photo: Michael Caswell.'
+- file: images/receipt-true-north-media-house.png
+  alt: MediaShift's 2010 article documenting True North Media House and the citizen media hub at the Vancouver Olympics.
+  role: archival-receipt
+  source: https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/
+  credit: Screenshot of MediaShift for editorial reference, captured August 12, 2026.
+- file: images/receipt-tedx-summit-kris-krug.png
+  alt: TED Blog's 2012 article naming Kris Krüg as a TEDxSummit photographer.
+  role: archival-receipt
+  source: https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/
+  credit: Screenshot of TED Blog for editorial reference, captured August 12, 2026.
+- file: images/receipt-dent-kris-krug.png
+  alt: Kris Krüg's 2023 DENT article with a group photograph from the conference.
+  role: archival-receipt
+  source: https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/
+  credit: Screenshot of KrisKrug.co, captured August 12, 2026.
+- file: images/vanai-space-centre-courtyard-community.webp
+  alt: Vancouver AI attendees talk in small groups across the Space Centre courtyard.
+  role: participation-proof
+  source: https://www.futureproof.website/photos/community/futureproof-photo-library/web/fph-011-ai-june-michellediamond-115.webp
+  credit: 'Photo: Michelle Diamond.'
+- file: images/space-centre-community-night.webp
+  alt: The H.R. MacMillan Space Centre glows pink and blue at night while people gather inside.
+  role: venue-proof
+  source: https://www.futureproof.website/photos/community/futureproof-photo-library/web/fph-097-nov2025-bcai-michellediamond-25.webp
+  credit: 'Photo: Michelle Diamond.'
 - file: images/futureproof-honest-conversation-poster.png
-  alt: Futureproof Festival poster with silhouetted figures walking toward a golden-lit
-    portal under ornate arches. White type reads The most honest AI conversation
-    happening anywhere this year. Dates Vancouver Oct 28-30, 2026.
-  role: official-graphic
+  alt: Futureproof Festival poster showing people gathered in a circle beneath an aurora, rising salmon, and a raven. Text reads The most honest AI conversation happening this year, Vancouver, October 28-30, 2026.
+  role: official-campaign-art
   source: https://www.futureproof.website/graphics/honest-conversation/futureproof-honest-conversation-poster.png
-- file: images/manifesto-01-future-cultural-question.webp
-  alt: Hand-painted Futureproof poster reading The Future Is a Cultural Question
-    over an aurora above a forested shoreline with salmon and painted eyes.
-  role: gallery-1
-  source: https://www.futureproof.website/graphics/manifesto/manifesto-01-future-cultural-question.webp
-- file: images/manifesto-06-who-shapes-us.webp
-  alt: Hand-painted Futureproof poster reading Who Gets to Shape What Shapes Us
-    over rivers running through open hands.
-  role: gallery-2
-  source: https://www.futureproof.website/graphics/manifesto/manifesto-06-who-shapes-us.webp
-- file: images/manifesto-14-places-to-think.webp
-  alt: Hand-painted Futureproof poster reading The Future Needs Places to Think
-    over a quiet tidepool reflecting stars.
-  role: gallery-3
-  source: https://www.futureproof.website/graphics/manifesto/manifesto-14-places-to-think.webp
-- file: images/futureproof-salmon-starfield-share-20260527.jpg
-  alt: Futureproof launch key art with coral salmon swimming toward a bright portal
-    under aurora and stars. Title type FUTUREPROOF FESTIVAL, October 28-30, 2026,
-    presented by BC+AI.
-  role: gallery-4
-  source: https://www.futureproof.website/media/launch/futureproof-salmon-starfield-share-20260527.jpg
+  credit: Futureproof Festival art layer.
 ---
 
-Last month I stood on a stage in front of a room that shouldn't have been full on a Wednesday night, and it was full anyway.
+On July 29, I stood onstage at [Vancouver AI Meetup #31](https://bc-ai.ca/events/vancouver-ai-meetup-2026-07) in front of a room that had no business being full on a Wednesday night. It was full anyway.
 
-Behind me: a slide painted with salmon and ravens and northern lights, the type reading **VANCOUVER, WE NEED TO TALK ABOUT AI.** In front of me: the Vancouver AI community, meetup number thirty-one, still showing up almost three years in. Michael Caswell caught the frame. I'm the guy mid-sentence, pointing at something I clearly believe.
+Behind me, salmon, ravens, northern lights, and seven words in very large type: **VANCOUVER, WE NEED TO TALK ABOUT AI.** In front of me, the crew that has kept showing up month after month to do exactly that. Michael Caswell caught the frame. I am mid-sentence, pointing at something I clearly believe.
 
-![Kris Krüg speaks on stage at Vancouver AI Meetup #31, in front of a Futureproof slide reading Vancouver, we need to talk about AI, with salmon and skyline artwork behind him.](images/vanai-meetup31-stage-kris-futureproof-slide.webp)
+![Kris Krüg speaks on stage at Vancouver AI Meetup #31 in front of a Futureproof slide reading Vancouver, we need to talk about AI.](images/vanai-meetup31-stage-kris-futureproof-slide.webp)
 
-That's not a metaphor for Futureproof. That's the rehearsal. The room already exists. I'm asking it to get bigger for three days in October.
+That night was not a metaphor for Futureproof. It was a rehearsal. The room already exists. I am asking it to get bigger for three days in October.
 
-I told the fuller origin story, FATALE and all, in [*The Long Road to Futureproof*](https://kriskrug.co/2026/06/01/long-road-to-futureproof/). This one isn't that story again. This one is about who's invited.
+[[VIDEO-MEETUP-31]]
+
+The [full recording](https://www.youtube.com/watch?v=YitQ4fNEDW8&t=1144s) starts the Futureproof part at 19:04. The [photo gallery](https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/index.html) shows what the camera onstage cannot: the people, the side conversations, and the room doing its real work.
+
+I told the origin story, including the FATALE name and the long road here, in [*The Long Road to Futureproof*](https://kriskrug.co/2026/06/01/long-road-to-futureproof/). This is the next chapter. It is about the rooms that taught me what to build, the Vancouver community already proving the model, and who I want beside us when the doors open.
 
 >>> Three decades on the internet. This is my bat signal.
 
+## The room already exists
+
+[Vancouver AI](https://kriskrug.co/vancouver-ai/) began in January 2024 as a monthly gathering in my studio. Eighty people squeezed into the first one. By July 2026 we were at meetup thirty-one, filling the Space Centre and producing an archive of talks, transcripts, photographs, demos, arguments, and very strange hallway conversations.
+
+The deeper story is in [*Zero to One: From Meetup to Movement*](https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/). The short version is that the meetup grew a spine. [BC + AI](https://bc-ai.ca/about) gave the work a nonprofit home, regional relationships, member programs, weekly office hours, film nights, hackathons, education work, and hundreds of people willing to keep showing up. Thousands of seats have been filled since the first gathering. The exact count matters less than the repetition: this is not one lucky sold-out night.
+
+![Dozens of Vancouver AI Meetup #31 participants gather on and in front of the stage for a closing group photo.](images/vanai-meetup31-community-group-photo.webp)
+
+The community has been practising what Futureproof needs: ceremony before slides, relationships before transactions, artists beside engineers, skeptics beside builders, and enough trust to disagree without turning the room into a blood sport.
+
+Futureproof did not arrive from a branding workshop. It grew out of those monthly rooms. [BC + AI's companion story](https://bc-ai.ca/news/futureproof-festival-regional-story-national-invitation) carries the regional invitation. This essay carries mine.
+
 ## The receipts, not the résumé
 
-I don't love talking about myself in the third-person conference-bio voice, all shiny awards and self-importance. So here's the version with names, years, and links instead. Someone once called me an international badass man of mystery. Cute. What I actually am is a guy who kept showing up to rooms with a camera until the rooms started trusting me with more than the photos.
+I do not love the third-person conference-bio voice, all polished credentials and suspiciously shiny adjectives. Someone once called me an international badass man of mystery. Cute. What I actually did was keep showing up with a camera until rooms started trusting me with more than the photographs.
 
-Before any of this was AI, it was:
+Before the AI conversation swallowed the calendar, there were other rooms:
 
-- **[Northern Voice](https://en.wikipedia.org/wiki/Northern_Voice)**, 2005 to 2013. Vancouver's own blogging and social-software conference, and I was one of the people who organized it, alongside Darren Barefoot, Boris Mann, and a dozen other Vancouver internet weirdos. First time I turned a scene into a conference. Not the last.
-- The **[2010 Winter Olympics](https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/)**, right here in this city. I wasn't credentialed press. I helped build **True North Media House**, an independent media hub for bloggers and citizen journalists who had no other seat at the world's biggest media event. That's the actual precedent for "non-extractive." I've done it before, at a bigger scale than this festival, with worse funding.
-- **[PopTech](https://www.flickr.com/photos/kk/albums/72157608995273506/)**, Camden, Maine, on and off from 2008 through 2013. PopTech's own account still credits the photos. Years of watching scientists, artists, and activists get put in one room on purpose.
-- **[TEDxSummit](https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/)**, Morocco, 2012, where TED's own blog called me "one of our photographers and a longtime friend of TEDx." Plus TEDxVancouver, TEDxOilSpill, and a few other cities. One format, endlessly local.
-- **[SXSW Interactive](https://www.flickr.com/photos/kk/albums/72157649379627911/)**, Austin, 2013. Eight hundred and one photos from one festival, because thirty thousand people in one convention center still has a hundred small rooms inside it if you look for them.
-- **[DENT](https://www.flickr.com/photos/kk/collections/72157691620626391/)**, Sun Valley and beyond, official photographer since 2014. I've called DENT a family reunion in public before, and I meant it. Creativity meets community, ideas take flight, you learn to karate spar with people you'll see again next year.
+- **[Northern Voice](https://en.wikipedia.org/wiki/Northern_Voice), Vancouver, 2005 to 2013.** Darren Barefoot, Boris Mann, Brian Lamb, and a crew of Vancouver internet weirdos turned a blogging and social-software scene into a conference. I helped organize it. It taught me that a community event can be scrappy and still become civic infrastructure.
+- **[True North Media House](https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/), Vancouver, 2010.** We helped build True North Media House, a virtual accreditation and coordination network outside the official Olympic press system, while W2 provided the physical workspace for independent media. That is the lineage behind Futureproof's insistence that the people affected by a system deserve a place in the conversation.
+- **[PopTech](https://www.flickr.com/photos/poptech/10468089914), Camden, Maine, 2008 to 2013.** PopTech's own archive credits my photography. I watched scientists, artists, technologists, and activists get put in one room on purpose, years before "multidisciplinary" became conference wallpaper.
+- **[TEDxSummit](https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/), Doha, Qatar, 2012.** TED's blog called me "one of our photographers and a longtime friend of TEDx." The lesson was not the red carpet. It was how a common format can travel across cities while each local community keeps its own voice.
+- **[SXSW Interactive](https://www.flickr.com/photos/kk/albums/72157649379627911/), Austin, 2013.** I made 801 photographs while roughly thirty thousand people spread across downtown. Even at that scale, the memorable thing was still a human-sized room inside the machine.
+- **[DENT](https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/), Sun Valley and beyond, since 2014.** I have photographed DENT for years and called it a family reunion because that is how it feels. People return. Trust compounds. The conference becomes part of your life instead of a transaction that vanishes with the lanyard.
 
-None of that is a flex. It's a pattern. Every one of those rooms taught me the same four things, and I never got to build my own version of the room until now.
+![MediaShift's 2010 article documenting True North Media House and the citizen media hub at the Vancouver Olympics.](images/receipt-true-north-media-house.png)
 
-## What twenty years behind the lens actually teaches you
+*[True North Media House](https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/), documented by MediaShift in 2010.*
 
-**The room is the product.** Not the stage, not the swag, not the sponsor logos. The unglamorous folding chairs and the hallway where the real conversation happens after the panel ends.
+![TED Blog's 2012 article naming Kris Krüg as a TEDxSummit photographer.](images/receipt-tedx-summit-kris-krug.png)
 
-**Hallways matter more than keynotes.** Every event I named above, the thing people remembered a year later happened between sessions, not during them.
+*[TED Blog](https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/), 2012.*
 
-**Art and disagreement belong beside the technology, not after it.** PopTech knew this in 2008. DENT knows it every year. Most AI conferences in 2026 still don't.
+![Kris Krüg's 2023 DENT article with a group photograph from the conference.](images/receipt-dent-kris-krug.png)
 
-**Audiences are participants, not tickets.** True North Media House existed because the Olympics' official media system had no room for the people the Games actually affected. Futureproof exists for the same reason, aimed at AI instead of a sporting event.
+*[DENT the Future](https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/), from my own archive.*
 
-![A wide shot from the back of the room, a full silhouetted audience facing the lit Futureproof stage and screen during Vancouver AI Meetup #31.](images/vanai-meetup31-audience-wide-shot.webp)
+Those screenshots are not decoration. They are public receipts. Links rot, bios inflate, and memory gets heroic when nobody checks it. I want this festival built on the opposite habit: name the people, show the source, keep the record.
 
-## Why Futureproof, why now, why Vancouver
+## What twenty years behind the lens taught me
 
-I started [Vancouver AI](https://vancouver.ai/) as Thursday nights, because you can't summon a founding festival out of a cold invite. You stack the small rooms until the scene can see itself. Then [BC + AI](https://bc-ai.ca/) became the nonprofit skeleton, because paperwork is where good ideas either become real or die of neglect. As of this writing that's **300 members**, **3,000+ people through the doors**, and **94+ documented events** since 2023. That's not my achievement. That's what a community builds when you stay out of its way and bring folding chairs.
+The room is the product. Stages, swag, and sponsor walls are furniture. The actual product is whether someone can walk in alone, find a conversation worth joining, and leave with a relationship that survives the closing slide.
 
-[Futureproof](https://futureproof.website/) is the next body growing out of that soil, built by BC + AI and this community, not by me alone. [Kevin Friel](https://www.futureproof.website/speakers/kevin-friel/) brings the BC + AI Film Club with him. A [growing public roster](https://www.futureproof.website/speakers/) of speakers is saying yes. Michael Caswell and Tristan Brand were the ones actually pointing cameras at the room the night this article opens on, because the guy who spent twenty years photographing other people's conferences finally gets to be caught in someone else's frame for a change.
+Hallways carry half the program. The talk gives people a shared object. The five minutes afterward, when two strangers compare notes beside a badly placed coffee urn, is where the object becomes useful.
 
-Vancouver, specifically, because I've spent more than a decade photographing rooms where people arrive as one version of themselves and leave a little rewired. You learn fast which venues are rentals and which ones are home. The [H.R. MacMillan Space Centre](https://www.hrmacmillanspacecentre.com/), with the Pacific outside and a planetarium dome overhead, is home.
+Art and disagreement belong beside the technology. They are not garnish for the reception. Too many AI events I have attended put product demos at the centre and invite culture in later to make the program look human. Futureproof starts with the humans already in the room.
 
-![Futureproof Festival poster with silhouetted figures walking toward a golden-lit portal under ornate arches. White type reads The most honest AI conversation happening anywhere this year. Dates Vancouver Oct 28-30, 2026.](images/futureproof-honest-conversation-poster.png)
+Audiences are participants. A good gathering gives people jobs to do: ask the sharper question, show the unfinished thing, challenge the premise, introduce two people, document what happened, or make the next room possible.
 
-## The bat signal
+![Vancouver AI attendees talk in small groups across the Space Centre courtyard.](images/vanai-space-centre-courtyard-community.webp)
 
-If you stacked chairs with me at Northern Voice. If you were in Camden, Sun Valley, Austin, or that room in Morocco. If you've sat in a Vancouver AI meetup, argued with me in a hallway, taught a workshop, opened with ceremony, photographed a room I was also photographing, or just kept showing up when the room was still half empty: this is the call.
+That is why Futureproof brings talks, film, creative work, demos, live performance, and room for conversations that are not onstage. The format should create useful collisions without manufacturing them. If every minute is programmed, nobody has time to become part of the story.
 
->>> Come make the room bigger. Bring your better questions, and bring the people you know who ask them too.
+## Why Futureproof Festival of AI, why now, why Vancouver
 
-Speakers, builders, artists, photographers, organizers, skeptics, founders, and the gloriously unclassifiable people every good conference collects by accident. Old network, new network, doesn't matter. I'm not asking you to attend a product launch with better lighting. I'm asking you to help hold a room that can stay honest without collapsing into hype or panic.
+[Futureproof Festival of AI](https://www.futureproof.website/) is an international AI culture and ideas festival in Vancouver, October 28 to 30, 2026. Opening night leads into two full program days at the [H.R. MacMillan Space Centre](https://www.spacecentre.ca/), with the film festival closing party carrying us out the other side.
 
-[[GALLERY-MANIFESTO]]
+The editorial line is simple: critique in one hand, curiosity in the other. No hype. No panic. We need a place where an artist can question the training data, a founder can show a working tool, an educator can talk about what is happening in classrooms, an Indigenous leader can challenge the assumptions underneath the system, and a skeptic can stay in the room long enough to hear something unexpected.
 
-## Come make it real
+The [public speaker roster](https://www.futureproof.website/speakers/) is already bringing together people from archives, design, healthcare, film, research, public-interest work, startups, and community building. Kevin Friel is carrying the [BC + AI Film Club](https://www.futureproof.website/speakers/kevin-friel/) thread into the festival. More of the program will become public as it is ready. I would rather publish a real name late than a fantasy schedule early.
 
-Everything below lives on the festival's own site, because prices and deadlines move faster than this post should try to track:
+![The H.R. MacMillan Space Centre glows pink and blue at night while people gather inside.](images/space-centre-community-night.webp)
 
-- **[Futureproof Festival](https://futureproof.website/)**, October 28-30, 2026, H.R. MacMillan Space Centre, Vancouver.
-- **[RSVP on Luma](https://luma.com/futureproof-festival)**
-- **[Tickets](https://www.futureproof.website/tickets/)**, Earlyworm pricing through August 15, standard pricing after.
-- **[Call for Talks](https://www.futureproof.website/call-for-talks/)**, open through August 15. First-time speakers and rough first drafts genuinely welcome.
-- **Sponsor or exhibit?** Start on the [tickets](https://www.futureproof.website/tickets/) page and find the rest of us through [BC + AI](https://bc-ai.ca/) and the [events calendar](https://bc-ai.ca/events).
+Vancouver matters here. This city knows how to build strange combinations: technology and land, cinema and software, activism and design, ceremony and experimentation. It also knows how to sell itself a little too easily. Futureproof should be honest about both. The [official venue page](https://www.futureproof.website/venues/) shows the Space Centre as it actually works, full of people, not as an empty rental brochure.
 
-I've been building toward this room since before I knew its name. Three decades on the internet, most of them spent photographing rooms like it, and the guest list is everyone who ever let me stand in theirs.
+![Futureproof Festival poster showing people gathered in a circle beneath an aurora, rising salmon, and a raven. Text reads The most honest AI conversation happening this year, Vancouver, October 28-30, 2026.](images/futureproof-honest-conversation-poster.png)
 
-**[Build what lasts.](https://futureproof.website/)**
+## The bat signal: who belongs in the room
+
+If you stacked chairs with me at Northern Voice, worked beside us during the Olympics, or crossed paths in Camden, Doha, Austin, or Sun Valley, this is the call.
+
+If you have sat in a Vancouver AI meetup, taught a workshop, opened with ceremony, screened a film, built a prototype, challenged me in a hallway, photographed the room, or helped clean it after everyone left, this is also the call.
+
+If we have never met but you are trying to build technology without surrendering culture, judgment, consent, or joy, there is a chair for you too.
+
+>>> Come make the room bigger. Bring your better questions, and bring the people who ask them.
+
+I am not inviting you to a product launch with better lighting. I am asking you to help hold a room that can stay honest without collapsing into boosterism or doom. Speakers, builders, artists, photographers, organizers, educators, policymakers, researchers, founders, skeptics, students, and the gloriously unclassifiable people every useful conference collects by accident.
+
+## Futureproof dates, tickets, and ways to take part
+
+Choose the door that fits:
+
+- **Attend:** [compare the passes](https://www.futureproof.website/tickets/) on the festival site, then [register on Luma](https://luma.com/futureproof-festival), where current availability is kept.
+- **[Propose a talk](https://www.futureproof.website/call-for-talks/):** first-time speakers and rough first drafts are welcome. If you are reading this before August 15, 2026, the current call is still open. Check the page for live status after that date.
+- **[Bring a working product](https://www.futureproof.website/startup-exhibitors/):** the Startup Exhibitor path is for small crews who want people to try something real, not stare at a logo wall.
+- **[Support the room](https://www.futureproof.website/sponsors/):** the sponsor page lays out the partnership options and what each package includes.
+- **[Meet the speakers](https://www.futureproof.website/speakers/):** use the live roster rather than an old list copied into somebody else's article.
+- **[Follow the wider scene](https://kriskrug.co/ai-events/):** my AI events archive has the recaps, talks, field notes, and other rooms feeding this one.
+
+The Earlyworm ticket window currently runs through August 15, 2026. After that, the official ticket and Luma pages remain the source of truth. Prices and deadlines move. The invitation does not.
+
+![Futureproof Festival key art with coral salmon and ravens moving toward a bright portal under an aurora. Text reads Futureproof Festival, October 28-30, 2026, presented by BC+AI.](images/futureproof-salmon-starfield-share-20260711.jpg)
+
+This is the first Futureproof Festival. It is not the first room.
+
+Three decades on the internet, most of them spent photographing gatherings like this, and the guest list is everyone who ever let me stand in theirs.
+
+**[Build what lasts.](https://www.futureproof.website/)**

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/research-polish-v2.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/research-polish-v2.md
@@ -1,0 +1,73 @@
+# Futureproof article polish v2: source and editorial brief
+
+**Prepared:** 2026-08-12
+**Target:** KrisKrug.co WordPress post `12732`
+**Publication state:** Live at `https://kriskrug.co/2026/08/11/futureproof-festival-announcement/`. The guarded v2 sync itself was draft-only; publication happened in a later WordPress action.
+
+## Thesis
+
+Futureproof Festival of AI is not a cold conference launch. It is the next room in a lineage that runs from Northern Voice and True North Media House through PopTech, TEDx, SXSW, DENT, Vancouver AI, and BC + AI. The article should prove that lineage, show the existing community, and give readers several specific ways into the festival.
+
+## Audience and search intent
+
+- People searching for **Futureproof Festival of AI in Vancouver**.
+- Kris's older conference, photography, and open-web network.
+- Vancouver and BC builders, artists, educators, researchers, public-interest practitioners, and curious skeptics.
+- Readers looking for tickets, speakers, talk submissions, startup exhibiting, or sponsorship.
+
+## Corrections from the prior draft
+
+- TEDxSummit 2012 was in **Doha, Qatar**, not Morocco.
+- The canonical Space Centre URL is `https://www.spacecentre.ca/`. The prior `hrmacmillanspacecentre.com` destination is a parked domain despite returning HTTP 200.
+- Vancouver AI began as a monthly room in January 2024; “Thursday nights” was too broad and was contradicted by Meetup #31 taking place on Wednesday.
+- “300 members,” “3,000+ people,” and “94+ events” had conflicting definitions across public and internal sources. The rewrite uses conservative language: hundreds of members and thousands of seats filled.
+- DENT is phrased as “photographed for years,” avoiding an independently unverified “official photographer” claim.
+- SXSW is described as spread across downtown Austin, not inside one convention centre.
+- Luma is registration, not an RSVP.
+- True North Media House is described as the virtual accreditation and coordination network; W2 is correctly identified as the physical independent-media workspace.
+- Program language is limited to currently published formats: talks, film, creative work, demos, live performance, and conversation.
+
+## Primary current sources
+
+- Futureproof homepage: https://www.futureproof.website/
+- Tickets: https://www.futureproof.website/tickets/
+- Speakers: https://www.futureproof.website/speakers/
+- Call for Talks: https://www.futureproof.website/call-for-talks/
+- Sponsors: https://www.futureproof.website/sponsors/
+- Startup exhibitors: https://www.futureproof.website/startup-exhibitors/
+- Venue: https://www.futureproof.website/venues/
+- Space Centre: https://www.spacecentre.ca/
+- Meetup #31 archive: https://bc-ai.ca/events/vancouver-ai-meetup-2026-07
+- Meetup #31 recording: https://www.youtube.com/watch?v=YitQ4fNEDW8&t=1144s
+- Meetup #31 gallery: https://pub-163cd0d1569e46f48b869a9070f97d71.r2.dev/events/vancouver-ai-meetup-2026-07/index.html
+- BC + AI companion story: https://bc-ai.ca/news/futureproof-festival-regional-story-national-invitation
+
+## Historical receipts
+
+- Northern Voice: https://en.wikipedia.org/wiki/Northern_Voice
+- True North Media House: https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/
+- PopTech organization credit: https://www.flickr.com/photos/poptech/10468089914
+- TEDxSummit: https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/
+- SXSW Interactive album: https://www.flickr.com/photos/kk/albums/72157649379627911/
+- DENT first-person archive: https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/
+
+## Visual narrative
+
+1. Branded salmon-starfield graphic as featured/OG media.
+2. Meetup #31 stage photograph as the opening proof.
+3. Full Meetup #31 recording embedded at the opening.
+4. Meetup #31 closing group photograph to establish the existing community without carrying an expired ticket offer in the frame.
+5. Three public-source screenshots as historical receipts.
+6. Approved Michelle Diamond FPH-011 courtyard photograph for community participation.
+7. Michelle Diamond Space Centre night photograph for place.
+8. One official campaign poster at the festival pivot.
+9. Salmon-starfield artwork at the closing invitation.
+
+The old three-poster manifesto grid was removed. It repeated campaign art without adding evidence or narrative variety.
+
+## Volatile follow-up checks
+
+- The August 15, 2026 Call for Talks and Earlyworm statements passed the publication-day check. Recheck or remove them after the deadline.
+- Keep using the live speaker roster rather than copying a fixed count into the article.
+- Production checks confirmed the August 11 publication date, canonical URL, SEO metadata, approved OG image, and `BlogPosting` schema.
+- Confirm credited cross-site reuse for the Michael Caswell photographs as a post-public follow-up. Michelle Diamond frames FPH-011 and FPH-097 have an explicit public-reuse receipt.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/seo-meta.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/seo-meta.md
@@ -1,45 +1,43 @@
-# SEO snapshot: The Bat Signal: Why I'm Building Futureproof Festival in Vancouver
+# SEO package: Futureproof Festival of AI
 
-Updated 2026-08-11 for #500. The visible title now keeps the bat-signal hook while making the subject explicit.
+Updated 2026-08-12 for the deeper v2 article.
 
 | Field | Value |
 |---|---|
-| Visible title (H1) | The Bat Signal: Why I'm Building Futureproof Festival in Vancouver |
-| SEO title (`<title>`) | Building Futureproof Festival in Vancouver \| Kris Krüg |
-| Slug | `futureproof-festival-announcement` (unchanged; permalink `/2026/08/11/futureproof-festival-announcement/` once dated) |
-| Meta description | Kris Krüg's network bat signal for Futureproof Festival, Oct 28-30 2026 in Vancouver. Receipts from PopTech to DENT. The invitation is the point. |
+| Authoring title | **Futureproof Festival of AI: A Bat Signal from Vancouver** |
+| SEO title | **Futureproof Festival of AI in Vancouver \| Kris Krüg** |
+| Focus keyphrase | `Futureproof Festival of AI in Vancouver` |
+| Secondary phrases | `Vancouver AI festival 2026`; `Futureproof Festival Vancouver`; `Kris Krüg Futureproof` |
+| Slug | `futureproof-festival-announcement` (preserved to keep draft identity stable) |
+| Meta description | **Kris Krüg's bat signal for Futureproof Festival of AI: three days of art, technology and honest AI conversation in Vancouver, October 28-30, 2026.** |
+| Excerpt | **Futureproof Festival of AI is the room Vancouver has been rehearsing for, three days of art, technology, argument, and better questions at the Space Centre.** |
 | Category | Vancouver AI Ecosystem |
-| Tags | Futureproof, BC + AI, Vancouver AI, Festival, Space Centre, Build What Lasts |
-| Excerpt | Decades of photographing other people's rooms taught me what makes one worth building. Futureproof is the room. This is the invitation to everyone who ever let me stand in theirs. |
-| Featured | YES (hero: `images/vanai-meetup31-stage-kris-futureproof-slide.webp`, per #644's preferred lead; `featured_media_id` assigned at #500 upload) |
-| Schema | Article (auto via kk-schema mu-plugin if deployed) |
-| OG image | Meetup #31 stage photo (2400x1600 landscape, safe OG crop). Landscape alternate if needed: `images/futureproof-salmon-starfield-share-20260527.jpg` (1200x630) |
-| Twitter Card | summary_large_image (Jetpack default) |
+| Schema | `BlogPosting`; do not add `Event` schema to this founder essay |
+| Featured / OG | Approved 1200×630 salmon-starfield graphic `futureproof-salmon-starfield-share-20260711.jpg`, WordPress media `12739` |
+| Twitter card | `summary_large_image` |
 
-## Character counts (SERP-safe)
+## Length gates
 
-| Field | Chars | Target |
-|---|---|---|
-| SEO title | 54 | ≤60 |
-| Meta description | 130 | 140-160 (slightly short; OK for voice, matches prior package's tolerance) |
+| Field | Characters | Gate |
+|---|---:|---|
+| Authoring title | 55 | descriptive and compact |
+| SEO title | 51 | ≤60 |
+| Meta description | 146 | 140–160 |
+| Excerpt | 156 | editorial excerpt, not a SERP field |
 
-## What changed from the July 26 snapshot
+## Search and entity decisions
 
-- **Title:** "The Bat Signal" → "The Bat Signal: Why I'm Building Futureproof Festival in Vancouver." The hook stays, but a reader no longer has to guess what the post is about.
-- **Featured image:** switched from the honest-conversation poster to the Meetup #31 stage photo, per #644's curation. The poster is now an official-graphic supporting image in the body, not the hero.
-- **Meta description:** no longer states ticket price or dates (those live on futureproof.website and move independently); instead names the two things this specific article does that the live origin post and the July 26 draft don't: the conference-lineage receipts and the direct invitation.
+- The H1, SEO title, first festival description, and metadata use the full canonical name **Futureproof Festival of AI**.
+- “Vancouver” disambiguates this event from similarly named US finance events.
+- Transactional intent remains on canonical festival pages for tickets, speakers, talk submissions, sponsors, and exhibitors.
+- The article adds five contextual KrisKrug.co internal links and links the BC + AI companion article instead of duplicating its regional framing.
+- The featured graphic is a dedicated 1.91:1 share asset rather than a 3:2 event photograph. The stage photograph stays as the opening editorial image.
 
-## OG / social notes
+## Production verification
 
-- Prefer the Meetup #31 stage photo as featured. It is landscape (2400×1600), which is safer for OG/card crops than the July 26 poster's portrait 1200×1800.
-- If a landscape alternate is still wanted, the salmon-starfield share JPEG remains the fallback (already used as kriskrug.co homepage Futureproof pillar art).
-- Share copy cue (not published here): "Three decades on the internet. This is my bat signal. Futureproof, Oct 28-30, Vancouver."
-- Do not invent speakers beyond what's linked to the live public roster; this draft intentionally does not hard-code names (see `speakers.md` #645 addendum).
-- Do not resurrect "The baby is here" language in social captions drawn from this piece; it belongs to the prior draft's framing, not this one's.
-
-## Next-step checks after #500 draft create (not this issue)
-
-- View source on draft preview: confirm `<meta name="description">` matches above.
-- Confirm featured image attached and `status=draft`.
-- Cards preview after KK voice sign-off, before public publish.
-- Re-confirm Earlyworm/Call for Talks dates are still both August 15 at time of draft create; if either festival-site date has moved, this package's "Come make it real" section links out rather than hard-coding, so only the VERIFY.md fact table needs a re-check, not the article body.
+- Canonical URL: `https://kriskrug.co/2026/08/11/futureproof-festival-announcement/`, HTTP 200.
+- The browser title uses the exact SEO title. The front end renders the authoring title as H1 **Futureproof Festival of AI** plus subtitle **A Bat Signal from Vancouver**.
+- The 146-character description, approved `12739` OG image, `summary_large_image` card, and `BlogPosting` block are present.
+- The live page has nine body images, one video iframe, responsive images, and no horizontal overflow at desktop or mobile widths.
+- Recheck or remove the August 15 deadline language after the deadline passes.
+- Add descriptive inbound links from the Long Road article, Vancouver AI hub, and AI Events hub as a separate scoped edit.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/speakers.md
@@ -6,7 +6,7 @@ The official public directory currently lists 13 speakers: Amber Case, Ana Serra
 
 This was refreshed again immediately before merge. Jos Duncan-Ase is on the current directory; Kaoru Yoshihira appears only in the dated July 26 snapshot preserved below and is no longer in the current public roster.
 
-The article does not reproduce this volatile roster. It names Kevin Friel in a specific community-credit sentence and links his live public profile; otherwise it links the canonical speaker directory. Recheck the directory immediately before public publication.
+The live article does not reproduce this volatile roster. It names Kevin Friel in a specific community-credit sentence and links his public profile; otherwise it links the canonical speaker directory. Recheck the directory before any speaker-specific follow-up.
 
 Verified **2026-07-26T19:47Z** against public web only.
 

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/00-summary.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/00-summary.md
@@ -1,0 +1,9 @@
+# Voice audit v2 summary
+
+**Verdict:** Voice-ready; live rendering verified.
+
+- Mechanical checker: 0 findings across Markdown and Gutenberg HTML.
+- Manual facet: Host with Anti-Hero edge.
+- Strongest voice beats: exact opening scene, receipts-over-résumé section, distributed credit, the room-as-product argument, and the final “first festival / not first room” turn.
+- No further voice revision is required.
+- Current facts, links, featured-card crop, and rendered metadata passed the 2026-08-12 production check. Photo-credit confirmation and the post-August-15 deadline refresh remain follow-ups.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/slop-check-findings.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/slop-check-findings.md
@@ -1,0 +1,9 @@
+# Mechanical slop findings
+
+`voicecheck.py --json` returned **0 findings** across `post.md` and `post.html` on 2026-08-12.
+
+- No authored em dashes.
+- No banned anti-glossary phrases.
+- No spelling violations for Kris Krüg or BC + AI.
+
+Mechanical cleanliness is not the voice verdict; the manual read is in `voice-alignment-report.md`.

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/slop-check-raw.json
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/slop-check-raw.json
@@ -1,0 +1,7 @@
+{
+  "total": 0,
+  "files": {
+    "content/drafts/2026-07-26-futureproof-festival-announcement/post.md": [],
+    "content/drafts/2026-07-26-futureproof-festival-announcement/post.html": []
+  }
+}

--- a/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/voice-alignment-report.md
+++ b/content/drafts/2026-07-26-futureproof-festival-announcement/voice-audit-v2/voice-alignment-report.md
@@ -1,0 +1,23 @@
+# Voice alignment report
+
+## Facet
+
+**The Host**, with **Anti-Hero** edge. The piece invites an old and new network into a real room while distrusting conference mythology, inflated bios, and hype.
+
+## Manual five-question pass
+
+1. **Would Kris say it?** Yes. “The room already exists,” “suspiciously shiny adjectives,” “badly placed coffee urn,” and “the gloriously unclassifiable people” carry conversational specificity without cosplay slang.
+2. **Does it credit others?** Yes. Michael Caswell, Michelle Diamond, Kevin Friel, Darren Barefoot, Boris Mann, and Brian Lamb are named. BC + AI and Vancouver AI are builders of the room, not scenery for a solo-founder story.
+3. **Are there real examples?** Yes. Meetup #31, the 19:04 video timestamp, six conference receipts, the Space Centre, exact festival dates, and six participation paths keep the article grounded.
+4. **Is banned language hiding?** No mechanical hits. The manual read found no reworded “not just X, but Y,” no “at its core,” no fake vulnerability, and no AI-generated conclusion recap.
+5. **Has it been polished into corporate nothing?** No. The article keeps friction: Vancouver can sell itself too easily, links rot, bios inflate, and the room must hold critique without boosterism or doom.
+
+## Judgment calls
+
+- The long invitation list near the end is deliberate. It names the mixed room rather than padding a generic CTA.
+- “This is the first Futureproof Festival. It is not the first room.” is a contrast, but it resolves the evidence established throughout the article rather than performing an empty redefinition reveal.
+- The six-item historical list is dense. The screenshot gallery and short follow-on paragraph break the rhythm before the framework section.
+
+## Verdict
+
+Voice-ready. The live WordPress rendering preserves the intended title treatment, visual rhythm, and evidence sequence. Photo-credit confirmation and the post-August-15 deadline refresh remain operational follow-ups, not voice changes.

--- a/scripts/notion-to-wp/sync_futureproof_polish_v2.py
+++ b/scripts/notion-to-wp/sync_futureproof_polish_v2.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Safely sync the Futureproof v2 package to its existing private WP draft.
+
+The command is authenticated and read-only by default. ``--apply`` snapshots
+the complete edit-context post before uploading missing media or updating the
+post. There is deliberately no publish, delete, or restore mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import mimetypes
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from create_local_wp_draft import (  # noqa: E402
+    DraftPackage,
+    WPConfig,
+    load_package,
+    load_wp_config,
+    quality_issues,
+)
+from kk_notion_to_wp import REPO_ROOT, WordPress  # noqa: E402
+from publish_common import build_seo_meta, select_media_match  # noqa: E402
+
+TARGET_POST_ID = 12732
+TARGET_SLUG = "futureproof-festival-announcement"
+FEATURED_FILENAME = "futureproof-salmon-starfield-share-20260711.jpg"
+DEFAULT_POST_MD = (
+    REPO_ROOT
+    / "content"
+    / "drafts"
+    / "2026-07-26-futureproof-festival-announcement"
+    / "post.md"
+)
+KNOWN_MEDIA_IDS = {
+    "vanai-meetup31-stage-kris-futureproof-slide.webp": 12725,
+    "vanai-meetup31-audience-wide-shot.webp": 12726,
+    "futureproof-honest-conversation-poster.png": 12727,
+}
+SEO_META_KEYS = ("jetpack_seo_html_title", "advanced_seo_description")
+PRESERVED_FIELDS = (
+    "status",
+    "slug",
+    "categories",
+    "tags",
+    "author",
+    "date",
+    "date_gmt",
+)
+IMAGE_BLOCK_RE = re.compile(
+    r"<!-- wp:image(?: (?P<attrs>\{.*?\}))? -->"
+    r"(?P<body>.*?)"
+    r"<!-- /wp:image -->",
+    flags=re.S,
+)
+IMG_TAG_RE = re.compile(r"<img\b[^>]*>", flags=re.I)
+IMG_SRC_RE = re.compile(r'\bsrc="([^"]+)"', flags=re.I)
+IMG_CLASS_RE = re.compile(r'\bclass="([^"]*)"', flags=re.I)
+
+
+@dataclass(frozen=True)
+class Asset:
+    filename: str
+    path: Path
+    alt: str
+    role: str
+    source: str
+    credit: str
+
+    @property
+    def title(self) -> str:
+        label = self.role.replace("-", " ").strip() or self.path.stem.replace("-", " ")
+        return f"Futureproof Festival: {label.title()}"
+
+    @property
+    def caption(self) -> str:
+        parts = [part for part in (self.credit, f"Source: {self.source}" if self.source else "") if part]
+        return " ".join(parts)
+
+    @property
+    def description(self) -> str:
+        return " ".join(part for part in (self.alt, self.caption) if part)
+
+
+def raw_field(value: object) -> str:
+    if isinstance(value, dict):
+        raw = value.get("raw")
+        if raw is not None:
+            return str(raw)
+        rendered = value.get("rendered")
+        if rendered is not None:
+            return str(rendered)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def rendered_content_report(post: dict) -> dict:
+    content = post.get("content") if isinstance(post.get("content"), dict) else {}
+    raw = raw_field(content)
+    rendered = str(content.get("rendered") or "")
+    return {
+        "raw_image_count": len(IMG_TAG_RE.findall(raw)),
+        "raw_image_ids": [
+            int(value)
+            for value in re.findall(r'<!-- wp:image \{[^>]*"id":(\d+)', raw)
+        ],
+        "rendered_image_count": len(IMG_TAG_RE.findall(rendered)),
+        "rendered_iframe_count": rendered.count("<iframe"),
+        "youtube_present": "YitQ4fNEDW8" in rendered,
+        "lazy_image_count": rendered.count('loading="lazy"'),
+        "srcset_image_count": rendered.count(" srcset="),
+        "sizes_image_count": rendered.count(" sizes="),
+        "lightbox_trigger_count": rendered.count("data-wp-on--click"),
+        "has_local_or_placeholder_markers": any(
+            marker in raw + rendered
+            for marker in ('src="images/', "wp-image-TBD", "content/drafts/", "/Users/")
+        ),
+    }
+
+
+def package_assets(pkg: DraftPackage) -> dict[str, Asset]:
+    assets: dict[str, Asset] = {}
+    images_dir = (pkg.draft_dir / "images").resolve()
+    for item in pkg.frontmatter.get("images") or []:
+        relative = str(item.get("file", "")).strip()
+        if not relative:
+            raise RuntimeError("image frontmatter entry is missing file")
+        relative_path = Path(relative)
+        filename = relative_path.name
+        if Path(relative).as_posix() != f"images/{filename}":
+            raise RuntimeError(
+                f"image path must use canonical images/<filename> form: {relative!r}"
+            )
+        path = (pkg.draft_dir / relative_path).resolve()
+        if not path.is_relative_to(images_dir) or not path.is_file():
+            raise RuntimeError(
+                f"image must resolve to a regular file inside {images_dir}: {relative!r}"
+            )
+        if filename in assets:
+            raise RuntimeError(f"duplicate image filename in frontmatter: {filename}")
+        assets[filename] = Asset(
+            filename=filename,
+            path=path,
+            alt=str(item.get("alt", "")).strip(),
+            role=str(item.get("role", "")).strip(),
+            source=str(item.get("source", "")).strip(),
+            credit=str(item.get("credit", "")).strip(),
+        )
+    return assets
+
+
+def local_image_filename(src: str) -> str | None:
+    decoded = html.unescape(src)
+    parsed = urlparse(decoded)
+    if parsed.scheme or parsed.netloc:
+        return None
+    path = unquote(parsed.path).replace("\\", "/")
+    if path.startswith("./"):
+        path = path[2:]
+    candidate = Path(path)
+    if path != f"images/{candidate.name}" or candidate.name in ("", ".", ".."):
+        return None
+    return candidate.name
+
+
+def referenced_image_filenames(body_html: str) -> list[str]:
+    filenames: list[str] = []
+    for tag in IMG_TAG_RE.findall(body_html):
+        match = IMG_SRC_RE.search(tag)
+        if not match:
+            raise RuntimeError("image tag is missing src")
+        filename = local_image_filename(match.group(1))
+        if not filename:
+            raise RuntimeError(
+                f"canonical post.html contains a non-local or hotlinked image source: {match.group(1)!r}"
+            )
+        filenames.append(filename)
+    return filenames
+
+
+def assert_local_package(pkg: DraftPackage) -> dict[str, Asset]:
+    issues = quality_issues(pkg)
+    if issues:
+        raise RuntimeError("quality gate failed: " + "; ".join(issues))
+    if pkg.slug != TARGET_SLUG:
+        raise RuntimeError(f"local slug mismatch: expected {TARGET_SLUG!r}, got {pkg.slug!r}")
+    if str(pkg.frontmatter.get("status", "")).strip() != "draft":
+        raise RuntimeError("local package must remain a draft")
+    declared_featured_id = int(pkg.frontmatter.get("featured_media_id") or 0)
+    if declared_featured_id < 0:
+        raise RuntimeError("featured_media_id must be zero or a positive media id")
+
+    assets = package_assets(pkg)
+    for asset in assets.values():
+        missing_metadata = [
+            field
+            for field, value in (
+                ("alt", asset.alt),
+                ("source", asset.source),
+                ("credit", asset.credit),
+            )
+            if not value
+        ]
+        if missing_metadata:
+            raise RuntimeError(
+                f"image {asset.filename} is missing frontmatter metadata: "
+                + ", ".join(missing_metadata)
+            )
+    referenced = referenced_image_filenames(pkg.body_html)
+    if not referenced:
+        raise RuntimeError("canonical post.html has no image blocks")
+    missing_entries = sorted(set(referenced) - set(assets))
+    if missing_entries:
+        raise RuntimeError(
+            "post.html images are missing from frontmatter: " + ", ".join(missing_entries)
+        )
+    if FEATURED_FILENAME not in assets:
+        raise RuntimeError(f"frontmatter is missing featured asset {FEATURED_FILENAME}")
+    return {
+        name: assets[name]
+        for name in dict.fromkeys([*referenced, FEATURED_FILENAME])
+    }
+
+
+def assert_target_post(post: dict, pkg: DraftPackage) -> None:
+    if int(post.get("id") or 0) != TARGET_POST_ID:
+        raise RuntimeError(
+            f"target id mismatch: expected {TARGET_POST_ID}, got {post.get('id')!r}"
+        )
+    if post.get("slug") != TARGET_SLUG or post.get("slug") != pkg.slug:
+        raise RuntimeError(
+            f"target slug mismatch: WP={post.get('slug')!r}, local={pkg.slug!r}"
+        )
+    if post.get("status") != "draft":
+        raise RuntimeError(
+            f"refusing to update non-draft post {TARGET_POST_ID}: status={post.get('status')!r}"
+        )
+
+
+def seo_meta_supported(post: dict) -> bool:
+    meta = post.get("meta")
+    return isinstance(meta, dict) and all(key in meta for key in SEO_META_KEYS)
+
+
+def media_record_matches(media: dict, path: Path) -> bool:
+    try:
+        match = select_media_match(
+            [media], path.stem, extensions=(path.suffix.lower(),)
+        )
+    except SystemExit:
+        return False
+    return match is not None
+
+
+def validate_known_media(wp: WordPress, asset: Asset, media_id: int) -> dict:
+    media = wp.get_media(media_id, context="edit")
+    if int(media.get("id") or 0) != media_id:
+        raise RuntimeError(
+            f"known media id mismatch for {asset.filename}: expected {media_id}, got {media.get('id')!r}"
+        )
+    if not media_record_matches(media, asset.path):
+        raise RuntimeError(
+            f"known media {media_id} does not match exact filename {asset.filename!r}"
+        )
+    source_url = str(media.get("source_url", "")).strip()
+    if not source_url:
+        raise RuntimeError(f"known media {media_id} has no source_url")
+    return {"id": media_id, "source_url": source_url}
+
+
+def search_media_exact(wp: WordPress, path: Path) -> dict | None:
+    response = wp.s.get(
+        f"{wp.base}/wp-json/wp/v2/media",
+        params={
+            "search": path.stem,
+            "per_page": 100,
+            "context": "edit",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    results = response.json()
+    if not isinstance(results, list):
+        raise RuntimeError(f"unexpected media search response for {path.name}")
+    try:
+        match = select_media_match(
+            results, path.stem, extensions=(path.suffix.lower(),)
+        )
+    except SystemExit as exc:
+        raise RuntimeError(str(exc)) from exc
+    if not match:
+        return None
+    media_id, source_url = match
+    return {"id": int(media_id), "source_url": str(source_url)}
+
+
+def resolve_media_plan(
+    wp: WordPress, assets: dict[str, Asset]
+) -> tuple[dict[str, dict], list[Asset]]:
+    resolved: dict[str, dict] = {}
+    missing: list[Asset] = []
+    for filename, asset in assets.items():
+        known_id = KNOWN_MEDIA_IDS.get(filename)
+        if known_id is not None:
+            resolved[filename] = validate_known_media(wp, asset, known_id)
+            continue
+        found = search_media_exact(wp, asset.path)
+        if found:
+            resolved[filename] = found
+        else:
+            missing.append(asset)
+    return resolved, missing
+
+
+def set_image_class(tag: str, media_id: int) -> str:
+    class_name = f"wp-image-{media_id}"
+    match = IMG_CLASS_RE.search(tag)
+    if match:
+        classes = [
+            value
+            for value in match.group(1).split()
+            if not re.fullmatch(r"wp-image-(?:TBD|\d+)", value)
+        ]
+        classes.append(class_name)
+        return tag[: match.start(1)] + " ".join(classes) + tag[match.end(1) :]
+    closing = "/>" if tag.endswith("/>") else ">"
+    return f'{tag[: -len(closing)]} class="{class_name}"{closing}'
+
+
+def rewrite_image_blocks(body_html: str, media: dict[str, dict]) -> str:
+    used: set[str] = set()
+
+    def replace_block(match: re.Match[str]) -> str:
+        body = match.group("body")
+        tags = IMG_TAG_RE.findall(body)
+        if len(tags) != 1:
+            raise RuntimeError("each Gutenberg image block must contain exactly one img tag")
+        tag = tags[0]
+        src_match = IMG_SRC_RE.search(tag)
+        if not src_match:
+            raise RuntimeError("image block is missing src")
+        filename = local_image_filename(src_match.group(1))
+        if not filename:
+            raise RuntimeError(
+                f"refusing to preserve hotlinked image source {src_match.group(1)!r}"
+            )
+        if filename not in media:
+            raise RuntimeError(f"image has no resolved WordPress media: {filename}")
+        record = media[filename]
+        media_id = int(record["id"])
+        source_url = str(record["source_url"])
+        escaped_url = html.escape(source_url, quote=True)
+        rewritten_tag = (
+            tag[: src_match.start(1)]
+            + escaped_url
+            + tag[src_match.end(1) :]
+        )
+        rewritten_tag = set_image_class(rewritten_tag, media_id)
+        rewritten_body = body.replace(tag, rewritten_tag, 1)
+
+        attrs_raw = match.group("attrs")
+        attrs = json.loads(attrs_raw) if attrs_raw else {}
+        if not isinstance(attrs, dict):
+            raise RuntimeError("Gutenberg image attributes must be a JSON object")
+        attrs["id"] = media_id
+        encoded_attrs = json.dumps(attrs, ensure_ascii=False, separators=(",", ":"))
+        used.add(filename)
+        return (
+            f"<!-- wp:image {encoded_attrs} -->"
+            f"{rewritten_body}"
+            "<!-- /wp:image -->"
+        )
+
+    rewritten = IMAGE_BLOCK_RE.sub(replace_block, body_html)
+    referenced = set(referenced_image_filenames(body_html))
+    if used != referenced:
+        missing = sorted(referenced - used)
+        raise RuntimeError(
+            "not every canonical image was inside a Gutenberg image block: "
+            + ", ".join(missing)
+        )
+    validate_rewritten_content(rewritten, media)
+    return rewritten
+
+
+def validate_rewritten_content(body_html: str, media: dict[str, dict]) -> None:
+    forbidden = ("wp-image-TBD", 'src="images/', "content/drafts/", "/Users/")
+    present = [value for value in forbidden if value in body_html]
+    if present:
+        raise RuntimeError("rewritten content contains forbidden local markers: " + ", ".join(present))
+
+    allowed_urls = {str(record["source_url"]) for record in media.values()}
+    tags = IMG_TAG_RE.findall(body_html)
+    sources: list[str] = []
+    for tag in tags:
+        src_match = IMG_SRC_RE.search(tag)
+        if not src_match:
+            raise RuntimeError("rewritten image is missing src")
+        source = html.unescape(src_match.group(1))
+        if source not in allowed_urls:
+            raise RuntimeError(f"rewritten content retains an unowned image source: {source!r}")
+        sources.append(source)
+
+    blocks = list(IMAGE_BLOCK_RE.finditer(body_html))
+    if len(blocks) != len(tags):
+        raise RuntimeError("every rewritten image must remain in its own Gutenberg image block")
+    for block in blocks:
+        attrs = json.loads(block.group("attrs") or "{}")
+        media_id = attrs.get("id")
+        if not isinstance(media_id, int) or media_id <= 0:
+            raise RuntimeError("every Gutenberg image block must carry a positive media id")
+        tag = IMG_TAG_RE.search(block.group("body"))
+        if not tag or f"wp-image-{media_id}" not in tag.group(0).split('class="', 1)[-1]:
+            raise RuntimeError(f"image block {media_id} is missing its matching wp-image class")
+
+
+def expected_seo_meta(pkg: DraftPackage) -> dict[str, str]:
+    seo = pkg.frontmatter.get("seo") or {}
+    return build_seo_meta(
+        str(seo.get("meta_title", "")).strip(),
+        str(seo.get("meta_description", "")).strip(),
+    )
+
+
+def build_post_payload(
+    pkg: DraftPackage,
+    content: str,
+    *,
+    featured_media_id: int,
+    seo_meta_supported: bool,
+) -> dict:
+    payload = {
+        "title": pkg.title,
+        "content": content,
+        "excerpt": pkg.excerpt,
+        "featured_media": featured_media_id,
+    }
+    if seo_meta_supported:
+        payload["meta"] = expected_seo_meta(pkg)
+    return payload
+
+
+def snapshot_post(pkg: DraftPackage, post: dict) -> Path:
+    snapshot_dir = pkg.draft_dir / "wp-snapshots"
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    path = snapshot_dir / f"rest-post-{TARGET_POST_ID}-before-polish-v2-{stamp}.json.tmp"
+    payload = (json.dumps(post, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(payload)
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    return path
+
+
+def preserved_values(post: dict) -> dict:
+    return {field: post[field] for field in PRESERVED_FIELDS if field in post}
+
+
+def concurrency_values(post: dict) -> dict:
+    return {
+        "modified": post.get("modified"),
+        "modified_gmt": post.get("modified_gmt"),
+        "title": raw_field(post.get("title")),
+        "content": raw_field(post.get("content")),
+        "excerpt": raw_field(post.get("excerpt")),
+        "featured_media": int(post.get("featured_media") or 0),
+        "meta": post.get("meta"),
+        **preserved_values(post),
+    }
+
+
+def assert_post_unchanged(before: dict, current: dict, pkg: DraftPackage) -> None:
+    assert_target_post(current, pkg)
+    expected = concurrency_values(before)
+    actual = concurrency_values(current)
+    changed = sorted(
+        field for field in set(expected) | set(actual) if expected.get(field) != actual.get(field)
+    )
+    if changed:
+        raise RuntimeError(
+            "target post changed during sync; aborting before content write: "
+            + ", ".join(changed)
+        )
+
+
+def verify_readback(
+    before: dict,
+    after: dict,
+    pkg: DraftPackage,
+    payload: dict,
+    media: dict[str, dict],
+    featured_media_id: int,
+) -> dict:
+    assert_target_post(after, pkg)
+    expected_fields = {
+        "title": pkg.title,
+        "content": payload["content"],
+        "excerpt": pkg.excerpt,
+    }
+    mismatches = [
+        field
+        for field, expected in expected_fields.items()
+        if raw_field(after.get(field)) != expected
+    ]
+    if mismatches:
+        raise RuntimeError("exact WordPress readback mismatch: " + ", ".join(mismatches))
+    if int(after.get("featured_media") or 0) != featured_media_id:
+        raise RuntimeError(
+            f"featured media readback mismatch: {after.get('featured_media')!r}"
+        )
+    if "meta" in payload:
+        after_meta = after.get("meta")
+        if not isinstance(after_meta, dict):
+            raise RuntimeError("SEO meta was sent but is absent from readback")
+        seo_mismatches = [
+            key for key, value in payload["meta"].items() if after_meta.get(key) != value
+        ]
+        if seo_mismatches:
+            raise RuntimeError("SEO meta readback mismatch: " + ", ".join(seo_mismatches))
+
+    before_preserved = preserved_values(before)
+    after_preserved = preserved_values(after)
+    if after_preserved != before_preserved:
+        changed = sorted(
+            field
+            for field in set(before_preserved) | set(after_preserved)
+            if before_preserved.get(field) != after_preserved.get(field)
+        )
+        raise RuntimeError("non-payload fields changed unexpectedly: " + ", ".join(changed))
+    validate_rewritten_content(raw_field(after.get("content")), media)
+    return after_preserved
+
+
+def receipt_base(
+    *,
+    cfg: WPConfig,
+    before: dict,
+    payload_fields: list[str],
+    supported_seo: bool,
+) -> dict:
+    base = cfg.base_url.rstrip("/")
+    return {
+        "post_id": TARGET_POST_ID,
+        "slug": TARGET_SLUG,
+        "status": "draft",
+        "published": False,
+        "seo_meta_supported": supported_seo,
+        "payload_fields": payload_fields,
+        "before_content_sha256": sha256_text(raw_field(before.get("content"))),
+        "featured_media_id": None,
+        "preview_url": f"{base}/?p={TARGET_POST_ID}",
+        "edit_url": f"{base}/wp-admin/post.php?post={TARGET_POST_ID}&action=edit",
+    }
+
+
+def sync_futureproof(post_md: Path = DEFAULT_POST_MD, *, apply: bool = False) -> dict:
+    pkg = load_package(post_md)
+    assets = assert_local_package(pkg)
+    cfg = load_wp_config()
+    wp = WordPress(cfg.base_url, cfg.user, cfg.app_password)
+
+    before = wp.get_post(TARGET_POST_ID)
+    assert_target_post(before, pkg)
+    supported_seo = seo_meta_supported(before)
+    payload_fields = ["title", "content", "excerpt", "featured_media"]
+    if supported_seo:
+        payload_fields.append("meta")
+
+    resolved, missing = resolve_media_plan(wp, assets)
+    declared_featured_id = int(pkg.frontmatter.get("featured_media_id") or 0)
+    resolved_featured = resolved.get(FEATURED_FILENAME)
+    if declared_featured_id and resolved_featured:
+        if int(resolved_featured["id"]) != declared_featured_id:
+            raise RuntimeError(
+                "frontmatter featured_media_id does not match the exact resolved "
+                f"{FEATURED_FILENAME}: declared={declared_featured_id}, "
+                f"resolved={resolved_featured['id']}"
+            )
+    elif declared_featured_id:
+        raise RuntimeError(
+            "frontmatter declares a featured_media_id, but the exact featured "
+            "filename was not found in WordPress"
+        )
+    missing_names = [asset.filename for asset in missing]
+    reused_ids = {name: int(record["id"]) for name, record in resolved.items()}
+    result = receipt_base(
+        cfg=cfg,
+        before=before,
+        payload_fields=payload_fields,
+        supported_seo=supported_seo,
+    )
+    result.update(
+        {
+            "dry_run": not apply,
+            "snapshot_path": None,
+            "new_media_ids": {},
+            "reused_media_ids": reused_ids,
+            "missing_media": missing_names,
+            "would_upload": missing_names,
+            "preserved_fields": preserved_values(before),
+            "after_content_sha256": None,
+            "restore_command": None,
+            "featured_media_id": (
+                int(resolved_featured["id"]) if resolved_featured else None
+            ),
+            "rendered_content": rendered_content_report(before),
+        }
+    )
+
+    if not apply:
+        if not missing:
+            content = rewrite_image_blocks(pkg.body_html, resolved)
+            result["after_content_sha256"] = sha256_text(content)
+        return result
+
+    snapshot = snapshot_post(pkg, before)
+    result["snapshot_path"] = str(snapshot)
+    result["restore_command"] = (
+        f"MANUAL ONLY: review {snapshot} and construct a separate minimal authenticated "
+        "REST restore payload; no automated restore mode is provided by this guarded sync"
+    )
+    new_ids: dict[str, int] = {}
+    for asset in missing:
+        mime = mimetypes.guess_type(asset.filename)[0] or "application/octet-stream"
+        media = wp.upload_media(
+            asset.path,
+            alt=asset.alt,
+            mime=mime,
+            title=asset.title,
+            caption=asset.caption,
+            description=asset.description,
+        )
+        media_id = int(media.get("id") or 0)
+        source_url = str(media.get("source_url", "")).strip()
+        if media_id <= 0 or not source_url:
+            raise RuntimeError(f"upload returned incomplete media for {asset.filename}")
+        resolved[asset.filename] = {"id": media_id, "source_url": source_url}
+        new_ids[asset.filename] = media_id
+
+    featured_media_id = int(resolved[FEATURED_FILENAME]["id"])
+    if declared_featured_id and declared_featured_id != featured_media_id:
+        raise RuntimeError(
+            "uploaded featured media does not match declared featured_media_id: "
+            f"declared={declared_featured_id}, resolved={featured_media_id}"
+        )
+    content = rewrite_image_blocks(pkg.body_html, resolved)
+    payload = build_post_payload(
+        pkg,
+        content,
+        featured_media_id=featured_media_id,
+        seo_meta_supported=supported_seo,
+    )
+    prewrite = wp.get_post(TARGET_POST_ID)
+    assert_post_unchanged(before, prewrite, pkg)
+    updated = wp.update_post(TARGET_POST_ID, payload)
+    if int(updated.get("id") or 0) != TARGET_POST_ID:
+        raise RuntimeError(f"unexpected update response id: {updated.get('id')!r}")
+    after = wp.get_post(TARGET_POST_ID)
+    preserved = verify_readback(
+        before,
+        after,
+        pkg,
+        payload,
+        resolved,
+        featured_media_id,
+    )
+
+    result.update(
+        {
+            "dry_run": False,
+            "new_media_ids": new_ids,
+            "reused_media_ids": {
+                name: media_id
+                for name, media_id in reused_ids.items()
+                if name not in new_ids
+            },
+            "missing_media": [],
+            "would_upload": [],
+            "after_content_sha256": sha256_text(raw_field(after.get("content"))),
+            "preserved_fields": preserved,
+            "featured_media_id": featured_media_id,
+            "rendered_content": rendered_content_report(after),
+        }
+    )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("post_md", nargs="?", type=Path, default=DEFAULT_POST_MD)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Snapshot, upload only missing media, and update the existing private draft.",
+    )
+    args = parser.parse_args()
+    try:
+        result = sync_futureproof(args.post_md, apply=args.apply)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notion-to-wp/tests/test_sync_futureproof_polish_v2.py
+++ b/scripts/notion-to-wp/tests/test_sync_futureproof_polish_v2.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import sync_futureproof_polish_v2 as sync  # noqa: E402
+import verify_futureproof_polish_v2 as verify  # noqa: E402
+
+
+class Response:
+    def __init__(self, payload: object, status_code: int = 200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> object:
+        return self.payload
+
+
+class FutureproofSyncTests(unittest.TestCase):
+    def write_package(
+        self,
+        root: Path,
+        *,
+        slug: str = sync.TARGET_SLUG,
+        status: str = "draft",
+    ) -> Path:
+        draft_dir = root / "futureproof"
+        images = draft_dir / "images"
+        images.mkdir(parents=True)
+        featured = images / sync.FEATURED_FILENAME
+        known = images / "vanai-meetup31-stage-kris-futureproof-slide.webp"
+        new = images / "receipt-dent-kris-krug.png"
+        featured.write_bytes(b"approved featured image")
+        known.write_bytes(b"known image")
+        new.write_bytes(b"new image")
+        (draft_dir / "post.md").write_text(
+            "---\n"
+            "title: 'Futureproof Festival of AI: A Bat Signal from Vancouver'\n"
+            f"slug: {slug}\n"
+            f"status: {status}\n"
+            "featured_media_id: 0\n"
+            "excerpt: A deeper invitation to Futureproof Festival of AI.\n"
+            "seo:\n"
+            "  meta_title: Futureproof Festival of AI in Vancouver | Kris Krüg\n"
+            "  meta_description: A clear Futureproof Festival description.\n"
+            "images:\n"
+            f"- file: images/{sync.FEATURED_FILENAME}\n"
+            "  alt: Approved Futureproof salmon key art.\n"
+            "  role: featured-graphic\n"
+            "  source: https://futureproof.example/approved-key-art.jpg\n"
+            "  credit: Futureproof Festival art layer.\n"
+            "- file: images/vanai-meetup31-stage-kris-futureproof-slide.webp\n"
+            "  alt: Kris presents Futureproof at Vancouver AI.\n"
+            "  role: opening-proof\n"
+            "  source: https://bc-ai.example/stage.webp\n"
+            "  credit: 'Photo: Michael Caswell.'\n"
+            "- file: images/receipt-dent-kris-krug.png\n"
+            "  alt: DENT article receipt.\n"
+            "  role: archival-receipt\n"
+            "  source: https://kriskrug.co/dent/\n"
+            "  credit: Screenshot captured for editorial reference.\n"
+            "---\n"
+            "Body\n",
+            encoding="utf-8",
+        )
+        (draft_dir / "post.html").write_text(
+            '<!-- wp:image {"sizeSlug":"large"} -->\n'
+            f'<figure><img src="images/{sync.FEATURED_FILENAME}" '
+            'alt="Key art" class="wp-image-TBD"/></figure>\n'
+            '<!-- /wp:image -->\n'
+            '<!-- wp:image {"sizeSlug":"large"} -->\n'
+            '<figure><img src="images/vanai-meetup31-stage-kris-futureproof-slide.webp" '
+            'alt="Stage" class="wp-image-TBD"/></figure>\n'
+            '<!-- /wp:image -->\n'
+            '<!-- wp:image {"lightbox":{"enabled":true}} -->\n'
+            '<figure><img src="images/receipt-dent-kris-krug.png" '
+            'alt="Receipt" class="visual wp-image-TBD"/></figure>\n'
+            '<!-- /wp:image -->',
+            encoding="utf-8",
+        )
+        return draft_dir / "post.md"
+
+    @staticmethod
+    def before_post(*, status: str = "draft", slug: str = sync.TARGET_SLUG) -> dict:
+        return {
+            "id": sync.TARGET_POST_ID,
+            "status": status,
+            "slug": slug,
+            "title": {"raw": "Old title"},
+            "content": {"raw": "<!-- wp:paragraph --><p>Old</p><!-- /wp:paragraph -->"},
+            "excerpt": {"raw": "Old excerpt"},
+            "featured_media": 12725,
+            "meta": {
+                "jetpack_seo_html_title": "Old SEO title",
+                "advanced_seo_description": "Old SEO description",
+            },
+            "categories": [4],
+            "tags": [8, 9],
+            "author": 1,
+            "date": "2026-07-26T12:00:00",
+            "modified": "2026-08-12T14:40:00",
+            "modified_gmt": "2026-08-12T22:40:00",
+        }
+
+    @staticmethod
+    def known_media() -> dict:
+        return {
+            "id": 12725,
+            "source_url": (
+                "https://kriskrug.co/wp-content/uploads/2026/08/"
+                "vanai-meetup31-stage-kris-futureproof-slide.webp"
+            ),
+            "media_details": {},
+        }
+
+    def config(self):
+        return sync.WPConfig("https://kriskrug.co", "user", "password", 1)
+
+    def test_verifier_accepts_manifest_receipts_when_ignored_images_are_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            draft_dir = Path(tmp)
+            lines = ["## V2 visual package"]
+            for name, (width, height) in verify.EXPECTED_IMAGE_SIZES.items():
+                lines.append(
+                    f"| `{name}` | {width}×{height} | "
+                    f"{verify.EXPECTED_IMAGE_HASHES[name]} |"
+                )
+            for name, media_id in verify.EXPECTED_MEDIA_IDS.items():
+                lines.append(f"| `{name}` | {media_id} | uploaded |")
+            (draft_dir / "asset-manifest.md").write_text(
+                "\n".join(lines), encoding="utf-8"
+            )
+
+            report = verify.image_artifact_report(draft_dir)
+
+        self.assertTrue(report["manifest_receipts"])
+        self.assertEqual(report["local_files_present"], 0)
+        self.assertTrue(report["local_hashes_match"])
+        self.assertTrue(report["local_state_valid"])
+
+    def test_verifier_rejects_complete_local_set_with_hash_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            draft_dir = Path(tmp)
+            images_dir = draft_dir / "images"
+            images_dir.mkdir()
+            for name in verify.EXPECTED_IMAGE_SIZES:
+                (images_dir / name).write_bytes(b"wrong artifact")
+
+            report = verify.image_artifact_report(draft_dir)
+
+        self.assertEqual(
+            report["local_files_present"], len(verify.EXPECTED_IMAGE_SIZES)
+        )
+        self.assertFalse(report["local_hashes_match"])
+        self.assertFalse(report["local_state_valid"])
+
+    def test_verifier_expected_featured_media_is_exact(self):
+        self.assertEqual(
+            verify.EXPECTED_MEDIA_IDS[
+                "futureproof-salmon-starfield-share-20260711.jpg"
+            ],
+            12739,
+        )
+
+    def test_target_guard_rejects_non_draft_before_media_or_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            wp = mock.Mock()
+            wp.get_post.return_value = self.before_post(status="publish")
+            with (
+                mock.patch.object(sync, "load_wp_config", return_value=self.config()),
+                mock.patch.object(sync, "WordPress", return_value=wp),
+                self.assertRaisesRegex(RuntimeError, "non-draft"),
+            ):
+                sync.sync_futureproof(post_md)
+
+        wp.get_media.assert_not_called()
+        wp.upload_media.assert_not_called()
+        wp.update_post.assert_not_called()
+
+    def test_package_rejects_image_path_escape_before_wordpress_access(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            post_md = self.write_package(root)
+            outside = post_md.parent / "outside.jpg"
+            outside.write_bytes(b"private bytes")
+            text = post_md.read_text(encoding="utf-8")
+            text = text.replace(
+                f"images/{sync.FEATURED_FILENAME}", "images/../outside.jpg", 1
+            )
+            post_md.write_text(text, encoding="utf-8")
+            with (
+                mock.patch.object(sync, "load_wp_config") as load_config,
+                self.assertRaisesRegex(RuntimeError, "canonical images/<filename>"),
+            ):
+                sync.sync_futureproof(post_md)
+
+        load_config.assert_not_called()
+
+    def test_package_rejects_symlink_escape_before_wordpress_access(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            post_md = self.write_package(root)
+            outside = root / "outside.jpg"
+            outside.write_bytes(b"private bytes")
+            featured = post_md.parent / "images" / sync.FEATURED_FILENAME
+            featured.unlink()
+            featured.symlink_to(outside)
+            with (
+                mock.patch.object(sync, "load_wp_config") as load_config,
+                self.assertRaisesRegex(RuntimeError, "regular file inside"),
+            ):
+                sync.sync_futureproof(post_md)
+
+        load_config.assert_not_called()
+
+    def test_dry_run_is_authenticated_but_never_uploads_or_writes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            wp = mock.Mock()
+            wp.get_post.return_value = self.before_post()
+            wp.get_media.return_value = self.known_media()
+            wp.s.get.return_value = Response([])
+            with (
+                mock.patch.object(sync, "load_wp_config", return_value=self.config()),
+                mock.patch.object(sync, "WordPress", return_value=wp),
+            ):
+                result = sync.sync_futureproof(post_md)
+
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(
+            result["missing_media"],
+            [sync.FEATURED_FILENAME, "receipt-dent-kris-krug.png"],
+        )
+        self.assertEqual(
+            result["would_upload"],
+            [sync.FEATURED_FILENAME, "receipt-dent-kris-krug.png"],
+        )
+        self.assertIsNone(result["snapshot_path"])
+        wp.get_post.assert_called_once_with(sync.TARGET_POST_ID)
+        wp.upload_media.assert_not_called()
+        wp.update_post.assert_not_called()
+
+    def test_rewrite_adds_block_ids_and_replaces_src_and_classes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            package = sync.load_package(post_md)
+            media = {
+                sync.FEATURED_FILENAME: {
+                    "id": 13001,
+                    "source_url": "https://kriskrug.co/uploads/key-art.jpg",
+                },
+                "vanai-meetup31-stage-kris-futureproof-slide.webp": {
+                    "id": 12725,
+                    "source_url": "https://kriskrug.co/uploads/stage.webp",
+                },
+                "receipt-dent-kris-krug.png": {
+                    "id": 13002,
+                    "source_url": "https://kriskrug.co/uploads/receipt.png",
+                },
+            }
+
+            rewritten = sync.rewrite_image_blocks(package.body_html, media)
+
+        self.assertIn('<!-- wp:image {"sizeSlug":"large","id":13001} -->', rewritten)
+        self.assertIn('<!-- wp:image {"sizeSlug":"large","id":12725} -->', rewritten)
+        self.assertIn('<!-- wp:image {"lightbox":{"enabled":true},"id":13002} -->', rewritten)
+        self.assertIn('src="https://kriskrug.co/uploads/key-art.jpg"', rewritten)
+        self.assertIn('class="visual wp-image-13002"', rewritten)
+        self.assertNotIn("wp-image-TBD", rewritten)
+        self.assertNotIn('src="images/', rewritten)
+
+    def test_minimal_payload_omits_unsupported_seo_meta(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            package = sync.load_package(self.write_package(Path(tmp)))
+            payload = sync.build_post_payload(
+                package,
+                "<!-- wp:paragraph --><p>Ready</p><!-- /wp:paragraph -->",
+                featured_media_id=13001,
+                seo_meta_supported=False,
+            )
+
+        self.assertEqual(
+            set(payload), {"title", "content", "excerpt", "featured_media"}
+        )
+        self.assertNotIn("status", payload)
+        self.assertNotIn("slug", payload)
+        self.assertNotIn("date", payload)
+        self.assertNotIn("meta", payload)
+
+    def test_exact_media_search_aborts_when_filename_is_ambiguous(self):
+        wp = mock.Mock()
+        wp.s.get.return_value = Response(
+            [
+                {
+                    "id": 41,
+                    "source_url": "https://kriskrug.co/uploads/receipt.png",
+                },
+                {
+                    "id": 42,
+                    "source_url": "https://kriskrug.co/uploads/receipt.png",
+                },
+            ]
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "ambiguous media match"):
+            sync.search_media_exact(wp, Path("receipt.png"))
+
+        wp.upload_media.assert_not_called()
+        wp.update_post.assert_not_called()
+
+    def test_apply_rechecks_draft_state_immediately_before_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            before = self.before_post()
+            published = dict(before, status="publish")
+            wp = mock.Mock()
+            wp.get_post.side_effect = [before, published]
+            wp.get_media.return_value = self.known_media()
+            wp.s.get.return_value = Response([])
+            wp.upload_media.side_effect = [
+                {
+                    "id": 13001,
+                    "source_url": f"https://kriskrug.co/uploads/{sync.FEATURED_FILENAME}",
+                },
+                {
+                    "id": 13002,
+                    "source_url": "https://kriskrug.co/uploads/receipt-dent-kris-krug.png",
+                },
+            ]
+            with (
+                mock.patch.object(sync, "load_wp_config", return_value=self.config()),
+                mock.patch.object(sync, "WordPress", return_value=wp),
+                self.assertRaisesRegex(RuntimeError, "non-draft"),
+            ):
+                sync.sync_futureproof(post_md, apply=True)
+
+        wp.update_post.assert_not_called()
+
+    def test_apply_aborts_when_editor_changes_content_during_uploads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            before = self.before_post()
+            changed = dict(before)
+            changed["content"] = {"raw": "<p>Concurrent editor change</p>"}
+            changed["modified_gmt"] = "2026-08-12T22:45:00"
+            wp = mock.Mock()
+            wp.get_post.side_effect = [before, changed]
+            wp.get_media.return_value = self.known_media()
+            wp.s.get.return_value = Response([])
+            wp.upload_media.side_effect = [
+                {
+                    "id": 13001,
+                    "source_url": f"https://kriskrug.co/uploads/{sync.FEATURED_FILENAME}",
+                },
+                {
+                    "id": 13002,
+                    "source_url": "https://kriskrug.co/uploads/receipt-dent-kris-krug.png",
+                },
+            ]
+            with (
+                mock.patch.object(sync, "load_wp_config", return_value=self.config()),
+                mock.patch.object(sync, "WordPress", return_value=wp),
+                self.assertRaisesRegex(RuntimeError, "changed during sync"),
+            ):
+                sync.sync_futureproof(post_md, apply=True)
+
+        wp.update_post.assert_not_called()
+
+    def test_apply_snapshots_uploads_missing_and_verifies_exact_readback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            post_md = self.write_package(Path(tmp))
+            before = self.before_post()
+            wp = mock.Mock()
+            wp.s.get.return_value = Response([])
+            wp.get_media.return_value = self.known_media()
+            wp.upload_media.side_effect = [
+                {
+                    "id": 13001,
+                    "source_url": f"https://kriskrug.co/uploads/{sync.FEATURED_FILENAME}",
+                },
+                {
+                    "id": 13002,
+                    "source_url": "https://kriskrug.co/uploads/receipt-dent-kris-krug.png",
+                },
+            ]
+
+            def read_post(_post_id: int) -> dict:
+                if not wp.update_post.called:
+                    return before
+                payload = wp.update_post.call_args.args[1]
+                after = dict(before)
+                after.update(
+                    {
+                        "title": {"raw": payload["title"]},
+                        "content": {"raw": payload["content"]},
+                        "excerpt": {"raw": payload["excerpt"]},
+                        "featured_media": payload["featured_media"],
+                        "meta": payload["meta"],
+                    }
+                )
+                return after
+
+            wp.get_post.side_effect = read_post
+            wp.update_post.return_value = {"id": sync.TARGET_POST_ID}
+            with (
+                mock.patch.object(sync, "load_wp_config", return_value=self.config()),
+                mock.patch.object(sync, "WordPress", return_value=wp),
+            ):
+                result = sync.sync_futureproof(post_md, apply=True)
+
+            snapshot = Path(result["snapshot_path"])
+            snapshot_payload = json.loads(snapshot.read_text(encoding="utf-8"))
+            snapshot_mode = stat.S_IMODE(snapshot.stat().st_mode)
+
+        self.assertFalse(result["dry_run"])
+        self.assertFalse(result["published"])
+        self.assertEqual(
+            result["new_media_ids"],
+            {sync.FEATURED_FILENAME: 13001, "receipt-dent-kris-krug.png": 13002},
+        )
+        self.assertEqual(result["featured_media_id"], 13001)
+        self.assertEqual(result["would_upload"], [])
+        self.assertEqual(snapshot_payload, before)
+        self.assertEqual(snapshot_mode, 0o600)
+        self.assertEqual(
+            result["payload_fields"],
+            ["title", "content", "excerpt", "featured_media", "meta"],
+        )
+        self.assertNotEqual(result["before_content_sha256"], result["after_content_sha256"])
+        self.assertEqual(result["rendered_content"]["raw_image_count"], 3)
+        self.assertFalse(
+            result["rendered_content"]["has_local_or_placeholder_markers"]
+        )
+        self.assertIn(str(snapshot), result["restore_command"])
+        self.assertIn("no automated restore mode", result["restore_command"])
+        upload_kwargs = wp.upload_media.call_args_list[1].kwargs
+        self.assertEqual(upload_kwargs["alt"], "DENT article receipt.")
+        self.assertIn("Screenshot captured", upload_kwargs["caption"])
+        self.assertIn("https://kriskrug.co/dent/", upload_kwargs["caption"])
+        payload = wp.update_post.call_args.args[1]
+        self.assertEqual(
+            set(payload),
+            {"title", "content", "excerpt", "featured_media", "meta"},
+        )
+        self.assertEqual(payload["featured_media"], 13001)
+        self.assertNotIn("wp-image-TBD", payload["content"])
+        self.assertNotIn('src="images/', payload["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/notion-to-wp/verify_futureproof_polish_v2.py
+++ b/scripts/notion-to-wp/verify_futureproof_polish_v2.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Verify the Futureproof v2 article package without changing WordPress."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+import yaml
+
+EXPECTED_TITLE = "Futureproof Festival of AI: A Bat Signal from Vancouver"
+EXPECTED_SEO_TITLE = "Futureproof Festival of AI in Vancouver | Kris Krüg"
+EXPECTED_SLUG = "futureproof-festival-announcement"
+EXPECTED_POST_DATE = "2026-08-11"
+
+CRITICAL_CONTENT = {
+    "https://bc-ai.ca/events/vancouver-ai-meetup-2026-07": "Vancouver AI Meetup",
+    "https://bc-ai.ca/news/futureproof-festival-regional-story-national-invitation": "Futureproof Festival",
+    "https://kriskrug.co/vancouver-ai/": "Vancouver AI Ecosystem",
+    "https://kriskrug.co/2026/06/30/zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey/": "Zero to One",
+    "https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/": "DENT the Future",
+    "https://kriskrug.co/ai-events/": "AI Events",
+    "https://mediashift.org/2010/02/true-north-media-house-w2-provide-citizen-media-hub-at-olympics053/": "True North Media House",
+    "https://blog.ted.com/what-does-tedx-mean-to-me-answering-tedxsummit-photographer-kris-krug/": "TEDxSummit photographer",
+    "https://www.spacecentre.ca/": "H.R. MacMillan Space Centre",
+    "https://www.futureproof.website/": "Futureproof Festival of AI",
+    "https://www.futureproof.website/tickets/": "Festival Pass",
+    "https://www.futureproof.website/call-for-talks/": "Call for Talks",
+    "https://www.futureproof.website/startup-exhibitors/": "Startup Exhibitor",
+    "https://www.futureproof.website/sponsors/": "Partner with",
+    "https://www.futureproof.website/speakers/": "Speakers",
+    "https://www.futureproof.website/venues/": "H.R. MacMillan Space Centre",
+}
+
+EXPECTED_IMAGE_SIZES = {
+    "futureproof-salmon-starfield-share-20260711.jpg": (1200, 630),
+    "vanai-meetup31-stage-kris-futureproof-slide.webp": (2400, 1600),
+    "vanai-meetup31-community-group-photo.webp": (2400, 1600),
+    "receipt-true-north-media-house.png": (1440, 900),
+    "receipt-tedx-summit-kris-krug.png": (1440, 900),
+    "receipt-dent-kris-krug.png": (1440, 900),
+    "vanai-space-centre-courtyard-community.webp": (1800, 1200),
+    "space-centre-community-night.webp": (1800, 1200),
+    "futureproof-honest-conversation-poster.png": (1024, 1536),
+}
+EXPECTED_MEDIA_IDS = {
+    "futureproof-salmon-starfield-share-20260711.jpg": 12739,
+    "vanai-meetup31-stage-kris-futureproof-slide.webp": 12725,
+    "vanai-meetup31-community-group-photo.webp": 12733,
+    "receipt-true-north-media-house.png": 12734,
+    "receipt-tedx-summit-kris-krug.png": 12735,
+    "receipt-dent-kris-krug.png": 12736,
+    "vanai-space-centre-courtyard-community.webp": 12737,
+    "space-centre-community-night.webp": 12738,
+    "futureproof-honest-conversation-poster.png": 12727,
+}
+EXPECTED_IMAGE_HASHES = {
+    "futureproof-salmon-starfield-share-20260711.jpg": "68ecc3c42b32857916e5d62c7ac30efe5bfc387bb2614045abb42791121dfc08",
+    "vanai-meetup31-stage-kris-futureproof-slide.webp": "4f2c77c776e54174b08b69a3e41cca4d954ffdb17149c59928ff04ab497e0647",
+    "vanai-meetup31-community-group-photo.webp": "e3d58e4b17ebcd8e20d673ea5b21a0f2abc3afdeb202000f4c3617bb916a6360",
+    "receipt-true-north-media-house.png": "bd630687fd16a0d4ef4507f1087c8be7f5abcadfe803f20926ae4b40a152390b",
+    "receipt-tedx-summit-kris-krug.png": "a7c864d3b2f5369261abd320ed3c00eb1db9e3b7bfbf8024d07bf558d12969a6",
+    "receipt-dent-kris-krug.png": "7d02497cfd2a4dc3ed82e6c2d5b04c5cc18fd1fd6b517bf9feb6945dedbe27c8",
+    "vanai-space-centre-courtyard-community.webp": "1bfe958b5ed5ad29a9f159032f5456fb1db18607d1d2e3a1e8252432bc9e7015",
+    "space-centre-community-night.webp": "b611a54de56815613bee5823413b67a39a620c1217e74e6c9e0be1ba3049dc26",
+    "futureproof-honest-conversation-poster.png": "01fdaa144ff92bfa7a7cbd4155714c91a12c550194b3771438f790ef27258a7f",
+}
+
+
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    match = re.match(r"\A---\n(.*?)\n---\n?(.*)\Z", text, flags=re.S)
+    if not match:
+        raise ValueError("post.md has no YAML frontmatter")
+    return yaml.safe_load(match.group(1)) or {}, match.group(2)
+
+
+def editorial_urls(body: str) -> list[str]:
+    urls: list[str] = []
+    for url in re.findall(r"\[[^\]]+\]\((https?://[^)]+)\)", body):
+        if url not in urls:
+            urls.append(url)
+    return urls
+
+
+def check_url(session: requests.Session, url: str) -> dict:
+    response = session.get(url, timeout=30, allow_redirects=True)
+    response.raise_for_status()
+    text = response.text
+    expected = CRITICAL_CONTENT.get(url)
+    if expected and expected.casefold() not in text.casefold():
+        raise AssertionError(f"{url} returned 200 but did not contain {expected!r}")
+    lowered = text.casefold()
+    if "domain for sale" in lowered or "buy this domain" in lowered:
+        raise AssertionError(f"{url} resolves to a parked-domain page")
+    return {
+        "url": url,
+        "status": response.status_code,
+        "final_url": response.url,
+        "expected_content": expected,
+        "content_verified": bool(expected),
+    }
+
+
+def image_artifact_report(draft_dir: Path) -> dict:
+    manifest_path = draft_dir / "asset-manifest.md"
+    manifest = manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else ""
+    current_manifest = manifest.split("## #500 WordPress receipt", 1)[0]
+    manifest_receipts = all(
+        f"`{name}`" in current_manifest
+        and f"{width}×{height}" in current_manifest
+        and f"| `{name}` | {EXPECTED_MEDIA_IDS[name]} |" in current_manifest
+        and EXPECTED_IMAGE_HASHES[name] in current_manifest
+        for name, (width, height) in EXPECTED_IMAGE_SIZES.items()
+    )
+
+    paths = {name: draft_dir / "images" / name for name in EXPECTED_IMAGE_SIZES}
+    present = {name: path for name, path in paths.items() if path.exists()}
+    expected_count = len(paths)
+    present_count = len(present)
+    hashes_match = all(
+        hashlib.sha256(path.read_bytes()).hexdigest() == EXPECTED_IMAGE_HASHES[name]
+        for name, path in present.items()
+    )
+    local_state_valid = present_count in (0, expected_count) and hashes_match
+    return {
+        "manifest_receipts": manifest_receipts,
+        "local_files_present": present_count,
+        "local_files_expected": expected_count,
+        "local_hashes_match": hashes_match,
+        "local_state_valid": local_state_valid,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("post_md", type=Path)
+    parser.add_argument("--skip-network", action="store_true")
+    args = parser.parse_args()
+
+    post_md = args.post_md.resolve()
+    draft_dir = post_md.parent
+    html_path = draft_dir / "post.html"
+    frontmatter, body = split_frontmatter(post_md.read_text(encoding="utf-8"))
+    html = html_path.read_text(encoding="utf-8")
+    urls = editorial_urls(body)
+    image_report = image_artifact_report(draft_dir)
+    declared_images = {
+        Path(str(item.get("file", ""))).as_posix()
+        for item in (frontmatter.get("images") or [])
+    }
+
+    checks = {
+        "title": frontmatter.get("title") == EXPECTED_TITLE,
+        "slug": frontmatter.get("slug") == EXPECTED_SLUG,
+        "post_date": frontmatter.get("post_date") == EXPECTED_POST_DATE,
+        "status_publish": frontmatter.get("status") == "publish",
+        "featured_media_declared": frontmatter.get("featured_media_id")
+        == EXPECTED_MEDIA_IDS["futureproof-salmon-starfield-share-20260711.jpg"],
+        "approved_featured_asset": any(
+            str(item.get("file", "")).endswith(
+                "futureproof-salmon-starfield-share-20260711.jpg"
+            )
+            and item.get("role") == "featured-graphic"
+            for item in (frontmatter.get("images") or [])
+        ),
+        "seo_title": (frontmatter.get("seo") or {}).get("meta_title") == EXPECTED_SEO_TITLE,
+        "seo_title_length": len((frontmatter.get("seo") or {}).get("meta_title", "")) <= 60,
+        "meta_description_length": 140 <= len((frontmatter.get("seo") or {}).get("meta_description", "")) <= 160,
+        "word_count": len(re.findall(r"\b[\w'-]+\b", body)) >= 1800,
+        "editorial_links": len(urls) >= 25,
+        "internal_links": len([u for u in urls if urlparse(u).netloc == "kriskrug.co"]) >= 5,
+        "html_images": html.count("<img ") == 9,
+        "image_declarations": declared_images
+        == {f"images/{name}" for name in EXPECTED_IMAGE_SIZES},
+        "html_image_sources": all(
+            f'src="images/{name}"' in html for name in EXPECTED_IMAGE_SIZES
+        ),
+        "image_dimensions": html.count(' width="') == 9 and html.count(' height="') == 9,
+        "video_embed": html.count("<!-- wp:embed ") == 1 and "YitQ4fNEDW8" in html,
+        "no_unresolved_markers": "[[" not in html and "]]" not in html,
+        "no_old_venue_domain": "hrmacmillanspacecentre.com" not in body + html,
+        "no_morocco_error": "Morocco" not in body + html,
+        "no_disputed_counts": not re.search(
+            r"(?:\b300 members\b|\b3,000\+|\b94\+)", body
+        ),
+        "no_em_dash": "—" not in post_md.read_text(encoding="utf-8") + html,
+        "no_absolute_paths": "/Users/" not in body + html,
+        "image_manifest_receipts": image_report["manifest_receipts"],
+        "local_image_artifacts_consistent": image_report["local_state_valid"],
+    }
+
+    failures = [name for name, passed in checks.items() if not passed]
+    network: list[dict] = []
+    network_errors: list[str] = []
+    if not args.skip_network:
+        session = requests.Session()
+        session.headers["User-Agent"] = "Mozilla/5.0 (compatible; KrisKrug editorial verifier/1.0)"
+        for url in urls:
+            try:
+                network.append(check_url(session, url))
+            except Exception as exc:
+                network_errors.append(f"{url}: {exc}")
+
+    report = {
+        "package": str(post_md),
+        "checks": checks,
+        "failures": failures,
+        "counts": {
+            "words": len(re.findall(r"\b[\w'-]+\b", body)),
+            "editorial_urls": len(urls),
+            "internal_urls": len([u for u in urls if urlparse(u).netloc == "kriskrug.co"]),
+            "html_images": html.count("<img "),
+            "video_embeds": html.count("<!-- wp:embed "),
+        },
+        "network": network,
+        "network_errors": network_errors,
+        "image_artifacts": image_report,
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 1 if failures or network_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- rewrites the Futureproof Festival article into a deeper Vancouver-origin story with a clearer title and SEO package
- replaces the rejected featured image and adds nine approved or credited visuals, three source receipts, and the Vancouver AI video at the Futureproof segment
- adds a guarded snapshot-first WordPress sync plus a deterministic publication verifier and focused safety tests
- records the exact live readback after Kris explicitly approved publication in this task

## Verification

- make test: 343 publisher, 12 SEO inventory, and 68 SEO backfill/link-safety tests passed; plugin/theme smoke passed
- focused sync/verifier suite: 13 passed
- Ruff, py_compile, and git diff --check passed
- package verifier: 25/25 editorial links returned HTTP 200; 9 images; 1 video; 5 internal links; no unresolved markers
- desktop and mobile production smoke passed with no horizontal overflow

## Production

Live: https://kriskrug.co/2026/08/11/futureproof-festival-announcement/

This is a direct WordPress publication path; no Vercel deployment is involved.

Non-blocking follow-ups: confirm Michael Caswell cross-site reuse wording and refresh the August 15 deadline language after it passes.

Closes #496