### PR TITLE
fixes(#706): prepare third-party script diet — gtag delay snippet + pixel removal runbook

### DIFF
--- a/fixes/issue-706-script-diet-snippet.php
+++ b/fixes/issue-706-script-diet-snippet.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * KK Script Diet — kriskrug.co (#706)
+ *
+ * Delays the Site Kit gtag.js load until the visitor interacts or the browser
+ * goes idle after load. Pairs with the Meta Pixel removal, which is a
+ * source-level change (deactivate the snippet that prints it) and is NOT done
+ * here — see fixes/issue-706-script-diet.md for that half and the apply order.
+ *
+ * KK ruling on #706 (2026-08-10): drop the Facebook pixel entirely; delay gtag.
+ *
+ * Measured cost being addressed (docs/current-state/reports/psi-mobile-2026-08-10.md):
+ * gtag G-X7JE8B32L7 is 178 KiB transfer, 156 ms main thread, two of the page's
+ * four long tasks (115 ms + 67 ms), 72.9 KiB unused, and a 34 ms forced reflow.
+ *
+ * What injects gtag today, verified against the public homepage on 2026-08-15:
+ * Site Kit by Google 1.185.0 enqueues the handle `google_gtagjs`
+ * (`<script id="google_gtagjs-js" src="…/gtag/js?id=G-X7JE8B32L7" async>`) with
+ * its config attached as `wp_add_inline_script(…, 'after')`
+ * (`<script id="google_gtagjs-js-after">`). Jetpack Boost's defer-JS pass then
+ * relocates both from `wp_head` to the footer. This snippet works on the
+ * enqueue, before Boost sees it, so the relocation is irrelevant.
+ *
+ * Design notes:
+ * - Site Kit stays the source of truth. We re-emit its own inline config
+ *   verbatim rather than hand-writing gtag() calls, so linker domains, the
+ *   developer_id, and anything Site Kit adds later survive untouched. Nothing
+ *   in Site Kit's settings changes, which is also what makes rollback a
+ *   one-toggle operation on this snippet.
+ * - We only take over when Site Kit actually enqueued gtag for this request.
+ *   If Site Kit is excluding the visitor (logged-in exclusion, consent gating),
+ *   or if a Site Kit update renames the handle, this snippet does nothing and
+ *   gtag behaves exactly as it does today. Failure mode is "no change", never
+ *   "analytics silently gone".
+ *
+ * Deployed via the Code Snippets plugin (front-end scope). This file is the
+ * source of truth — keep it in sync if either side is edited.
+ *
+ * When pasting into Code Snippets: strip the opening <?php tag (Code Snippets
+ * wraps the snippet automatically).
+ */
+
+/**
+ * Shared between the capture pass and the footer loader. Code Snippets
+ * evaluates a snippet inside a function body, so this is snippet-local.
+ */
+$kk_gtag_delay = ['src' => '', 'inline' => '', 'handled' => false];
+
+/**
+ * 1. Capture Site Kit's gtag registration, then unhook it.
+ *
+ * Registered on two actions because Site Kit's enqueue priority is its own
+ * business and has moved between releases: `wp_enqueue_scripts` at 999 catches
+ * the normal case, `wp_print_scripts` at 100 is the last point before head
+ * scripts print. The `handled` flag makes the second pass a no-op.
+ */
+$kk_gtag_capture = static function () use (&$kk_gtag_delay): void {
+    if ($kk_gtag_delay['handled'] || is_admin()) {
+        return;
+    }
+    if (!wp_script_is('google_gtagjs', 'enqueued')) {
+        return;
+    }
+
+    $scripts    = wp_scripts();
+    $registered = $scripts->registered['google_gtagjs'] ?? null;
+    if (!$registered || empty($registered->src)) {
+        return;
+    }
+
+    $after = $scripts->get_data('google_gtagjs', 'after');
+
+    $kk_gtag_delay['src']     = $registered->src;
+    $kk_gtag_delay['inline']  = is_array($after) ? trim(implode("\n", array_filter($after))) : '';
+    $kk_gtag_delay['handled'] = true;
+
+    wp_dequeue_script('google_gtagjs');
+    wp_deregister_script('google_gtagjs');
+};
+add_action('wp_enqueue_scripts', $kk_gtag_capture, 999);
+add_action('wp_print_scripts', $kk_gtag_capture, 100);
+
+/**
+ * 2. Print the delayed loader in place of the eager tag.
+ *
+ * The dataLayer + gtag() shim is installed immediately so any gtag() call
+ * elsewhere on the page queues instead of throwing; gtag.js drains that queue
+ * when it finally loads. Only the network fetch and Site Kit's config are
+ * deferred.
+ *
+ * Fires on the first real interaction intent (pointerdown / keydown /
+ * touchstart / wheel), or on idle after the load event with a 3s ceiling —
+ * whichever comes first. Idle is measured from `load`, not from parse, so the
+ * tag never competes with the page's own critical path.
+ */
+add_action('wp_footer', static function () use (&$kk_gtag_delay): void {
+    if (!$kk_gtag_delay['handled']) {
+        return;
+    }
+
+    $template = <<<'JS'
+(function (w, d) {
+	w.dataLayer = w.dataLayer || [];
+	if (!w.gtag) {
+		w.gtag = function () { w.dataLayer.push(arguments); };
+	}
+
+	var events = ['pointerdown', 'keydown', 'touchstart', 'wheel'];
+	var opts = { passive: true, capture: true };
+	var fired = false;
+
+	function boot() {
+		if (fired) { return; }
+		fired = true;
+		events.forEach(function (name) { w.removeEventListener(name, boot, opts); });
+
+		%2$s
+
+		var s = d.createElement('script');
+		s.async = true;
+		s.src = %1$s;
+		d.head.appendChild(s);
+	}
+
+	function idle() {
+		if (w.requestIdleCallback) {
+			w.requestIdleCallback(boot, { timeout: 3000 });
+		} else {
+			w.setTimeout(boot, 3000);
+		}
+	}
+
+	events.forEach(function (name) { w.addEventListener(name, boot, opts); });
+
+	if (d.readyState === 'complete') {
+		idle();
+	} else {
+		w.addEventListener('load', idle, { once: true });
+	}
+})(window, document);
+JS;
+
+    $js = sprintf($template, wp_json_encode($kk_gtag_delay['src']), $kk_gtag_delay['inline']);
+
+    wp_print_inline_script_tag($js, ['id' => 'kk-gtag-delayed']);
+}, 20);

--- a/fixes/issue-706-script-diet.md
+++ b/fixes/issue-706-script-diet.md
@@ -1,0 +1,178 @@
+# Third-party script diet — apply runbook (#706)
+
+Prepared 2026-08-15. **Nothing here has been applied.** Both halves are live writes and stay KK-gated.
+
+KK ruling on #706 (2026-08-10): **drop the Facebook pixel entirely; delay gtag** to first interaction or 3 s idle.
+
+Artifact: [`issue-706-script-diet-snippet.php`](issue-706-script-diet-snippet.php) — the gtag half. The pixel half is a source-level deactivation, not code.
+
+---
+
+## What injects each script today
+
+Verified 2026-08-15 by reading the public homepage (`curl https://kriskrug.co/`, logged out) and grepping the repo. Both findings were re-confirmed against live HTML, not assumed from the PSI report.
+
+### gtag → Site Kit by Google 1.185.0
+
+- `<meta name="generator" content="Site Kit by Google 1.185.0" />` in `<head>`.
+- `<!-- Google tag (gtag.js) snippet added by Site Kit -->` and `<!-- Google Analytics snippet added by Site Kit -->` immediately after the core block-supports style block.
+- The tag itself: `<script id="google_gtagjs-js" src="https://www.googletagmanager.com/gtag/js?id=G-X7JE8B32L7" async>` followed by `<script id="google_gtagjs-js-after">`. The `-js` / `-js-after` id pair is WordPress printing an enqueued handle named `google_gtagjs` plus a `wp_add_inline_script(…, 'after')` payload. The payload contains `gtag("set", "developer_id.dZTNiMT", true)` — `dZTNiMT` is Site Kit's own developer ID, so this is Site Kit's tag, not a hand-pasted GA snippet.
+- `google-site-kit/v1` is present in the public `https://kriskrug.co/wp-json/` namespace list.
+- Not in the repo: no `gtag`/`googletagmanager` reference anywhere under `theme/`, `inc/`, `plugins/`, or `fixes/`.
+
+**Consequence:** the injection point is a WordPress enqueue, so it can be intercepted in PHP without touching a single Site Kit setting. That is what the snippet does, and it is why rollback is one toggle.
+
+### Facebook pixel → hand-installed markup in `wp_head`, not a plugin and not the theme
+
+- `<!-- Meta Pixel Code -->` … `<!-- End Meta Pixel Code -->` — Meta's own canonical comment wrapper, i.e. someone pasted the block Meta hands you in Events Manager.
+- Pixel ID `1720755522050230`. Base code is the standard `!function(f,b,e,v,n,t,s)` loader for `https://connect.facebook.net/en_US/fbevents.js`, then `fbq('init', '1720755522050230'); fbq('track', 'PageView');`.
+- It prints inside `wp_head`, bracketed between Site Kit's AdSense platform meta and Site Kit's `google-site-verification` meta (Site Kit prints that one at `wp_head` priority 99), so the pixel's hook priority sits below 99.
+- **Not the theme:** `grep -rn "fbq\|fbevents\|Meta Pixel" theme/ inc/ plugins/ fixes/` returns nothing.
+- **Not a dedicated pixel plugin:** no pixel-related namespace in the public REST namespace list. What is there: `code-snippets/v1`, `google-site-kit/v1`, `jetpack/v4`, `jetpack-boost/v1`, `popup-maker/v2`, `redirection/v1`, `akismet/v1`, `zbscrm/v1`.
+- Repo corroboration: `content/drafts/alt-text-backfill-2026-08-02/inventory.csv` already logged this pixel's `<noscript>` image site-wide with source `tracking-pixel-snippet`.
+
+**Conclusion, stated at the confidence the evidence supports:** the pixel is hand-installed PHP/HTML on a `wp_head` hook, and the Code Snippets plugin is active and is the only surface on this site that does that. It is almost certainly a Code Snippet. This has **not** been confirmed by reading the snippet list, because that needs an authenticated REST call and credentials did not resolve in this worktree. Step 1 of the apply closes that gap in one call. Do not skip it.
+
+### One mechanism detail that matters for verification
+
+Both scripts are injected into `<head>` but *render* near the end of `<body>`. Jetpack Boost's defer-JS pass relocates them. The head-side evidence of this is visible: the `<!-- Meta Pixel Code -->` wrapper in `<head>` is empty except for the `<noscript>` fallback, because the `<script>` inside it was moved out.
+
+So: when you verify, grep the **whole document**, not the `<head>`. And note the snippet intervenes at enqueue time, before Boost ever sees the tag, so Boost's relocation is irrelevant to whether it works.
+
+---
+
+## Apply order
+
+Do the pixel first. It is the bigger, more certain win and it is pure subtraction — if PSI moves as expected, that isolates the gtag change cleanly.
+
+### 0. Snapshot before touching anything
+
+```bash
+# Rendered HTML, logged out — the before-picture for every grep below
+curl -s https://kriskrug.co/ > /tmp/kk-706-home-before.html
+grep -c "fbevents" /tmp/kk-706-home-before.html          # expect 1
+grep -c "google_gtagjs-js" /tmp/kk-706-home-before.html  # expect 2 (tag + -after)
+```
+
+```bash
+# Full Code Snippets snapshot — code bodies included, this is the restore source.
+# Write it OUTSIDE the repo: it is a code dump, do not commit it.
+varlock run --inject vars -- sh -c \
+  'curl -s -u "$WP_USER:$WP_APP_PASSWORD" \
+    https://kriskrug.co/wp-json/code-snippets/v1/snippets \
+    > "$HOME/kk-snapshots/code-snippets-before-706-$(date -u +%Y%m%dT%H%M%SZ).json"'
+```
+
+PSI baseline already exists and is committed: `docs/current-state/reports/psi-mobile-2026-08-10.md`. Do not re-baseline — the whole point is comparing to it.
+
+### 1. Locate the pixel, then read what else its snippet contains
+
+From the snapshot JSON, find the snippet whose `code` contains `fbq` or `1720755522050230`. Record its `id`, `name`, `scope`, and `active`.
+
+**Before deactivating, read the whole snippet body.** If it only prints the Meta Pixel block, deactivating it is the entire fix. If it also carries unrelated head markup — a verification meta, a Pinterest tag, anything — deactivating the snippet takes that down too. In that case edit the pixel block out and leave the rest, rather than flipping `active`.
+
+The `<meta name="google-site-verification">` that renders directly after the pixel is *probably* Site Kit's (Site Kit prints it at `wp_head` 99), but confirm from the snippet body rather than trusting that.
+
+If no snippet matches, stop and report. The pixel is then coming from a surface this prep did not identify, and the removal step needs re-derivation before anything is touched.
+
+### 2. Deactivate the pixel
+
+```bash
+varlock run --inject vars -- curl -s -X POST \
+  -u "$WP_USER:$WP_APP_PASSWORD" \
+  -H 'Content-Type: application/json' \
+  -d '{"active": false}' \
+  https://kriskrug.co/wp-json/code-snippets/v1/snippets/<ID>
+```
+
+Deactivate, do not delete. Per `wp-snippet-deploy`, REST DELETE is WAF-blocked anyway, and deactivation keeps the re-enable path to one call. Delete via wp-admin only after a soak, and only if KK wants it gone permanently.
+
+Purge Pagely cache after the write (REST edits do not auto-purge).
+
+**Verify:**
+
+```bash
+curl -s https://kriskrug.co/ | grep -c "fbevents\|fbq(\|facebook.com/tr"   # expect 0
+curl -s https://kriskrug.co/about/ | grep -c "fbevents\|fbq("              # expect 0
+```
+
+Confirm no other snippet auto-deactivated (a PHP fatal makes Code Snippets disable things): re-fetch the snippet list and diff `active` flags against the snapshot.
+
+### 3. Install the gtag delay
+
+Paste `issue-706-script-diet-snippet.php` into Code Snippets as a new snippet, **stripping the leading `<?php`**. Name it `KK Script Diet`. Scope **front-end**. Sibling for reference: the existing `KK Asset Diet` snippet, same scope, same source-of-truth-in-repo convention.
+
+It has passed `php -l` and `make validate` (phpcs, WordPress security ruleset) in the repo. The emitted JavaScript was also syntax-checked and exercised against a browser-semantics harness: nothing loads before interaction, an early `gtag()` call queues into `dataLayer` and survives, the tag is appended exactly once with `async`, interaction listeners are removed after boot, and the idle path fires via `requestIdleCallback(…, {timeout: 3000})` with a `setTimeout` fallback.
+
+Purge Pagely cache.
+
+**Verify:**
+
+```bash
+curl -s https://kriskrug.co/ > /tmp/kk-706-home-after.html
+grep -c "google_gtagjs-js" /tmp/kk-706-home-after.html   # expect 0
+grep -c "kk-gtag-delayed"  /tmp/kk-706-home-after.html   # expect 1
+grep -c "G-X7JE8B32L7"     /tmp/kk-706-home-after.html   # expect >=1, inside the delayed loader
+```
+
+If `google_gtagjs-js` is still present, the dequeue did not win the hook race. The snippet already registers its capture on both `wp_enqueue_scripts` (999) and `wp_print_scripts` (100); if both miss, Site Kit changed how it enqueues and the handle capture needs re-derivation. The snippet fails safe in that case — gtag simply loads as it does today, nothing breaks.
+
+Then confirm analytics still fires, in a browser with devtools open:
+
+1. Load `https://kriskrug.co/` logged out. Network tab filtered to `googletagmanager` — **nothing** during load.
+2. Click anywhere. `gtag/js?id=G-X7JE8B32L7` requests, followed by a `/g/collect` beacon.
+3. Reload, touch nothing, wait ~5 s. Same requests fire via the idle path.
+4. Realtime in GA4 shows the session.
+
+Step 4 is the one that actually proves the ruling was honoured — delayed, not dropped.
+
+---
+
+## Rollback
+
+Each step is independently reversible. Nothing here needs a restore drill.
+
+| To undo | Do this | Effect |
+|---|---|---|
+| gtag delay | POST `{"active": false}` to the `KK Script Diet` snippet id | Dequeue stops, Site Kit's own tag prints eagerly again. Site Kit settings were never touched, so there is nothing to restore. |
+| Pixel removal | POST `{"active": true}` to the pixel snippet id | Pixel returns. If step 1 required editing the body instead of toggling, restore the `code` field verbatim from the before-snapshot JSON. |
+| Everything, instantly | Code Snippets safe mode | Disables all snippets at once. bc-ai.ca uses `…/wp-admin/admin.php?page=snippets&snippets-safe-mode=1`; confirm the same works here before relying on it as the panic button, since it is version-dependent. |
+
+Purge Pagely cache after any rollback, then re-run the verify greps above inverted.
+
+Pixel ID `1720755522050230` is recorded here so a re-add never needs an Events Manager dig. It is public in the page source, not a secret.
+
+---
+
+## Expected measurement delta
+
+Baseline: `docs/current-state/reports/psi-mobile-2026-08-10.md` (mobile, Lighthouse 13.4.1, emulated Moto G Power, slow 4G).
+
+**Should move:**
+
+| Metric | Before | Expected after | Why |
+|---|---|---|---|
+| Third-party transfer | 354 KiB | ~0 KiB during load | 176 KiB pixel deleted; 178 KiB gtag moved past the load window |
+| Third-party main thread | 342 ms | ~0 ms during load | 186 ms pixel + 156 ms gtag |
+| Long tasks from these origins | 4 (146, 115, 88, 67 ms) | 0 | All four belong to the pixel and gtag |
+| Total Blocking Time | 160 ms | under 50 ms | Those four tasks were the TBT |
+| Unused JavaScript | 131 KiB flagged | 131 KiB less | 58.2 pixel + 72.9 gtag |
+| Legacy JS polyfills | 12.5 KiB | 0 | All of it was in `fbevents.js` |
+| Efficient cache policy | fbevents 20-min TTL flagged | audit clears | Origin gone |
+| Performance score | 43 | expect 50s | TBT improves; LCP and CLS do not, and they dominate this score |
+
+**Should NOT move, and do not credit this change if they do:**
+
+LCP 7.6 s and CLS 0.430. Both trace to the theme's reveal system and the Boost critical-CSS snapshot (#701), and the 944 KiB image-delivery backlog is its own lane. If LCP or CLS shifts in the rerun, that is same-day content drift or the still-owed Boost critical-CSS regeneration, not this diet.
+
+**One honest caveat on the gtag half.** The bytes are not saved, they are moved. Whether PSI *shows* the gtag improvement depends on where Lighthouse's trace ends relative to the fire point. The snippet measures its 3 s idle window from the `load` event rather than from parse, and on this page load lands late, so gtag should fall outside the trace and the win should be visible. But if the rerun still attributes gtag cost, the fix is not broken — check the browser waterfall in the verify step above, which measures the thing that actually matters. If KK wants the metric to move unambiguously, the knob is the `3000` in `requestIdleCallback(boot, { timeout: 3000 })`; raising it or going interaction-only pushes the tag further out at the cost of losing bounced sessions from GA4.
+
+**How to confirm:** rerun PSI mobile against `https://kriskrug.co/` (https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fkriskrug.co%2F, Mobile tab), then write `docs/current-state/reports/psi-mobile-<YYYY-MM-DD>.md` in the same shape as the 2026-08-10 report and commit it. Close #706 against the third acceptance criterion: "Post-apply PSI shows TBT long tasks from these origins gone."
+
+Run it at least 30 minutes after the cache purge so PSI is not scoring a partially-warm edge.
+
+---
+
+## Not in scope
+
+#709 (security headers, prep-only) touches the same Best Practices section of the same PSI report. It is a separate lane and stays separate.


### PR DESCRIPTION
Prep only for #706. **No live writes, no deploy.** Nothing in this PR has been applied to production, and applying it stays KK-gated.

KK ruling on #706 (2026-08-10): drop the Facebook pixel entirely; delay gtag.

## What injects each script today (verified, not assumed)

Read back from the public homepage on 2026-08-15 (`curl https://kriskrug.co/`, logged out) plus a repo grep.

**gtag → Site Kit by Google 1.185.0.** `<script id="google_gtagjs-js" src=".../gtag/js?id=G-X7JE8B32L7" async>` plus `<script id="google_gtagjs-js-after">` is WordPress printing an enqueued handle named `google_gtagjs` with a `wp_add_inline_script(..., 'after')` payload. That payload sets `developer_id.dZTNiMT`, Site Kit's own developer ID. `google-site-kit/v1` is in the public REST namespace list, and nothing under `theme/`, `inc/`, `plugins/`, or `fixes/` mentions gtag.

**Facebook pixel → hand-installed markup on a `wp_head` hook, pixel `1720755522050230`.** Meta's canonical `<!-- Meta Pixel Code -->` wrapper, printed between Site Kit's AdSense platform meta and its `google-site-verification` meta. Not the theme (`grep -rn "fbq\|fbevents\|Meta Pixel" theme/ inc/ plugins/ fixes/` is empty) and not a pixel plugin (no matching REST namespace; what is registered is `code-snippets/v1`, `google-site-kit/v1`, `jetpack/v4`, `jetpack-boost/v1`, `popup-maker/v2`, `redirection/v1`, `akismet/v1`, `zbscrm/v1`). Code Snippets is the only surface on this site that prints hand-pasted head markup, so that is where it lives — stated at that confidence because confirming it needs an authenticated snippet read, which credentials in this worktree could not do. Step 1 of the runbook closes the gap in one call.

The pixel is still live, so this is a real fix for a real problem, not a stale finding.

**Mechanism detail that matters:** both are injected into `<head>` but render near the end of `<body>` — Jetpack Boost's defer-JS pass relocates them, visible in the head as an empty `<!-- Meta Pixel Code -->` wrapper containing only the `<noscript>`. The snippet acts at enqueue time, before Boost sees the tag, so the relocation is irrelevant. Verification greps must scan the whole document, not the head.

## Files

- `fixes/issue-706-script-diet-snippet.php` — the gtag half. Captures Site Kit's own src and inline config, dequeues `google_gtagjs`, re-emits both behind a first-interaction / idle-after-load loader. Site Kit's settings are never touched, which is what makes rollback a single snippet toggle. It engages only when Site Kit actually enqueued gtag for the request, so a logged-in exclusion or a renamed handle degrades to today's behaviour instead of silently dropping analytics.
- `fixes/issue-706-script-diet.md` — snapshot-first apply order, verification greps, GA4 browser check, rollback table, expected delta.

The pixel half is deliberately not code. It is a source-level deactivation; adding an output-buffer stripper would be a second thing to maintain for a change that is one reversible toggle.

## Validation

- `php -l` clean; `make validate` clean (phpcs, WordPress security ruleset, 8 files).
- Emitted JavaScript syntax-checked with `node --check` and exercised against a browser-semantics harness: nothing loads pre-interaction, an early `gtag()` call queues into `dataLayer` and survives boot, the tag appends exactly once with `async`, interaction listeners are removed after boot, the double-boot guard holds, and the idle path fires via `requestIdleCallback(..., {timeout: 3000})` with a `setTimeout` fallback.

## Expected delta vs `docs/current-state/reports/psi-mobile-2026-08-10.md`

354 KiB and 342 ms of third-party work off the load path, all four long tasks (146/115/88/67 ms) gone, TBT 160 ms → under 50 ms, 131 KiB less unused JS, 12.5 KiB of legacy polyfills gone with `fbevents.js`, and the 20-minute cache-TTL audit clears.

LCP 7.6 s and CLS 0.430 should **not** move — those are #701 and the image backlog. Caveat recorded in the runbook: the gtag bytes are moved, not saved, so whether PSI shows that half depends on where Lighthouse's trace ends relative to the fire point. The browser waterfall check in the runbook measures the thing that actually matters, and the `3000` timeout is the documented knob if KK wants the metric to move unambiguously.

Confirm by rerunning PSI mobile and committing `docs/current-state/reports/psi-mobile-<date>.md`.

## Scope

Does not touch #709 (security headers), which shares the same PSI report and stays its own lane.

Draft on purpose. Do not merge without KK.

Closes nothing yet — #706 closes on post-apply PSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQwWo8jpy3M9rwh5PFDEst