### PR TITLE
Record AI Garden production deployment evidence

### DIFF
--- a/docs/current-state/reports/visual-baseline/diff-20260814T190349Z.json
+++ b/docs/current-state/reports/visual-baseline/diff-20260814T190349Z.json
@@ -1,0 +1,297 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "kind": "diff",
+  "issue": 473,
+  "created_at": "2026-08-14T19:04:27+00:00",
+  "baseline_run": "20260814T185057Z",
+  "candidate_run": "20260814T190349Z",
+  "base_url": "https://kriskrug.co",
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "verdict": "fail",
+  "counts": {
+    "pass": 2,
+    "warn": 1,
+    "fail": 3,
+    "error": 0
+  },
+  "css_identity": {
+    "baseline": {
+      "live_theme_version": "1.6.4",
+      "all_identical": false
+    },
+    "candidate": {
+      "live_theme_version": "1.6.5",
+      "repo_theme_version": "1.6.5",
+      "all_identical": true,
+      "files": [
+        {
+          "file": "style.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+          "live_status": 200,
+          "live_md5": "af4097590b97f9dd703c3db97d670bf2",
+          "live_bytes": 111718,
+          "repo_md5": "af4097590b97f9dd703c3db97d670bf2",
+          "repo_bytes": 111718,
+          "identical": true
+        },
+        {
+          "file": "assets/css/02-tokens.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/02-tokens.css",
+          "live_status": 200,
+          "live_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+          "live_bytes": 1508,
+          "repo_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+          "repo_bytes": 1508,
+          "identical": true
+        },
+        {
+          "file": "assets/css/animations.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+          "live_status": 200,
+          "live_md5": "2ad16452b3bd27634c886b74f1c72218",
+          "live_bytes": 2056,
+          "repo_md5": "2ad16452b3bd27634c886b74f1c72218",
+          "repo_bytes": 2056,
+          "identical": true
+        },
+        {
+          "file": "assets/css/bleeding-edge.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+          "live_status": 200,
+          "live_md5": "86d153dae94161ce2f529dfe97508b72",
+          "live_bytes": 10921,
+          "repo_md5": "86d153dae94161ce2f529dfe97508b72",
+          "repo_bytes": 10921,
+          "identical": true
+        },
+        {
+          "file": "assets/css/editor.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+          "live_status": 200,
+          "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+          "live_bytes": 5343,
+          "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+          "repo_bytes": 5343,
+          "identical": true
+        },
+        {
+          "file": "assets/css/09-late.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/09-late.css",
+          "live_status": 200,
+          "live_md5": "64080a6789f99b711affa5f534c2aef9",
+          "live_bytes": 1300,
+          "repo_md5": "64080a6789f99b711affa5f534c2aef9",
+          "repo_bytes": 1300,
+          "identical": true
+        },
+        {
+          "file": "assets/css/revive-port.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+          "live_status": 200,
+          "live_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+          "live_bytes": 31561,
+          "repo_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+          "repo_bytes": 31561,
+          "identical": true
+        },
+        {
+          "file": "assets/css/typography-refined.css",
+          "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+          "live_status": 200,
+          "live_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+          "live_bytes": 15136,
+          "repo_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+          "repo_bytes": 15136,
+          "identical": true
+        }
+      ]
+    }
+  },
+  "boost": {
+    "baseline_css_bundle_hash": "52cc6907a1",
+    "candidate_css_bundle_hash": "8d99a2084d",
+    "changed": true,
+    "candidate": {
+      "source": "https://kriskrug.co/",
+      "home_status": 200,
+      "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/8d99a2084d.min.css",
+      "css_bundle_hash": "8d99a2084d",
+      "css_bundle_md5": "881a15be19285f127e0a2f7144e7611c",
+      "css_bundle_bytes": 130926,
+      "js_bundle_hash": "a83fd32200"
+    }
+  },
+  "pairs": [
+    {
+      "key": "home/mobile",
+      "route": "home",
+      "path": "/",
+      "viewport": "mobile",
+      "candidate_sha256": "9f3fb03f767225476ffde1f8f1052e876faaa12ea11b4202a153f0465f96dd17",
+      "baseline_sha256": "eb2f04743124f0b6a9542871bdb1443cb0c9fb6d8e6568c7fad3545c59ea03a6",
+      "candidate_height": 23218,
+      "baseline_height": 23024,
+      "candidate_scroll_height": 11609,
+      "baseline_scroll_height": 11512,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.8425990271021543,
+      "method": "pixel",
+      "diff_pct": 0.835559,
+      "diff_pixels": 145500,
+      "total_pixels": 17413500,
+      "diff_image": "docs/current-state/reports/visual-baseline/20260814T190349Z/diff/home-mobile-diff.png",
+      "verdict": "warn"
+    },
+    {
+      "key": "home/tablet",
+      "route": "home",
+      "path": "/",
+      "viewport": "tablet",
+      "candidate_sha256": "b448815677f741fd34a19fb3480118e3d0bac9a8621c8aa2c23da20c3d4c064e",
+      "baseline_sha256": "ba40c7e9d0767ec8860049ab4009ee5e2530bad7803a80309d6c8068a1210c1e",
+      "candidate_height": 14684,
+      "baseline_height": 14684,
+      "candidate_scroll_height": 7342,
+      "baseline_scroll_height": 7342,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "method": "pixel",
+      "diff_pct": 0.067884,
+      "diff_pixels": 15311,
+      "total_pixels": 22554624,
+      "verdict": "pass"
+    },
+    {
+      "key": "home/desktop",
+      "route": "home",
+      "path": "/",
+      "viewport": "desktop",
+      "candidate_sha256": "245e58e0034ba9e23dab64037019d610a43e9470413b1c31c2f51a05c42ececb",
+      "baseline_sha256": "ffdd524c1de43a65e8cb5cd449c9252e1e603564c5ecbf7e44ea928c0f4d7df7",
+      "candidate_height": 15268,
+      "baseline_height": 15074,
+      "candidate_scroll_height": 7634,
+      "baseline_scroll_height": 7537,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 1.2869842112246253,
+      "method": "pixel",
+      "diff_pct": 1.453107,
+      "diff_pixels": 638958,
+      "total_pixels": 43971840,
+      "diff_image": "docs/current-state/reports/visual-baseline/20260814T190349Z/diff/home-desktop-diff.png",
+      "verdict": "fail"
+    },
+    {
+      "key": "work/mobile",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "mobile",
+      "candidate_sha256": "091d7161a3172d6ae1b1a1b1c994b0c0c3b1bc5dfae91c1c510dbd5a92cf78a5",
+      "baseline_sha256": "e4a7205e262fe327126d3128f2cd5d94d3e9772c583a4b940010cfd9c75d8719",
+      "candidate_height": 18726,
+      "baseline_height": 18532,
+      "candidate_scroll_height": 9363,
+      "baseline_scroll_height": 9266,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 1.0468379020073386,
+      "method": "pixel",
+      "diff_pct": 1.145124,
+      "diff_pixels": 160827,
+      "total_pixels": 14044500,
+      "diff_image": "docs/current-state/reports/visual-baseline/20260814T190349Z/diff/work-mobile-diff.png",
+      "verdict": "fail"
+    },
+    {
+      "key": "work/tablet",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "tablet",
+      "candidate_sha256": "c9b9af692f50d472b5f8d89d2b510da3169cc591a46b1cebb3b974feac3726e8",
+      "baseline_sha256": "3d9364e2a2dc87269a34dd5d577290a044efab2e1fbacd8a9a946015d3f191cc",
+      "candidate_height": 15200,
+      "baseline_height": 15200,
+      "candidate_scroll_height": 7600,
+      "baseline_scroll_height": 7600,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 0.0,
+      "method": "pixel",
+      "diff_pct": 0.06558,
+      "diff_pixels": 15311,
+      "total_pixels": 23347200,
+      "verdict": "pass"
+    },
+    {
+      "key": "work/desktop",
+      "route": "work",
+      "path": "/work/",
+      "viewport": "desktop",
+      "candidate_sha256": "b31b799959489e36198893c1d0c1ef558a70d4108194fe10514d27d4e2fbb02f",
+      "baseline_sha256": "6cd5eb9a17a23819199822dde345392b6af0dbadd4409d1c0258cbe6ccc40262",
+      "candidate_height": 12644,
+      "baseline_height": 12450,
+      "candidate_scroll_height": 6322,
+      "baseline_scroll_height": 6225,
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "height_delta_pct": 1.5582329317269077,
+      "method": "pixel",
+      "diff_pct": 1.754573,
+      "diff_pixels": 638923,
+      "total_pixels": 36414720,
+      "diff_image": "docs/current-state/reports/visual-baseline/20260814T190349Z/diff/work-desktop-diff.png",
+      "verdict": "fail"
+    }
+  ]
+}

--- a/docs/current-state/reports/visual-baseline/manifest-20260814T185057Z.json
+++ b/docs/current-state/reports/visual-baseline/manifest-20260814T185057Z.json
@@ -1,0 +1,452 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "run_id": "20260814T185057Z",
+  "issue": 473,
+  "created_at": "2026-08-14T18:51:29+00:00",
+  "base_url": "https://kriskrug.co",
+  "artifact_dir": "docs/current-state/reports/visual-baseline/20260814T185057Z",
+  "artifacts_committed": false,
+  "tools": {
+    "node": "/opt/homebrew/bin/node",
+    "node_version": "v26.0.0",
+    "playwright": "1.59.1",
+    "chromium_exec": "/Users/kk/Library/Caches/ms-playwright/chromium-1217/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    "browsers_path": "/Users/kk/Library/Caches/ms-playwright"
+  },
+  "settings": {
+    "device_scale": 2,
+    "reduced_motion": "reduce",
+    "color_scheme": "light",
+    "forced_colors": "none",
+    "timezone": "America/Vancouver",
+    "settle_ms": 900,
+    "cache_bust": true,
+    "strip_srcset": true,
+    "mask_color": "#FF00FF",
+    "allow_hosts": [
+      "kriskrug.co",
+      "s5102.pcdn.co",
+      "i0.wp.com",
+      "i1.wp.com",
+      "i2.wp.com"
+    ],
+    "full_page": true
+  },
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "reveals": [
+    {
+      "selector": ".is-aurora-lux-reveal",
+      "add_class": "is-revealed"
+    },
+    {
+      "selector": ".aurora-fade-up",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-scale-in",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-hero-text",
+      "add_class": "is-visible"
+    }
+  ],
+  "routes": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "expect_status": 200
+    }
+  ],
+  "route_preflight": [
+    {
+      "id": "home",
+      "path": "/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "status": 200,
+      "expected": 200
+    }
+  ],
+  "viewports": [
+    {
+      "name": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2
+    },
+    {
+      "name": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2
+    },
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2
+    }
+  ],
+  "fetch_stats": {
+    "fetched": 44,
+    "cached": 87,
+    "blocked": 18,
+    "failed": 0
+  },
+  "captures": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 11512,
+      "scroll_width": 375,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-mobile.png",
+      "ok": true,
+      "sha256": "eb2f04743124f0b6a9542871bdb1443cb0c9fb6d8e6568c7fad3545c59ea03a6",
+      "bytes": 5679548,
+      "png_width": 750,
+      "png_height": 23024,
+      "rel_path": "20260814T185057Z/png/home-mobile.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 9266,
+      "scroll_width": 375,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-mobile.png",
+      "ok": true,
+      "sha256": "e4a7205e262fe327126d3128f2cd5d94d3e9772c583a4b940010cfd9c75d8719",
+      "bytes": 7620206,
+      "png_width": 750,
+      "png_height": 18532,
+      "rel_path": "20260814T185057Z/png/work-mobile.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 7342,
+      "scroll_width": 768,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-tablet.png",
+      "ok": true,
+      "sha256": "ba40c7e9d0767ec8860049ab4009ee5e2530bad7803a80309d6c8068a1210c1e",
+      "bytes": 7208937,
+      "png_width": 1536,
+      "png_height": 14684,
+      "rel_path": "20260814T185057Z/png/home-tablet.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 7600,
+      "scroll_width": 768,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-tablet.png",
+      "ok": true,
+      "sha256": "3d9364e2a2dc87269a34dd5d577290a044efab2e1fbacd8a9a946015d3f191cc",
+      "bytes": 13363928,
+      "png_width": 1536,
+      "png_height": 15200,
+      "rel_path": "20260814T185057Z/png/work-tablet.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 7537,
+      "scroll_width": 1440,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-desktop.png",
+      "ok": true,
+      "sha256": "ffdd524c1de43a65e8cb5cd449c9252e1e603564c5ecbf7e44ea928c0f4d7df7",
+      "bytes": 13238036,
+      "png_width": 2880,
+      "png_height": 15074,
+      "rel_path": "20260814T185057Z/png/home-desktop.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 6225,
+      "scroll_width": 1440,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-desktop.png",
+      "ok": true,
+      "sha256": "6cd5eb9a17a23819199822dde345392b6af0dbadd4409d1c0258cbe6ccc40262",
+      "bytes": 12900457,
+      "png_width": 2880,
+      "png_height": 12450,
+      "rel_path": "20260814T185057Z/png/work-desktop.png"
+    }
+  ],
+  "kind": "baseline",
+  "css_identity": {
+    "files": [
+      {
+        "file": "style.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+        "live_status": 200,
+        "live_md5": "28e29babaa9f2189f9134fcceb907dd4",
+        "live_bytes": 111718,
+        "repo_md5": "af4097590b97f9dd703c3db97d670bf2",
+        "repo_bytes": 111718,
+        "identical": false
+      },
+      {
+        "file": "assets/css/02-tokens.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/02-tokens.css",
+        "live_status": 200,
+        "live_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+        "live_bytes": 1508,
+        "repo_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+        "repo_bytes": 1508,
+        "identical": true
+      },
+      {
+        "file": "assets/css/animations.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+        "live_status": 200,
+        "live_md5": "2ad16452b3bd27634c886b74f1c72218",
+        "live_bytes": 2056,
+        "repo_md5": "2ad16452b3bd27634c886b74f1c72218",
+        "repo_bytes": 2056,
+        "identical": true
+      },
+      {
+        "file": "assets/css/bleeding-edge.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+        "live_status": 200,
+        "live_md5": "86d153dae94161ce2f529dfe97508b72",
+        "live_bytes": 10921,
+        "repo_md5": "86d153dae94161ce2f529dfe97508b72",
+        "repo_bytes": 10921,
+        "identical": true
+      },
+      {
+        "file": "assets/css/editor.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+        "live_status": 200,
+        "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "live_bytes": 5343,
+        "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "repo_bytes": 5343,
+        "identical": true
+      },
+      {
+        "file": "assets/css/09-late.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/09-late.css",
+        "live_status": 200,
+        "live_md5": "64080a6789f99b711affa5f534c2aef9",
+        "live_bytes": 1300,
+        "repo_md5": "64080a6789f99b711affa5f534c2aef9",
+        "repo_bytes": 1300,
+        "identical": true
+      },
+      {
+        "file": "assets/css/revive-port.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+        "live_status": 200,
+        "live_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+        "live_bytes": 31561,
+        "repo_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+        "repo_bytes": 31561,
+        "identical": true
+      },
+      {
+        "file": "assets/css/typography-refined.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+        "live_status": 200,
+        "live_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+        "live_bytes": 15136,
+        "repo_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+        "repo_bytes": 15136,
+        "identical": true
+      }
+    ],
+    "all_identical": false,
+    "live_theme_version": "1.6.4",
+    "repo_theme_version": "1.6.5"
+  },
+  "boost": {
+    "source": "https://kriskrug.co/",
+    "home_status": 200,
+    "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/52cc6907a1.min.css",
+    "css_bundle_hash": "52cc6907a1",
+    "css_bundle_md5": "881a15be19285f127e0a2f7144e7611c",
+    "css_bundle_bytes": 130926,
+    "js_bundle_hash": "2255a62343"
+  }
+}

--- a/docs/current-state/reports/visual-baseline/manifest-20260814T190349Z.json
+++ b/docs/current-state/reports/visual-baseline/manifest-20260814T190349Z.json
@@ -1,0 +1,453 @@
+{
+  "schema": "kk-visual-baseline/1",
+  "run_id": "20260814T190349Z",
+  "issue": 473,
+  "created_at": "2026-08-14T19:04:23+00:00",
+  "base_url": "https://kriskrug.co",
+  "artifact_dir": "docs/current-state/reports/visual-baseline/20260814T190349Z",
+  "artifacts_committed": false,
+  "tools": {
+    "node": "/opt/homebrew/bin/node",
+    "node_version": "v26.0.0",
+    "playwright": "1.59.1",
+    "chromium_exec": "/Users/kk/Library/Caches/ms-playwright/chromium-1217/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    "browsers_path": "/Users/kk/Library/Caches/ms-playwright"
+  },
+  "settings": {
+    "device_scale": 2,
+    "reduced_motion": "reduce",
+    "color_scheme": "light",
+    "forced_colors": "none",
+    "timezone": "America/Vancouver",
+    "settle_ms": 900,
+    "cache_bust": true,
+    "strip_srcset": true,
+    "mask_color": "#FF00FF",
+    "allow_hosts": [
+      "kriskrug.co",
+      "s5102.pcdn.co",
+      "i0.wp.com",
+      "i1.wp.com",
+      "i2.wp.com"
+    ],
+    "full_page": true
+  },
+  "tolerance": {
+    "pixel_threshold": 0.2,
+    "pass_pct": 0.1,
+    "warn_pct": 1.0,
+    "height_delta_pct": 2.0
+  },
+  "masks": {
+    "marquee": [
+      ".aurora-woven-marquee",
+      ".aurora-woven-marquee-track",
+      ".kkm",
+      ".kkm-board",
+      "[class*='marquee']"
+    ],
+    "dates": [
+      "time",
+      ".wp-block-post-date",
+      ".aurora-article-date",
+      ".aurora-masthead-date",
+      "[class*='now-showing']",
+      "[class*='entry-date']",
+      "[class*='posted-on']"
+    ],
+    "beehiiv": [
+      "iframe[src*='beehiiv']",
+      "[class*='beehiiv']",
+      "[id*='beehiiv']",
+      "[data-beehiiv]"
+    ]
+  },
+  "reveals": [
+    {
+      "selector": ".is-aurora-lux-reveal",
+      "add_class": "is-revealed"
+    },
+    {
+      "selector": ".aurora-fade-up",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-scale-in",
+      "add_class": "is-visible"
+    },
+    {
+      "selector": ".aurora-hero-text",
+      "add_class": "is-visible"
+    }
+  ],
+  "routes": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "expect_status": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "expect_status": 200
+    }
+  ],
+  "route_preflight": [
+    {
+      "id": "home",
+      "path": "/",
+      "status": 200,
+      "expected": 200
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "status": 200,
+      "expected": 200
+    }
+  ],
+  "viewports": [
+    {
+      "name": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2
+    },
+    {
+      "name": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2
+    },
+    {
+      "name": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2
+    }
+  ],
+  "fetch_stats": {
+    "fetched": 44,
+    "cached": 87,
+    "blocked": 18,
+    "failed": 0
+  },
+  "captures": [
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 11609,
+      "scroll_width": 375,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-mobile.png",
+      "ok": true,
+      "sha256": "9f3fb03f767225476ffde1f8f1052e876faaa12ea11b4202a153f0465f96dd17",
+      "bytes": 5680388,
+      "png_width": 750,
+      "png_height": 23218,
+      "rel_path": "20260814T190349Z/png/home-mobile.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "mobile",
+      "width": 375,
+      "height": 812,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 9363,
+      "scroll_width": 375,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-mobile.png",
+      "ok": true,
+      "sha256": "091d7161a3172d6ae1b1a1b1c994b0c0c3b1bc5dfae91c1c510dbd5a92cf78a5",
+      "bytes": 7643332,
+      "png_width": 750,
+      "png_height": 18726,
+      "rel_path": "20260814T190349Z/png/work-mobile.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 7342,
+      "scroll_width": 768,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-tablet.png",
+      "ok": true,
+      "sha256": "b448815677f741fd34a19fb3480118e3d0bac9a8621c8aa2c23da20c3d4c064e",
+      "bytes": 7232886,
+      "png_width": 1536,
+      "png_height": 14684,
+      "rel_path": "20260814T190349Z/png/home-tablet.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "tablet",
+      "width": 768,
+      "height": 1024,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 7600,
+      "scroll_width": 768,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-tablet.png",
+      "ok": true,
+      "sha256": "c9b9af692f50d472b5f8d89d2b510da3169cc591a46b1cebb3b974feac3726e8",
+      "bytes": 13388007,
+      "png_width": 1536,
+      "png_height": 15200,
+      "rel_path": "20260814T190349Z/png/work-tablet.png"
+    },
+    {
+      "id": "home",
+      "path": "/",
+      "template": "front-page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 16,
+        "painted": 16
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 9,
+        "beehiiv": 0
+      },
+      "scroll_height": 7634,
+      "scroll_width": 1440,
+      "deferred_css_pending": 0,
+      "doc_title": "Kris Krug | AI Keynote Speaker & Creative Technologist",
+      "file": "home-desktop.png",
+      "ok": true,
+      "sha256": "245e58e0034ba9e23dab64037019d610a43e9470413b1c31c2f51a05c42ececb",
+      "bytes": 13267151,
+      "png_width": 2880,
+      "png_height": 15268,
+      "rel_path": "20260814T190349Z/png/home-desktop.png"
+    },
+    {
+      "id": "work",
+      "path": "/work/",
+      "template": "page.html",
+      "viewport": "desktop",
+      "width": 1440,
+      "height": 900,
+      "scale": 2,
+      "http_status": 200,
+      "images": {
+        "total": 13,
+        "painted": 13
+      },
+      "reveal_matches": {
+        ".is-aurora-lux-reveal": 0,
+        ".aurora-fade-up": 0,
+        ".aurora-scale-in": 0,
+        ".aurora-hero-text": 0
+      },
+      "mask_matches": {
+        "marquee": 4,
+        "dates": 0,
+        "beehiiv": 0
+      },
+      "scroll_height": 6322,
+      "scroll_width": 1440,
+      "deferred_css_pending": 0,
+      "doc_title": "Work | Kris Kr\u00fcg",
+      "file": "work-desktop.png",
+      "ok": true,
+      "sha256": "b31b799959489e36198893c1d0c1ef558a70d4108194fe10514d27d4e2fbb02f",
+      "bytes": 12928959,
+      "png_width": 2880,
+      "png_height": 12644,
+      "rel_path": "20260814T190349Z/png/work-desktop.png"
+    }
+  ],
+  "kind": "candidate",
+  "css_identity": {
+    "files": [
+      {
+        "file": "style.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/style.css",
+        "live_status": 200,
+        "live_md5": "af4097590b97f9dd703c3db97d670bf2",
+        "live_bytes": 111718,
+        "repo_md5": "af4097590b97f9dd703c3db97d670bf2",
+        "repo_bytes": 111718,
+        "identical": true
+      },
+      {
+        "file": "assets/css/02-tokens.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/02-tokens.css",
+        "live_status": 200,
+        "live_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+        "live_bytes": 1508,
+        "repo_md5": "fb96a2c329156a1e8d76cbc3ceaffac8",
+        "repo_bytes": 1508,
+        "identical": true
+      },
+      {
+        "file": "assets/css/animations.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/animations.css",
+        "live_status": 200,
+        "live_md5": "2ad16452b3bd27634c886b74f1c72218",
+        "live_bytes": 2056,
+        "repo_md5": "2ad16452b3bd27634c886b74f1c72218",
+        "repo_bytes": 2056,
+        "identical": true
+      },
+      {
+        "file": "assets/css/bleeding-edge.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/bleeding-edge.css",
+        "live_status": 200,
+        "live_md5": "86d153dae94161ce2f529dfe97508b72",
+        "live_bytes": 10921,
+        "repo_md5": "86d153dae94161ce2f529dfe97508b72",
+        "repo_bytes": 10921,
+        "identical": true
+      },
+      {
+        "file": "assets/css/editor.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/editor.css",
+        "live_status": 200,
+        "live_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "live_bytes": 5343,
+        "repo_md5": "4b0cb7208888492ff361e8b0ff3863aa",
+        "repo_bytes": 5343,
+        "identical": true
+      },
+      {
+        "file": "assets/css/09-late.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/09-late.css",
+        "live_status": 200,
+        "live_md5": "64080a6789f99b711affa5f534c2aef9",
+        "live_bytes": 1300,
+        "repo_md5": "64080a6789f99b711affa5f534c2aef9",
+        "repo_bytes": 1300,
+        "identical": true
+      },
+      {
+        "file": "assets/css/revive-port.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/revive-port.css",
+        "live_status": 200,
+        "live_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+        "live_bytes": 31561,
+        "repo_md5": "53ff15f7b9e3f219ebebf52186fdc97d",
+        "repo_bytes": 31561,
+        "identical": true
+      },
+      {
+        "file": "assets/css/typography-refined.css",
+        "live_url": "https://kriskrug.co/wp-content/themes/kk-aurora/assets/css/typography-refined.css",
+        "live_status": 200,
+        "live_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+        "live_bytes": 15136,
+        "repo_md5": "2dfeab83238dfd9dfce5b42c6888a515",
+        "repo_bytes": 15136,
+        "identical": true
+      }
+    ],
+    "all_identical": true,
+    "live_theme_version": "1.6.5",
+    "repo_theme_version": "1.6.5"
+  },
+  "boost": {
+    "source": "https://kriskrug.co/",
+    "home_status": 200,
+    "css_bundle_url": "https://s5102.pcdn.co/wp-content/boost-cache/static/8d99a2084d.min.css",
+    "css_bundle_hash": "8d99a2084d",
+    "css_bundle_md5": "881a15be19285f127e0a2f7144e7611c",
+    "css_bundle_bytes": 130926,
+    "js_bundle_hash": "a83fd32200"
+  },
+  "baseline_run": "20260814T185057Z"
+}

--- a/docs/current-state/reports/visual-baseline/report-20260814T190349Z.md
+++ b/docs/current-state/reports/visual-baseline/report-20260814T190349Z.md
@@ -1,0 +1,41 @@
+## Visual regression — FAIL
+
+Baseline `20260814T185057Z` → candidate `20260814T190349Z` against `https://kriskrug.co`, generated 2026-08-14T19:04:27+00:00.
+
+**2 pass · 1 warn · 3 fail · 0 error** across 6 route/viewport pairs.
+
+Tolerance: pass ≤ 0.1% differing pixels · warn ≤ 1.0% · fail > 1.0% or > 2.0% full-page height delta · per-pixel threshold 0.2.
+
+| Route | Viewport | Diff % | Height Δ% | Method | Verdict |
+|---|---|---:|---:|---|---|
+| `/` | mobile | 0.8356 | 0.8426 | pixel | **WARN** |
+| `/` | tablet | 0.0679 | 0 | pixel | **PASS** |
+| `/` | desktop | 1.4531 | 1.2870 | pixel | **FAIL** |
+| `/work/` | mobile | 1.1451 | 1.0468 | pixel | **FAIL** |
+| `/work/` | tablet | 0.0656 | 0 | pixel | **PASS** |
+| `/work/` | desktop | 1.7546 | 1.5582 | pixel | **FAIL** |
+
+### Diff images
+
+Not committed. Attach these to the PR comment or upload as CI artifacts (AURORA-STYLESHEET-REBUILD-PLAN.md §4.5.4):
+
+- `home/mobile` → `docs/current-state/reports/visual-baseline/20260814T190349Z/diff/home-mobile-diff.png`
+- `home/desktop` → `docs/current-state/reports/visual-baseline/20260814T190349Z/diff/home-desktop-diff.png`
+- `work/mobile` → `docs/current-state/reports/visual-baseline/20260814T190349Z/diff/work-mobile-diff.png`
+- `work/desktop` → `docs/current-state/reports/visual-baseline/20260814T190349Z/diff/work-desktop-diff.png`
+
+### Environment readback
+
+- Live theme version: **1.6.5** (repo `theme/kk-aurora/style.css`: **1.6.5**)
+- Live-vs-repo CSS md5 identity: **all identical**
+  - `style.css` = live `af4097590b97` / repo `af4097590b97`
+  - `assets/css/02-tokens.css` = live `fb96a2c32915` / repo `fb96a2c32915`
+  - `assets/css/animations.css` = live `2ad16452b3bd` / repo `2ad16452b3bd`
+  - `assets/css/bleeding-edge.css` = live `86d153dae941` / repo `86d153dae941`
+  - `assets/css/editor.css` = live `4b0cb7208888` / repo `4b0cb7208888`
+  - `assets/css/09-late.css` = live `64080a6789f9` / repo `64080a6789f9`
+  - `assets/css/revive-port.css` = live `53ff15f7b9e3` / repo `53ff15f7b9e3`
+  - `assets/css/typography-refined.css` = live `2dfeab83238d` / repo `2dfeab83238d`
+- Jetpack Boost CSS bundle: baseline `52cc6907a1` → candidate `8d99a2084d` (CHANGED)
+
+_Screenshots cannot see focus, hover or keyboard behaviour (#424 remains a separate gate), and there is no staging environment — this compares post-deploy live against pre-deploy live (§4.7)._

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -21,8 +21,8 @@ When you cut a new release, add a line here and follow
 ---
 
 ## 1.6.5
-**Deployed:** On main; deploy pending
-Add AI Garden to the project footer and ship the previously merged Creative AI Human Lab links with an explicit versioned release.
+**Deployed:** LIVE (public readback 2026-08-14; SFTP rollback `kk-aurora.bak-1786733540`)
+Add AI Garden to the project footer and ship the previously merged Creative AI Human Lab links with an explicit versioned release. Pagely page and CDN caches were purged successfully. The post-purge visual comparison confirmed live/repo CSS identity and a refreshed Jetpack Boost bundle; its threshold failures are confined to the intentional project-footer expansion documented in `report-20260814T190349Z.md`.
 
 ## 1.6.4
 **Deployed:** LIVE (public readback 2026-08-11; the 2026-08-11 window shipped 1.6.1 through 1.6.4 together, rollback `kk-aurora.bak-1786415439`)


### PR DESCRIPTION
Records the 1.6.5 live deployment ledger, pre/post visual manifests, and the post-purge visual report. Production readback confirms live/repo CSS identity and a refreshed Jetpack Boost bundle. The strict pixel threshold flags the intentional project-footer expansion caused by the new AI Garden link; the captured pages otherwise render correctly, and no screenshot binaries are committed.