### PR TITLE
theme(#756,#735): title pipe + Krüg chrome; Aurora 1.6.7

### DIFF
--- a/scripts/tests/test_issue_345_og_site_name.py
+++ b/scripts/tests/test_issue_345_og_site_name.py
@@ -73,7 +73,7 @@ class Issue345OpenGraphSiteNameTests(unittest.TestCase):
             self.theme,
             re.compile(r"'og:site_name'\s*=>\s*public_site_name\(\)"),
         )
-        self.assertIn("return 'Kris Krug';", self.theme)
+        self.assertIn("return 'Kris Krüg';", self.theme)
         self.assertIn("add_filter('get_bloginfo_rss'", self.theme)
         self.assertIn("add_filter('get_wp_title_rss'", self.theme)
         self.assertRegex(
@@ -81,7 +81,7 @@ class Issue345OpenGraphSiteNameTests(unittest.TestCase):
             re.compile(r"\$site\s*=\s*get_bloginfo\('name'\)"),
         )
         self.assertIn(
-            "Kris Krug | AI Keynote Speaker & Creative Technologist",
+            "Kris Krüg | AI Keynote Speaker & Creative Technologist",
             self.theme,
         )
         self.assertIn("Code Snippet 12 is inactive", self.handoff)
@@ -90,9 +90,16 @@ class Issue345OpenGraphSiteNameTests(unittest.TestCase):
     def test_deployment_requires_approval_snapshot_and_public_readback(self):
         deployment = self.data["future_deployment_if_separately_approved"]
 
-        self.assertIn("explicit approval of the exact blogname change", deployment["requires"])
-        self.assertIn("fresh authenticated readback of the current blogname", deployment["requires"])
-        self.assertIn("complete rollback snapshot of the current blogname", deployment["requires"])
+        self.assertIn(
+            "explicit approval of the exact blogname change", deployment["requires"]
+        )
+        self.assertIn(
+            "fresh authenticated readback of the current blogname",
+            deployment["requires"],
+        )
+        self.assertIn(
+            "complete rollback snapshot of the current blogname", deployment["requires"]
+        )
         self.assertEqual(["set blogname to Kris Krug"], deployment["allowed_actions"])
         self.assertIn("restore the exact captured blogname", deployment["rollback"])
         self.assertIn("purge PressCACHE", deployment["rollback"])
@@ -104,9 +111,14 @@ class Issue345OpenGraphSiteNameTests(unittest.TestCase):
         self.assertIn("public_rest_root", evaluation["checks"])
         self.assertIn("anonymous_cache_busted_html", evaluation["checks"])
         self.assertIn("crawler_user_agents", evaluation["checks"])
-        self.assertIn("exactly one og:site_name with value Kris Krug", evaluation["expected"])
+        self.assertIn(
+            "exactly one og:site_name with value Kris Krug", evaluation["expected"]
+        )
         self.assertIn("document titles remain unchanged", evaluation["expected"])
-        self.assertIn("Aurora remains the only active social metadata owner", evaluation["expected"])
+        self.assertIn(
+            "Aurora remains the only active social metadata owner",
+            evaluation["expected"],
+        )
 
     def test_adjacent_defects_are_separately_tracked(self):
         adjacent = self.data["adjacent_findings"]

--- a/scripts/tests/test_issue_347_blog_canonical.py
+++ b/scripts/tests/test_issue_347_blog_canonical.py
@@ -111,7 +111,7 @@ class Issue347BlogCanonicalTests(unittest.TestCase):
         self.assertEqual("https://kriskrug.co/blog/page/2/", result["canonical"])
         self.assertEqual(result["canonical"], result["tags"]["og:url"])
         self.assertIn('href="https://kriskrug.co/blog/page/2/"', result["link"])
-        self.assertEqual("Writing — Kris Krug", result["tags"]["og:title"])
+        self.assertEqual("Writing | Kris Krüg", result["tags"]["og:title"])
 
     def test_non_blog_routes_do_not_gain_an_archive_canonical(self):
         result = render_archive_identity(

--- a/scripts/tests/test_issue_415_homepage_trust_identity.py
+++ b/scripts/tests/test_issue_415_homepage_trust_identity.py
@@ -8,9 +8,10 @@ THEME_FUNCTIONS = ROOT / "theme/kk-aurora/functions.php"
 FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
 SCHEMA_SOURCE = ROOT / "fixes/schema-snippets-deployed.php"
 SITE_NAME = "Kris Krug"
+PUBLIC_SITE_NAME = "Kris Krüg"
 STALE_IDENTITY = "Generative AI Tools & Techniques"
 HOME_DESCRIPTION = (
-    "Kris Krug is a Vancouver AI keynote speaker, creative technologist, and "
+    "Kris Krüg is a Vancouver AI keynote speaker, creative technologist, and "
     "community builder leading BC + AI and curating Futureproof Festival."
 )
 
@@ -23,7 +24,9 @@ class Issue415HomepageTrustIdentityTests(unittest.TestCase):
 
     @staticmethod
     def _function_block(source: str, name: str, next_name: str) -> str:
-        pattern = rf"function {re.escape(name)}\(.*?(?=function {re.escape(next_name)}\()"
+        pattern = (
+            rf"function {re.escape(name)}\(.*?(?=function {re.escape(next_name)}\()"
+        )
         match = re.search(pattern, source, re.DOTALL)
         if match is None:
             raise AssertionError(f"missing function block: {name}")
@@ -62,7 +65,7 @@ class Issue415HomepageTrustIdentityTests(unittest.TestCase):
             "render_social_meta_tags",
         )
 
-        self.assertIn(f"return '{SITE_NAME}';", self.theme)
+        self.assertIn(f"return '{PUBLIC_SITE_NAME}';", self.theme)
         self.assertIn("'og:site_name'   => public_site_name()", social)
         self.assertNotIn("get_bloginfo('name')", social)
         self.assertIn("function filter_feed_bloginfo", self.theme)

--- a/scripts/tests/test_issue_735_brand_canon.py
+++ b/scripts/tests/test_issue_735_brand_canon.py
@@ -1,0 +1,43 @@
+"""#735: live Aurora chrome uses BC + AI (spaces) and Kris Krüg."""
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME = ROOT / "theme/kk-aurora"
+LIVE_CHROME = [
+    THEME / "parts/header.html",
+    THEME / "parts/footer.html",
+    THEME / "patterns/hero-gradient.php",
+    THEME / "patterns/stats-counter.php",
+]
+
+
+class Issue735BrandCanonTests(unittest.TestCase):
+    def test_live_chrome_does_not_use_unspaced_bc_ai(self):
+        offenders = []
+        for path in LIVE_CHROME:
+            text = path.read_text(encoding="utf-8")
+            if "BC+AI" in text:
+                offenders.append(path.relative_to(ROOT).as_posix())
+        self.assertEqual(offenders, [])
+
+    def test_header_and_footer_use_krug_umlaut(self):
+        header = (THEME / "parts/header.html").read_text(encoding="utf-8")
+        footer = (THEME / "parts/footer.html").read_text(encoding="utf-8")
+        self.assertIn("Kris Krüg home", header)
+        self.assertIn('aria-label="Kris Krüg"', footer)
+        self.assertIn("Kris Krüg", footer)
+        self.assertNotIn("Kris Krug home", header)
+        self.assertNotIn("Copyright 2026 Kris Krug.", footer)
+
+    def test_title_separator_is_not_an_em_dash(self):
+        source = (THEME / "functions.php").read_text(encoding="utf-8")
+        self.assertNotIn("return '\u2014';", source)
+        self.assertIn("return '|';", source)
+        self.assertNotIn("Writing \u2014", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.7
+**Deployed:** NOT LIVE (deploy pending)
+Chrome copy: sitewide `<title>` separator becomes a pipe and the surname takes the umlaut (#756). Front page keeps the full descriptor; inner pages take a short `Kris Krüg` tail. Writing-archive og/twitter titles, `public_site_name()`, header, footer, and shipped patterns follow the same ruling. Live chrome uses `BC + AI` (spaces) per #735. Descriptors are not unified. No CSS change.
+
 ## 1.6.6
 **Deployed:** NOT LIVE (source merged in PR #751 at `dcb7ff4`; deploy pending)
 Copy and dead-file cleanup, no layout or CSS change. Strips the five user-visible em dashes from theme copy: the homepage hero dek and services lede, the marquee archive lede, and the photo-gallery pattern's lede plus its placeholder alt text (#733). Removes the orphaned speaking proof-grid template part and its `theme.json` registration; the part was placed by zero templates and live proof-grid content is DB page content, not this part (#743).

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.6');
+define('KK_AURORA_VERSION', '1.6.7');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';
@@ -335,24 +335,27 @@ add_action('init', __NAMESPACE__ . '\\register_block_styles');
  * @return array<string, string>
  */
 function filter_document_title_parts(array $title): array {
-    $site_descriptor = 'Kris Krug | AI Keynote Speaker & Creative Technologist';
+    // Front page keeps the full descriptor for SEO; inner pages take a short
+    // tail so the post title survives SERP truncation (#756).
+    $front_page_descriptor = 'Kris Krüg | AI Keynote Speaker & Creative Technologist';
+    $site_suffix           = 'Kris Krüg';
 
     unset($title['tagline']);
 
     if (is_front_page()) {
-        $title['title'] = $site_descriptor;
+        $title['title'] = $front_page_descriptor;
         unset($title['site']);
         return $title;
     }
 
-    $title['site'] = $site_descriptor;
+    $title['site'] = $site_suffix;
 
     return $title;
 }
 add_filter('document_title_parts', __NAMESPACE__ . '\\filter_document_title_parts');
 
 function filter_document_title_separator(string $separator): string {
-    return '—';
+    return '|';
 }
 add_filter('document_title_separator', __NAMESPACE__ . '\\filter_document_title_separator');
 
@@ -579,11 +582,11 @@ function exclude_current_post_from_related_query(array $query, \WP_Block $block)
 add_filter('query_loop_block_query_vars', __NAMESPACE__ . '\\exclude_current_post_from_related_query', 10, 2);
 
 function public_site_name(): string {
-    return 'Kris Krug';
+    return 'Kris Krüg';
 }
 
 function homepage_meta_description(): string {
-    return 'Kris Krug is a Vancouver AI keynote speaker, creative technologist, and community builder leading BC + AI and curating Futureproof Festival.';
+    return 'Kris Krüg is a Vancouver AI keynote speaker, creative technologist, and community builder leading BC + AI and curating Futureproof Festival.';
 }
 
 function filter_feed_bloginfo(string $value, string $show): string {
@@ -787,7 +790,7 @@ function work_page_open_graph_fallback(array $tags): array {
 }
 
 function writing_archive_meta_description(): string {
-    $fallback = 'Read Kris Krug field notes on responsible AI, creative technology, community building, Indigenous tech, media, culture, practical workflows, and events.';
+    $fallback = 'Read Kris Krüg field notes on responsible AI, creative technology, community building, Indigenous tech, media, culture, practical workflows, and events.';
     $posts_page_id = (int) get_option('page_for_posts');
     if ($posts_page_id <= 0) {
         return $fallback;
@@ -827,7 +830,7 @@ function writing_archive_open_graph_fallback(array $tags): array {
     $description = writing_archive_meta_description();
     $canonical = writing_archive_canonical_url();
 
-    $tags['og:title'] = 'Writing — Kris Krug';
+    $tags['og:title'] = 'Writing | Kris Krüg';
     if ($canonical !== '') {
         $tags['og:url'] = $canonical;
     }
@@ -838,7 +841,7 @@ function writing_archive_open_graph_fallback(array $tags): array {
     $tags['og:image:height'] = '686';
     $tags['og:image:alt'] = 'Mycelial network artwork representing connected AI-era field notes';
     $tags['twitter:card'] = 'summary_large_image';
-    $tags['twitter:title'] = 'Writing — Kris Krug';
+    $tags['twitter:title'] = 'Writing | Kris Krüg';
     $tags['twitter:description'] = $description;
     $tags['twitter:image'] = $image;
     $tags['twitter:image:alt'] = 'Mycelial network artwork representing connected AI-era field notes';
@@ -923,7 +926,7 @@ function writing_archive_category_feed_discovery(): void {
 
         printf(
             "<link rel=\"alternate\" type=\"application/rss+xml\" title=\"%s\" href=\"%s\" />\n",
-            esc_attr(sprintf('%s category feed - Kris Krug', wp_strip_all_tags($category->name))),
+            esc_attr(sprintf('%s category feed - Kris Krüg', wp_strip_all_tags($category->name))),
             esc_url($feed_url)
         );
     }

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -4,8 +4,8 @@
     <svg preserveAspectRatio="none" viewBox="0 0 120 12" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="auroraWovenFoot" x="0" y="0" width="60" height="12" patternUnits="userSpaceOnUse"><rect x="0" y="0" width="4" height="12" fill="#171310"/><rect x="4" y="0" width="6" height="12" fill="#d94a1f"/><rect x="10" y="0" width="4" height="12" fill="#171310"/><rect x="14" y="0" width="6" height="12" fill="#e8b53a"/><rect x="20" y="0" width="4" height="12" fill="#efe6d2"/><rect x="24" y="0" width="6" height="12" fill="#1f8a86"/><rect x="30" y="0" width="4" height="12" fill="#171310"/><rect x="34" y="0" width="6" height="12" fill="#39a8d8"/><rect x="40" y="0" width="4" height="12" fill="#171310"/><rect x="44" y="0" width="6" height="12" fill="#6b3a97"/><rect x="50" y="0" width="4" height="12" fill="#efe6d2"/><rect x="54" y="0" width="6" height="12" fill="#d6337a"/></pattern></defs><rect width="120" height="12" fill="url(#auroraWovenFoot)"/></svg>
   </div>
   <div class="aurora-footer-shell">
-    <section class="aurora-footer-tile aurora-footer-tile-brand" aria-label="Kris Krug">
-      <p class="aurora-kicker">Kris Krug</p>
+    <section class="aurora-footer-tile aurora-footer-tile-brand" aria-label="Kris Krüg">
+      <p class="aurora-kicker">Kris Krüg</p>
       <h2>Still paying attention. Now with better tools.</h2>
       <p>AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
       <div class="aurora-footer-actions">
@@ -76,7 +76,7 @@
   </div>
 
   <div class="aurora-footer-bottom">
-    <p>Copyright 2026 Kris Krug. All rights reserved.</p>
+    <p>Copyright 2026 Kris Krüg. All rights reserved.</p>
     <p><a href="/reconciliation-indigenous-land-acknowledgement/">Reconciliation</a> / <a href="/the-kk-worldview/">Worldview</a></p>
   </div>
 </footer>

--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -35,8 +35,8 @@
     </div>
   </div>
   <div class="aurora-header-shell">
-    <a class="aurora-brand" href="/" aria-label="Kris Krug home">
-      <img class="aurora-brand-logo" src="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp" srcset="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp 1x, /wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-234.webp 2x" alt="Kris Krug home" width="117" height="57" decoding="async">
+    <a class="aurora-brand" href="/" aria-label="Kris Krüg home">
+      <img class="aurora-brand-logo" src="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp" srcset="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp 1x, /wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-234.webp 2x" alt="Kris Krüg home" width="117" height="57" decoding="async">
     </a>
 
     <nav class="aurora-primary-nav" aria-label="Primary navigation">

--- a/theme/kk-aurora/patterns/hero-gradient.php
+++ b/theme/kk-aurora/patterns/hero-gradient.php
@@ -20,7 +20,7 @@
       <!-- /wp:heading -->
       
       <!-- wp:paragraph {"align":"center","className":"aurora-hero-description","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"textColor":"text-secondary","fontSize":"lg"} -->
-      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC+AI · Lead Curator, Futureproof Festival · Techartist &amp; Culture Hacker</p>
+      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC + AI · Lead Curator, Futureproof Festival · Techartist &amp; Culture Hacker</p>
       <!-- /wp:paragraph -->
       
       <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
@@ -28,7 +28,7 @@
         <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
         <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
           <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"signal"} -->
-          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">BC+AI</p>
+          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">BC + AI</p>
           <!-- /wp:paragraph -->
         </div>
         <!-- /wp:group -->

--- a/theme/kk-aurora/patterns/stats-counter.php
+++ b/theme/kk-aurora/patterns/stats-counter.php
@@ -21,7 +21,7 @@
         <!-- /wp:heading -->
 
         <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
-        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">BC+AI Members</p>
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">BC + AI Members</p>
         <!-- /wp:paragraph -->
       </div>
       <!-- /wp:group -->

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -40,6 +40,10 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.6.7 =
+* content (#756): sitewide `<title>` separator is a pipe; inner pages take a short `Kris Krüg` tail; front page keeps the full descriptor.
+* content (#735): live chrome uses `BC + AI` (spaces) and `Kris Krüg` in header, footer, patterns, and `public_site_name()`.
+
 = 1.6.6 =
 * content (#733, PR #751): rewrite the five listed user-visible em dashes in the homepage, marquee archive, and photo-gallery pattern copy.
 * cleanup (#743, PR #751): remove the unplaced speaking proof-grid template part and its theme.json registration.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.6
+Version: 1.6.7
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/templates/single.html
+++ b/theme/kk-aurora/templates/single.html
@@ -52,7 +52,7 @@
         <h2 class="wp-block-heading aurora-author-title">About Kris</h2>
         <!-- /wp:heading -->
         <!-- wp:paragraph -->
-        <p>Kris Krug is an AI keynote speaker, creative technologist, photographer, and community builder working across BC + AI, Vancouver AI, and Futureproof Festival, and a living network of AI-era projects.</p>
+        <p>Kris Krüg is an AI keynote speaker, creative technologist, photographer, and community builder working across BC + AI, Vancouver AI, and Futureproof Festival, and a living network of AI-era projects.</p>
         <!-- /wp:paragraph -->
         <!-- wp:buttons {"layout":{"type":"flex","flexWrap":"wrap"}} -->
         <div class="wp-block-buttons">


### PR DESCRIPTION
Closes #756.
Refs #735.

## What

The sitewide `<title>` format lived in two hardcoded values in `theme/kk-aurora/functions.php`. On every page lacking a custom SEO title it rendered an em dash separator and `Kris Krug` without the umlaut. RSS and writing-archive og/twitter titles inherited the same faults. Header, footer, and shipped patterns still used `BC+AI` and ASCII Krug.

## Fix

- Separator `—` → `|`.
- Front page keeps the full descriptor for SEO; inner pages take a short `Kris Krüg` tail.
- `public_site_name()`, writing-archive og/twitter titles, header, footer, and shipped patterns use `Kris Krüg`.
- Live chrome uses `BC + AI` (spaces). Descriptors are not unified.
- Aurora **1.6.7**. No CSS change.

Rewritten off current `main` so it also absorbs the #735 chrome from #806. That PR is superseded.

## Gate

Track B. Merge of source is the ask here. Deploy still needs KK and the pixel gate; deploy alongside or right after 1.6.6. Post-deploy: confirm no em dash in `<title>` across a post, an archive, the 404, and `/feed/`.