### PR TITLE
fixes: warn that activating OG restore snippet 12 regresses metadata

### DIFF
--- a/fixes/og-restore-snippet.php
+++ b/fixes/og-restore-snippet.php
@@ -2,12 +2,17 @@
 /**
  * KK OG Restore — kriskrug.co
  *
- * Temporary production bridge for social link previews while Aurora 1.3.37 is
- * reviewed and deployed. The live Code Snippet must match this file exactly,
- * without the opening PHP tag.
+ * Code Snippet ID 12. INACTIVE since 2026-07-13. Do not activate.
  *
- * Rollback: deactivate the "Open Graph + Twitter Card meta (social link
- * previews)" snippet. Retire it after Aurora 1.3.37 is live and verified.
+ * Aurora now emits every Open Graph and Twitter Card tag from
+ * theme/kk-aurora/functions.php. This file is a historical bridge only.
+ * Activating it makes the theme stand down and regresses live metadata
+ * (homepage description, og:site_name, curated post descriptions).
+ *
+ * Ledger: fixes/README.md
+ * Evidence: docs/current-state/reports/og-restore-snippet-diagnosis-20260815.md
+ *
+ * If this snippet is ever re-enabled by mistake: deactivate ID 12 immediately.
  */
 
 if (!defined('KK_OG_SNIPPET_ACTIVE')) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the remaining paper-trail gap on #759.

`fixes/README.md` and the 2026-08-15 diagnosis already record snippet ID 12 as inactive since 2026-07-13, with the Aurora theme as the sole OG/Twitter provider. The PHP file header still told the next editor this was a temporary 1.3.37 bridge to keep in sync with a live snippet.

This PR updates only the file header:

- Names snippet ID 12
- States it is inactive and must not be activated
- Warns that enabling it makes the theme stand down and regresses homepage `description`, `og:site_name`, and curated post descriptions
- Points at `fixes/README.md` and `docs/current-state/reports/og-restore-snippet-diagnosis-20260815.md`

No snippet deploy, no live write, no theme change.

Fixes #759

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

