### PR TITLE
fix: close issue 764 pre-write revalidation gap

### DIFF
--- a/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/fix-764/RUNBOOK.md
+++ b/content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/fix-764/RUNBOOK.md
@@ -83,20 +83,23 @@ unless all three hold for all of them:
    else's edit,
 3. the payload file still hashes to what was reviewed in this PR.
 
-After every target passes preflight, `--apply` writes a mode-0600
-`backup/issue-764-em-dash-404/rest-post-<id>-before-<stamp>.json` file for every
-pending post. Only after every snapshot succeeds does the first POST begin.
-That ordering prevents a second-post validation or snapshot failure from
-leaving a one-post partial apply. The script prints the exact rollback command
-on success. After each update, it performs a separate authenticated
-`context=edit` GET, revalidates the ID and slug, and hashes that fresh body
-against the reviewed payload; the POST response is not treated as readback.
-If a live body already equals its payload it prints `[SKIP]` and moves on, so
-re-running is safe.
+After every target passes preflight, `--apply` performs a second authenticated
+`context=edit` GET and baseline-hash check for every pending target before any
+snapshot or POST. That all-target barrier catches edits made during preflight
+without leaving a one-post partial apply. Immediately before each target POST,
+the script fetches and validates it once more, then writes that fresh response
+to a mode-0600
+`backup/issue-764-em-dash-404/rest-post-<id>-before-<stamp>.json` snapshot. A
+body change observed by either revalidation aborts before the snapshot or POST,
+so stale preflight data cannot become the rollback artifact. After each update,
+a separate authenticated `context=edit` GET revalidates the ID, slug, and
+reviewed payload hash; the POST response is not treated as readback. If a live
+body already equals its payload it prints `[SKIP]` and moves on, so re-running
+is safe.
 
 ## Verify
 
-The PATCH is a post save, which triggers Pagely's site-wide ARES purge, so no
+The POST is a post save, which triggers Pagely's site-wide ARES purge, so no
 separate purge step is needed. Prove it anyway, because an authenticated fetch always
 shows `BYPASS`, so only an anonymous curl proves the public edge.
 
@@ -146,8 +149,10 @@ make varlock-run CMD='python3 scripts/apply_issue_764_fix.py --restore backup/is
 Restore is dry-run by default too. It refuses a snapshot whose ID is outside
 the two-post allowlist, whose slug or body hash differs from the approved
 baseline, or whose live target has drifted from the reviewed payload. With
-`--apply`, it first saves the current live payload to a fresh mode-0600
-`rest-post-<id>-before-restore-<stamp>.json`, then performs the restore and
+`--apply`, it performs another authenticated `context=edit` GET immediately
+before the write, revalidates the ID, slug, and reviewed payload hash, and saves
+that fresh response to a mode-0600
+`rest-post-<id>-before-restore-<stamp>.json`. It then performs the restore and
 verifies it through a separate authenticated `context=edit` GET with the same
 ID, slug, and approved baseline-body hash checks. If the original snapshot is
 missing, the committed `*-baseline-20260815.json` files in these `fix-764/`

--- a/scripts/apply_issue_764_fix.py
+++ b/scripts/apply_issue_764_fix.py
@@ -55,7 +55,6 @@ BASE_URL = "https://kriskrug.co"
 class PreparedTarget:
     post_id: int
     spec: dict
-    live: dict
     payload: str
     already_applied: bool
 
@@ -65,7 +64,6 @@ class PreparedRestore:
     post_id: int
     spec: dict
     snapshot: dict
-    live: dict
     already_restored: bool
 
 
@@ -150,6 +148,25 @@ def response_matches(
     )
 
 
+def fetch_expected_live(
+    post_id: int,
+    spec: dict,
+    header: str,
+    expected_sha256: str,
+    operation: str,
+) -> dict:
+    live = request(f"{BASE_URL}/wp-json/wp/v2/posts/{post_id}?context=edit", header)
+    validate_live_identity(live, post_id, spec)
+    content = live.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str) or sha256(body) != expected_sha256:
+        sys.exit(
+            f"[ABORT] {post_id}: live body changed after preflight before "
+            f"{operation}; refusing to overwrite it."
+        )
+    return live
+
+
 def preflight_target(post_id: int, spec: dict, header: str) -> PreparedTarget:
     payload = (spec["dir"] / f"{post_id}-content-payload.html").read_text(
         encoding="utf-8"
@@ -163,7 +180,7 @@ def preflight_target(post_id: int, spec: dict, header: str) -> PreparedTarget:
     current = live["content"]["raw"]
     if sha256(current) == spec["payload_sha256"]:
         print(f"[SKIP] {post_id}: live body already equals the payload. Nothing to do.")
-        return PreparedTarget(post_id, spec, live, payload, True)
+        return PreparedTarget(post_id, spec, payload, True)
     if sha256(current) != spec["baseline_sha256"]:
         sys.exit(
             f"[ABORT] {post_id}: live body drifted from the 2026-08-15 baseline "
@@ -187,10 +204,18 @@ def preflight_target(post_id: int, spec: dict, header: str) -> PreparedTarget:
     for line in diff:
         print("   " + line)
 
-    return PreparedTarget(post_id, spec, live, payload, False)
+    return PreparedTarget(post_id, spec, payload, False)
 
 
-def apply_target(plan: PreparedTarget, header: str, snapshot: Path) -> bool:
+def apply_target(plan: PreparedTarget, header: str, stamp: str) -> bool:
+    live = fetch_expected_live(
+        plan.post_id,
+        plan.spec,
+        header,
+        plan.spec["baseline_sha256"],
+        "apply",
+    )
+    snapshot = write_snapshot(live, plan.post_id, stamp, "before")
     updated = request(
         f"{BASE_URL}/wp-json/wp/v2/posts/{plan.post_id}?context=edit",
         header,
@@ -236,13 +261,16 @@ def run_targets(
             )
         return True
 
-    snapshots = {
-        plan.post_id: write_snapshot(plan.live, plan.post_id, stamp, "before")
-        for plan in pending
-    }
-    return all(
-        apply_target(plan, header, snapshots[plan.post_id]) for plan in pending
-    )
+    for plan in pending:
+        fetch_expected_live(
+            plan.post_id,
+            plan.spec,
+            header,
+            plan.spec["baseline_sha256"],
+            "the apply batch",
+        )
+
+    return all(apply_target(plan, header, stamp) for plan in pending)
 
 
 def preflight_restore(path: Path, header: str) -> PreparedRestore:
@@ -271,13 +299,13 @@ def preflight_restore(path: Path, header: str) -> PreparedRestore:
     validate_live_identity(live, post_id, spec)
     current_hash = sha256(live["content"]["raw"])
     if current_hash == spec["baseline_sha256"]:
-        return PreparedRestore(post_id, spec, snapshot, live, True)
+        return PreparedRestore(post_id, spec, snapshot, True)
     if current_hash != spec["payload_sha256"]:
         sys.exit(
             f"[ABORT] {post_id}: current body matches neither the reviewed payload "
             "nor the approved baseline; refusing to overwrite live drift."
         )
-    return PreparedRestore(post_id, spec, snapshot, live, False)
+    return PreparedRestore(post_id, spec, snapshot, False)
 
 
 def restore(path: Path, header: str, stamp: str, apply: bool) -> bool:
@@ -291,9 +319,14 @@ def restore(path: Path, header: str, stamp: str, apply: bool) -> bool:
         print("[DRY RUN] restore validated; no local or WordPress write.")
         return True
 
-    recovery = write_snapshot(
-        plan.live, plan.post_id, stamp, "before-restore"
+    live = fetch_expected_live(
+        plan.post_id,
+        plan.spec,
+        header,
+        plan.spec["payload_sha256"],
+        "restore",
     )
+    recovery = write_snapshot(live, plan.post_id, stamp, "before-restore")
     updated = request(
         f"{BASE_URL}/wp-json/wp/v2/posts/{plan.post_id}?context=edit",
         header,

--- a/scripts/tests/test_apply_issue_764_fix.py
+++ b/scripts/tests/test_apply_issue_764_fix.py
@@ -87,12 +87,14 @@ class ApplyIssue764FixTests(unittest.TestCase):
         self.assertTrue(all(body is None for _, body in calls))
         self.assertFalse(snapshot_dir.exists())
 
-    def test_apply_snapshots_every_target_before_first_wordpress_write(self):
+    def test_apply_snapshots_each_fresh_target_before_its_wordpress_write(self):
         snapshot_dir = self.tmp_path / "snapshots"
         writes = []
         saved = {}
         calls = []
         get_urls = []
+        get_counts = {}
+        latest_live = {}
 
         def fake_request(url, _header, body=None):
             post_id = int(url.split("/posts/")[1].split("?")[0])
@@ -100,14 +102,22 @@ class ApplyIssue764FixTests(unittest.TestCase):
             if body is None:
                 calls.append(("GET", post_id))
                 get_urls.append(url)
+                get_counts[post_id] = get_counts.get(post_id, 0) + 1
+                live["modified_gmt"] = f"fresh-{get_counts[post_id]}"
                 if post_id in saved:
                     live["content"]["raw"] = saved[post_id]
+                latest_live[post_id] = live
                 return live
 
             snapshots = list(snapshot_dir.glob("*.json"))
-            self.assertEqual(len(MODULE.TARGETS), len(snapshots))
+            self.assertEqual(len(writes) + 1, len(snapshots))
             self.assertTrue(
                 all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in snapshots)
+            )
+            snapshot = next(path for path in snapshots if f"-{post_id}-" in path.name)
+            self.assertEqual(
+                latest_live[post_id],
+                json.loads(snapshot.read_text(encoding="utf-8")),
             )
             writes.append(post_id)
             calls.append(("POST", post_id))
@@ -123,14 +133,48 @@ class ApplyIssue764FixTests(unittest.TestCase):
         ordered_ids = sorted(MODULE.TARGETS)
         self.assertEqual(
             [("GET", post_id) for post_id in ordered_ids]
+            + [("GET", post_id) for post_id in ordered_ids]
             + [
                 item
                 for post_id in ordered_ids
-                for item in (("POST", post_id), ("GET", post_id))
+                for item in (
+                    ("GET", post_id),
+                    ("POST", post_id),
+                    ("GET", post_id),
+                )
             ],
             calls,
         )
         self.assertTrue(all(url.endswith("?context=edit") for url in get_urls))
+
+    def test_apply_revalidates_all_targets_before_snapshot_or_post(self):
+        ordered_ids = sorted(MODULE.TARGETS)
+        get_counts = {}
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+
+        def fake_request(url, _header, body=None):
+            post_id = int(url.split("/posts/")[1].split("?")[0])
+            calls.append(("POST" if body else "GET", post_id))
+            live = baseline(post_id)
+            if body is None:
+                get_counts[post_id] = get_counts.get(post_id, 0) + 1
+                if post_id == ordered_ids[1] and get_counts[post_id] == 2:
+                    live["content"]["raw"] += "<!-- concurrent edit -->"
+            return live
+
+        with mock.patch.object(
+            MODULE, "SNAPSHOT_DIR", snapshot_dir
+        ), mock.patch.object(MODULE, "request", side_effect=fake_request):
+            with self.assertRaisesRegex(SystemExit, "changed after preflight"):
+                run_main("--apply")
+
+        self.assertEqual(
+            [("GET", post_id) for post_id in ordered_ids]
+            + [("GET", post_id) for post_id in ordered_ids],
+            calls,
+        )
+        self.assertFalse(snapshot_dir.exists())
 
     def test_apply_fails_when_post_claims_success_but_fresh_get_disagrees(self):
         post_id = sorted(MODULE.TARGETS)[0]
@@ -148,7 +192,10 @@ class ApplyIssue764FixTests(unittest.TestCase):
         ), mock.patch.object(MODULE, "request", side_effect=fake_request):
             self.assertEqual(1, run_main("--post-id", str(post_id), "--apply"))
 
-        self.assertEqual(["GET", "POST", "GET"], [method for method, _ in calls])
+        self.assertEqual(
+            ["GET", "GET", "GET", "POST", "GET"],
+            [method for method, _ in calls],
+        )
         self.assertTrue(calls[-1][1].endswith("?context=edit"))
 
     def test_apply_fails_on_mismatched_post_response_even_if_fresh_get_matches(self):
@@ -172,7 +219,10 @@ class ApplyIssue764FixTests(unittest.TestCase):
         ), mock.patch.object(MODULE, "request", side_effect=fake_request):
             self.assertEqual(1, run_main("--post-id", str(post_id), "--apply"))
 
-        self.assertEqual(["GET", "POST", "GET"], [method for method, _ in calls])
+        self.assertEqual(
+            ["GET", "GET", "GET", "POST", "GET"],
+            [method for method, _ in calls],
+        )
         self.assertTrue(calls[-1][1].endswith("?context=edit"))
 
     def test_apply_refuses_fresh_readback_slug_mismatch(self):
@@ -317,7 +367,32 @@ class ApplyIssue764FixTests(unittest.TestCase):
             )
 
         self.assertEqual([{"content": original["content"]["raw"]}], writes)
-        self.assertEqual(["GET", "POST", "GET"], calls)
+        self.assertEqual(["GET", "GET", "POST", "GET"], calls)
+
+    def test_restore_revalidates_before_snapshot_or_post(self):
+        post_id = sorted(MODULE.TARGETS)[0]
+        original = baseline(post_id)
+        restore_file = self.tmp_path / "baseline.json"
+        restore_file.write_text(json.dumps(original), encoding="utf-8")
+        current = {**original, "content": {"raw": payload(post_id)}}
+        snapshot_dir = self.tmp_path / "snapshots"
+        calls = []
+
+        def fake_request(_url, _header, body=None):
+            calls.append("POST" if body else "GET")
+            live = {**current, "content": {"raw": current["content"]["raw"]}}
+            if calls == ["GET", "GET"]:
+                live["content"]["raw"] += "<!-- concurrent edit -->"
+            return live
+
+        with mock.patch.object(
+            MODULE, "SNAPSHOT_DIR", snapshot_dir
+        ), mock.patch.object(MODULE, "request", side_effect=fake_request):
+            with self.assertRaisesRegex(SystemExit, "changed after preflight"):
+                run_main("--restore", str(restore_file), "--apply")
+
+        self.assertEqual(["GET", "GET"], calls)
+        self.assertFalse(snapshot_dir.exists())
 
     def test_restore_fails_when_post_claims_success_but_fresh_get_disagrees(self):
         post_id = sorted(MODULE.TARGETS)[0]
@@ -340,7 +415,7 @@ class ApplyIssue764FixTests(unittest.TestCase):
                 1, run_main("--restore", str(restore_file), "--apply")
             )
 
-        self.assertEqual(["GET", "POST", "GET"], calls)
+        self.assertEqual(["GET", "GET", "POST", "GET"], calls)
 
     def test_restore_fails_on_mismatched_post_response_even_if_fresh_get_matches(self):
         post_id = sorted(MODULE.TARGETS)[0]
@@ -366,7 +441,10 @@ class ApplyIssue764FixTests(unittest.TestCase):
                 1, run_main("--restore", str(restore_file), "--apply")
             )
 
-        self.assertEqual(["GET", "POST", "GET"], [method for method, _ in calls])
+        self.assertEqual(
+            ["GET", "GET", "POST", "GET"],
+            [method for method, _ in calls],
+        )
         self.assertTrue(calls[-1][1].endswith("?context=edit"))
 
 


### PR DESCRIPTION
Corrective follow-up to merged PR #774 after further review found a pre-write time-of-check/time-of-use gap.

No live WordPress write, restore, snapshot, cache purge, or deployment occurred. All write-path tests use offline fakes and temporary directories.

What this corrects:
- retains the global all-target preflight before any write;
- performs a second authenticated context=edit GET and baseline-hash check for every pending apply target before any snapshot or POST;
- immediately before each target POST, performs another authenticated GET, revalidates ID, slug, and baseline hash, and snapshots that exact fresh response;
- immediately before restore, revalidates ID, slug, and the reviewed payload hash, then snapshots that exact fresh response;
- aborts without a POST or snapshot when a target changes after preflight;
- removes stale preflight response objects from the prepared write plans;
- updates the runbook to document the pre-write revalidation and fresh-snapshot contract;
- expands the focused offline safety suite from 12 to 14 tests.

Verified locally:
- python3 -m unittest scripts.tests.test_apply_issue_764_fix -v: 14 passed
- make verify voice-check: passed
- 383 operational tests passed
- 12 SEO inventory tests passed
- 68 SEO backfill/link-safety tests passed
- JavaScript, PHP syntax, PHPCS, plugin, theme, docs-truth, and voice gates passed

Draft on purpose. The editorial apply remains separately KK-authorized and is not part of this PR.

Refs #764
Follow-up to #774