### PR TITLE
feat(#747): voice gate, em-dash + slop check on payload copy and theme strings

### DIFF
--- a/.voice-waivers.json
+++ b/.voice-waivers.json
@@ -1,0 +1,153 @@
+{
+  "_readme": [
+    "Per-file exemptions for `make voice-check` (scripts/voice_check.py, #747).",
+    "",
+    "Add an entry only when the violation is legitimate: quoted source material, a",
+    "banned-words list that has to name the banned words, a verbatim third-party",
+    "pull quote, or a pre-gate file whose remediation is owned by another issue.",
+    "If you are writing *about* an em dash rather than shipping one, do not use a",
+    "waiver at all: write the character as the token {EMDASH}, the convention set",
+    "by content/drafts/2026-08-02-emdash-remediation/dash-ledger.md.",
+    "",
+    "This is a ratchet, not a mute button. When a waived file stops violating, the",
+    "gate reports the waiver as stale and fails until the entry is deleted, so the",
+    "grandfathered baseline below shrinks to zero instead of living forever.",
+    "",
+    "Fields: `path` (repo-relative), `rules` (rule ids, or [\"*\"] for all),",
+    "`issue` (who owns the fix or the ruling), `reason` (why this is not a bug)."
+  ],
+  "waivers": [
+    {
+      "path": "theme/kk-aurora/templates/front-page.html",
+      "rules": ["em-dash"],
+      "issue": "#733",
+      "reason": "TEMPORARY. The hero dek and services lede em dashes are already rewritten in PR #751 (Aurora 1.6.6), which is open and unmerged. Delete this entry in that PR; the stale-waiver check will demand it."
+    },
+    {
+      "path": "theme/kk-aurora/templates/archive-marquee_board.html",
+      "rules": ["em-dash"],
+      "issue": "#733",
+      "reason": "TEMPORARY. Marquee archive lede em dash is rewritten in PR #751. Delete this entry in that PR."
+    },
+    {
+      "path": "theme/kk-aurora/patterns/photo-gallery.php",
+      "rules": ["em-dash"],
+      "issue": "#733",
+      "reason": "TEMPORARY. Photo lede and the placeholder-alt sprintf are rewritten in PR #751. Delete this entry in that PR."
+    },
+    {
+      "path": "content/drafts/2026-07-26-client-logo-soup/copy.md",
+      "rules": ["slop:delve"],
+      "issue": "#747",
+      "reason": "Names the banned words in a do-not-use list ('Em dashes, \"delve\", \"landscape\", \"robust\", \"leverage\"'). Quoting the lexicon is the point of the line."
+    },
+    {
+      "path": "content/drafts/2026-07-31-ai-lands-inside-every-profession/post.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Pre-remediation source for post 12653. The corrected body lives in content/drafts/2026-08-02-emdash-remediation/remediated-body.md; this file is kept as the before-state of record."
+    },
+    {
+      "path": "content/drafts/2026-07-31-ai-lands-inside-every-profession/post.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Pre-remediation source for post 12653. See the .md sibling."
+    },
+    {
+      "path": "content/drafts/2026-05-23-data-center-protest-signs/post.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Not rewritten by the 2026-08-01 voice sweep."
+    },
+    {
+      "path": "content/drafts/2026-05-24-human-element-shane-loki-talk/post.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Not rewritten by the 2026-08-01 voice sweep."
+    },
+    {
+      "path": "content/drafts/2026-05-24-keynote-music-elevation-series-haus-of-owl/post.md",
+      "rules": ["slop:tapestry"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Not rewritten by the 2026-08-01 voice sweep."
+    },
+    {
+      "path": "content/drafts/2026-05-24-keynote-music-elevation-series-haus-of-owl/post.html",
+      "rules": ["slop:tapestry"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. See the .md sibling."
+    },
+    {
+      "path": "content/drafts/2026-05-24-nobel-chemistry-foldit/post.md",
+      "rules": ["slop:testament"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Not rewritten by the 2026-08-01 voice sweep."
+    },
+    {
+      "path": "content/drafts/2026-05-24-nobel-chemistry-foldit/post.html",
+      "rules": ["slop:testament"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. See the .md sibling."
+    },
+    {
+      "path": "content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Not rewritten by the 2026-08-01 voice sweep."
+    },
+    {
+      "path": "content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/post.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. See the .md sibling."
+    },
+    {
+      "path": "content/drafts/2026-06-18-creative-ai-human-lab-network/post.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft, single instance."
+    },
+    {
+      "path": "content/drafts/2026-06-18-creative-ai-human-lab-network/post.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft, single instance. See the .md sibling."
+    },
+    {
+      "path": "content/drafts/2026-07-24-accessibility-statement/post.md",
+      "rules": ["em-dash"],
+      "issue": "#288",
+      "reason": "Grandfathered pre-gate draft. Superseded by the 2026-07-25 revision and kept for provenance."
+    },
+    {
+      "path": "content/drafts/2026-07-25-accessibility-statement/post.md",
+      "rules": ["em-dash"],
+      "issue": "#288",
+      "reason": "Grandfathered pre-gate draft, still awaiting KK copy approval. Fix the dashes in the same pass that fills the [KK: ...] placeholders."
+    },
+    {
+      "path": "content/drafts/2026-07-24-sponsor-deck/post.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft."
+    },
+    {
+      "path": "content/drafts/2026-08-01-testimonials-overhaul/copy.md",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Grandfathered pre-gate draft. Page copy, not yet applied."
+    },
+    {
+      "path": "content/drafts/wp-draft-10594-post-10594/post-body.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Snapshot of an existing WordPress draft, pulled down verbatim. Editing it here would desync it from the live draft it mirrors."
+    },
+    {
+      "path": "content/drafts/wp-draft-11178-post-11178/post-body.html",
+      "rules": ["em-dash"],
+      "issue": "#603",
+      "reason": "Snapshot of an existing WordPress draft, pulled down verbatim. Editing it here would desync it from the live draft it mirrors."
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing to the [kriskrug.co](https://kriskru
 - [Issue Guidelines](#issue-guidelines)
 - [Pull Request Process](#pull-request-process)
 - [Coding Standards](#coding-standards)
+- [Voice Gate](#voice-gate)
 - [Agent Automation](#agent-automation)
 
 ## Code of Conduct
@@ -111,6 +112,7 @@ Labels: bug, priority:high, mobile
 - [ ] Changes are documented in PR description
 - [ ] Issue is linked (use `Fixes #123` or `Closes #456`)
 - [ ] Commit messages are clear and descriptive
+- [ ] Run `make voice-check` if you touched payload copy or theme templates (see [Voice Gate](#voice-gate))
 - [ ] If you changed content via the Notion → WP publisher, you ran with `--dry-run` first and confirmed the slug-based idempotency match (see [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md))
 
 ### PR Template
@@ -254,6 +256,69 @@ Bad:
 - "changes"
 ```
 
+## Voice Gate
+
+`make voice-check` is the machine gate on the copy rules that are mechanically
+decidable (#747). It is a grep-class check in `scripts/voice_check.py`, not a
+voice-similarity scorer, and it never needs network or credentials.
+
+**What it flags**
+
+| Rule id | What it catches |
+|---|---|
+| `em-dash` | U+2014 in user-visible copy |
+| `slop:delve`, `slop:tapestry`, `slop:testament`, `slop:nestled`, `slop:in-a-world` | the small hard-rule slop lexicon |
+
+**What it scans**
+
+- **Payload copy**: `content/drafts/**/{post.md,post.html,post-body.html,copy.md}`.
+  The glob is narrow on purpose. Voice-audit reports, dash ledgers, and
+  remediation READMEs in the same tree legitimately *discuss* em dashes and are
+  out of scope by construction.
+- **Theme chrome**: `theme/kk-aurora/{templates,parts,patterns}`. HTML, CSS, and
+  PHP comments are blanked before matching, because a dash in a comment never
+  reaches a reader. On 2026-08-15 the theme carried 11 em dashes, of which 6
+  were comments and only 5 rendered (#733).
+
+**Writing *about* a dash.** Do not reach for a waiver. Write the character as
+the literal token `{EMDASH}`, the convention set by
+[`content/drafts/2026-08-02-emdash-remediation/dash-ledger.md`](content/drafts/2026-08-02-emdash-remediation/dash-ledger.md).
+That lets a ledger quote its originals without carrying them.
+
+**Chrome copy that lives outside the repo.** The sitewide `<title>` format
+string (#756) is a Jetpack setting, not a repo file, so no static scan can see
+it. Pipe a live readback through the same rules instead:
+
+```bash
+curl -s https://kriskrug.co/ | grep -o '<title>[^<]*</title>' | python3 scripts/voice_check.py -
+```
+
+**Waivers.** `.voice-waivers.json` at the repo root records per-file exemptions,
+each with an owning issue and a reason. Add one only for a legitimate case: a
+verbatim third-party pull quote, quoted source material, a banned-words list
+that has to name the banned words, or a pre-gate file whose remediation another
+issue owns.
+
+It is a ratchet, not a mute button. When a waived file stops violating, the gate
+reports the waiver as **stale** and fails until the entry is deleted, so the
+grandfathered baseline shrinks to zero instead of living forever. The same
+discipline as `.css-budget.json` (#472).
+
+**CI.** The `voice-gate` job in `test-pr.yml` runs on PRs that touch payload
+copy, theme templates, or the gate's own files. It scans the whole scope, not
+just changed files, which is what makes the waiver baseline a ratchet.
+
+**The fuller local pass.** CI deliberately checks hard rules only. The real
+checker (crystal facets, anti-glossary, similarity scoring) lives outside this
+repo and stays a manual local deep pass:
+
+```bash
+python3 ~/Code/kk-voice/scripts/voicecheck.py <file>
+```
+
+`make voice-check` prints that reminder on every run. Nothing in CI requires
+`~/Code/kk-voice` to exist.
+
 ## Testing
 
 This repo has focused automated tests for the Notion publisher safety guards, plus manual validation for production-adjacent WordPress changes.
@@ -264,6 +329,7 @@ Automated tests:
 - `make test` (runs the Notion publisher tests plus the sidebar promo smoke test)
 - `make validate` (runs the focused WordPress PHP security ruleset)
 - `make verify` (runs the standard local gate)
+- `make voice-check` (hard-rule copy gate; see [Voice Gate](#voice-gate))
 
 Manual validation:
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # kriskrug-wp Development Makefile
 # Quick access to common development commands
 
-.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke seo-publisher-smoke check-live-parity wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check env-check varlock-run clean
+.PHONY: help test python-test javascript-syntax php-syntax plugin-smoke theme-smoke verify validate health issues pr dashboard stats agent-status backup-check wp-package aurora-package sidebar-promos-package marquee-package draft-queue-audit jetpack-feedback-audit seo-audit public-image-audit performance-audit wp7-smoke seo-publisher-smoke check-live-parity wp7-admin-readiness current-state-drift-check morning-truth status-readonly docs-truth-check voice-check env-check varlock-run clean
 
 PYTHON ?= python3
 VARLOCK ?= varlock
@@ -303,6 +303,9 @@ varlock-run: ## Run CMD with Varlock-injected env (requires varlock + resolved s
 
 docs-truth-check: ## Scan non-evidence docs for known stale current-state claims
 	@python3 scripts/docs_truth_check.py --exclude docs/current-state/reports --exclude docs/current-state/raw
+
+voice-check: ## Hard-rule voice gate: em dashes + slop lexicon in payload copy and theme strings (#747)
+	@$(PYTHON) scripts/voice_check.py $(FILES)
 
 clean: ## Clean up test artifacts and temporary files
 	@echo "Cleaning up..."

--- a/scripts/tests/fixtures/voice_check/clean-post.md
+++ b/scripts/tests/fixtures/voice_check/clean-post.md
@@ -1,0 +1,7 @@
+# A clean post
+
+Judgment is a team sport. The room got real: sixty-five people showed up,
+and nobody needed a dash to say so.
+
+This sentence has an en dash range, 2026–2027, which is fine.
+It also has a hyphenated-compound and a URL, https://kriskrug.co/about/.

--- a/scripts/tests/fixtures/voice_check/commented-pattern.php
+++ b/scripts/tests/fixtures/voice_check/commented-pattern.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Placeholder sources are replaced on insertion — every image is swapped.
+ */
+// Docs live at https://developer.wordpress.org/ — see the block reference.
+?>
+<p class="aurora-photo-lede">Documentary work across climate, culture, music, and power — 144,000+ exposures.</p>

--- a/scripts/tests/fixtures/voice_check/commented-template.html
+++ b/scripts/tests/fixtures/voice_check/commented-template.html
@@ -1,0 +1,10 @@
+<!-- wp:template-part -->
+<!--
+  Historical note: the old header — nav flex-wrapped to ~98px, and the
+  marquee SVGs sat at ~53px — until the deferred bundle landed.
+-->
+<p>Three ways to work together, from a single keynote to ongoing advisory.</p>
+<style>
+  /* board body (dek + source) — used on WP single pages */
+  .aurora-hero { color: #fff; }
+</style>

--- a/scripts/tests/fixtures/voice_check/dashed-post.md
+++ b/scripts/tests/fixtures/voice_check/dashed-post.md
@@ -1,0 +1,5 @@
+# A dashed post
+
+Here is the rest of the story — the part that does not fit in a news brief.
+
+I had spent a year deep in the machine — testing tools, talking to labs.

--- a/scripts/tests/fixtures/voice_check/slop-post.md
+++ b/scripts/tests/fixtures/voice_check/slop-post.md
@@ -1,0 +1,4 @@
+In a world where every deck sounds the same, we must act.
+
+Let us delve into the rich tapestry of the ecosystem. The turnout was
+a testament to the community, nestled between two mountains.

--- a/scripts/tests/test_voice_check.py
+++ b/scripts/tests/test_voice_check.py
@@ -1,0 +1,163 @@
+"""Unit tests for the #747 voice gate.
+
+Fixtures live in ``fixtures/voice_check/`` rather than inline strings so that the
+em-dash cases are real files on disk, the same shape the gate sees in CI. They
+sit outside ``content/drafts/`` and outside the theme, so they are deliberately
+out of the gate's own scan scope and cannot trip it.
+"""
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import voice_check  # noqa: E402
+
+FIXTURES = Path("scripts/tests/fixtures/voice_check")
+EM_DASH = "\u2014"
+
+
+def run(paths, waivers=None, stdin=None):
+    """Run main() with an optional temporary waiver set; return (code, stdout)."""
+    buf = io.StringIO()
+    waiver_path = voice_check.WAIVER_PATH
+    if waivers is not None:
+        waiver_path = Path(__file__).parent / "_tmp_voice_waivers.json"
+        waiver_path.write_text(json.dumps({"waivers": waivers}), encoding="utf-8")
+    try:
+        with mock.patch.object(voice_check, "WAIVER_PATH", waiver_path):
+            if stdin is not None:
+                with mock.patch.object(sys, "stdin", io.StringIO(stdin)):
+                    with redirect_stdout(buf):
+                        code = voice_check.main(paths)
+            else:
+                with redirect_stdout(buf):
+                    code = voice_check.main(paths)
+    finally:
+        if waivers is not None:
+            waiver_path.unlink(missing_ok=True)
+    return code, buf.getvalue()
+
+
+class ExitCodeTests(unittest.TestCase):
+    def test_clean_fixture_exits_zero(self):
+        code, out = run([str(FIXTURES / "clean-post.md")], waivers=[])
+        self.assertEqual(code, 0, out)
+        self.assertIn("0 violation(s)", out)
+
+    def test_dashed_fixture_exits_nonzero(self):
+        code, out = run([str(FIXTURES / "dashed-post.md")], waivers=[])
+        self.assertEqual(code, 1)
+        self.assertIn("2 violation(s)", out)
+        self.assertEqual(out.count("[em-dash]"), 2)
+
+    def test_slop_fixture_flags_every_lexicon_term(self):
+        code, out = run([str(FIXTURES / "slop-post.md")], waivers=[])
+        self.assertEqual(code, 1)
+        for rule in (
+            "slop:in-a-world",
+            "slop:delve",
+            "slop:tapestry",
+            "slop:testament",
+            "slop:nestled",
+        ):
+            self.assertIn(rule, out)
+        self.assertIn("5 violation(s)", out)
+
+    def test_stdin_mode_gates_chrome_copy(self):
+        """#756: the sitewide <title> is a Jetpack setting, so it arrives piped."""
+        title = f"<title>AI Lands Inside Every Profession {EM_DASH} Kris Krug</title>"
+        code, out = run(["-"], waivers=[], stdin=title)
+        self.assertEqual(code, 1)
+        self.assertIn("<stdin>:1:", out)
+        code, _ = run(
+            ["-"], waivers=[], stdin="<title>Kris Krug: AI Keynote Speaker</title>"
+        )
+        self.assertEqual(code, 0)
+
+
+class CommentExclusionTests(unittest.TestCase):
+    """The distinction that matters: a dash in a comment never reaches a reader."""
+
+    def test_html_and_css_comments_are_not_flagged(self):
+        code, out = run([str(FIXTURES / "commented-template.html")], waivers=[])
+        self.assertEqual(code, 0, out)
+
+    def test_php_docblock_and_line_comments_are_not_flagged(self):
+        code, out = run([str(FIXTURES / "commented-pattern.php")], waivers=[])
+        self.assertEqual(code, 1)
+        self.assertIn("1 violation(s)", out)
+        self.assertIn("aurora-photo-lede", out)
+
+    def test_url_scheme_is_not_mistaken_for_a_php_line_comment(self):
+        text = f"<p>See https://kriskrug.co/about/ for more {EM_DASH} it is worth it.</p>\n"
+        self.assertEqual(len(voice_check.scan_text(text, ".php")), 1)
+
+    def test_line_numbers_survive_multi_line_comment_blanking(self):
+        text = f"<!--\n\n\n-->\n<p>a {EM_DASH} b</p>\n"
+        hits = voice_check.scan_text(text, ".html")
+        self.assertEqual([hit[1] for hit in hits], [5])
+
+    def test_emdash_token_convention_is_not_a_violation(self):
+        text = "| Original (dash = `{EMDASH}`) | Here is the story `{EMDASH}` the rest. |\n"
+        self.assertEqual(voice_check.scan_text(text, ".md"), [])
+
+
+class WaiverTests(unittest.TestCase):
+    def test_waiver_suppresses_its_own_rule_only(self):
+        waivers = [{"path": str(FIXTURES / "slop-post.md"), "rules": ["slop:delve"]}]
+        code, out = run([str(FIXTURES / "slop-post.md")], waivers=waivers)
+        self.assertEqual(code, 1)
+        self.assertNotIn("slop:delve", out)
+        self.assertIn("slop:tapestry", out)
+        self.assertIn("1 waived", out)
+
+    def test_wildcard_waiver_clears_the_file(self):
+        waivers = [{"path": str(FIXTURES / "dashed-post.md"), "rules": ["*"]}]
+        code, out = run([str(FIXTURES / "dashed-post.md")], waivers=waivers)
+        self.assertEqual(code, 0, out)
+        self.assertIn("2 waived", out)
+
+    def test_stale_waiver_fails_so_the_baseline_ratchets_down(self):
+        waivers = [
+            {
+                "path": str(FIXTURES / "clean-post.md"),
+                "rules": ["em-dash"],
+                "issue": "#751",
+            }
+        ]
+        code, out = run([str(FIXTURES / "clean-post.md")], waivers=waivers)
+        self.assertEqual(code, 1)
+        self.assertIn("[stale-waiver]", out)
+        self.assertIn("#751", out)
+
+    def test_unscanned_waiver_is_not_reported_stale(self):
+        """CI may scan a subset; a waiver for an untouched file must stay quiet."""
+        waivers = [{"path": str(FIXTURES / "dashed-post.md"), "rules": ["*"]}]
+        code, out = run([str(FIXTURES / "clean-post.md")], waivers=waivers)
+        self.assertEqual(code, 0, out)
+        self.assertNotIn("[stale-waiver]", out)
+
+
+class RepoBaselineTests(unittest.TestCase):
+    def test_committed_waiver_file_parses_and_documents_every_entry(self):
+        data = json.loads(voice_check.WAIVER_PATH.read_text(encoding="utf-8"))
+        self.assertTrue(data["waivers"])
+        for entry in data["waivers"]:
+            self.assertTrue(entry.get("issue"), entry)
+            self.assertTrue(entry.get("reason"), entry)
+            self.assertTrue(entry.get("rules"), entry)
+
+    def test_repo_is_green_under_the_gate(self):
+        """#747 acceptance: `make voice-check` passes on main with the baseline."""
+        code, out = run([])
+        self.assertEqual(code, 0, out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/voice_check.py
+++ b/scripts/voice_check.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Voice gate: em dashes and a hard-rule slop lexicon in copy that ships (#747).
+
+Scope is deliberately narrow. This is a grep-class gate on the two rules that
+are mechanically decidable, not a voice-similarity scorer. The real checker
+(``voicecheck.py``, crystal facets, anti-glossary) lives outside this repo in
+``~/Code/kk-voice`` and stays a manual local deep pass; see ``--help`` output.
+
+What gets scanned
+-----------------
+
+* **Payload copy**: ``content/drafts/**/{post.md,post.html,post-body.html,copy.md}``.
+  Narrow on purpose: voice-audit reports, dash ledgers, and remediation READMEs
+  in the same tree legitimately *discuss* em dashes and must never be flagged.
+  Those files quote the character as the literal token ``{EMDASH}`` (see
+  ``content/drafts/2026-08-02-emdash-remediation/dash-ledger.md``); use that
+  convention rather than a waiver when you are writing *about* a dash.
+* **Theme chrome**: ``theme/kk-aurora/{templates,parts,patterns}``. HTML, CSS,
+  and PHP comments are blanked before matching, because a dash inside
+  ``<!-- ... -->`` or a PHP docblock never reaches a reader. Getting that
+  distinction wrong is the whole difficulty: of the 11 em dashes in the theme on
+  2026-08-15, 6 were comments and only 5 rendered (#733).
+
+Chrome copy that lives outside the repo
+---------------------------------------
+
+The sitewide ``<title>`` format string (#756) is a Jetpack setting, not a repo
+file, so no static scan can see it. Pipe a live readback through the same rules
+instead::
+
+    curl -s https://kriskrug.co/ | grep -o '<title>[^<]*</title>' | \
+        python3 scripts/voice_check.py -
+
+Waivers
+-------
+
+``.voice-waivers.json`` at the repo root records per-file exemptions with an
+issue reference and a reason. It is a **ratchet**, not a mute button: a waiver
+whose file no longer violates anything is reported as stale and fails the run,
+so grandfathered entries get deleted as the backlog is cleaned up rather than
+accumulating forever. Same discipline as ``.css-budget.json`` (#472).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WAIVER_PATH = REPO_ROOT / ".voice-waivers.json"
+
+# Written as an escape and never as a literal, so that this checker, its docs,
+# and its own output can be grepped without the character being reintroduced.
+EM_DASH = "\u2014"
+
+PAYLOAD_ROOT = Path("content/drafts")
+PAYLOAD_NAMES = ("post.md", "post.html", "post-body.html", "copy.md")
+THEME_DIRS = (
+    Path("theme/kk-aurora/templates"),
+    Path("theme/kk-aurora/parts"),
+    Path("theme/kk-aurora/patterns"),
+)
+
+RULES = (
+    (
+        "em-dash",
+        re.compile(re.escape(EM_DASH)),
+        "em dash; rewrite as a colon, period, or comma",
+    ),
+    ("slop:delve", re.compile(r"\bdelv(?:e|es|ed|ing)\b", re.I), "slop lexicon: delve"),
+    (
+        "slop:tapestry",
+        re.compile(r"\btapestr(?:y|ies)\b", re.I),
+        "slop lexicon: tapestry",
+    ),
+    (
+        "slop:testament",
+        re.compile(r"\ba testament to\b", re.I),
+        "slop lexicon: a testament to",
+    ),
+    ("slop:nestled", re.compile(r"\bnestled\b", re.I), "slop lexicon: nestled"),
+    (
+        "slop:in-a-world",
+        re.compile(r"(?:\A|\n)[ \t>#*_]*In a world\b"),
+        'slop lexicon: "In a world" opener',
+    ),
+)
+
+# Blanked before matching. `//` is PHP-only and guarded against `https://`.
+BLOCK_COMMENTS = (re.compile(r"<!--.*?-->", re.S), re.compile(r"/\*.*?\*/", re.S))
+PHP_LINE_COMMENT = re.compile(r"(?<!:)//[^\n]*")
+
+
+def blank_comments(text: str, suffix: str) -> str:
+    """Replace comment bodies with spaces, preserving offsets and line numbers."""
+
+    def blank(match: re.Match) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in match.group(0))
+
+    for pattern in BLOCK_COMMENTS:
+        text = pattern.sub(blank, text)
+    if suffix == ".php":
+        text = PHP_LINE_COMMENT.sub(blank, text)
+    return text
+
+
+def scan_text(text: str, suffix: str) -> list[tuple[str, int, int, str, str]]:
+    """Return (rule_id, line, col, message, excerpt) for every violation."""
+    scannable = blank_comments(text, suffix)
+    found = []
+    for rule_id, pattern, message in RULES:
+        for match in pattern.finditer(scannable):
+            line = scannable.count("\n", 0, match.start()) + 1
+            col = match.start() - (scannable.rfind("\n", 0, match.start()) + 1) + 1
+            excerpt = text.split("\n")[line - 1].strip()[:100]
+            found.append((rule_id, line, col, message, excerpt))
+    return sorted(found, key=lambda hit: (hit[1], hit[2]))
+
+
+def default_targets() -> list[Path]:
+    """Every payload and theme file in scope, relative to the repo root."""
+    targets = [
+        path
+        for path in sorted((REPO_ROOT / PAYLOAD_ROOT).rglob("*"))
+        if path.name in PAYLOAD_NAMES
+    ]
+    for theme_dir in THEME_DIRS:
+        targets.extend(
+            sorted(p for p in (REPO_ROOT / theme_dir).rglob("*") if p.is_file())
+        )
+    return [path.relative_to(REPO_ROOT) for path in targets]
+
+
+def load_waivers() -> dict[str, dict]:
+    if not WAIVER_PATH.exists():
+        return {}
+    data = json.loads(WAIVER_PATH.read_text(encoding="utf-8"))
+    return {entry["path"]: entry for entry in data.get("waivers", [])}
+
+
+def is_waived(waiver: dict | None, rule_id: str) -> bool:
+    if waiver is None:
+        return False
+    rules = waiver.get("rules", ["*"])
+    return "*" in rules or rule_id in rules
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files to scan; '-' reads stdin. Default: all payload + theme files in scope.",
+    )
+    args = parser.parse_args(argv)
+
+    waivers = load_waivers()
+    violations: list[tuple[str, str, int, int, str, str]] = []
+    waived_count = 0
+    scanned_waived: set[str] = set()
+    hit_waived: set[str] = set()
+
+    if args.paths == ["-"]:
+        for rule_id, line, col, message, excerpt in scan_text(sys.stdin.read(), ".txt"):
+            violations.append(("<stdin>", rule_id, line, col, message, excerpt))
+        targets: list[Path] = []
+    else:
+        targets = [Path(p) for p in args.paths] if args.paths else default_targets()
+
+    for target in targets:
+        absolute = target if target.is_absolute() else REPO_ROOT / target
+        if not absolute.is_file():
+            continue
+        key = str(target)
+        waiver = waivers.get(key)
+        if waiver is not None:
+            scanned_waived.add(key)
+        for rule_id, line, col, message, excerpt in scan_text(
+            absolute.read_text(encoding="utf-8", errors="replace"), absolute.suffix
+        ):
+            if is_waived(waiver, rule_id):
+                waived_count += 1
+                hit_waived.add(key)
+                continue
+            violations.append((key, rule_id, line, col, message, excerpt))
+
+    stale = sorted(scanned_waived - hit_waived)
+
+    for path, rule_id, line, col, message, excerpt in violations:
+        print(f"{path}:{line}:{col}: [{rule_id}] {message}\n    {excerpt}")
+    for path in stale:
+        print(
+            f"{path}: [stale-waiver] no violations left; delete this entry from "
+            f"{WAIVER_PATH.name} ({waivers[path].get('issue', 'no issue')})"
+        )
+
+    scanned = len(targets) or 1
+    print(
+        f"\nvoice-check: {scanned} file(s) scanned, {len(violations)} violation(s), "
+        f"{waived_count} waived, {len(stale)} stale waiver(s)."
+    )
+    if violations or stale:
+        print(
+            "Hard rules only. For the full voice pass when the corpus is available:\n"
+            "  python3 ~/Code/kk-voice/scripts/voicecheck.py <file>"
+        )
+        return 1
+    print(
+        "Clean. Full local voice pass (optional, needs ~/Code/kk-voice):\n"
+        "  python3 ~/Code/kk-voice/scripts/voicecheck.py <file>"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Track A / tooling. `make voice-check` is the machine gate on KK's hard copy rules. Grep-class checks, no NLP, no network, no credentials, no dependency on `~/Code/kk-voice`.

Closes #747
Refs #756, #733, #603

## What it covers

| Rule id | Catches |
|---|---|
| `em-dash` | U+2014 in user-visible copy |
| `slop:delve` `slop:tapestry` `slop:testament` `slop:nestled` `slop:in-a-world` | the small hard-rule slop lexicon |

**Payload copy:** `content/drafts/**/{post.md,post.html,post-body.html,copy.md}`. The glob is deliberately narrow so voice-audit reports, dash ledgers, and remediation READMEs in the same tree, which legitimately *discuss* the character, are out of scope by construction rather than by waiver. Those keep using the existing `{EMDASH}` token convention from `content/drafts/2026-08-02-emdash-remediation/dash-ledger.md`, and the gate's docs point at it.

**Theme chrome:** `theme/kk-aurora/{templates,parts,patterns}`, with HTML comments, CSS comments, and PHP docblock/line comments blanked before matching. That distinction is the whole difficulty of this job. The theme carries 11 em dashes today; 6 are comments and only 5 render. The gate flags exactly the 5 in #751's table and none of the 6 in `header.html:9-10`, `marquee-current.html:44`, `marquee-hero.php:12`, `photo-gallery.php:12`, `shop-buy-button.php:27`. Line numbers survive the blanking, so reported positions stay accurate.

**Chrome copy that is not a repo file (#756):** the sitewide `<title>` format lives in a Jetpack setting, so no static scan can reach it. The gate reads stdin, which lets #756's own verification command feed the same rules:

```bash
curl -s https://kriskrug.co/ | grep -o '<title>[^<]*</title>' | python3 scripts/voice_check.py -
```

## The #751 sequencing problem, and how it is resolved

The five user-visible theme em dashes are fixed in **PR #751, which is open and unmerged**. A theme-scanning gate therefore fails against `main` as it stands today.

I shipped theme scanning now, with a **temporary waiver referencing #733**, rather than deferring theme coverage to a follow-up. Reasons:

1. #756 is explicit that chrome copy is the point, and it outranks the body sweep because `<title>` and hero copy are the highest-visibility strings on the site. Shipping payload-only would have parked the highest-value surface behind another PR's merge.
2. The waiver mechanism is a required deliverable anyway. Using it for the real case gives it a worked example instead of a hypothetical one.
3. The waiver cannot rot silently, because of the next section.

No `theme/` file is touched in this PR. Those five rewrites stay #751's diff.

## Waivers are a ratchet, not a mute button

`.voice-waivers.json` records per-file exemptions with an owning issue and a reason. When a waived file **stops** violating, the gate reports a **stale waiver** and fails until the entry is deleted. Same discipline as `.css-budget.json` (#472), whose `--check` also fails on a budget that has grown slack.

Concretely: when #751 merges and rewrites those five dashes, its PR touches exactly the waived theme files, the voice gate runs, and the three now-stale theme waivers fail with a message naming the file and the issue. Deleting three JSON entries clears it. **#751's author should expect that and delete the three `theme/kk-aurora/...` entries in the same PR.** That is the mechanism working, not a bug.

## What it flags on `main` today

265 hits across 22 files, all waived to establish the baseline, so the gate is green on `main`:

| Group | Files | Owning issue |
|---|---|---|
| Theme copy, TEMPORARY, delete when #751 merges | `front-page.html`, `archive-marquee_board.html`, `photo-gallery.php` | #733 |
| Banned-words list that has to name `"delve"` | `2026-07-26-client-logo-soup/copy.md` | #747 |
| Pre-remediation source for post 12653 | `2026-07-31-ai-lands-inside-every-profession/post.{md,html}` | #603 |
| Verbatim snapshots of live WP drafts | `wp-draft-10594`, `wp-draft-11178` | #603 |
| Accessibility copy awaiting KK approval | `2026-07-{24,25}-accessibility-statement` | #288 |
| Other grandfathered pre-gate drafts | 8 files | #603 |

Every entry carries a reason. A unit test asserts that no waiver can be added without `issue`, `reason`, and `rules`.

## Blocker: the CI wiring could not be pushed

The `voice-gate` job is written and YAML-validated, but **it is not in this branch**. The pushing token has `repo` but not `workflow` scope, so GitHub refused any push touching `.github/workflows/test-pr.yml`:

```
! [remote rejected] refusing to allow an OAuth App to create or update
  workflow `.github/workflows/test-pr.yml` without `workflow` scope
```

A session with `workflow` scope should apply this diff to the branch. It follows the `css-ratchet` pattern for changed-file detection, and it scans the whole scope rather than only changed files, which is what makes the waiver baseline a ratchet.

<details>
<summary>The <code>test-pr.yml</code> diff to apply</summary>

```diff
@@ -21,6 +21,7 @@ jobs:
       has_docs: ${{ steps.changed-files.outputs.has_docs }}
       has_css: ${{ steps.changed-files.outputs.has_css }}
       has_deps: ${{ steps.changed-files.outputs.has_deps }}
+      has_voice: ${{ steps.changed-files.outputs.has_voice }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
@@ -47,12 +48,21 @@ jobs:
               ['composer.json', 'composer.lock', 'package.json', 'package-lock.json'].includes(name) ||
               /(?:^|\/)requirements[\w.-]*\.txt$/.test(name)
             );
+            // Voice gate (#747): payload copy under content/drafts/, any theme
+            // template/part/pattern, and the gate's own files.
+            const payloadNames = ['post.md', 'post.html', 'post-body.html', 'copy.md'];
+            const hasVoice = names.some((name) =>
+              (name.startsWith('content/drafts/') && payloadNames.includes(name.split('/').pop())) ||
+              /^theme\/kk-aurora\/(templates|parts|patterns)\//.test(name) ||
+              ['.voice-waivers.json', 'scripts/voice_check.py'].includes(name)
+            );
             core.info(`Changed files: ${names.length}`);
-            core.info(`has_php=${hasPhp} has_docs=${hasDocs} has_css=${hasCss} has_deps=${hasDeps}`);
+            core.info(`has_php=${hasPhp} has_docs=${hasDocs} has_css=${hasCss} has_deps=${hasDeps} has_voice=${hasVoice}`);
             core.setOutput('has_php', hasPhp ? 'true' : 'false');
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
             core.setOutput('has_css', hasCss ? 'true' : 'false');
             core.setOutput('has_deps', hasDeps ? 'true' : 'false');
+            core.setOutput('has_voice', hasVoice ? 'true' : 'false');
 
       - name: Check PR links to issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -148,6 +158,27 @@ jobs:
             --base-ref "${{ steps.base.outputs.ref }}" \
             --github-summary
 
+  # Voice gate (issue #747, chrome-copy scope from #756).
+  # Hard rules only: em dashes in user-visible copy, plus a small slop lexicon.
+  # Scans the whole payload + theme scope rather than only the changed files, so
+  # the .voice-waivers.json baseline works as a ratchet the way .css-budget.json
+  # does: a waived file that stops violating fails until its entry is deleted.
+  # The full voice-similarity pass stays local (~/Code/kk-voice), never in CI.
+  voice-gate:
+    needs: validate
+    if: needs.validate.outputs.has_voice == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Voice check
+        run: make voice-check PYTHON=python3
+
   # JavaScript/Node validation
   javascript-validation:
     needs: validate
@@ -200,7 +231,7 @@ jobs:
 
   # Summarize all checks
   summary:
-    needs: [validate, php-validation, python-tests, css-ratchet, javascript-validation, docs-truth-check, security-scan]
+    needs: [validate, php-validation, python-tests, css-ratchet, voice-gate, javascript-validation, docs-truth-check, security-scan]
     if: always()
     runs-on: ubuntu-latest
     steps:
```

</details>

## Verification

```
$ make voice-check
voice-check: 161 file(s) scanned, 0 violation(s), 265 waived, 0 stale waiver(s).
Clean. Full local voice pass (optional, needs ~/Code/kk-voice):
  python3 ~/Code/kk-voice/scripts/voicecheck.py <file>
exit 0
```

`make python-test` exits 0 with 15 new tests (operational suite 343 to 358; publisher 161, SEO inventory 12, backfill 68 all unchanged).

Probe, per the issue's verification criteria. Adding one em dash to a payload file:

```
$ python3 scripts/voice_check.py
content/drafts/2026-08-15-voice-gate-probe/post.md:3:20: [em-dash] em dash; rewrite as a colon, period, or comma
    A line with a dash {EMDASH} right here.

voice-check: 162 file(s) scanned, 1 violation(s), 265 waived, 0 stale waiver(s).
exit 1
```

(Probe file removed; the dash is written as `{EMDASH}` here per the ledger convention.)

The 15 tests cover exit codes on clean / dashed / slop fixtures, every lexicon term, comment exclusion for HTML + CSS + PHP, the `https://` guard against mistaking a URL for a PHP line comment, line-number preservation across multi-line comment blanking, `{EMDASH}` not being a violation, per-rule and wildcard waivers, stale-waiver failure, waivers for unscanned files staying quiet, waiver-file schema, and `main` being green.

## Review notes

- No `theme/` file is modified. Confirmed by `git diff --stat`.
- `scripts/tests/fixtures/voice_check/commented-pattern.php` is outside `phpcs.xml.dist` scope and outside `make php-syntax`'s globs, so it does not enter PHP validation. It passes `php -l` anyway.
- `landscape`, `robust`, and `leverage` were considered for the lexicon and left out. KK is a photographer; gating on "landscape" would be all false positives.
