### PR TITLE
theme(#690): keep cream surface/elevated as honest aliases

### DIFF
--- a/scripts/tests/test_aurora_contrast_tokens.py
+++ b/scripts/tests/test_aurora_contrast_tokens.py
@@ -33,6 +33,17 @@ class AuroraContrastTokenTests(unittest.TestCase):
         theme = json.loads((THEME_DIR / "theme.json").read_text(encoding="utf-8"))
         palette = theme["settings"]["color"]["palette"]
         self.colors = {entry["slug"]: entry["color"] for entry in palette}
+        self.names = {entry["slug"]: entry["name"] for entry in palette}
+
+    def test_surface_and_elevated_preset_slugs_are_kept(self):
+        """#690: never delete these slugs; live editor/content may reference them."""
+        self.assertIn("surface", self.colors)
+        self.assertIn("elevated", self.colors)
+        self.assertEqual(self.colors["surface"].lower(), "#e6dcc2")
+        self.assertEqual(
+            self.colors["elevated"].lower(), self.colors["surface"].lower()
+        )
+        self.assertIn("same as Panel", self.names["elevated"])
 
     def test_text_tokens_meet_wcag_aa_on_dark_surfaces(self):
         foregrounds = ("text-primary", "text-secondary", "text-muted", "signal")
@@ -56,7 +67,9 @@ class AuroraContrastTokenTests(unittest.TestCase):
 
     def test_primary_cta_control_colors_meet_wcag_aa(self):
         css = (THEME_DIR / "style.css").read_text(encoding="utf-8")
-        control_colors = re.findall(r"--aurora-signal-control(?:-hover)?:\s*(#[0-9a-fA-F]{6});", css)
+        control_colors = re.findall(
+            r"--aurora-signal-control(?:-hover)?:\s*(#[0-9a-fA-F]{6});", css
+        )
 
         self.assertEqual(len(control_colors), 2)
         for color in control_colors:
@@ -64,7 +77,9 @@ class AuroraContrastTokenTests(unittest.TestCase):
 
     def test_homepage_feature_band_contrast_floor_is_present(self):
         css = (THEME_DIR / "style.css").read_text(encoding="utf-8")
-        front_page = (THEME_DIR / "templates/front-page.html").read_text(encoding="utf-8")
+        front_page = (THEME_DIR / "templates/front-page.html").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("aurora-feature-band-contrast", front_page)
         self.assertIn(".aurora-feature-band-contrast > .aurora-section-heading", css)

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.9
+**Deployed:** NOT LIVE (source pending; 1.6.7 is PR #789 title-format, 1.6.8 is PR #796 homepage)
+Document that palette slugs `surface` ("Cream Panel") and `elevated` ("Cream Elevated (same as Panel)") are the same hex `#e6dcc2`. Both slugs stay because CSS, patterns, and possible live editor classes reference them. Do not invent a lift hex without a designed cream step, and do not delete a preset (#690).
+
 ## 1.6.6
 **Deployed:** NOT LIVE (source merged in PR #751 at `dcb7ff4`; deploy pending)
 Copy and dead-file cleanup, no layout or CSS change. Strips the five user-visible em dashes from theme copy: the homepage hero dek and services lede, the marquee archive lede, and the photo-gallery pattern's lede plus its placeholder alt text (#733). Removes the orphaned speaking proof-grid template part and its `theme.json` registration; the part was placed by zero templates and live proof-grid content is DB page content, not this part (#743).

--- a/theme/kk-aurora/assets/css/02-tokens.css
+++ b/theme/kk-aurora/assets/css/02-tokens.css
@@ -12,7 +12,11 @@
  */
 @layer tokens {
   :root {
-    /* Surfaces */
+    /* Surfaces.
+       surface + elevated are the same cream (#e6dcc2). Keep both slugs:
+       editor/content may use has-surface-* / has-elevated-*. Do not delete
+       either preset (issue #690). Raised vs sunk is not a distinct cream
+       yet — same alias pattern as deep + paper (#efe6d2). */
     --kk-surface: var(--wp--preset--color--paper);
     --kk-surface-sunk: var(--wp--preset--color--surface);
     --kk-surface-raised: var(--wp--preset--color--elevated);

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.6');
+define('KK_AURORA_VERSION', '1.6.9');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -31,6 +31,7 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 == Color Palette ==
 
 * Cream surface: #efe6d2
+* Cream panel / elevated (alias): #e6dcc2
 * Ink text: #171310
 * Burnt orange accent (text/AA): #9a2f14
 * Burnt orange control fill: #c03f18
@@ -39,6 +40,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 * Rainbow accents: teal / cyan / cobalt / violet / magenta
 
 == Changelog ==
+
+= 1.6.9 =
+* tokens (#690): keep `surface` and `elevated` as the same cream `#e6dcc2`. Rename the elevated swatch to "Cream Elevated (same as Panel)" so the editor is honest. Do not delete either slug.
 
 = 1.6.6 =
 * content (#733, PR #751): rewrite the five listed user-visible em dashes in the homepage, marquee archive, and photo-gallery pattern copy.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.6
+Version: 1.6.9
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -33,7 +33,7 @@
         },
         {
           "slug": "elevated",
-          "name": "Cream Elevated",
+          "name": "Cream Elevated (same as Panel)",
           "color": "#e6dcc2"
         },
         {


### PR DESCRIPTION
## Summary
- Confirmed `theme.json` still defines `surface` ("Cream Panel") and `elevated` as the same hex `#e6dcc2` on current `origin/main`.
- Both slugs are used: `surface` as fills (`has-surface-background-color`, `--kk-surface-sunk`), `elevated` as borders / raised fills / separators (`--kk-surface-raised`). `fixes/` and sampled `content/` do not reference the classes. Deleting a slug would still be a live-editor landmine.
- Smallest honest fix: **do not change the hex** (no designed cream lift exists; `--aurora-panel-solid` is already `#e6dcc2`; inventing `#ece3d0` would be an un-gated visual change). Keep both slugs. Rename the elevated swatch to **Cream Elevated (same as Panel)** so the editor is honest. Same alias pattern as `deep` / `paper` (`#efe6d2`).
- Aurora **1.6.9** (1.6.7 is PR #789, 1.6.8 is PR #796). No homepage template edits. No live deploy.

Closes #690

## Test plan
- [x] `python3 -m unittest scripts.tests.test_aurora_contrast_tokens -v`
- [x] `composer install` + `make validate`
- [ ] KK: confirm we should keep the shared hex rather than design a lift later
- [ ] Do not merge / deploy until KK approval (Track B)


Made with [Cursor](https://cursor.com)