### PR TITLE
docs: record live state of custom WP code (#746) and declare the canonical Python test env (#750)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,17 +203,20 @@ There is no local app server to boot. The live site runs on Pagely and is not fi
 
 CI runs the gates on PHP 8.2, Python 3.12, and Node 20 (pinned in [`.github/workflows/test-pr.yml`](.github/workflows/test-pr.yml)). The Aurora theme declares a minimum of PHP 8.0 in [`theme/kk-aurora/style.css`](theme/kk-aurora/style.css). You don't need exact version matches locally, but if a gate behaves differently than CI, check your runtime versions first.
 
+Two requirement files, one canonical test environment. Root [`requirements-test.txt`](requirements-test.txt) **is the canonical Python test env** — CI installs it, and it is the only file that satisfies `make python-test` (it is the runtime deps plus `pytest`). [`scripts/notion-to-wp/requirements.txt`](scripts/notion-to-wp/requirements.txt) is **runtime-only**: it exists so several `Makefile` targets can call `scripts/notion-to-wp/.venv/bin/python` directly, and installing only it leaves you unable to run that package's test suites. Install the root file when you want to run tests, including the `scripts/notion-to-wp/tests` suites.
+
 ```bash
 # Clone repository
 git clone https://github.com/WalksWithASwagger/kriskrug-wp.git
 cd kriskrug-wp
 
-# Full Python test gate (repo root)
+# Full Python test gate (repo root) — canonical test env
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements-test.txt
 make python-test PYTHON=python
 
 # Notion → WP publisher (its own venv; several Makefile targets call it directly)
+# Runtime-only. Add -r ../../requirements-test.txt if you also want to run tests from this venv.
 cd scripts/notion-to-wp
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt

--- a/inc/digital-composting.php
+++ b/inc/digital-composting.php
@@ -2,6 +2,25 @@
 /**
  * Digital Composting Module
  * Registers Custom Post Type for Transcripts and Topics Taxonomy
+ *
+ * WHERE THIS RUNS: nowhere, as of 2026-08-15. Dormant.
+ *
+ * No tracked PHP loads this file. theme/kk-aurora/functions.php requires only
+ * inc/seo-title.php and inc/seo-meta-rest.php from the theme's own inc/ dir,
+ * and nothing else in the repo requires this repo-root path. So the only way it
+ * could be running is out of repo scope, as a Code Snippet or an mu-plugin on
+ * kriskrug.co. It is not.
+ *
+ * Read-only live check, 2026-08-15 against https://kriskrug.co:
+ *   - /wp-json/wp/v2/types      -> no `transcript` key
+ *   - /wp-json/wp/v2/taxonomies -> no `transcript_topic` key
+ *   - /wp-json/wp/v2/transcript -> 404
+ *   - /transcript/              -> 404
+ * Both registrations below set 'show_in_rest' => true, so they would appear in
+ * those two indexes if this code were loaded anywhere on live. It is not.
+ *
+ * Do not delete without KK approval. Archiving is proposed in issue #746.
+ * Re-verify with the four URLs above before acting on this note.
  */
 if (!defined('ABSPATH')) {
     exit;

--- a/plugins/kk-marquee-board/DEPLOYMENT.md
+++ b/plugins/kk-marquee-board/DEPLOYMENT.md
@@ -4,6 +4,8 @@ This plugin lives in the repo because the live WordPress install isn't version-c
 It makes `/marquee/` a real WordPress route. **Deployment is gated** (live writes require KK
 approval + a WP application password). Nothing here runs automatically.
 
+**Live status: NO, not installed or active on kriskrug.co. Verified 2026-08-15 (read-only), how: `marquee_board` is absent from `https://kriskrug.co/wp-json/wp/v2/types` and the CPT registers `show_in_rest => true` so it would appear there if active; `https://kriskrug.co/wp-json/wp/v2/marquee_board` returns 404; `https://kriskrug.co/marquee/` returns 404; `https://kriskrug.co/wp-content/plugins/kk-marquee-board/assets/marquee.css` returns 404.** The gated go-live below has never been executed. The `aurora-woven-marquee` element in live page markup is an unrelated Aurora theme decoration, not this plugin.
+
 ## Order of operations (the gated go-live)
 
 1. **Deploy the plugin** (Path A or B below) → activate. Activation flushes rewrite rules.

--- a/plugins/kk-sidebar-promos/DEPLOYMENT.md
+++ b/plugins/kk-sidebar-promos/DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 This plugin lives in the issue-tracking repo because the live WordPress install isn't version-controlled here. Two install paths — pick whichever is easier.
 
+**Live status: NO, not installed or active on kriskrug.co. Verified 2026-08-15 (read-only), how: `kk_promo` is absent from `https://kriskrug.co/wp-json/wp/v2/types` and the CPT registers `show_in_rest => true` so it would appear there if active; `https://kriskrug.co/wp-json/wp/v2/kk_promo` returns 404; no `kk-sp` markup renders on the homepage or on a published post page; `https://kriskrug.co/wp-content/plugins/kk-sidebar-promos/assets/css/` returns 404.** Re-run those checks before trusting this line. Nothing below has been executed against live.
+
 ## Path A — Upload via WP admin (fastest)
 
 1. Build and verify the upload zip:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+# Canonical Python test environment for this repo. CI installs this file, and it is the only one that can run `make python-test` (it is the superset: runtime deps plus pytest).
 requests>=2.34.2
 python-dotenv>=1.2.2
 pyyaml>=6.0.3

--- a/scripts/notion-to-wp/requirements.txt
+++ b/scripts/notion-to-wp/requirements.txt
@@ -1,3 +1,4 @@
+# Runtime-only deps for the notion-to-wp connector. It has no test deps: the canonical test environment is the repo-root requirements-test.txt, so install that one to run this package's suites.
 requests>=2.34.2
 python-dotenv>=1.2.2
 pyyaml>=6.0.3


### PR DESCRIPTION
Lane E (small docs) of the 2026-08-15 Round-1 swarm. Docs and comments only. No behavior change, no live writes, no version specifier touched.

Closes #746
Closes #750

## #746 — live deployment state of the custom WP code

**All three surfaces are confirmed NOT running on kriskrug.co.** Read-only checks, 2026-08-15:

| Check | Result |
|---|---|
| `/wp-json/wp/v2/types` | no `transcript`, no `kk_promo`, no `marquee_board` |
| `/wp-json/wp/v2/taxonomies` | no `transcript_topic` |
| `/wp-json/wp/v2/transcript` | 404 |
| `/transcript/` | 404 |
| `/marquee/` | 404 |
| `/wp-json/wp/v2/marquee_board`, `/wp-json/wp/v2/kk_promo` | 404 |
| `kk-sp` markup on homepage + a published post | absent |
| `/wp-content/plugins/kk-{sidebar-promos,marquee-board}/...` assets | 404 |

Why the types index is the load-bearing evidence: all three registrations set `show_in_rest => true`, so any of them would appear in `/wp-json/wp/v2/types` if the code were loaded anywhere on live — theme, mu-plugin, or Code Snippet. Absence there is the proof, not just the 404s.

That closes the open question in the issue about `inc/digital-composting.php`. The key fact holds: `theme/kk-aurora/functions.php` requires only `theme/kk-aurora/inc/seo-title.php` and `seo-meta-rest.php` (lines 23-24), and no other tracked PHP references this repo-root file. Since it is also not registering anything on live, it is not running as a snippet or mu-plugin either. It is dormant, full stop.

Written:
- `inc/digital-composting.php` — header comment: dormant, why no tracked PHP loads it, the four URLs checked, and "do not delete without KK approval."
- `plugins/kk-sidebar-promos/DEPLOYMENT.md` and `plugins/kk-marquee-board/DEPLOYMENT.md` — a dated `Live status:` line each, with the URLs and status codes used. `grep -n "Live status" plugins/*/DEPLOYMENT.md` returns two dated lines, as the issue's verification asks.

One small trap documented in the marquee file: live page markup does contain the string `marquee`, but it is `aurora-woven-marquee`, an unrelated Aurora theme decoration. Do not read it as the plugin rendering.

### Archive proposal (KK decision, nothing deleted here)

`inc/digital-composting.php` is confirmed dead code: not loaded by the repo, not running on live, 31 lines, no callers. **Proposal: move it to an archive path rather than keep it at a live-looking `inc/` path**, since `inc/` reads as production code and `phpcs.xml.dist` lints the whole directory. Not done in this PR — deleting/moving is out of the issue's scope and the file is one of the two surfaces `AGENTS.md` names. If you want it gone, say so and it is a one-line follow-up.

Both plugins are a different case: complete, tested, packaged, never deployed. They are not dead, they are pending a gated go-live. Leave them.

`AGENTS.md` was left untouched. Its sentence ("Custom repo-side WP code **includes** `inc/digital-composting.php` and `plugins/kk-sidebar-promos/`") is a scope statement, not a liveness claim, so it stays accurate as written.

## #750 — canonical Python test env

Written:
- `requirements-test.txt` — header comment declaring it the canonical test env (CI installs it; it is the superset, runtime deps plus pytest).
- `scripts/notion-to-wp/requirements.txt` — header comment declaring it runtime-only, pointing at the root file for tests.
- `CONTRIBUTING.md` Local Setup — a short paragraph stating the same split, plus an inline note on the notion-to-wp venv block.

### constraints.txt: skipped, on purpose

Not free, so per the task instruction it is out. A `constraints.txt` snapshot is only useful if something regenerates it (a pip-compile step or a scheduled refresh) and something enforces it (CI installing with `-c`). Both are real changes to the CI gate, which is out of scope for a docs issue, and an unrefreshed snapshot is worse than no snapshot: it silently pins the repo to whatever versions happened to be resolved on the day it was written, while the four `>=` specifiers keep claiming to float. If reproducibility becomes a real problem, the honest fix is pinning the four specifiers with a refresh cadence, which the issue explicitly puts out of scope. Happy to file that as its own issue.

## Verification

- `make validate` — green. `php-syntax: 40 files passed php -l`; phpcs `8/8`, no coding standard violations. (Needed `composer install` in this worktree first; `vendor/` is gitignored and not in the diff.)
- `make python-test` — green in a **fresh venv** built exactly as the #750 verification step specifies: `python3 -m venv` + `pip install -r requirements-test.txt` + `make python-test PYTHON=<that venv>`. 343 + 12 unittest tests OK, 68 pytest passed.
- `pip install --dry-run -r scripts/notion-to-wp/requirements.txt` — parses fine with the new header comment.
- `grep -n "Live status" plugins/*/DEPLOYMENT.md` — two dated lines.

## Review notes

Draft, as instructed. Not merged, no merge label applied. This touches `inc/` and `plugins/`, so per `AGENTS.md` it needs KK approval before merge even though the changes are comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQwWo8jpy3M9rwh5PFDEst
