### PR TITLE
content: point Gorgeous Ghost draft at Signal Atlas

### DIFF
--- a/content/drafts/2026-08-12-gorgeous-ghost-art-project-internal-links.md
+++ b/content/drafts/2026-08-12-gorgeous-ghost-art-project-internal-links.md
@@ -8,8 +8,8 @@
 
 ## Network hubs
 
-- https://kriskrug.co/recent-projects-include/ - KrisKrug.co Work hub
-- https://kriskrug.ai/ - Hopecode Garden public project index
+- https://kriskrug.co/work/ - KrisKrug.co Work hub
+- https://kriskrug.ai/network - canonical Signal Atlas for the full project network
 - https://www.punkrockai.com/ - Punk Rock AI keynote portal
 - https://www.bothhandsfull.com/ - Both Hands Full keynote and learning portal
 

--- a/content/drafts/2026-08-12-gorgeous-ghost-art-project.md
+++ b/content/drafts/2026-08-12-gorgeous-ghost-art-project.md
@@ -51,8 +51,8 @@ Gorgeous Ghost now has a home of its own, but it is not an island.
 - [Punk Rock AI](https://www.punkrockai.com/) is the argument about taste, theft, refusal, and making with the tools without handing over the wheel.
 - [Both Hands Full](https://www.bothhandsfull.com/) is the film and learning portal for holding critique in one hand and curiosity in the other.
 - [Ghost Radio](https://ghost.radio.fm/) is the audio lab and broadcast deck.
-- [kriskrug.ai](https://kriskrug.ai/) is the living index of the weird public things I am building.
-- [KrisKrug.co Work](https://kriskrug.co/recent-projects-include/) is the narrative hub where the threads meet.
+- [The Signal Atlas](https://kriskrug.ai/network) is the living map of the weird public things I am building.
+- [KrisKrug.co Work](https://kriskrug.co/work/) is the narrative hub where the threads meet.
 
 That connective tissue matters. A project can be a film and still have a source trail. A song can be a song and still point to the people who helped it become real. An AI-assisted work can show the machinery without pretending the machinery had the taste.
 


### PR DESCRIPTION
## Summary\n- update the unpublished Gorgeous Ghost art-project draft to name the Signal Atlas as the canonical network map\n- replace the retired recent-projects include URL with the current Work hub\n- keep the article package unpublished for human editorial approval\n\n## Verification\n- voice check passed with zero flags\n- public WordPress smoke passed\n- live Aurora theme and repo are in sync\n\nNo WordPress content mutation is included.