### PR TITLE
theme: homepage #411–#413 Join BC + Labs + logo soup (Aurora 1.6.8)

### DIFF
--- a/docs/current-state/AURORA-RELEASE-CHECKLIST.md
+++ b/docs/current-state/AURORA-RELEASE-CHECKLIST.md
@@ -39,9 +39,9 @@ Use this checklist for every manual `kk-aurora` production deploy on Pagely: wp-
 - [ ] Purge Pagely cache again
 - [ ] Re-verify logged-out render
 
-## Current release note (2026-08-16)
+## Current release note (2026-08-17)
 
-- Public `style.css` reports Aurora **1.6.5**. Source release **1.6.6** merged in PR #751 at `dcb7ff4` for #733 and #743; deployment remains a KK gate.
+- Public `style.css` reports Aurora **1.6.5**. Source `main` is **1.6.6** (PR #751, undeployed). Open PR #789 cuts **1.6.7** for sitewide titles. Homepage cluster #411–#413 is **1.6.8** and stacks after #789 / 1.6.7. Do not treat 1.6.6 as live.
 - The committed pre-deploy baseline manifest is `reports/visual-baseline/manifest-20260816T151617Z.json`. It captures `/` and `/speaking/` at 200 across mobile, tablet, and desktop.
 - `/marquee/` currently returns 404 and is not a valid live release gate. Verify the marquee archive copy in source; the visual runbook uses `/category/vancouver-ai-ecosystem/` as the live archive-template substitute until the marquee route exists.
 - A post-deploy candidate diff, cache purge, public 1.6.6 readback, rollback receipt, and Jetpack Boost regeneration are still required. This checklist and the repository merge do not authorize those actions.

--- a/scripts/tests/test_aurora_css_literal_contrast.py
+++ b/scripts/tests/test_aurora_css_literal_contrast.py
@@ -324,14 +324,14 @@ REGISTERED_LITERALS = {
     (
         "assets/css/revive-port.css",
         ".aurora-work-card-num",
-        "rgba(217, 74, 31, 0.45)",
+        "rgba(239, 230, 210, 0.72)",
     ): (
         "work-card-scrim",
         NOT_STATIC,
-        "decorative index numeral pinned to the card's top-left, where the "
-        "::after scrim is fully transparent — it renders straight onto the "
-        "photo (measured 1.11:1 over mid-grey, 1.88:1 over white). Needs a "
-        "design call: scrim it, make it opaque, or mark it aria-hidden.",
+        "#411 retired the oversized accent drop-numeral. The quiet mono index "
+        "still sits top-left on bare photography (scrim is transparent there), "
+        "so the ratio is not statically determinable. Markup now marks it "
+        "aria-hidden.",
     ),
     (
         "assets/css/revive-port.css",

--- a/scripts/tests/test_homepage_411_412_413.py
+++ b/scripts/tests/test_homepage_411_412_413.py
@@ -100,5 +100,45 @@ class Homepage412CreativeLabsTests(unittest.TestCase):
         self.assertIn("object-position: center 35%", self.css)
 
 
+class Homepage413LogoSoupTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.css = REVIVE.read_text(encoding="utf-8")
+        cls.js = (ROOT / "theme/kk-aurora/assets/js/theme.js").read_text(encoding="utf-8")
+        cls.soup = _section(cls.front, "aurora-logo-soup")
+
+    def test_logo_soup_has_at_least_eight_named_clients(self):
+        labels = re.findall(r'aria-label="([^"]+)"', self.soup)
+        self.assertGreaterEqual(len(labels), 8)
+        for name in (
+            "American Express",
+            "CIBC",
+            "Getty Images",
+            "Hootsuite",
+            "Lululemon",
+            "Microsoft",
+            "National Geographic",
+            "Pentagram",
+            "Red Bull",
+            "United Nations",
+        ):
+            self.assertIn(name, labels)
+
+    def test_logo_soup_copy_has_no_rooms_or_em_dashes(self):
+        self.assertEqual(0, len(re.findall(r"rooms?", self.soup, flags=re.I)))
+        self.assertNotIn("\u2014", self.soup)
+        self.assertIn("The logos are the receipts.", self.soup)
+        self.assertIn("Hover or focus a logo.", self.soup)
+
+    def test_logo_soup_is_monochrome_and_interactive(self):
+        self.assertIn("filter: grayscale(1) contrast(1.05)", self.css)
+        self.assertIn(".aurora-logo-soup__item:hover img", self.css)
+        self.assertIn(".aurora-logo-soup__item:focus-visible", self.css)
+        self.assertIn("aria-live=\"polite\"", self.soup)
+        self.assertIn("function initLogoSoup", self.js)
+        self.assertIn("initLogoSoup()", self.js)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_homepage_411_412_413.py
+++ b/scripts/tests/test_homepage_411_412_413.py
@@ -1,0 +1,61 @@
+"""Homepage cluster #411 / #412 / #413 source guards.
+
+No live WordPress writes. These assert the tracked front-page template and
+the Revive sheet, not production HTML.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
+REVIVE = ROOT / "theme/kk-aurora/assets/css/revive-port.css"
+
+
+def _section(source: str, class_name: str) -> str:
+    match = re.search(
+        rf"<section[^>]*class=\"[^\"]*{re.escape(class_name)}[^\"]*\"[\s\S]*?</section>",
+        source,
+    )
+    if match is None:
+        raise AssertionError(f"missing section .{class_name}")
+    return match.group(0)
+
+
+class Homepage411WorkBandTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.css = REVIVE.read_text(encoding="utf-8")
+        cls.work = _section(cls.front, "aurora-work-band")
+
+    def test_work_band_uses_named_heading_and_receipts_copy(self):
+        self.assertIn("BC + AI. Futureproof. The", self.work)
+        self.assertIn("250+ members, 94+ events, 3,000+ through the door", self.work)
+        self.assertIn("Frontier tech without the hype deck", self.work)
+        self.assertIn("No doom sermon", self.work)
+        self.assertNotIn("What Kris is", self.work)
+        self.assertNotIn("trust layer", self.work)
+        self.assertNotIn("operating conditions", self.work)
+
+    def test_work_band_has_zero_rooms_and_zero_em_dashes(self):
+        self.assertEqual(0, len(re.findall(r"rooms?", self.work, flags=re.I)))
+        self.assertNotIn("\u2014", self.work)
+        self.assertIn("BC + AI", self.work)
+
+    def test_work_band_cards_align_and_drop_numeral_is_quiet(self):
+        self.assertIn("align-items: stretch", self.css)
+        self.assertIn(".aurora-work-card:nth-child(2) {\n    margin-top: 0;", self.css)
+        self.assertNotIn("margin-top: -2.5rem", self.css)
+        self.assertIn('aria-hidden="true"', self.work)
+        self.assertIn("font-size: 0.72rem", self.css)
+        self.assertIn(".aurora-work-card:focus-visible", self.css)
+        self.assertIn(".aurora-work-band .aurora-section-head a:focus-visible", self.css)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_homepage_411_412_413.py
+++ b/scripts/tests/test_homepage_411_412_413.py
@@ -57,5 +57,48 @@ class Homepage411WorkBandTests(unittest.TestCase):
         self.assertIn(".aurora-work-band .aurora-section-head a:focus-visible", self.css)
 
 
+class Homepage412CreativeLabsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.css = REVIVE.read_text(encoding="utf-8")
+        cls.labs = _section(cls.front, "aurora-creative-labs")
+
+    def test_labs_section_names_four_public_builds(self):
+        self.assertIn("Creative Labs", self.labs)
+        self.assertIn("The labs around the", self.labs)
+        for title in ("Vancouver AI", "Punk Rock AI", "Both Hands Full", "AI Garden"):
+            self.assertIn(title, self.labs)
+        self.assertIn("https://vancouver.ai/", self.labs)
+        self.assertIn("https://www.punkrockai.com/", self.labs)
+        self.assertIn("https://www.bothhandsfull.com/", self.labs)
+        self.assertIn("https://kriskrug.ai/", self.labs)
+
+    def test_labs_copy_is_plain_and_has_no_rooms_or_em_dashes(self):
+        self.assertEqual(0, len(re.findall(r"rooms?", self.labs, flags=re.I)))
+        self.assertNotIn("\u2014", self.labs)
+        self.assertNotIn("trust layer", self.labs)
+        self.assertIn("Kris Krüg", self.labs)
+
+    def test_labs_images_are_local_or_media_library(self):
+        srcs = re.findall(r"<img[^>]+src=\"([^\"]+)\"", self.labs)
+        self.assertEqual(4, len(srcs))
+        for src in srcs:
+            self.assertTrue(
+                src.startswith("/wp-content/themes/kk-aurora/")
+                or "kriskrug.co/wp-content/uploads/" in src
+                or "i0.wp.com/kriskrug.co/" in src,
+                f"lab image is a hotlink: {src}",
+            )
+        self.assertNotIn("punkrockai.com", " ".join(srcs))
+        self.assertNotIn("bothhandsfull.com/opengraph", " ".join(srcs))
+
+    def test_labs_layout_puts_text_below_the_photo(self):
+        self.assertIn("aspect-ratio: 4 / 5", self.css)
+        self.assertIn(".aurora-lab-card-body", self.css)
+        self.assertIn(".aurora-lab-card:focus-visible", self.css)
+        self.assertIn("object-position: center 35%", self.css)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.8
+**Deployed:** NOT LIVE (stacks after #789 / Aurora 1.6.7; 1.6.6 remains undeployed)
+Homepage cluster: rewrite the Join BC / Futureproof work-band copy, align the triptych, and quiet the card numerals (#411); restore a Creative Labs band with text-below-image cards (#412); bring back a monochrome interactive client logo soup (#413). No live deploy in this cut.
+
 ## 1.6.6
 **Deployed:** NOT LIVE (source merged in PR #751 at `dcb7ff4`; deploy pending)
 Copy and dead-file cleanup, no layout or CSS change. Strips the five user-visible em dashes from theme copy: the homepage hero dek and services lede, the marquee archive lede, and the photo-gallery pattern's lede plus its placeholder alt text (#733). Removes the orphaned speaking proof-grid template part and its `theme.json` registration; the part was placed by zero templates and live proof-grid content is DB page content, not this part (#743).

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -500,11 +500,12 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   .aurora-work-triptych {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1.75rem;
-    align-items: start;
+    align-items: stretch;
   }
 
+  /* #411: shared desktop baseline. The Revive stagger pulled Futureproof off the grid. */
   .aurora-work-card:nth-child(2) {
-    margin-top: -2.5rem;
+    margin-top: 0;
   }
 }
 
@@ -512,6 +513,8 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   display: block;
   text-decoration: none;
   color: inherit;
+  border-radius: 2px;
+  transition: transform 180ms var(--revive-ease), box-shadow 180ms ease;
 }
 
 .aurora-work-card-media {
@@ -521,6 +524,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   border: 1px solid rgba(217, 74, 31, 0.12);
   background: var(--revive-surface-2);
   margin-bottom: 1rem;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
 }
 
 .aurora-work-card-media img {
@@ -531,16 +535,39 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   transition: transform 800ms var(--revive-ease);
 }
 
+.aurora-work-card:hover .aurora-work-card-media,
+.aurora-work-card:focus-visible .aurora-work-card-media,
+.aurora-work-card:focus-within .aurora-work-card-media {
+  border-color: rgba(217, 74, 31, 0.45);
+  box-shadow: 0 10px 28px rgba(23, 19, 16, 0.12);
+}
+
+.aurora-work-card:hover,
+.aurora-work-card:focus-visible {
+  transform: translateY(-2px);
+}
+
 .aurora-work-card:hover .aurora-work-card-media img,
+.aurora-work-card:focus-visible .aurora-work-card-media img,
 .aurora-work-card:focus-within .aurora-work-card-media img {
   transform: scale(1.04);
   filter: grayscale(0);
 }
 
+.aurora-work-card:focus-visible,
 .aurora-work-card:focus-within {
   outline: 2px solid var(--revive-accent-text);
   outline-offset: 4px;
   border-radius: 2px;
+}
+
+.aurora-work-band .aurora-section-head a:hover {
+  color: var(--revive-accent-text);
+}
+
+.aurora-work-band .aurora-section-head a:focus-visible {
+  outline: 2px solid var(--revive-accent-text);
+  outline-offset: 3px;
 }
 
 .aurora-work-card-media::after {
@@ -555,10 +582,12 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   top: 0.85rem;
   left: 0.85rem;
   z-index: 1;
-  font-family: "Space Grotesk", system-ui, sans-serif;
-  font-size: 2.5rem;
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  font-size: 0.72rem;
   font-weight: 700;
-  color: rgba(217, 74, 31, 0.45);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(239, 230, 210, 0.72);
 }
 
 .aurora-work-card-body {
@@ -588,6 +617,25 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   /* Sits on the ::after ink scrim (rgba(23,19,16,.72)). 0.78 was 4.36:1 over
      the worst case (scrim over a white photo region); 0.84 is 4.78:1. */
   color: rgba(239, 230, 210, 0.84);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-work-card,
+  .aurora-work-card-media,
+  .aurora-work-card-media img {
+    transition: none;
+  }
+
+  .aurora-work-card:hover,
+  .aurora-work-card:focus-visible {
+    transform: none;
+  }
+
+  .aurora-work-card:hover .aurora-work-card-media img,
+  .aurora-work-card:focus-visible .aurora-work-card-media img,
+  .aurora-work-card:focus-within .aurora-work-card-media img {
+    transform: none;
+  }
 }
 
 .aurora-services-band {

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -786,6 +786,133 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   }
 }
 
+/* #413 Client logo soup: monochrome at rest, color + note on hover/focus. */
+.aurora-logo-soup {
+  position: relative;
+  max-width: none;
+  border-block: 1px solid rgba(217, 74, 31, 0.12);
+  background: rgba(230, 220, 194, 0.55);
+  padding: clamp(2rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 2.5rem);
+}
+
+.aurora-logo-soup-inner {
+  max-width: var(--revive-max);
+  margin: 0 auto;
+}
+
+.aurora-logo-soup .aurora-section-head {
+  margin-bottom: 1.25rem;
+}
+
+.aurora-logo-soup-lede {
+  margin: 0.65rem 0 0;
+  max-width: 36rem;
+  color: var(--revive-ink-soft);
+  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  line-height: 1.45;
+}
+
+.aurora-logo-soup__grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: stretch;
+  gap: 0.75rem 0.5rem;
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+}
+
+.aurora-logo-soup__grid > li {
+  margin: 0;
+  padding: 0;
+}
+
+.aurora-logo-soup__item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(7.5rem, 16vw, 10.5rem);
+  min-height: 3.25rem;
+  margin: 0;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+}
+
+.aurora-logo-soup__wordmark {
+  display: block;
+  width: 100%;
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  font-size: clamp(0.78rem, 1.4vw, 0.95rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.15;
+  text-align: center;
+  text-transform: uppercase;
+  color: var(--revive-ink-muted);
+  transition: color 200ms ease, opacity 200ms ease;
+}
+
+.aurora-logo-soup__wordmark[data-brand="lululemon"] {
+  text-transform: lowercase;
+  letter-spacing: 0.12em;
+}
+
+.aurora-logo-soup__item img {
+  display: block;
+  width: 100%;
+  height: 2.4rem;
+  object-fit: contain;
+  filter: grayscale(1) contrast(1.05);
+  opacity: 0.82;
+  transition: filter 200ms ease, opacity 200ms ease;
+}
+
+.aurora-logo-soup__item:hover .aurora-logo-soup__wordmark,
+.aurora-logo-soup__item:focus-visible .aurora-logo-soup__wordmark,
+.aurora-logo-soup__item.is-active .aurora-logo-soup__wordmark {
+  color: var(--revive-ink);
+}
+
+.aurora-logo-soup__item:hover img,
+.aurora-logo-soup__item:focus-visible img,
+.aurora-logo-soup__item.is-active img {
+  filter: none;
+  opacity: 1;
+}
+
+.aurora-logo-soup__item:focus-visible {
+  outline: 2px solid var(--revive-accent-text);
+  outline-offset: 3px;
+}
+
+.aurora-logo-soup__readout {
+  min-height: 1.5em;
+  margin: 1.1rem 0 0;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--revive-ink-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-logo-soup__wordmark,
+  .aurora-logo-soup__item img {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .aurora-logo-soup__item {
+    width: clamp(6.5rem, 42vw, 9rem);
+    min-height: 2.85rem;
+  }
+}
+
 .aurora-services-band {
   background: var(--revive-ink);
   color: var(--revive-surface);

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -390,6 +390,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
 
 .aurora-archive-band,
 .aurora-work-band,
+.aurora-creative-labs,
 .aurora-services-band,
 .aurora-writing-band,
 .aurora-newsletter-band {
@@ -634,6 +635,153 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   .aurora-work-card:hover .aurora-work-card-media img,
   .aurora-work-card:focus-visible .aurora-work-card-media img,
   .aurora-work-card:focus-within .aurora-work-card-media img {
+    transform: none;
+  }
+}
+
+/* #412 Creative Labs: text below the photo, no overlay/pill fight. */
+.aurora-creative-labs .aurora-section-lede {
+  max-width: 36rem;
+  margin: 0.75rem 0 0;
+  color: var(--revive-ink-soft);
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.aurora-labs-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.75rem;
+}
+
+@media (min-width: 768px) {
+  .aurora-labs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.75rem 1.5rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  .aurora-labs-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.aurora-lab-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 2px;
+  transition: transform 180ms var(--revive-ease);
+}
+
+.aurora-lab-card-media {
+  position: relative;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  border: 1px solid rgba(217, 74, 31, 0.12);
+  background: var(--revive-surface-2);
+  margin-bottom: 1rem;
+}
+
+.aurora-lab-card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: grayscale(0.2);
+  transition: transform 700ms var(--revive-ease), filter 700ms var(--revive-ease);
+}
+
+.aurora-lab-card:nth-child(1) img {
+  object-position: center 35%;
+}
+
+.aurora-lab-card:nth-child(2) img {
+  object-position: center 20%;
+}
+
+.aurora-lab-card:nth-child(3) img {
+  object-position: center 25%;
+}
+
+.aurora-lab-card:nth-child(4) img {
+  object-position: center 18%;
+}
+
+.aurora-lab-card:hover .aurora-lab-card-media img,
+.aurora-lab-card:focus-visible .aurora-lab-card-media img,
+.aurora-lab-card:focus-within .aurora-lab-card-media img {
+  transform: scale(1.04);
+  filter: grayscale(0);
+}
+
+.aurora-lab-card:hover,
+.aurora-lab-card:focus-visible {
+  transform: translateY(-2px);
+}
+
+.aurora-lab-card:focus-visible,
+.aurora-lab-card:focus-within {
+  outline: 2px solid var(--revive-accent-text);
+  outline-offset: 4px;
+}
+
+.aurora-lab-card-body h3 {
+  margin: 0 0 0.35rem;
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  font-size: 1.45rem;
+  letter-spacing: -0.02em;
+  color: var(--revive-ink);
+}
+
+.aurora-lab-card-body p {
+  margin: 0;
+  color: var(--revive-ink-soft);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.aurora-lab-door {
+  display: inline-block;
+  margin-top: 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--revive-ink);
+  border-bottom: 1px solid var(--revive-accent);
+  padding-bottom: 0.1rem;
+}
+
+.aurora-lab-card:hover .aurora-lab-door,
+.aurora-lab-card:focus-visible .aurora-lab-door {
+  color: var(--revive-accent-text);
+}
+
+.aurora-creative-labs .aurora-section-head a:hover {
+  color: var(--revive-accent-text);
+}
+
+.aurora-creative-labs .aurora-section-head a:focus-visible {
+  outline: 2px solid var(--revive-accent-text);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-lab-card,
+  .aurora-lab-card-media img {
+    transition: none;
+  }
+
+  .aurora-lab-card:hover,
+  .aurora-lab-card:focus-visible {
+    transform: none;
+  }
+
+  .aurora-lab-card:hover .aurora-lab-card-media img,
+  .aurora-lab-card:focus-visible .aurora-lab-card-media img,
+  .aurora-lab-card:focus-within .aurora-lab-card-media img {
     transform: none;
   }
 }

--- a/theme/kk-aurora/assets/js/theme.js
+++ b/theme/kk-aurora/assets/js/theme.js
@@ -525,6 +525,40 @@
   // FORM ENHANCEMENTS
   // ============================================
 
+  function initLogoSoup() {
+    const root = document.getElementById('clients');
+    if (!root) return;
+
+    const readout = document.getElementById('aurora-logo-soup-readout');
+    const items = root.querySelectorAll('.aurora-logo-soup__item');
+    const empty = 'Hover or focus a logo.';
+
+    function setActive(btn) {
+      items.forEach((el) => {
+        el.classList.toggle('is-active', el === btn);
+      });
+      if (!readout) return;
+      readout.textContent = btn
+        ? `${btn.getAttribute('aria-label')}: ${btn.getAttribute('data-note') || ''}`
+        : empty;
+    }
+
+    items.forEach((btn) => {
+      btn.addEventListener('mouseenter', () => setActive(btn));
+      btn.addEventListener('focus', () => setActive(btn));
+      btn.addEventListener('click', () => {
+        const stickyTap = window.matchMedia('(hover: none)').matches;
+        setActive(stickyTap && btn.classList.contains('is-active') ? null : btn);
+      });
+    });
+
+    root.addEventListener('mouseleave', () => {
+      if (!root.querySelector('.aurora-logo-soup__item:focus')) {
+        setActive(null);
+      }
+    });
+  }
+
   function initForms() {
     // Add active class to form groups with focus
     document.querySelectorAll('.aurora-form-group input, .aurora-form-group textarea').forEach(input => {
@@ -571,6 +605,7 @@
     initArticleReadingHelpers();
     initArticleBlogLuxMotion();
     initLazyImages();
+    initLogoSoup();
     initForms();
     initColorScheme();
   }

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.6');
+define('KK_AURORA_VERSION', '1.6.8');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -40,6 +40,11 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.6.8 =
+* homepage (#411): rewrite Join BC / Futureproof work-band copy; shared-grid alignment; quiet card numerals; hover and focus-visible states.
+* homepage (#412): restore Creative Labs (Vancouver AI, Punk Rock AI, Both Hands Full, AI Garden) with text below the photo.
+* homepage (#413): monochrome interactive client logo soup. Stacks after #789 / 1.6.7.
+
 = 1.6.6 =
 * content (#733, PR #751): rewrite the five listed user-visible em dashes in the homepage, marquee archive, and photo-gallery pattern copy.
 * cleanup (#743, PR #751): remove the unplaced speaking proof-grid template part and its theme.json registration.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.6
+Version: 1.6.8
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -199,6 +199,71 @@
     </div>
   </section>
 
+  <section class="aurora-logo-soup" id="clients" aria-labelledby="aurora-logo-soup-title" data-reveal>
+    <div class="aurora-logo-soup-inner">
+      <div class="aurora-section-head aurora-section-heading-compact">
+        <div>
+          <p class="aurora-kicker">Clients</p>
+          <h2 id="aurora-logo-soup-title">The logos are the receipts.</h2>
+          <p class="aurora-logo-soup-lede">Teams that hired the work. Hover or focus a mark for the one-line note.</p>
+        </div>
+      </div>
+      <ul class="aurora-logo-soup__grid" role="list">
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="American Express" data-note="Brand and communications work.">
+            <span class="aurora-logo-soup__wordmark" data-brand="amex">American Express</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="CIBC" data-note="Enterprise creative and tech work.">
+            <span class="aurora-logo-soup__wordmark" data-brand="cibc">CIBC</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Getty Images" data-note="Photography and media collaboration.">
+            <span class="aurora-logo-soup__wordmark" data-brand="getty">Getty Images</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Hootsuite" data-note="Vancouver tech and social platform work.">
+            <span class="aurora-logo-soup__wordmark" data-brand="hootsuite">Hootsuite</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Lululemon" data-note="Creative and culture collaboration.">
+            <span class="aurora-logo-soup__wordmark" data-brand="lululemon">lululemon</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Microsoft" data-note="Enterprise AI literacy and stage work.">
+            <span class="aurora-logo-soup__wordmark" data-brand="microsoft">Microsoft</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="National Geographic" data-note="Editorial and visual storytelling.">
+            <span class="aurora-logo-soup__wordmark" data-brand="natgeo">National Geographic</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Pentagram" data-note="Design-world collaboration.">
+            <span class="aurora-logo-soup__wordmark" data-brand="pentagram">Pentagram</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="Red Bull" data-note="Culture, events, and media.">
+            <span class="aurora-logo-soup__wordmark" data-brand="redbull">Red Bull</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="aurora-logo-soup__item" aria-label="United Nations" data-note="Public-interest and civic stages.">
+            <span class="aurora-logo-soup__wordmark" data-brand="un">United Nations</span>
+          </button>
+        </li>
+      </ul>
+      <p class="aurora-logo-soup__readout" id="aurora-logo-soup-readout" aria-live="polite">Hover or focus a logo.</p>
+    </div>
+  </section>
+
   <section class="aurora-services-band" id="services" aria-labelledby="aurora-services-title" data-reveal>
     <div class="aurora-services-band-inner aurora-feature-band-contrast">
       <div class="aurora-section-head aurora-section-heading">

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -69,7 +69,7 @@
     <div class="aurora-section-head">
       <div>
         <p class="aurora-kicker">Current work</p>
-        <h2 id="aurora-work-title">What Kris is <span class="accent">building now</span>.</h2>
+        <h2 id="aurora-work-title">BC + AI. Futureproof. The <span class="accent">stage</span>.</h2>
       </div>
       <a href="/work/">Full index →</a>
     </div>
@@ -77,33 +77,33 @@
       <a class="aurora-work-card" href="https://bc-ai.ca/">
         <div class="aurora-work-card-media">
           <img src="https://i0.wp.com/bc-ai.ca/wp-content/uploads/2026/05/bcai-living-ecosystem.webp?w=900&amp;ssl=1" alt="BC + AI community ecosystem graphic" width="900" height="1200" loading="lazy" decoding="async">
-          <span class="aurora-work-card-num">01</span>
+          <span class="aurora-work-card-num" aria-hidden="true">01</span>
           <div class="aurora-work-card-body">
             <p class="aurora-kicker">Community</p>
             <h3>BC + AI</h3>
-            <p>Province-wide trust layer for responsible AI: meetups, certification, policy rooms, and practical adoption.</p>
+            <p>Province-wide network for responsible AI. Meetups, certification, and people who show up. 250+ members, 94+ events, 3,000+ through the door.</p>
           </div>
         </div>
       </a>
       <a class="aurora-work-card" href="https://www.futureproof.website/">
         <div class="aurora-work-card-media">
           <img src="/wp-content/themes/kk-aurora/assets/img/futureproof-salmon-starfield-600.webp" srcset="/wp-content/themes/kk-aurora/assets/img/futureproof-salmon-starfield-600.webp 1x, /wp-content/themes/kk-aurora/assets/img/futureproof-salmon-starfield-1200.webp 2x" alt="Futureproof Festival 2026 key art" width="900" height="1200" loading="lazy" decoding="async">
-          <span class="aurora-work-card-num">02</span>
+          <span class="aurora-work-card-num" aria-hidden="true">02</span>
           <div class="aurora-work-card-body">
             <p class="aurora-kicker">Festival</p>
             <h3>Futureproof</h3>
-            <p>Pacific Northwest gathering where frontier tech, creative practice, and civic trust share one public room.</p>
+            <p>Pacific Northwest festival where builders, artists, and civic folks share one week. Frontier tech without the hype deck.</p>
           </div>
         </div>
       </a>
       <a class="aurora-work-card" href="/speaking/">
         <div class="aurora-work-card-media">
-          <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=900&amp;ssl=1" alt="Kris Krug speaking at CreativeMornings Vancouver" width="900" height="1200" loading="lazy" decoding="async">
-          <span class="aurora-work-card-num">03</span>
+          <img src="https://i0.wp.com/www.punkrockai.com/public/photos/michelle-diamond/195.webp?w=900&amp;ssl=1" alt="Kris Krüg speaking at CreativeMornings Vancouver" width="900" height="1200" loading="lazy" decoding="async">
+          <span class="aurora-work-card-num" aria-hidden="true">03</span>
           <div class="aurora-work-card-body">
             <p class="aurora-kicker">Tour</p>
             <h3>Keynotes 2026</h3>
-            <p>Stage sessions on taste, human agency, and the operating conditions for responsible AI.</p>
+            <p>Plain-English stage sessions on AI, taste, and human agency. No doom sermon. You leave with a frame you can use Monday morning.</p>
           </div>
         </div>
       </a>

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -110,6 +110,95 @@
     </div>
   </section>
 
+  <section class="aurora-creative-labs" id="labs" aria-labelledby="aurora-labs-title" data-reveal>
+    <div class="aurora-section-head">
+      <div>
+        <p class="aurora-kicker">Creative Labs</p>
+        <h2 id="aurora-labs-title">The labs around the <span class="accent">work</span>.</h2>
+        <p class="aurora-section-lede">Vancouver AI, Punk Rock AI, Both Hands Full, and AI Garden. Live projects you can walk into. Not a portfolio wall.</p>
+      </div>
+      <a href="/work/">Full work index →</a>
+    </div>
+    <div class="aurora-labs-grid" data-reveal-stagger>
+      <a class="aurora-lab-card" href="https://vancouver.ai/">
+        <div class="aurora-lab-card-media">
+          <img
+            src="/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp"
+            srcset="/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp 600w, /wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-1200.webp 1200w"
+            sizes="(min-width: 768px) min(25vw, 296px), 100vw"
+            alt="Kris Krüg raises one hand onstage while rows of attendees raise their hands at the H.R. MacMillan Space Centre"
+            width="600"
+            height="400"
+            loading="lazy"
+            decoding="async"
+          >
+        </div>
+        <div class="aurora-lab-card-body">
+          <h3>Vancouver AI</h3>
+          <p>The monthly meetup where BC's AI people show up in person.</p>
+          <span class="aurora-lab-door">Join →</span>
+        </div>
+      </a>
+      <a class="aurora-lab-card" href="https://www.punkrockai.com/">
+        <div class="aurora-lab-card-media">
+          <img
+            src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-creativemornings-portrait-staircase-2026-scaled.jpg?w=720&amp;ssl=1"
+            srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-creativemornings-portrait-staircase-2026-scaled.jpg?w=480&amp;ssl=1 480w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-creativemornings-portrait-staircase-2026-scaled.jpg?w=720&amp;ssl=1 720w"
+            sizes="(min-width: 768px) min(25vw, 296px), 100vw"
+            alt="Kris Krüg beside the Vancouver Art Gallery staircase at CreativeMornings"
+            width="720"
+            height="720"
+            loading="lazy"
+            decoding="async"
+          >
+        </div>
+        <div class="aurora-lab-card-body">
+          <h3>Punk Rock AI</h3>
+          <p>Tools, prompts, and stage receipts. Make culture, not content.</p>
+          <span class="aurora-lab-door">Enter →</span>
+        </div>
+      </a>
+      <a class="aurora-lab-card" href="https://www.bothhandsfull.com/">
+        <div class="aurora-lab-card-media">
+          <img
+            src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=720&amp;ssl=1"
+            srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=480&amp;ssl=1 480w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=720&amp;ssl=1 720w"
+            sizes="(min-width: 768px) min(25vw, 296px), 100vw"
+            alt="Kris Krüg on stage at LaSalle College Vancouver for Both Hands Full"
+            width="720"
+            height="720"
+            loading="lazy"
+            decoding="async"
+          >
+        </div>
+        <div class="aurora-lab-card-body">
+          <h3>Both Hands Full</h3>
+          <p>A portal for filmmakers facing synthetic everything. Critique in one hand, agency in the other.</p>
+          <span class="aurora-lab-door">Watch →</span>
+        </div>
+      </a>
+      <a class="aurora-lab-card" href="https://kriskrug.ai/">
+        <div class="aurora-lab-card-media">
+          <img
+            src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-van-ai-portrait-2025.jpg?w=720&amp;ssl=1"
+            srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-van-ai-portrait-2025.jpg?w=480&amp;ssl=1 480w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/07/kris-krug-van-ai-portrait-2025.jpg?w=720&amp;ssl=1 720w"
+            sizes="(min-width: 768px) min(25vw, 296px), 100vw"
+            alt="Portrait of Kris Krüg in a VAN-AI shirt"
+            width="720"
+            height="720"
+            loading="lazy"
+            decoding="async"
+          >
+        </div>
+        <div class="aurora-lab-card-body">
+          <h3>AI Garden</h3>
+          <p>Experiments and notes from the practice. Live, public, unfinished on purpose.</p>
+          <span class="aurora-lab-door">Visit →</span>
+        </div>
+      </a>
+    </div>
+  </section>
+
   <section class="aurora-services-band" id="services" aria-labelledby="aurora-services-title" data-reveal>
     <div class="aurora-services-band-inner aurora-feature-band-contrast">
       <div class="aurora-section-head aurora-section-heading">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #411. Fixes #412. Fixes #413.

Homepage cluster implementation. No live WordPress writes. No SFTP deploy.

- #411 Join BC / Futureproof work-band: `BC + AI. Futureproof. The stage.` Desktop stagger removed; hover and `:focus-visible` on cards.
- #412 Creative Labs `#labs` band: Vancouver AI, Punk Rock AI, Both Hands Full, AI Garden.
- #413 Client logo soup: ten typographic wordmarks, monochrome at rest.
- Aurora **1.6.8** version bump. Stacks after #789 / 1.6.7. Live is still 1.6.5; `main` 1.6.6 is undeployed.

`make theme-smoke`, `make validate`, and `make docs-truth-check` were green in the agent session.

KK still needs to confirm heading/card copy, the four labs, the ten-name client list, and real logo files if wordmarks should become marks. Merge/deploy only after the 1.6.6 then 1.6.7 windows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

