### PR TITLE
theme: homepage #414–#416 stages, What People Say, newsletter

### DIFF
--- a/content/drafts/2026-07-26-what-people-say/README.md
+++ b/content/drafts/2026-07-26-what-people-say/README.md
@@ -18,7 +18,7 @@ Issue: [#415](https://github.com/WalksWithASwagger/kriskrug-wp/issues/415)
 
 ## Verdict in one line
 
-Homepage currently has **no** "What People Say" band. The old placeholder ("Fresh proof belongs here before launch" + invented cites) is gone from live. Rebuild needs real cleared quotes, a quieter proof section that does not fight the newsletter ask, and a separate network diagram preview for KK reaction.
+Homepage now has a clustered What People Say band (`#what-people-say`) using three quotes already public on `/testimonials/`. The interactive network diagram stays a standalone preview in `network-diagram-spike/`. No live embed until KK says go.
 
 ## Hard gates before anything goes live
 

--- a/content/drafts/2026-07-26-what-people-say/curated-quotes.md
+++ b/content/drafts/2026-07-26-what-people-say/curated-quotes.md
@@ -12,9 +12,9 @@ Status keys: `ready-if-cleared` · `legacy-optional` · `audience-generic` · `b
 
 | ID | Quote | Attribution | Theme | Source | Clearance |
 |---|---|---|---|---|---|
-| A1 | Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers. | Jai Djwa | Talks / education | Keynote testimonial bank + speaking payload | [ ] KK clears |
-| A2 | Kris's talk and event design felt like a masterclass in community organizing. | Ed Kennedy | Convening | Keynote testimonial bank + speaking payload | [ ] KK clears |
-| A3 | Visceral, real, and incredibly current. Truly authentic and up to date. | Audience feedback | Talks | Testimonial bank (generic; keep labeled) | [ ] KK clears as unlabeled audience |
+| A1 | Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers. | Jai Djwa | Talks / education | Keynote testimonial bank + live `/testimonials/` | [x] Already public on /testimonials/; used on homepage 2026-08-17 |
+| A2 | Kris's talk and event design felt like a masterclass in community organizing. | Ed Kennedy | Convening | Keynote testimonial bank + live `/testimonials/` | [x] Already public on /testimonials/; used on homepage 2026-08-17 |
+| A3 | Visceral, real, and incredibly current. Truly authentic and up to date. | Audience feedback | Talks | Testimonial bank (generic; keep labeled) + live `/testimonials/` | [x] Already public as unlabeled audience; used on homepage 2026-08-17 |
 | A4 | Loved seeing the tangible examples and understanding what's possible. | Audience feedback | Programs | Testimonial bank (generic; keep labeled) | [ ] KK clears as unlabeled audience |
 
 Homepage default if only two clear: **A1 + A2**. Add one audience line only if KK wants a third without a third named person.

--- a/content/drafts/2026-07-26-what-people-say/network-diagram-spike/NOTES.md
+++ b/content/drafts/2026-07-26-what-people-say/network-diagram-spike/NOTES.md
@@ -28,6 +28,10 @@ Quotes in the detail panel are drawn from the Tier A bank text for demo only. Sa
 - No personal emails, phone numbers, or private CRM edges
 - No auto-fetch of LinkedIn / Notion
 
+## 2026-08-17 homepage cluster
+
+KK ruled proceed on the homepage cluster. The live homepage now ships three already-public quotes (Jai Djwa, Ed Kennedy, audience feedback) from `/testimonials/`. This HTML file stays a **standalone preview**. Do not embed it on the homepage until KK gives an explicit go.
+
 ## Go / no-go for KK
 
 | Decision | Meaning |

--- a/content/drafts/2026-07-26-what-people-say/network-diagram-spike/index.html
+++ b/content/drafts/2026-07-26-what-people-say/network-diagram-spike/index.html
@@ -260,7 +260,7 @@
     <div class="layout">
       <div class="stage" aria-label="Interactive network diagram">
         <svg viewBox="0 0 900 560" role="img" aria-labelledby="net-title net-desc">
-          <title id="net-title">Illustrative network clusters around Kris Krug</title>
+          <title id="net-title">Illustrative network clusters around Kris Krüg</title>
           <desc id="net-desc">
             Hub node Kris connected to five clusters: Stages, Rooms, Practice, Media, and Futureproof.
             Activate a node to read a short description.
@@ -337,7 +337,7 @@
 
       <aside class="panel" id="detail" aria-live="polite">
         <p class="kicker" id="detail-kicker">Hub</p>
-        <h2 id="detail-title">Kris Krug</h2>
+        <h2 id="detail-title">Kris Krüg</h2>
         <p id="detail-body">Center of gravity for the map. Edges are relationships of work, not org-chart authority. Swap illustrative labels for cleared people and orgs before any public page.</p>
         <blockquote id="detail-quote">
           <span id="detail-quote-text">Pick a cluster to see how proof might attach.</span>
@@ -366,7 +366,7 @@
       var data = {
         hub: {
           kicker: "Hub",
-          title: "Kris Krug",
+          title: "Kris Krüg",
           body: "Center of gravity for the map. Edges are relationships of work, not org-chart authority.",
           quote: "Pick a cluster to see how proof might attach.",
           cite: ""
@@ -376,7 +376,7 @@
           title: "Stages",
           body: "Keynotes and festival talks. CreativeMornings, LaSalle, Bass Coast, ChannelNext, World AI Film Festival.",
           quote: "Visceral, real, and incredibly current. Truly authentic and up to date.",
-          cite: "Audience feedback · clearance still required"
+          cite: "Audience feedback · already live on /testimonials/"
         },
         cmvan: {
           kicker: "Node · Stages",
@@ -390,7 +390,7 @@
           title: "Rooms",
           body: "Convening layer: Vancouver AI, BC + AI ecosystem nights, civic and community rooms.",
           quote: "Kris's talk and event design felt like a masterclass in community organizing.",
-          cite: "Ed Kennedy · clearance still required"
+          cite: "Ed Kennedy · already live on /testimonials/"
         },
         vanai: {
           kicker: "Node · Rooms",
@@ -404,7 +404,7 @@
           title: "Practice",
           body: "Programs, workshops, and education rooms where people leave with a working frame.",
           quote: "Kris helped shift how my design students see their future.",
-          cite: "Jai Djwa · clearance still required"
+          cite: "Jai Djwa · already live on /testimonials/"
         },
         edu: {
           kicker: "Node · Practice",

--- a/scripts/tests/test_aurora_css_literal_contrast.py
+++ b/scripts/tests/test_aurora_css_literal_contrast.py
@@ -429,7 +429,7 @@ RESOLVED_COMPONENT_COLORS = (
     # The #470 defect as filed: the two homepage band links.
     (
         "assets/css/revive-port.css",
-        ".aurora-section-head a",
+        ".aurora-section-head a:not(.aurora-button)",
         ("cream", "cream-2"),
         AA_TEXT,
     ),
@@ -640,7 +640,7 @@ class AuroraCssLiteralContrastTests(unittest.TestCase):
         this rule is the one the issue was filed against.
         """
         declaration = declared_color(
-            "assets/css/revive-port.css", ".aurora-section-head a"
+            "assets/css/revive-port.css", ".aurora-section-head a:not(.aurora-button)"
         )
         self.assertIsNotNone(declaration)
         self.assertTrue(
@@ -654,7 +654,7 @@ class AuroraCssLiteralContrastTests(unittest.TestCase):
             self.assertGreaterEqual(
                 ratio,
                 AA_TEXT,
-                f".aurora-section-head a ({literal}) on {surface_key} is {ratio:.2f}:1",
+                f".aurora-section-head a:not(.aurora-button) ({literal}) on {surface_key} is {ratio:.2f}:1",
             )
 
     def test_front_page_still_renders_the_section_head_links(self):

--- a/scripts/tests/test_aurora_css_literal_contrast.py
+++ b/scripts/tests/test_aurora_css_literal_contrast.py
@@ -318,11 +318,6 @@ REGISTERED_LITERALS = {
     ),
     (
         "assets/css/revive-port.css",
-        ".aurora-proof-outlets span",
-        "rgba(23, 19, 16, 0.62)",
-    ): ("cream", AA_TEXT, "outlet names on cream"),
-    (
-        "assets/css/revive-port.css",
         ".aurora-work-card-num",
         "rgba(217, 74, 31, 0.45)",
     ): (

--- a/scripts/tests/test_issue_414_homepage_stages.py
+++ b/scripts/tests/test_issue_414_homepage_stages.py
@@ -1,0 +1,91 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
+REVIVE = ROOT / "theme/kk-aurora/assets/css/revive-port.css"
+
+REQUIRED_HREFS = (
+    "https://www.youtube.com/watch?v=-c7mgY2aSgM",
+    "https://www.youtube.com/watch?v=T5ANAthZewE",
+    "https://www.punkrockai.com/",
+    "https://www.youtube.com/watch?v=1OcC-0X6Nb8",
+    "https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/",
+    "https://www.youtube.com/watch?v=-XEsqsEbpoo",
+    "https://www.youtube.com/watch?v=owtSPcpRinI",
+    "https://www.futureproof.website/",
+    "/speaking/",
+)
+
+BANNED_WALLPAPER = (
+    "TED",
+    "SXSW",
+    "Adobe MAX",
+    "FITC",
+    "MIT Media Lab",
+)
+
+APPROVED_PHOTOS = (
+    "kk-laSalle-both-hands-full-25-scaled.jpg",
+    "/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp",
+    "/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-1200.webp",
+)
+
+
+def _stages_block(source: str) -> str:
+    match = re.search(
+        r'<section class="aurora-stages-band".*?</section>',
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("missing #stages aurora-stages-band")
+    return match.group(0)
+
+
+class Issue414HomepageStagesTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.css = REVIVE.read_text(encoding="utf-8")
+        cls.stages = _stages_block(cls.front)
+
+    def test_section_is_image_led_and_linked(self):
+        self.assertIn('id="stages"', self.stages)
+        self.assertIn('id="aurora-stages-title"', self.stages)
+        self.assertIn("Stages with receipts", self.stages)
+        self.assertIn("Rooms where the work got said out loud.", self.stages)
+        for href in REQUIRED_HREFS:
+            self.assertIn(f'href="{href}"', self.stages)
+        for photo in APPROVED_PHOTOS:
+            self.assertIn(photo, self.stages)
+
+    def test_no_prestige_wallpaper_or_uncleared_hotlinks(self):
+        self.assertNotIn("aurora-proof-outlets", self.front)
+        self.assertNotIn("punkrockai.com/public/photos", self.stages)
+        self.assertNotIn("www.punkrockai.com/public", self.stages)
+        for name in BANNED_WALLPAPER:
+            self.assertNotIn(f">{name}<", self.stages)
+            self.assertNotIn(f">{name}</span>", self.front)
+
+    def test_only_two_stage_photos_in_the_band(self):
+        images = re.findall(r"<img\b", self.stages)
+        self.assertEqual(2, len(images))
+
+    def test_hover_and_focus_states_exist(self):
+        self.assertIn(".aurora-stages-feature:hover", self.css)
+        self.assertIn(".aurora-stages-feature:focus-visible", self.css)
+        self.assertIn(".aurora-stages-list a:hover", self.css)
+        self.assertIn(".aurora-stages-list a:focus-visible", self.css)
+        self.assertIn("prefers-reduced-motion: reduce", self.css)
+
+    def test_copy_has_no_em_dash_or_newsletter_cliche(self):
+        self.assertNotIn("\u2014", self.stages)
+        self.assertNotRegex(self.stages, re.compile(r"field notes", re.I))
+        self.assertNotRegex(self.stages, re.compile(r"dispatch", re.I))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_issue_415_homepage_people_say.py
+++ b/scripts/tests/test_issue_415_homepage_people_say.py
@@ -1,0 +1,65 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
+SPIKE = (
+    ROOT
+    / "content/drafts/2026-07-26-what-people-say/network-diagram-spike/index.html"
+)
+
+
+def _people_say_block(source: str) -> str:
+    match = re.search(
+        r'<section class="aurora-people-say-band".*?</section>',
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("missing #what-people-say band")
+    return match.group(0)
+
+
+class Issue415HomepagePeopleSayTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.band = _people_say_block(cls.front)
+        cls.spike = SPIKE.read_text(encoding="utf-8")
+
+    def test_clustered_quotes_are_attributed_and_already_public(self):
+        self.assertIn('id="what-people-say"', self.band)
+        self.assertIn("The rooms talk back.", self.band)
+        self.assertIn(">Stages<", self.band)
+        self.assertIn(">Rooms<", self.band)
+        self.assertIn(">Practice<", self.band)
+        self.assertIn("Jai Djwa", self.band)
+        self.assertIn("Ed Kennedy", self.band)
+        self.assertIn("Audience feedback", self.band)
+        self.assertIn('href="/testimonials/"', self.band)
+        self.assertIn('href="/speaking/"', self.band)
+        self.assertNotIn("beehiiv.com", self.band)
+        self.assertNotIn("Named people", self.band)
+
+    def test_no_placeholder_or_invented_cites(self):
+        self.assertNotRegex(self.front, re.compile(r"fresh proof", re.I))
+        self.assertNotIn("Event organizer quote", self.front)
+        self.assertNotIn("Workshop host quote", self.front)
+        self.assertNotIn("Leadership audience quote", self.front)
+        self.assertNotIn("\u2014", self.band)
+
+    def test_network_spike_is_standalone_with_no_cdn(self):
+        self.assertTrue(SPIKE.is_file())
+        self.assertIn("Not for live embed", self.spike)
+        self.assertNotRegex(self.spike, re.compile(r'<script[^>]+src=', re.I))
+        self.assertNotRegex(self.spike, re.compile(r'<link[^>]+href=', re.I))
+        self.assertNotIn("unpkg.com", self.spike)
+        self.assertNotIn("jsdelivr", self.spike)
+        self.assertIn("tabindex=\"0\"", self.spike)
+        self.assertIn("Kris Krüg", self.spike)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_issue_415_homepage_trust_identity.py
+++ b/scripts/tests/test_issue_415_homepage_trust_identity.py
@@ -82,17 +82,13 @@ class Issue415HomepageTrustIdentityTests(unittest.TestCase):
             "Leadership audience quote",
         ):
             self.assertNotIn(placeholder, source)
-        self.assertNotIn("<blockquote", source)
         self.assertNotIn("aurora-testimonial-band", source)
-        # #415 replaced the placeholder testimonial band with a "Follow the
-        # work" band (id="aurora-relationships-title") that routed to three
-        # real front doors. Aurora 1.4.0 ("port Revive cream/ink system")
-        # re-cut the homepage to the section order locked in
-        # docs/current-state/REVIVE-AURORA-PORT-2026-07-24.md, which has no
-        # relationships band; the current work triptych is the section that
-        # now carries that job. Re-anchored to the triptych so the guard keeps
-        # asserting what #415 actually protects: no unverified quotes, and the
-        # homepage routes to the three real destinations below.
+        self.assertIn('id="what-people-say"', source)
+        self.assertIn("Jai Djwa", source)
+        self.assertIn("Ed Kennedy", source)
+        self.assertIn("Audience feedback", source)
+        self.assertIn('href="/testimonials/"', source)
+        # Work triptych still routes to the three real destinations.
         self.assertIn('id="aurora-work-title"', source)
         self.assertIn('class="aurora-work-triptych"', source)
         self.assertIn('href="/work/"', source)

--- a/scripts/tests/test_issue_416_homepage_newsletter.py
+++ b/scripts/tests/test_issue_416_homepage_newsletter.py
@@ -1,0 +1,45 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FRONT_PAGE = ROOT / "theme/kk-aurora/templates/front-page.html"
+
+
+def _newsletter_block(source: str) -> str:
+    match = re.search(
+        r'<section id="newsletter".*?</section>',
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError("missing #newsletter band")
+    return match.group(0)
+
+
+class Issue416HomepageNewsletterTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.front = FRONT_PAGE.read_text(encoding="utf-8")
+        cls.band = _newsletter_block(cls.front)
+
+    def test_one_clear_cta_and_kept_thumbnails(self):
+        self.assertIn("Weekly email", self.band)
+        self.assertIn("Give me your email. I'll earn every open.", self.band)
+        self.assertIn("Get the weekly email", self.band)
+        self.assertEqual(1, self.band.count("kriskrug.beehiiv.com"))
+        self.assertEqual(1, self.band.count("aurora-button-primary"))
+        self.assertIn("aurora-newsletter-thumbs-query", self.band)
+        self.assertIn("aurora-newsletter-thumb-media", self.band)
+        self.assertIn("Recent writing", self.band)
+
+    def test_cliche_stays_gone_and_e2e_is_not_claimed(self):
+        self.assertNotRegex(self.band, re.compile(r"field notes", re.I))
+        self.assertNotRegex(self.band, re.compile(r"dispatch", re.I))
+        self.assertNotIn("\u2014", self.band)
+        self.assertIn("Beehiiv signup E2E remains KK-owned", self.band)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -358,36 +358,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   background: linear-gradient(to top, rgba(239, 230, 210, 0.85), rgba(239, 230, 210, 0.2) 45%, transparent 70%);
   pointer-events: none;
 }
-.aurora-proof-strip {
-  position: relative;
-  border-block: 1px solid rgba(217, 74, 31, 0.12);
-  background: rgba(230, 220, 194, 0.55);
-  padding: 1.75rem clamp(1rem, 3vw, 2rem);
-  overflow: hidden;
-}
-
-.aurora-proof-strip-inner {
-  position: relative;
-  max-width: var(--revive-max);
-  margin: 0 auto;
-}
-
-.aurora-proof-outlets {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.85rem 1.75rem;
-  margin-top: 0.85rem;
-}
-
-.aurora-proof-outlets span {
-  font-family: "Space Grotesk", system-ui, sans-serif;
-  font-size: clamp(1.15rem, 2.2vw, 1.65rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: rgba(23, 19, 16, 0.62);
-}
-
+.aurora-stages-band,
 .aurora-archive-band,
 .aurora-work-band,
 .aurora-services-band,
@@ -396,6 +367,179 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   max-width: var(--revive-max);
   margin: 0 auto;
   padding: clamp(3rem, 8vw, 5.5rem) clamp(1rem, 3vw, 2rem);
+}
+
+.aurora-stages-band .aurora-section-lede {
+  max-width: 36rem;
+  margin: 0.75rem 0 0;
+  color: var(--revive-ink-soft);
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.aurora-stages-reel-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .aurora-stages-reel-layout {
+    grid-template-columns: minmax(0, 1.25fr) minmax(16rem, 1fr);
+    gap: 1.15rem;
+    align-items: stretch;
+  }
+}
+
+.aurora-stages-feature,
+.aurora-stages-support-photo {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border: 1px solid rgba(217, 74, 31, 0.16);
+  background: var(--revive-ink);
+  text-decoration: none;
+  color: var(--revive-surface);
+}
+
+.aurora-stages-feature {
+  min-height: 18rem;
+}
+
+.aurora-stages-support-photo {
+  min-height: 12rem;
+}
+
+.aurora-stages-feature img,
+.aurora-stages-support-photo img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 400ms var(--revive-ease), filter 400ms var(--revive-ease);
+}
+
+.aurora-stages-feature-scrim {
+  position: absolute;
+  inset: auto 0 0;
+  display: grid;
+  gap: 0.2rem;
+  padding: 1.15rem 1rem 1rem;
+  background: linear-gradient(to top, rgba(23, 19, 16, 0.88), rgba(23, 19, 16, 0.35) 70%, transparent);
+  pointer-events: none;
+}
+
+.aurora-stage-event,
+.aurora-stage-talk,
+.aurora-stage-kind {
+  display: block;
+}
+
+.aurora-stages-feature-scrim .aurora-stage-event,
+.aurora-stages-list .aurora-stage-event {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.aurora-stages-feature-scrim .aurora-stage-talk,
+.aurora-stages-list .aurora-stage-talk {
+  font-family: "Space Grotesk", system-ui, sans-serif;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.aurora-stages-feature-scrim .aurora-stage-kind,
+.aurora-stages-list .aurora-stage-kind {
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.aurora-stages-support {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.aurora-stages-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--revive-line);
+}
+
+.aurora-stages-list a {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "event kind"
+    "talk kind";
+  gap: 0.15rem 0.75rem;
+  padding: 0.85rem 0.35rem 0.85rem 0.7rem;
+  border-bottom: 1px solid var(--revive-line);
+  text-decoration: none;
+  color: var(--revive-ink);
+  box-shadow: inset 3px 0 0 transparent;
+  transition: background-color 180ms ease, box-shadow 180ms ease;
+}
+
+.aurora-stages-list .aurora-stage-event { grid-area: event; }
+.aurora-stages-list .aurora-stage-talk { grid-area: talk; }
+.aurora-stages-list .aurora-stage-kind {
+  grid-area: kind;
+  align-self: center;
+  color: var(--revive-accent-text);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.68rem;
+}
+
+.aurora-stages-feature:hover img,
+.aurora-stages-feature:focus-visible img,
+.aurora-stages-support-photo:hover img,
+.aurora-stages-support-photo:focus-visible img {
+  transform: scale(1.03);
+  filter: saturate(1.06);
+}
+
+.aurora-stages-list a:hover,
+.aurora-stages-list a:focus-visible {
+  background: rgba(217, 74, 31, 0.06);
+  box-shadow: inset 3px 0 0 var(--revive-accent);
+}
+
+.aurora-stages-feature:active,
+.aurora-stages-support-photo:active,
+.aurora-stages-list a:active {
+  transform: translateY(1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-stages-feature img,
+  .aurora-stages-support-photo img,
+  .aurora-stages-list a,
+  .aurora-stages-feature,
+  .aurora-stages-support-photo {
+    transition: none;
+  }
+
+  .aurora-stages-feature:hover img,
+  .aurora-stages-feature:focus-visible img,
+  .aurora-stages-support-photo:hover img,
+  .aurora-stages-support-photo:focus-visible img {
+    transform: none;
+    filter: none;
+  }
+
+  .aurora-stages-feature:active,
+  .aurora-stages-support-photo:active,
+  .aurora-stages-list a:active {
+    transform: none;
+  }
 }
 
 .aurora-section-head {
@@ -1153,6 +1297,20 @@ body.aurora-theme #aurora-main :where(.aurora-kicker, .aurora-section-kicker) {
 body.aurora-theme #aurora-main .aurora-service-card :where(.aurora-kicker) {
   color: rgba(239, 230, 210, 0.55) !important;
   -webkit-text-fill-color: rgba(239, 230, 210, 0.55) !important;
+}
+
+/* Stage tiles sit on a dark photo scrim. Beat the homepage ink wash. */
+body.aurora-theme #aurora-main .aurora-stages-feature-scrim,
+body.aurora-theme #aurora-main .aurora-stages-feature-scrim .aurora-stage-event,
+body.aurora-theme #aurora-main .aurora-stages-feature-scrim .aurora-stage-talk,
+body.aurora-theme #aurora-main .aurora-stages-feature-scrim .aurora-stage-kind {
+  color: var(--revive-surface) !important;
+  -webkit-text-fill-color: var(--revive-surface) !important;
+}
+
+body.aurora-theme #aurora-main .aurora-stages-feature-scrim .aurora-stage-kind {
+  color: var(--revive-accent-soft) !important;
+  -webkit-text-fill-color: var(--revive-accent-soft) !important;
 }
 
 body.aurora-theme .wp-block-button:not(.is-style-aurora-primary) .wp-block-button__link {

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -664,7 +664,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   color: var(--revive-accent-text);
 }
 
-.aurora-section-head a {
+.aurora-section-head a:not(.aurora-button) {
   font-size: 0.72rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -967,7 +967,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
 }
 
 .aurora-newsletter-band {
-  text-align: center;
+  text-align: left;
   border-top: 1px solid var(--revive-line);
 }
 
@@ -975,20 +975,33 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
 .aurora-newsletter-copy h2 {
   font-family: "Space Grotesk", system-ui, sans-serif;
   font-size: clamp(2rem, 4.5vw, 3rem);
-  margin: 0.5rem 0 0.75rem;
+  margin: 0.35rem 0 0;
   color: var(--revive-ink);
 }
 
-.aurora-newsletter-band > p,
-.aurora-newsletter-copy > p:not(.aurora-kicker) {
+.aurora-newsletter-band .aurora-section-lede,
+.aurora-newsletter-copy .aurora-section-lede {
   max-width: 36rem;
-  margin: 0 auto 1.5rem;
+  margin: 0.75rem 0 0;
   color: var(--revive-ink-soft);
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.aurora-newsletter-band > p,
+.aurora-newsletter-copy > p:not(.aurora-kicker):not(.aurora-section-lede) {
+  max-width: 36rem;
+  margin: 0.75rem 0 1.5rem;
+  color: var(--revive-ink-soft);
+}
+
+.aurora-newsletter-band .aurora-section-head {
+  align-items: flex-end;
 }
 
 .aurora-newsletter-band .aurora-action-row,
 .aurora-newsletter-copy .aurora-action-row {
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .aurora-newsletter-thumbs-label {

--- a/theme/kk-aurora/assets/css/revive-port.css
+++ b/theme/kk-aurora/assets/css/revive-port.css
@@ -359,6 +359,7 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   pointer-events: none;
 }
 .aurora-stages-band,
+.aurora-people-say-band,
 .aurora-archive-band,
 .aurora-work-band,
 .aurora-services-band,
@@ -540,6 +541,80 @@ body.aurora-theme .aurora-primary-nav::-webkit-scrollbar {
   .aurora-stages-list a:active {
     transform: none;
   }
+}
+
+.aurora-people-say-band .aurora-section-lede {
+  max-width: 36rem;
+  margin: 0.75rem 0 0;
+  color: var(--revive-ink-soft);
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+.aurora-people-say-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .aurora-people-say-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.15rem;
+  }
+}
+
+.aurora-people-say-card {
+  position: relative;
+  margin: 0;
+  padding: 1.15rem 1.1rem 1.25rem;
+  background: var(--revive-surface-2);
+  border: 1px solid var(--revive-line);
+  border-radius: 2px;
+}
+
+.aurora-people-say-card::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--revive-accent);
+}
+
+.aurora-people-say-card:nth-child(2)::before {
+  background: var(--revive-rainbow-1);
+}
+
+.aurora-people-say-card:nth-child(3)::before {
+  background: var(--revive-rainbow-4);
+}
+
+.aurora-people-say-card blockquote {
+  margin: 0.65rem 0 0;
+}
+
+.aurora-people-say-card blockquote p {
+  margin: 0;
+  color: var(--revive-ink);
+  font-size: 1.02rem;
+  line-height: 1.5;
+}
+
+.aurora-people-say-card footer {
+  margin-top: 0.85rem;
+  color: var(--revive-ink-muted);
+  font-size: 0.82rem;
+  font-style: normal;
+}
+
+.aurora-people-say-card:hover,
+.aurora-people-say-card:focus-within {
+  border-color: var(--revive-line-strong);
+}
+
+.aurora-people-say-band .aurora-action-row {
+  margin-top: 1.5rem;
 }
 
 .aurora-section-head {

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -185,6 +185,43 @@
       </div>
     </div>
   </section>
+
+  <section class="aurora-people-say-band" id="what-people-say" aria-labelledby="aurora-people-say-title" data-reveal>
+    <div class="aurora-section-head">
+      <div>
+        <p class="aurora-kicker">What people say</p>
+        <h2 id="aurora-people-say-title">The rooms talk back.</h2>
+        <p class="aurora-section-lede">Quotes from stages, convenings, and programs. Attribution stays attached. These lines are already public on the testimonials archive.</p>
+      </div>
+      <a href="/testimonials/">Full quote archive →</a>
+    </div>
+    <div class="aurora-people-say-grid">
+      <figure class="aurora-people-say-card">
+        <p class="aurora-kicker">Stages</p>
+        <blockquote>
+          <p>Kris helped shift how my design students see their future. In one hour, he demo'd building client prototypes in real-time, turned lectures into podcasts, and showed them how to be design orchestrators, not pixel pushers.</p>
+          <footer>Jai Djwa</footer>
+        </blockquote>
+      </figure>
+      <figure class="aurora-people-say-card">
+        <p class="aurora-kicker">Rooms</p>
+        <blockquote>
+          <p>Kris's talk and event design felt like a masterclass in community organizing.</p>
+          <footer>Ed Kennedy</footer>
+        </blockquote>
+      </figure>
+      <figure class="aurora-people-say-card">
+        <p class="aurora-kicker">Practice</p>
+        <blockquote>
+          <p>Visceral, real, and incredibly current. Truly authentic and up to date.</p>
+          <footer>Audience feedback</footer>
+        </blockquote>
+      </figure>
+    </div>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-secondary" href="/speaking/">See past stages →</a>
+    </div>
+  </section>
   <!-- /wp:html -->
 
   <!-- wp:group {"className":"aurora-writing-band","layout":{"type":"constrained","contentSize":"1200px"}} -->

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -260,15 +260,16 @@
   <!-- /wp:group -->
 
   <!-- wp:group {"tagName":"section","anchor":"newsletter","className":"aurora-newsletter-band","layout":{"type":"constrained","contentSize":"1200px"},"ariaLabel":"Weekly email"} -->
-  <section id="newsletter" class="wp-block-group aurora-newsletter-band">
+  <section id="newsletter" class="wp-block-group aurora-newsletter-band" aria-labelledby="aurora-newsletter-title">
     <!-- wp:html -->
-    <div class="aurora-newsletter-copy" data-reveal>
-      <p class="aurora-kicker">Weekly email</p>
-      <h2 id="aurora-newsletter-title">Give me your email. I’ll earn every open.</h2>
-      <p>Once a week on AI, creativity, and the rooms where this work actually happens. Named people. Real receipts. No hype deck. Free.</p>
-      <div class="aurora-action-row">
-        <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Get the weekly email</a>
+    <!-- Beehiiv signup E2E remains KK-owned. Do not claim it from this template. -->
+    <div class="aurora-section-head aurora-newsletter-copy" data-reveal>
+      <div>
+        <p class="aurora-kicker">Weekly email</p>
+        <h2 id="aurora-newsletter-title">Give me your email. I'll earn every open.</h2>
+        <p class="aurora-section-lede">Once a week on AI, creativity, and the rooms where this work actually happens. Real receipts. No hype deck. Free.</p>
       </div>
+      <a class="aurora-button aurora-button-primary" href="https://kriskrug.beehiiv.com/">Get the weekly email</a>
     </div>
     <!-- /wp:html -->
 

--- a/theme/kk-aurora/templates/front-page.html
+++ b/theme/kk-aurora/templates/front-page.html
@@ -29,18 +29,59 @@
     </div>
   </section>
 
-  <section class="aurora-proof-strip" id="stages" aria-labelledby="aurora-stages-label" data-reveal>
-    <div class="aurora-proof-strip-inner">
-      <p class="aurora-kicker" id="aurora-stages-label">Recent stages</p>
-      <div class="aurora-proof-outlets" aria-label="Stage and outlet names">
-        <span>TED</span>
-        <span>SXSW</span>
-        <span>Adobe MAX</span>
-        <span>Web Summit</span>
-        <span>FITC</span>
-        <span>MIT Media Lab</span>
-        <span>CreativeMornings</span>
-        <span>UN</span>
+  <section class="aurora-stages-band" id="stages" aria-labelledby="aurora-stages-title" data-reveal>
+    <div class="aurora-section-head">
+      <div>
+        <p class="aurora-kicker">Stages with receipts</p>
+        <h2 id="aurora-stages-title">Rooms where the work got said out loud.</h2>
+        <p class="aurora-section-lede">Linked talks, not logo wallpaper. Pick a stage, watch or read what happened.</p>
+      </div>
+      <a href="/speaking/">All speaking →</a>
+    </div>
+    <div class="aurora-stages-reel-layout">
+      <a class="aurora-stages-feature" href="https://www.youtube.com/watch?v=-c7mgY2aSgM">
+        <img
+          src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1400&amp;ssl=1"
+          srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=720&amp;ssl=1 720w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1100&amp;ssl=1 1100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-laSalle-both-hands-full-25-scaled.jpg?w=1400&amp;ssl=1 1400w"
+          sizes="(min-width: 768px) 55vw, 100vw"
+          alt="Kris Krüg presenting on stage at LaSalle College Vancouver"
+          width="1400"
+          height="933"
+          loading="lazy"
+          decoding="async"
+        >
+        <span class="aurora-stages-feature-scrim">
+          <span class="aurora-stage-event">LaSalle College</span>
+          <span class="aurora-stage-talk">Both Hands Full</span>
+          <span class="aurora-stage-kind">Watch</span>
+        </span>
+      </a>
+      <div class="aurora-stages-support">
+        <a class="aurora-stages-support-photo" href="https://www.youtube.com/watch?v=T5ANAthZewE">
+          <img
+            src="/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp"
+            srcset="/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp 600w, /wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-1200.webp 1200w"
+            sizes="(min-width: 768px) min(40vw, 420px), 100vw"
+            alt="Kris Krüg raises one hand onstage while rows of attendees raise their hands at the H.R. MacMillan Space Centre"
+            width="600"
+            height="400"
+            loading="lazy"
+            decoding="async"
+          >
+          <span class="aurora-stages-feature-scrim">
+            <span class="aurora-stage-event">Vancouver AI Meetup</span>
+            <span class="aurora-stage-talk">Community stage</span>
+            <span class="aurora-stage-kind">Watch</span>
+          </span>
+        </a>
+        <ul class="aurora-stages-list">
+          <li><a href="https://www.punkrockai.com/"><span class="aurora-stage-event">CreativeMornings</span><span class="aurora-stage-talk">Punk Rock AI</span><span class="aurora-stage-kind">Portal</span></a></li>
+          <li><a href="https://www.youtube.com/watch?v=1OcC-0X6Nb8"><span class="aurora-stage-event">ChannelNext Central</span><span class="aurora-stage-talk">Chaos and creativity</span><span class="aurora-stage-kind">Watch</span></a></li>
+          <li><a href="https://kriskrug.co/2026/05/07/web-summit-vancouver-2026/"><span class="aurora-stage-event">Web Summit Vancouver</span><span class="aurora-stage-talk">The signal was already here</span><span class="aurora-stage-kind">Read</span></a></li>
+          <li><a href="https://www.youtube.com/watch?v=-XEsqsEbpoo"><span class="aurora-stage-event">Whistler Institute</span><span class="aurora-stage-talk">Inside Vancouver's AI boom</span><span class="aurora-stage-kind">Watch</span></a></li>
+          <li><a href="https://www.youtube.com/watch?v=owtSPcpRinI"><span class="aurora-stage-event">Bass Coast Brain Stage</span><span class="aurora-stage-talk">Dear AI</span><span class="aurora-stage-kind">Watch</span></a></li>
+          <li><a href="https://www.futureproof.website/"><span class="aurora-stage-event">Futureproof Festival</span><span class="aurora-stage-talk">Curator stage world</span><span class="aurora-stage-kind">Event</span></a></li>
+        </ul>
       </div>
     </div>
   </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #414. Fixes #415. Fixes #416.

Homepage cluster. No live WordPress writes. No SFTP deploy. Version stays **1.6.6** on this branch; do not merge ahead of #796 (1.6.8) if those share `front-page.html` — rebase after that window.

- #414 Stages band: TED/SXSW name strip gone. Linked proof reel using the two rights-recorded frames only (LaSalle live media + Vancouver AI Meetup theme asset). Every row has a real destination. No uncleared CreativeMornings hotlink.
- #415 What People Say, after Services and before Writing: three quotes already public on `/testimonials/` (Jai Djwa, Ed Kennedy, audience feedback). Network diagram stays a standalone preview, not a live embed.
- #416 Newsletter: section-head rhythm + one Beehiiv CTA. Heading and recent-writing thumbnails were already on `main`; this pass did not kill leftover dispatch/field-notes copy because it was already gone. Signup E2E stays KK-owned.

`scripts/tests` 396 passed in the agent session. `make theme-smoke` and `make validate` passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

