### PR TITLE
theme: apply #735 BC + AI spacing and Krüg in live chrome (Aurora 1.6.10)

### DIFF
--- a/scripts/tests/test_issue_735_brand_canon.py
+++ b/scripts/tests/test_issue_735_brand_canon.py
@@ -1,0 +1,37 @@
+"""#735: live Aurora chrome uses BC + AI (spaces) and Kris Krüg."""
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THEME = ROOT / "theme/kk-aurora"
+LIVE_CHROME = [
+    THEME / "parts/header.html",
+    THEME / "parts/footer.html",
+    THEME / "patterns/hero-gradient.php",
+    THEME / "patterns/stats-counter.php",
+]
+
+
+class Issue735BrandCanonTests(unittest.TestCase):
+    def test_live_chrome_does_not_use_unspaced_bc_ai(self):
+        offenders = []
+        for path in LIVE_CHROME:
+            text = path.read_text(encoding="utf-8")
+            if "BC+AI" in text:
+                offenders.append(path.relative_to(ROOT).as_posix())
+        self.assertEqual(offenders, [])
+
+    def test_header_and_footer_use_krug_umlaut(self):
+        header = (THEME / "parts/header.html").read_text(encoding="utf-8")
+        footer = (THEME / "parts/footer.html").read_text(encoding="utf-8")
+        self.assertIn("Kris Krüg home", header)
+        self.assertIn('aria-label="Kris Krüg"', footer)
+        self.assertIn("Kris Krüg", footer)
+        self.assertNotIn("Kris Krug home", header)
+        self.assertNotIn("Copyright 2026 Kris Krug.", footer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.10
+**Deployed:** NOT LIVE (stacks after 1.6.7 #789, 1.6.8 #796, 1.6.9 #801)
+Brand-string sweep from the #735 ruling: live chrome uses `BC + AI` (spaces) and `Kris Krüg`. Header, footer, and the unused-but-shipped `hero-gradient` / `stats-counter` patterns. Descriptors are not unified. Title-tag umlaut stays on 1.6.7. Front-page gallery alts stay on the homepage PRs.
+
 ## 1.6.6
 **Deployed:** NOT LIVE (source merged in PR #751 at `dcb7ff4`; deploy pending)
 Copy and dead-file cleanup, no layout or CSS change. Strips the five user-visible em dashes from theme copy: the homepage hero dek and services lede, the marquee archive lede, and the photo-gallery pattern's lede plus its placeholder alt text (#733). Removes the orphaned speaking proof-grid template part and its `theme.json` registration; the part was placed by zero templates and live proof-grid content is DB page content, not this part (#743).

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.6');
+define('KK_AURORA_VERSION', '1.6.10');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -4,8 +4,8 @@
     <svg preserveAspectRatio="none" viewBox="0 0 120 12" xmlns="http://www.w3.org/2000/svg"><defs><pattern id="auroraWovenFoot" x="0" y="0" width="60" height="12" patternUnits="userSpaceOnUse"><rect x="0" y="0" width="4" height="12" fill="#171310"/><rect x="4" y="0" width="6" height="12" fill="#d94a1f"/><rect x="10" y="0" width="4" height="12" fill="#171310"/><rect x="14" y="0" width="6" height="12" fill="#e8b53a"/><rect x="20" y="0" width="4" height="12" fill="#efe6d2"/><rect x="24" y="0" width="6" height="12" fill="#1f8a86"/><rect x="30" y="0" width="4" height="12" fill="#171310"/><rect x="34" y="0" width="6" height="12" fill="#39a8d8"/><rect x="40" y="0" width="4" height="12" fill="#171310"/><rect x="44" y="0" width="6" height="12" fill="#6b3a97"/><rect x="50" y="0" width="4" height="12" fill="#efe6d2"/><rect x="54" y="0" width="6" height="12" fill="#d6337a"/></pattern></defs><rect width="120" height="12" fill="url(#auroraWovenFoot)"/></svg>
   </div>
   <div class="aurora-footer-shell">
-    <section class="aurora-footer-tile aurora-footer-tile-brand" aria-label="Kris Krug">
-      <p class="aurora-kicker">Kris Krug</p>
+    <section class="aurora-footer-tile aurora-footer-tile-brand" aria-label="Kris Krüg">
+      <p class="aurora-kicker">Kris Krüg</p>
       <h2>Still paying attention. Now with better tools.</h2>
       <p>AI keynotes, workshops, and ecosystem work from the traditional, ancestral, and unceded territories of the Musqueam, Squamish, and Tsleil-Waututh Nations.</p>
       <div class="aurora-footer-actions">
@@ -76,7 +76,7 @@
   </div>
 
   <div class="aurora-footer-bottom">
-    <p>Copyright 2026 Kris Krug. All rights reserved.</p>
+    <p>Copyright 2026 Kris Krüg. All rights reserved.</p>
     <p><a href="/reconciliation-indigenous-land-acknowledgement/">Reconciliation</a> / <a href="/the-kk-worldview/">Worldview</a></p>
   </div>
 </footer>

--- a/theme/kk-aurora/parts/header.html
+++ b/theme/kk-aurora/parts/header.html
@@ -35,8 +35,8 @@
     </div>
   </div>
   <div class="aurora-header-shell">
-    <a class="aurora-brand" href="/" aria-label="Kris Krug home">
-      <img class="aurora-brand-logo" src="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp" srcset="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp 1x, /wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-234.webp 2x" alt="Kris Krug home" width="117" height="57" decoding="async">
+    <a class="aurora-brand" href="/" aria-label="Kris Krüg home">
+      <img class="aurora-brand-logo" src="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp" srcset="/wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-117.webp 1x, /wp-content/themes/kk-aurora/assets/img/kriskrug-wordmark-234.webp 2x" alt="Kris Krüg home" width="117" height="57" decoding="async">
     </a>
 
     <nav class="aurora-primary-nav" aria-label="Primary navigation">

--- a/theme/kk-aurora/patterns/hero-gradient.php
+++ b/theme/kk-aurora/patterns/hero-gradient.php
@@ -20,7 +20,7 @@
       <!-- /wp:heading -->
       
       <!-- wp:paragraph {"align":"center","className":"aurora-hero-description","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"textColor":"text-secondary","fontSize":"lg"} -->
-      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC+AI · Lead Curator, Futureproof Festival · Techartist &amp; Culture Hacker</p>
+      <p class="has-text-align-center aurora-hero-description has-text-secondary-color has-text-color has-lg-font-size" style="margin-top:var(--wp--preset--spacing--60)">Executive Director BC + AI · Lead Curator, Futureproof Festival · Techartist &amp; Culture Hacker</p>
       <!-- /wp:paragraph -->
       
       <!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
@@ -28,7 +28,7 @@
         <!-- wp:group {"className":"aurora-badge-gradient","style":{"border":{"radius":"9999px"},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}}},"backgroundColor":"surface"} -->
         <div class="wp-block-group aurora-badge-gradient has-surface-background-color has-background" style="border-radius:9999px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)">
           <!-- wp:paragraph {"style":{"typography":{"fontSize":"0.75rem","fontStyle":"normal","fontWeight":"600","textTransform":"uppercase","letterSpacing":"0.05em"}},"textColor":"signal"} -->
-          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">BC+AI</p>
+          <p class="has-signal-color has-text-color" style="font-size:0.75rem;font-style:normal;font-weight:600;letter-spacing:0.05em;text-transform:uppercase">BC + AI</p>
           <!-- /wp:paragraph -->
         </div>
         <!-- /wp:group -->

--- a/theme/kk-aurora/patterns/stats-counter.php
+++ b/theme/kk-aurora/patterns/stats-counter.php
@@ -21,7 +21,7 @@
         <!-- /wp:heading -->
 
         <!-- wp:paragraph {"align":"center","style":{"typography":{"textTransform":"uppercase","letterSpacing":"0.05em"},"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"textColor":"text-secondary","fontSize":"xs"} -->
-        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">BC+AI Members</p>
+        <p class="has-text-align-center has-text-secondary-color has-text-color has-xs-font-size" style="margin-top:var(--wp--preset--spacing--30);letter-spacing:0.05em;text-transform:uppercase">BC + AI Members</p>
         <!-- /wp:paragraph -->
       </div>
       <!-- /wp:group -->

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -40,6 +40,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.6.10 =
+* content (#735): sitewide live chrome uses `BC + AI` and `Kris Krüg`. Header, footer, hero-gradient pattern, stats-counter pattern. Descriptors not unified.
+
 = 1.6.6 =
 * content (#733, PR #751): rewrite the five listed user-visible em dashes in the homepage, marquee archive, and photo-gallery pattern copy.
 * cleanup (#743, PR #751): remove the unplaced speaking proof-grid template part and its theme.json registration.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.6
+Version: 1.6.10
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #735.

KK ruling 2026-08-17: **`BC + AI`** (spaces) sitewide; **Kris Krüg** everywhere; descriptors **not** unified.

This PR applies that to live Aurora chrome only:

- Header brand aria-label/alt and footer kicker/copyright: `Kris Krüg`
- `hero-gradient` pattern badge + dek: `BC + AI`
- `stats-counter` pattern: `BC + AI Members`

Left on purpose:

- Sitewide `<title>` umlaut is PR #789 (Aurora 1.6.7)
- Homepage gallery alts still say Krug; those files are owned by #796 / #797
- Descriptor set is not collapsed (ruled)

Aurora **1.6.10**, stacked after 1.6.7 / 1.6.8 / 1.6.9. No live SFTP.

`python3 -m unittest scripts.tests.test_issue_735_brand_canon` passed. PHP is not on PATH in this pod so `make theme-smoke` was skipped here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41b93c2b-2479-47a3-a2bf-8d2b013e516c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

