### PR TITLE
feat: add AI Garden to the Aurora project footer

### DIFF
--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.5
+**Deployed:** On main; deploy pending
+Add AI Garden to the project footer and ship the previously merged Creative AI Human Lab links with an explicit versioned release.
+
 ## 1.6.4
 **Deployed:** LIVE (public readback 2026-08-11; the 2026-08-11 window shipped 1.6.1 through 1.6.4 together, rollback `kk-aurora.bak-1786415439`)
 CLS/LCP fix: critical-geometry guard in the header part pins marquee + header layout during the stale-Boost-critical-CSS window; reveal hide moves from stylesheet to JS ownership with synchronous above-fold reveal (#701, PR pending). After deploying, regenerate Jetpack Boost critical CSS.

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.4');
+define('KK_AURORA_VERSION', '1.6.5');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -27,6 +27,7 @@
         <a href="https://bc-ai.ca/">BC + AI</a>
         <a href="https://vancouver.ai/">Vancouver AI</a>
         <a href="https://futureproof.website/">Futureproof Festival</a>
+        <a href="https://kriskrug.ai/">AI Garden</a>
         <a href="https://skywhaleairways.com/">Skywhale Airways</a>
         <a href="https://www.punkrockai.com/">Punk Rock AI</a>
         <a href="https://wedges.dev/">Wedges</a>

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.4
+Version: 1.6.5
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary
- add AI Garden to the global project footer
- bump Aurora to 1.6.5 so the deployment is observable
- record the pending release in the theme changelog

## Verification
- make theme-smoke
- make test (343 publisher tests, 12 SEO inventory tests, 68 link-safety tests)
- git diff --check

User-approved Creative AI Human Lab reciprocal-link rollout.