### PR TITLE
docs: record Aurora 1.6.6 source merge

### DIFF
--- a/docs/current-state/AURORA-RELEASE-CHECKLIST.md
+++ b/docs/current-state/AURORA-RELEASE-CHECKLIST.md
@@ -1,6 +1,6 @@
 # Aurora Theme Release Checklist
 
-Use this checklist for every manual `kk-aurora` production deploy on Pagely (wp-admin zip upload — no SFTP/SSH).
+Use this checklist for every manual `kk-aurora` production deploy on Pagely: wp-admin zip upload, no SFTP/SSH.
 
 ## Pre-release (repo)
 
@@ -30,7 +30,7 @@ Use this checklist for every manual `kk-aurora` production deploy on Pagely (wp-
 
 - [ ] Purge Pagely cache
 - [ ] Logged-out spot-check: homepage, `/blog/`, one real post
-- [ ] `make status-readonly` — confirm GSAP CDN check if version includes GSAP removal
+- [ ] `make status-readonly`: confirm GSAP CDN check if version includes GSAP removal
 - [ ] Cross-post evidence to open issues (#125, #127, #189 as applicable)
 
 ## Rollback
@@ -41,7 +41,7 @@ Use this checklist for every manual `kk-aurora` production deploy on Pagely (wp-
 
 ## Current release note (2026-08-16)
 
-- Public `style.css` reports Aurora **1.6.5**. Draft PR #751 prepares **1.6.6** for #733 and #743; merge and deploy remain KK gates.
+- Public `style.css` reports Aurora **1.6.5**. Source release **1.6.6** merged in PR #751 at `dcb7ff4` for #733 and #743; deployment remains a KK gate.
 - The committed pre-deploy baseline manifest is `reports/visual-baseline/manifest-20260816T151617Z.json`. It captures `/` and `/speaking/` at 200 across mobile, tablet, and desktop.
 - `/marquee/` currently returns 404 and is not a valid live release gate. Verify the marquee archive copy in source; the visual runbook uses `/category/vancouver-ai-ecosystem/` as the live archive-template substitute until the marquee route exists.
-- A post-deploy candidate diff, cache purge, public 1.6.6 readback, rollback receipt, and Jetpack Boost regeneration are still required. This checklist and PR do not authorize those actions.
+- A post-deploy candidate diff, cache purge, public 1.6.6 readback, rollback receipt, and Jetpack Boost regeneration are still required. This checklist and the repository merge do not authorize those actions.

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -21,7 +21,7 @@ When you cut a new release, add a line here and follow
 ---
 
 ## 1.6.6
-**Deployed:** NOT LIVE (draft PR #751; merge and deploy pending)
+**Deployed:** NOT LIVE (source merged in PR #751 at `dcb7ff4`; deploy pending)
 Copy and dead-file cleanup, no layout or CSS change. Strips the five user-visible em dashes from theme copy: the homepage hero dek and services lede, the marquee archive lede, and the photo-gallery pattern's lede plus its placeholder alt text (#733). Removes the orphaned speaking proof-grid template part and its `theme.json` registration; the part was placed by zero templates and live proof-grid content is DB page content, not this part (#743).
 
 ## 1.6.5


### PR DESCRIPTION
## Summary

- record PR #751 and source release 1.6.6 as merged
- keep the public Aurora 1.6.5 and deploy-pending boundary explicit
- remove two pre-existing em dashes exposed by the exact-file voice gate

## Verification

- `make docs-truth-check`
- focused `make voice-check` on both changed docs: 0 violations
- `git diff --check`

No package, deploy, provider mutation, cache purge, CMS write, or production change occurred.

Refs #733
Refs #743