### PR TITLE
ops: make morning truth ephemeral by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ content/drafts/2026-06-28-keep-the-machine-strange/img/
 # lightbox backfill rollback manifests (large, operational; keep on disk, not in git)
 scripts/notion-to-wp/backfill-rollback*.jsonl
 
+# Routine generated startup state is local and reproducible. Durable checkpoint
+# reports remain tracked under docs/current-state/reports/.
+.generated/current-state/
+
 # Operational capture artifacts under current-state reports — keep .md summaries,
 # ignore heavy captures (screenshots, page snapshots) so the folder stops re-bloating.
 # See REPO-HYGIENE-AUDIT-2026-07-12.md. Existing tracked copies stay until an approved cleanup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ This file is the entry point for any AI agent (Claude Code, Cursor, Codex, etc.)
 
 ## What this repo is
 
-The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site running the Aurora theme (`kk-aurora`). **Live** theme (`style.css` Version) as of 2026-08-12 public readback: **1.6.4**, **in sync** with repo `main` (SFTP-deployed 2026-08-11, shipping 1.6.1 through 1.6.4 — form-message colors, breakpoint consolidation, the PSI perf round, and the #701 CLS/LCP guard — in one window; server-side rollback at `kk-aurora.bak-1786415439`). **Post-deploy step still owed: regenerate Jetpack Boost critical CSS** (stale-snapshot geometry was the #701 root cause). WordPress publicly reports **7.0.4**. How verified: `curl -s https://kriskrug.co/wp-content/themes/kk-aurora/style.css | grep -i version` against `theme/kk-aurora/style.css`. Do not treat the repo `style.css` version as proof of production. Read back the public file, in either direction. The repo is **adjacent to** the live site, not a mirror of it. `main` contains the canonical tracked theme line, plus content/ops tooling and docs. Custom repo-side WP code includes `inc/digital-composting.php` and `plugins/kk-sidebar-promos/` (deploy only with an explicit rollback path and KK approval).
+The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagely-hosted WordPress site running the Aurora theme (`kk-aurora`). Live WordPress and theme versions change independently of this repo. Run `make status-readonly` and use the public `style.css` readback before making a current-state claim; never treat the repo version as production proof. The repo is **adjacent to** the live site, not a mirror of it. `main` contains the canonical tracked theme line, plus content/ops tooling and docs. Custom repo-side WP code includes `inc/digital-composting.php` and `plugins/kk-sidebar-promos/` (deploy only with an explicit rollback path and KK approval).
 
 ## Read this in order (top of repo, top of context)
 
-1. [`docs/current-state/README.md`](docs/current-state/README.md) — index; start with the newest `reports/morning-truth-*.md`
+1. [`docs/current-state/README.md`](docs/current-state/README.md) — current-state front door; run `make status-readonly` for live counters
 2. [`docs/current-state/CURRENT-STATE-2026-07-30.md`](docs/current-state/CURRENT-STATE-2026-07-30.md) — declared snapshot for drift/morning-truth (Makefile default)
 3. [`docs/current-state/WORK-PLAN-2026-08-09.md`](docs/current-state/WORK-PLAN-2026-08-09.md) — **day runbook** (repo-integrity rescue → truth → deploy window; supersedes 2026-08-05)
 4. [`docs/current-state/MASTER-PLAN-2026-07-30.md`](docs/current-state/MASTER-PLAN-2026-07-30.md) — hygiene + lane sequencing plan of record
@@ -45,7 +45,7 @@ Legacy branch split context is in [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-
 - **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `CURRENT-STATE-2026-07-30.md`, `WORK-PLAN-2026-07-30.md`, `MASTER-PLAN-2026-07-30.md`, and the newest committed morning-truth report for current truth. May–June handoffs live under `docs/current-state/archive/`.
+- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `CURRENT-STATE-2026-07-30.md`, `WORK-PLAN-2026-07-30.md`, `MASTER-PLAN-2026-07-30.md`, and a fresh `make status-readonly` run for current truth. May–June handoffs live under `docs/current-state/archive/`.
 
 Anything banner-tagged `STATUS: Historical` at the top is reference-only.
 
@@ -72,11 +72,11 @@ Read [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODE
 
 ## Morning truth command
 
-Run `make morning-truth` at session start (or before execution) to emit a timestamped read-only report under `docs/current-state/reports/` with git/issue/worktree state, WP smoke, draft queue counts, and current-state drift flags.
+Run `make status-readonly` at session start (or before execution). It prints git/issue/worktree state, WP smoke, draft queue counts, and current-state drift flags without writing a file.
 
-If the task explicitly forbids file changes, run `make status-readonly` instead. It prints the same startup truth shape to stdout and does not write a report file.
+Use `make morning-truth` only when a local copy is useful. It writes the same report to the gitignored `.generated/current-state/` directory.
 
-**Keeping the cadence alive:** `make morning-truth` writes the `.md` but does *not* auto-commit it — the report only becomes the shared source of truth once someone commits it. The report others read stays current only if the session that runs `morning-truth` also commits the fresh `docs/current-state/reports/morning-truth-*.md` (these `.md` summaries are tracked; only `reports/` PNG/HTML/CSV captures are gitignored). If the newest committed report is more than a few days stale, that means recent sessions ran `status-readonly` (stdout-only) or skipped the commit — not that the target is broken. Regenerate and commit one.
+Use `make morning-truth-checkpoint` only for an explicit release, incident, durable decision, or handoff checkpoint. That deliberate mode writes under `docs/current-state/reports/`; review and commit the report with the related work. Existing committed reports remain historical evidence, not a freshness requirement for routine sessions.
 
 ## Cursor Cloud specific instructions
 
@@ -92,9 +92,9 @@ Non-obvious caveats for future agents (the update script already installs deps):
 - **GitHub merge from Cloud:** set Cursor Cloud secret `GH_TOKEN` to a classic PAT with `repo` scope owned by an account that has write access (same value as Actions secret `AGENT_MERGE_TOKEN`). Without it, `gh pr review --approve` / `gh pr merge` fail under branch protection even when CI is green. Details: [`docs/current-state/AGENT-MERGE-PATH-2026-07-26.md`](docs/current-state/AGENT-MERGE-PATH-2026-07-26.md).
 - Without those env vars (and without a gitignored `scripts/notion-to-wp/.env` cache), connector/publisher paths stay unauthenticated: the live publisher and `create_local_wp_draft.py` **hard-exit requiring creds even in dry-run**. Use credential-free paths instead — `LOCAL_ONLY=1 make draft-queue-audit` and `make status-readonly`.
 - Read [`.env.schema`](.env.schema) and [`docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md`](docs/current-state/VARLOCK-ROLLOUT-2026-07-16.md) for the Varlock env contract. Do **not** read, print, or commit `.env` / `.env.local`. Use `make env-check` when `varlock` is on `PATH` (soft-OK if secrets are absent). Prefer `make varlock-run CMD='…'` / `varlock run --inject vars -- …` when secrets are resolved. Sibling-path `KKAI_ENV_PATH` fallbacks are **compat only**, not the secret source of truth.
-- - `make morning-truth`, `make status-readonly`, and the audit targets make live HTTP calls to `https://kriskrug.co` when reachable; they degrade gracefully but expect outbound network for the WP smoke portions.
-- Live Aurora and repo Aurora drift in **either** direction. As of 2026-08-11 they are **in sync at 1.6.4** (second deploy window executed). Historically the drift has gone both ways: on 2026-07-27 they were in sync at 1.5.0, and on 2026-08-01 live ran *ahead* of `main` because the 1.5.7 hero was SFTP-deployed before PR #618 merged. Do not treat `theme/kk-aurora/style.css` Version as proof of production without a public `style.css` readback, and do not assume the direction of any future drift. Readback, don't assume, in either direction.
+- `make morning-truth`, `make status-readonly`, and the audit targets make live HTTP calls to `https://kriskrug.co` when reachable; they degrade gracefully but expect outbound network for the WP smoke portions.
+- Live Aurora and repo Aurora drift in **either** direction. Do not treat `theme/kk-aurora/style.css` Version as proof of production without a public `style.css` readback, and do not assume the direction of any future drift. Read back, don't assume.
 
 ---
 
-**Last verified:** 2026-08-12 (live WP **7.0.4**; Aurora live and repo `main` **in sync at 1.6.4**; public route smoke passed after refreshing the expected WordPress version; pixel gate repaired (#697) and ran clean on the 1.6.4 window — 33 small diffs all accounted for by intentional changes + same-day content drift; front door is CURRENT-STATE 2026-07-30 / WORK-PLAN 2026-08-09 / MASTER-PLAN 2026-07-30; Cloud secrets may still be unset in long-lived pods). If you're reading this much later and the repo has drifted, run `make morning-truth` (or `make status-readonly`) and treat the newest committed `docs/current-state/reports/morning-truth-*.md` as the source of truth.
+**Instruction review:** 2026-08-13. Runtime state is deliberately not pinned here. Run `make status-readonly`, consult the current-state front door, and use public readback evidence before acting on live-state assumptions.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke seo-publisher-smoke check-live-parity wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
+.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke seo-publisher-smoke check-live-parity wp7-admin-readiness current-state-drift-check morning-truth morning-truth-checkpoint status-readonly docs-truth-check env-check varlock-run clean
 
 PYTHON ?= python3
 VARLOCK ?= varlock
@@ -259,8 +259,11 @@ wp7-admin-readiness: ## Run authenticated read-only WP 7 readiness snapshot (ENV
 current-state-drift-check: ## Compare declared current-state snapshot values vs live read-only checks
 	@python3 scripts/check_current_state_drift.py --work-plan "$${WORK_PLAN:-$(WORK_PLAN_DEFAULT)}" --base-url "$${BASE_URL:-https://kriskrug.co}"
 
-morning-truth: ## Run startup truth checks and write a timestamped markdown report
+morning-truth: ## Write startup truth to the ignored generated-state directory
 	@python3 scripts/morning_truth_report.py --work-plan "$${WORK_PLAN:-$(WORK_PLAN_DEFAULT)}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-$(EXPECT_VERSION_DEFAULT)}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
+
+morning-truth-checkpoint: ## Write an explicit durable checkpoint under current-state reports
+	@python3 scripts/morning_truth_report.py --checkpoint --work-plan "$${WORK_PLAN:-$(WORK_PLAN_DEFAULT)}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-$(EXPECT_VERSION_DEFAULT)}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"
 
 status-readonly: ## Print startup truth checks without writing a report
 	@python3 scripts/morning_truth_report.py --stdout --skip-fetch --work-plan "$${WORK_PLAN:-$(WORK_PLAN_DEFAULT)}" --base-url "$${BASE_URL:-https://kriskrug.co}" --expect-version "$${EXPECT_VERSION:-$(EXPECT_VERSION_DEFAULT)}" --request-timeout "$${REQUEST_TIMEOUT:-20}" --command-timeout "$${COMMAND_TIMEOUT:-120}"

--- a/README.md
+++ b/README.md
@@ -85,12 +85,13 @@ skills/                          # Claude Code skills used in this repo
 
 - **Reading the site state:** `docs/current-state/README.md`
 - **Planning next work:** the newest dated `docs/current-state/CURRENT-STATE-*.md` and `docs/current-state/WORK-PLAN-*.md` (the index in `docs/current-state/README.md` names the current ones)
-- **Latest startup truth:** the newest `docs/current-state/reports/morning-truth-*.md` (run `make morning-truth` for a fresh one; dated links go stale fast, so always take the newest)
+- **Current startup truth:** `make status-readonly` prints current repo/site signals without writing a file
+- **Local generated report:** `make morning-truth` writes to the gitignored `.generated/current-state/` directory
+- **Durable checkpoint:** `make morning-truth-checkpoint` writes to `docs/current-state/reports/` only for an explicit release, incident, durable decision, or handoff
 - **Latest diagnostic truth:** `docs/current-state/DIAGNOSTIC-POLISH-2026-05-20.md`
 - **Longer roadmap references:** `docs/current-state/ROADMAP.md` and `docs/current-state/FIX_QUEUE.md`
 - **Publishing a Notion post:** `scripts/notion-to-wp/README.md`
 - **Reviewing staged drafts:** `content/drafts/README.md`
-- **Read-only startup status:** `make status-readonly` prints current repo/site signals without writing a report
 - **Filing an issue:** `issues-to-create/` for drafts; existing ones at [WalksWithASwagger/kriskrug-wp/issues](https://github.com/WalksWithASwagger/kriskrug-wp/issues)
 
 ## How work happens here
@@ -133,7 +134,7 @@ If you're editing a post, page, schema, redirect, or category → Track A. If yo
 
 There is no local app server. The live WordPress site runs on Pagely and is not file-synced with this repo. "Running" this repo means the CLI and validation surfaces:
 
-- `make status-readonly` or `make morning-truth` for startup truth
+- `make status-readonly` for startup truth; use `make morning-truth` only when a local generated copy is useful
 - `make test` for the local test suite (Python, JavaScript syntax, plugin and theme smoke)
 - `make validate` for the WordPress PHP security ruleset (run `composer install` first)
 - `make verify` for the standard local gate (test + docs-truth-check + validate)
@@ -161,7 +162,7 @@ Start at [`AGENTS.md`](AGENTS.md), then read [`docs/current-state/README.md`](do
 
 ## Technology Stack
 
-- **Platform:** WordPress **7.0.1** on Pagely (production), Aurora `kk-aurora` theme (live may lag repo — check CURRENT-STATE)
+- **Platform:** WordPress on Pagely with the Aurora `kk-aurora` theme; run `make status-readonly` for current production versions
 - **Content pipeline:** Python (Notion API → WordPress REST API)
 - **Custom code:** PHP snippets (Code Snippets plugin on prod), `inc/digital-composting.php`, and packaged helper plugins such as `plugins/kk-sidebar-promos/`
 - **CLI Tools:** GitHub CLI (`gh`), Claude Code / Cursor agents

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,7 +8,7 @@ Navigation for everything in this repo. Entries are grouped by what they're for,
 
 ## 🟢 Current State And Dated Evidence
 
-The canonical baseline snapshot and current handoffs live in [`docs/current-state/`](current-state/). The May 14 files are frozen evidence; use the newest dated closeout plus the latest `make status-readonly` or `make morning-truth` output as the startup front door.
+The canonical baseline snapshot and current handoffs live in [`docs/current-state/`](current-state/). The May 14 files are frozen evidence; use the newest dated closeout plus a fresh `make status-readonly` run as the startup front door. Use `make morning-truth` only for an ignored local copy.
 
 | File | What it covers |
 |---|---|
@@ -22,7 +22,7 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 | [`current-state/ROLLBACK_PLAYBOOK.md`](current-state/ROLLBACK_PLAYBOOK.md) | Order of operations if a prod change breaks |
 | [`current-state/AURORA-STYLESHEET-REBUILD-PLAN.md`](current-state/AURORA-STYLESHEET-REBUILD-PLAN.md) | Path A stylesheet rebuild plan of record (#423) |
 | [`current-state/SEO-INDEXING-RUNBOOK.md`](current-state/SEO-INDEXING-RUNBOOK.md) | Indexing/distribution checklist |
-| [`current-state/reports/`](current-state/reports/) | Timestamped `make morning-truth` outputs; prefer newest `morning-truth-*.md` |
+| [`current-state/reports/`](current-state/reports/) | Explicit durable `make morning-truth-checkpoint` outputs; consult the checkpoint relevant to the release, incident, decision, or handoff |
 | [`current-state/archive/`](current-state/archive/) | Superseded May–June plans and closeouts (#549) |
 | [`current-state/AURORA-MOTION-GOVERNANCE-2026-05-20.md`](current-state/archive/AURORA-MOTION-GOVERNANCE-2026-05-20.md) | Motion budget and QA rules for Aurora |
 | [`current-state/TOMORROW-ROADMAP-2026-05-20.md`](current-state/archive/TOMORROW-ROADMAP-2026-05-20.md) | Historical next-session roadmap after rewrite recovery and branch/worktree cleanup |

--- a/docs/current-state/MASTER-PLAN-2026-07-30.md
+++ b/docs/current-state/MASTER-PLAN-2026-07-30.md
@@ -28,7 +28,7 @@ Make this repo trustworthy again so agents and humans stop navigating by stale w
 - Write this file + CURRENT-STATE + WORK-PLAN 2026-07-30
 - Retarget AGENTS.md, README, Makefile `WORK_PLAN_DEFAULT`, docs/INDEX
 - Banner-demote WORK-PLAN 07-16 / 07-19 / 07-26 (and peers)
-- Commit fresh `make morning-truth` report
+- Create, review, and commit a `make morning-truth-checkpoint` report for this durable truth reset
 - Fix obvious post-merge lies in active docs (e.g. CHANGELOG 1.5.0 “still unmerged”)
 
 ### Phase 1 — Docs archive (#549)

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -1,15 +1,15 @@
 # Current State of kriskrug.co
 
-Ops truth for [kriskrug.co](https://kriskrug.co/). Every May and June 2026 plan now lives under [`archive/`](archive/) (#549, see the close-out section at the bottom). Read the front door below, then the newest `reports/morning-truth-*.md`.
+Ops truth for [kriskrug.co](https://kriskrug.co/). Every May and June 2026 plan now lives under [`archive/`](archive/) (#549, see the close-out section at the bottom). Read the front door below, then run `make status-readonly` for current runtime signals.
 
 ## Current Front Door (verified 2026-08-12)
 
 Read these first:
 
-1. **[WORK-PLAN-2026-08-09.md](WORK-PLAN-2026-08-09.md)**, latest dated runbook (supersedes 2026-08-05; use the newest morning-truth report for live counters)
-2. **[CURRENT-STATE-2026-07-30.md](CURRENT-STATE-2026-07-30.md)**, declared snapshot for `make morning-truth` / drift (counts drifted — see newest report)
+1. **[WORK-PLAN-2026-08-09.md](WORK-PLAN-2026-08-09.md)**, latest dated runbook (supersedes 2026-08-05; use `make status-readonly` for live counters)
+2. **[CURRENT-STATE-2026-07-30.md](CURRENT-STATE-2026-07-30.md)**, declared snapshot for morning-truth drift checks (compare it with a fresh `make status-readonly` run)
 3. **[MASTER-PLAN-2026-07-30.md](MASTER-PLAN-2026-07-30.md)**, truth then reclaim then product lanes (hygiene phases complete)
-4. Newest **[reports/morning-truth-*.md](reports/)**, or run `make status-readonly` / `make morning-truth`
+4. Run `make status-readonly` for current signals; use the newest **[reports/morning-truth-*.md](reports/)** only as durable checkpoint evidence
 5. **[TWO-TRACK-MODEL.md](TWO-TRACK-MODEL.md)**, Track A vs Track B
 6. **[INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)**, slug/idempotency safety rules. Dated May, deliberately kept at top level: it is a standing safety rule, not a plan.
 7. **[../../.env.schema](../../.env.schema)** plus **[VARLOCK-ROLLOUT-2026-07-16.md](VARLOCK-ROLLOUT-2026-07-16.md)**, env contract (never read plaintext `.env`)
@@ -92,7 +92,8 @@ Neither is a plan you execute from. Check with `ls docs/current-state/*.md | gre
 
 ## Reports and subdirectories
 
-- `reports/`, timestamped `make morning-truth` output and ops evidence. Prefer the newest `morning-truth-*.md`. Markdown stays tracked; screenshot binaries are reclaim targets (#369 bucket D).
+- `.generated/current-state/`, gitignored local `make morning-truth` output. Routine startup telemetry stays here and is not committed.
+- `reports/`, durable checkpoint and ops evidence. `make morning-truth-checkpoint` writes here only for an explicit release, incident, durable decision, or handoff. Existing morning-truth Markdown remains tracked historical evidence; screenshot binaries are reclaim targets (#369 bucket D).
 - `raw/`, unprocessed captures feeding the audits.
 - `marketing/`, `portal/`, `templates/`, scoped working sets, not startup context.
 - `archive/`, everything above.

--- a/docs/current-state/WORK-PLAN-2026-08-09.md
+++ b/docs/current-state/WORK-PLAN-2026-08-09.md
@@ -39,7 +39,7 @@
 ## North star (ordered)
 
 1. **Lane 0 — repo integrity rescue.** The git database evaporates on reboot. Nothing else is durable until this is done.
-2. **Truth re-baseline** — fresh committed morning-truth + doc version corrections (WP 7.0.3, Aurora 1.5.9/1.6.0).
+2. **Truth re-baseline** — explicit durable `make morning-truth-checkpoint` snapshot + doc version corrections (WP 7.0.3, Aurora 1.5.9/1.6.0).
 3. **Deploy window** — Aurora 1.6.0 → live (pixel-gated). Ships three queued versions at once; unblocks #601/#602 testimonials chain.
 4. **Track B a11y debt** — #684 (empty `09-late.css`, invisible service titles) is the highest-priority open code bug.
 5. **Track A apply wave** — carry-over from Aug 5; apply-ready artifacts still waiting on KK per-post approval.
@@ -65,8 +65,8 @@ KK approval for the `mv` (state-changing) and for every branch deletion (proof-b
 
 ## Lane 1: Truth re-baseline (docs, ~30 min)
 
-1. `make morning-truth` while online; confirm the report shows real counts (0 PRs / 44 issues / WP 7.0.3 / Aurora 1.5.9 vs 1.6.0).
-2. Commit the fresh report. Decide the two offline Aug 7 reports: commit as historical record of the outage, or delete (KK call; they document the git-repair day).
+1. Run `make morning-truth-checkpoint` while online because this truth reset is a durable checkpoint; confirm the report shows real counts (0 PRs / 44 issues / WP 7.0.3 / Aurora 1.5.9 vs 1.6.0).
+2. Review and commit the checkpoint report. Decide the two offline Aug 7 reports: commit as historical record of the outage, or delete (KK call; they document the git-repair day).
 3. Correct AGENTS.md **Last verified** block + CURRENT-STATE header facts: WP 7.0.3, live 1.5.9 / repo 1.6.0, gap description. (Successor to the #688 pattern.)
 4. One `docs:` commit, push immediately (do not let commits sit in an at-risk gitdir — Lane 0 first if possible).
 
@@ -150,7 +150,7 @@ Speaking wave is the ripest: #637 (photo rights) and #638 (taxonomy) prep merged
 Follow docs/current-state/WORK-PLAN-2026-08-09.md as the day runbook.
 0) FIRST: ls -la .git — if it is still a symlink into /private/tmp, do Lane 0 (with KK) before anything else.
 1) Run: make status-readonly && make env-check
-2) Read the newest committed reports/morning-truth-*.md + this work plan.
+2) Read this work plan; consult the newest committed reports/morning-truth-*.md only when its durable checkpoint context is relevant.
 3) Pick ONE lane: rescue (Lane 0), truth (Lane 1), deploy (Lane 2, needs KK), Track B (Lane 3), Track A apply (Lane 4, needs KK), or hygiene (Lane 6).
 4) No live WP writes without explicit KK approval of the exact artifact/checklist.
 5) One concern per commit. Push promptly — do not park commits locally while the gitdir is at risk.

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -127,7 +127,7 @@ CURRENT_LANGUAGE_PATTERNS = [
 ]
 
 ANCHOR_PATTERN = re.compile(
-    r"2026-\d\d-\d\d|morning-truth|reports/|HANDOFF-2026-05-24|TRACK-A-MORNING-TRUTH|AURORA-V3-QA",
+    r"2026-\d\d-\d\d|morning-truth|status-readonly|reports/|HANDOFF-2026-05-24|TRACK-A-MORNING-TRUTH|AURORA-V3-QA",
     re.I,
 )
 

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -133,11 +133,11 @@ ACTIVE_GUIDANCE_PATHS = {
 STALE_MORNING_TRUTH_FLOW_PATTERNS: list[re.Pattern[str]] = [
     re.compile(
         r"\bmake\s+morning-truth(?!-checkpoint)\b[^\n]*"
-        r"(?:\n\s*(?:[-*]|\d+[.)])?\s*)?\bcommit\b",
+        r"(?:\n\s*(?:[-*]|\d+[.)])?\s*)?(?<!not )\bcommit\b",
         re.I,
     ),
     re.compile(
-        r"\bcommit\b[^\n]*\bmake\s+morning-truth(?!-checkpoint)\b",
+        r"(?<!not )\bcommit\b[^\n]*\bmake\s+morning-truth(?!-checkpoint)\b",
         re.I,
     ),
 ]

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -121,6 +121,27 @@ STALE_FRONT_DOOR_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
 ]
 
+ACTIVE_GUIDANCE_PATHS = {
+    Path("AGENTS.md"),
+    Path("README.md"),
+    Path("docs/INDEX.md"),
+    Path("docs/current-state/README.md"),
+    Path("docs/current-state/WORK-PLAN-2026-08-09.md"),
+    Path("docs/current-state/MASTER-PLAN-2026-07-30.md"),
+}
+
+STALE_MORNING_TRUTH_FLOW_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\bmake\s+morning-truth(?!-checkpoint)\b[^\n]*"
+        r"(?:\n\s*(?:[-*]|\d+[.)])?\s*)?\bcommit\b",
+        re.I,
+    ),
+    re.compile(
+        r"\bcommit\b[^\n]*\bmake\s+morning-truth(?!-checkpoint)\b",
+        re.I,
+    ),
+]
+
 CURRENT_LANGUAGE_PATTERNS = [
     re.compile(r"\bcurrent (?:front door|execution truth|startup context|startup truth)\b", re.I),
     re.compile(r"\blatest startup truth\b", re.I),
@@ -182,6 +203,18 @@ def scan_file(repo_root: Path, path: Path) -> list[Finding]:
     findings: list[Finding] = []
     relative_path = path.relative_to(repo_root)
     text = path.read_text(encoding="utf-8")
+
+    if relative_path in ACTIVE_GUIDANCE_PATHS:
+        for pattern in STALE_MORNING_TRUTH_FLOW_PATTERNS:
+            for match in pattern.finditer(text):
+                findings.append(
+                    Finding(
+                        relative_path,
+                        text.count("\n", 0, match.start()) + 1,
+                        "Routine `make morning-truth` output must not be committed; use `make morning-truth-checkpoint` for durable evidence.",
+                        match.group(0).replace("\n", " ").strip(),
+                    )
+                )
 
     for line_number, line in enumerate(text.splitlines(), start=1):
         for pattern, message in KNOWN_STALE_PATTERNS + STALE_FRONT_DOOR_PATTERNS:

--- a/scripts/morning_truth_report.py
+++ b/scripts/morning_truth_report.py
@@ -232,6 +232,27 @@ def render_command_block(result: CommandResult) -> str:
     return "\n".join(lines)
 
 
+def resolve_output_path(
+    repo_root: Path,
+    stamp: str,
+    *,
+    stdout: bool = False,
+    out: str | None = None,
+    checkpoint: bool = False,
+) -> Path | None:
+    if sum((stdout, out is not None, checkpoint)) > 1:
+        raise ValueError("only one output mode may be selected")
+    if stdout:
+        return None
+    if out:
+        path = Path(out)
+    elif checkpoint:
+        path = Path("docs/current-state/reports") / f"morning-truth-{stamp}.md"
+    else:
+        path = Path(".generated/current-state") / f"morning-truth-{stamp}.md"
+    return path if path.is_absolute() else (repo_root / path).resolve()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", default="https://kriskrug.co")
@@ -253,11 +274,17 @@ def main() -> int:
         default=20,
         help="Timeout for each public smoke HTTP request.",
     )
-    parser.add_argument("--out", help="Write report to this path.")
-    parser.add_argument(
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument("--out", help="Write report to this deliberate path.")
+    output_group.add_argument(
         "--stdout",
         action="store_true",
         help="Print the report instead of writing a file.",
+    )
+    output_group.add_argument(
+        "--checkpoint",
+        action="store_true",
+        help="Write a durable report under docs/current-state/reports/.",
     )
     parser.add_argument(
         "--skip-fetch",
@@ -270,21 +297,18 @@ def main() -> int:
         help="Exit non-zero when any startup truth data source is unavailable (opt-in automation gate).",
     )
     args = parser.parse_args()
-    if args.stdout and args.out:
-        parser.error("--stdout cannot be combined with --out")
 
     repo_root = Path(__file__).resolve().parents[1]
     now = datetime.now(UTC)
     stamp = now.strftime("%Y%m%d-%H%M%SZ")
-    out_path = None
-    if not args.stdout:
-        out_path = (
-            Path(args.out)
-            if args.out
-            else repo_root / "docs/current-state/reports" / f"morning-truth-{stamp}.md"
-        )
-        if not out_path.is_absolute():
-            out_path = (repo_root / out_path).resolve()
+    out_path = resolve_output_path(
+        repo_root,
+        stamp,
+        stdout=args.stdout,
+        out=args.out,
+        checkpoint=args.checkpoint,
+    )
+    if out_path:
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
     startup_results = []
@@ -640,6 +664,7 @@ def main() -> int:
     if args.stdout:
         print(report, end="")
     else:
+        assert out_path is not None
         out_path.write_text(report, encoding="utf-8")
         print(out_path)
     if args.fail_on_error and truth_errors:

--- a/scripts/tests/test_docs_truth_check.py
+++ b/scripts/tests/test_docs_truth_check.py
@@ -61,6 +61,25 @@ class EphemeralMorningTruthGuidanceTests(unittest.TestCase):
             any("morning-truth-checkpoint" in finding.message for finding in findings)
         )
 
+    def test_active_guidance_allows_negated_commit_safety_language(self):
+        samples = [
+            "Use `make morning-truth` for an ignored local copy; do not commit it.\n",
+            "Do not commit output from `make morning-truth`; it is ephemeral.\n",
+        ]
+
+        for sample in samples:
+            with self.subTest(sample=sample), tempfile.TemporaryDirectory() as tmp:
+                repo_root = Path(tmp)
+                readme = repo_root / "docs/current-state/README.md"
+                readme.parent.mkdir(parents=True)
+                readme.write_text(sample, encoding="utf-8")
+
+                findings = docs_truth_check.scan_file(repo_root, readme)
+
+            self.assertFalse(
+                any("morning-truth-checkpoint" in finding.message for finding in findings)
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_docs_truth_check.py
+++ b/scripts/tests/test_docs_truth_check.py
@@ -1,0 +1,66 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import docs_truth_check  # noqa: E402
+
+
+class EphemeralMorningTruthGuidanceTests(unittest.TestCase):
+    def test_active_guidance_rejects_routine_report_commit_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            work_plan = repo_root / "docs/current-state/WORK-PLAN-2026-08-09.md"
+            work_plan.parent.mkdir(parents=True)
+            work_plan.write_text(
+                "1. `make morning-truth` while online.\n"
+                "2. Commit the fresh report.\n",
+                encoding="utf-8",
+            )
+
+            findings = docs_truth_check.scan_file(repo_root, work_plan)
+
+        self.assertTrue(
+            any("morning-truth-checkpoint" in finding.message for finding in findings)
+        )
+
+    def test_active_guidance_rejects_commit_first_routine_report_flow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            master_plan = repo_root / "docs/current-state/MASTER-PLAN-2026-07-30.md"
+            master_plan.parent.mkdir(parents=True)
+            master_plan.write_text(
+                "- Commit fresh `make morning-truth` report\n",
+                encoding="utf-8",
+            )
+
+            findings = docs_truth_check.scan_file(repo_root, master_plan)
+
+        self.assertTrue(
+            any("morning-truth-checkpoint" in finding.message for finding in findings)
+        )
+
+    def test_active_guidance_allows_ephemeral_and_checkpoint_modes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            readme = repo_root / "docs/current-state/README.md"
+            readme.parent.mkdir(parents=True)
+            readme.write_text(
+                "Run `make status-readonly` for routine startup.\n"
+                "Use `make morning-truth` only for an ignored local copy.\n"
+                "Use `make morning-truth-checkpoint` and commit it for a durable handoff.\n",
+                encoding="utf-8",
+            )
+
+            findings = docs_truth_check.scan_file(repo_root, readme)
+
+        self.assertFalse(
+            any("morning-truth-checkpoint" in finding.message for finding in findings)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_morning_truth_report.py
+++ b/scripts/tests/test_morning_truth_report.py
@@ -166,6 +166,52 @@ class MorningTruthAvailabilityTests(unittest.TestCase):
         self.assertEqual(errors, [])
 
 
+class MorningTruthOutputPathTests(unittest.TestCase):
+    def test_default_report_uses_generated_state_directory(self):
+        repo_root = Path("/workspace/kriskrug-wp")
+
+        output = morning_truth_report.resolve_output_path(
+            repo_root, "20260813-120000Z"
+        )
+
+        self.assertEqual(
+            output,
+            repo_root
+            / ".generated/current-state"
+            / "morning-truth-20260813-120000Z.md",
+        )
+
+    def test_checkpoint_report_uses_durable_reports_directory(self):
+        repo_root = Path("/workspace/kriskrug-wp")
+
+        output = morning_truth_report.resolve_output_path(
+            repo_root, "20260813-120000Z", checkpoint=True
+        )
+
+        self.assertEqual(
+            output,
+            repo_root
+            / "docs/current-state/reports"
+            / "morning-truth-20260813-120000Z.md",
+        )
+
+    def test_stdout_has_no_output_path(self):
+        output = morning_truth_report.resolve_output_path(
+            Path("/workspace/kriskrug-wp"), "20260813-120000Z", stdout=True
+        )
+
+        self.assertIsNone(output)
+
+    def test_output_modes_are_mutually_exclusive(self):
+        with self.assertRaisesRegex(ValueError, "only one output mode"):
+            morning_truth_report.resolve_output_path(
+                Path("/workspace/kriskrug-wp"),
+                "20260813-120000Z",
+                stdout=True,
+                checkpoint=True,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
## Summary

- make `status-readonly` the default session-start truth command
- write routine `morning-truth` reports to ignored `.generated/current-state/`
- add explicit `morning-truth-checkpoint` mode for durable release, incident, decision, or handoff evidence
- remove volatile live WordPress/theme versions from root agent guidance while preserving public-readback safety
- preserve every existing committed report as historical evidence

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider scripts/tests/test_morning_truth_report.py` — 19 passed
- `PYTHONDONTWRITEBYTECODE=1 make docs-truth-check` — passed
- `make status-readonly COMMAND_TIMEOUT=5 REQUEST_TIMEOUT=5` — passed, no report written
- `make morning-truth COMMAND_TIMEOUT=1 REQUEST_TIMEOUT=1` — passed; wrote only to ignored generated state
- `git check-ignore .generated/current-state/morning-truth-*.md` — generated output ignored
- durable checkpoint fixture path remains trackable
- `git diff --check` — passed

The broad `python3 -m pytest -q` gate was not run locally because the swarm host hit a low-disk condition. The focused behavior and docs gates passed; CI remains the broad gate.

Closes #725\n\n## Review follow-up\n\n- corrected canonical active guidance so routine startup uses `make status-readonly` and durable truth resets use `make morning-truth-checkpoint`\n- added an active-guidance regression guard covering both command-then-commit and commit-then-command forms\n- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider scripts/tests/test_docs_truth_check.py scripts/tests/test_morning_truth_report.py` — 23 passed, 2 subtests passed\n- `PYTHONDONTWRITEBYTECODE=1 make docs-truth-check` — passed\n- `git diff --check` — passed\n- tracked historical report count remains unchanged (200 at base and head before this docs-only follow-up)