### PR TITLE
fixes(#331): draft v2 archive sitemap policy (prep only)

### DIFF
--- a/fixes/issue-331-apply.md
+++ b/fixes/issue-331-apply.md
@@ -1,0 +1,136 @@
+# Archive sitemap policy — apply / rollback (#331)
+
+Prepared 2026-08-16. **Nothing here has been applied.** Activating this snippet
+is a live write and stays KK-gated. Do not change `robots.txt`. Do not submit,
+resubmit, or remove anything in Search Console from this lane.
+
+REST `/wp/v2/users` and `/?author=N` probes are **not** this packet. Those
+are #767 / draft PR #793.
+
+---
+
+## Live sitemap inventory (2026-08-16, logged out)
+
+`/sitemap.xml` still `301`s to `/wp-sitemap.xml` (`x-redirect-by: WordPress`).
+`robots.txt` still points at `/sitemap.xml` and still disallows only
+`/wp-admin/`, `/?s=`, and `/search/`. That handoff is intentional; leave it.
+
+| Child sitemap | URL count | What it is |
+|---|---:|---|
+| `wp-sitemap-posts-post-1.xml` | 973 | published posts — **keep** |
+| `wp-sitemap-posts-page-1.xml` | 46 | published pages — **keep** |
+| `wp-sitemap-taxonomies-category-1.xml` | 14 | category archives — drop |
+| `wp-sitemap-taxonomies-post_tag-1.xml` | 633 | tag archives — drop |
+| `wp-sitemap-users-1.xml` | 2 | author archives — drop |
+| **Total** | **1,668** | |
+
+No custom-taxonomy child sitemap exists. Public REST taxonomies are
+`category`, `post_tag`, `nav_menu`, and `wp_pattern_category`. Only the first
+two appear in `/wp-sitemap.xml`.
+
+Sampled archives (category, tag, both authors, year/month/day) all return
+`200`, emit `meta robots=max-image-preview:large` only, and have **no**
+canonical. A control post still has a self-canonical. Date archives are
+**not** in the sitemap and are still indexable.
+
+---
+
+## Is v1 enough?
+
+`fixes/issue-331-archive-sitemap-policy.php` is **not live** (confirmed again
+by the users/category/tag children above). If activated as written it would:
+
+- **Yes — drop the author sitemap.** `wp_sitemaps_add_provider` returns
+  `false` for `users`, so `wp-sitemap-users-1.xml` leaves the index. That is
+  the sitemap half of #767. It does **not** hide REST users or `?author=N`.
+- **Yes — drop all 14 category URLs and all 633 tag URLs** from the sitemap.
+- **Yes — `noindex,follow`** on author, tag, and category HTML, including
+  `/page/N/` variants.
+- **No — date archives stay indexable.** `/2026/`, `/2026/07/`, and
+  `/2003/10/14/` would keep today's permissive robots meta. That is the hole
+  the 2026-08-02 proposal called out.
+- **No — a future public taxonomy would still get a sitemap child.** v1 only
+  unsets `category` and `post_tag`.
+
+Use **v2** as the deploy candidate:
+`fixes/issue-331-archive-sitemap-policy-v2.php`. Leave v1 in the repo as the
+receipt artifact. Do not activate both.
+
+---
+
+## Blast radius if v2 is activated
+
+Sitemap membership after a cache purge should be **973 posts + 46 pages =
+1,019 URLs**. Re-count immediately before deploy; these numbers move.
+
+| Class | Sitemap | Also noindex? | URLs that drop from the sitemap |
+|---|---|---|---|
+| Posts | keep | no | none |
+| Pages | keep | no | none |
+| Author archives | drop | **yes** (`noindex,follow`) | 2 (`/author/<redacted>/`) |
+| Tag archives | drop | **yes** | 633 (`/tag/{slug}/`) |
+| Category archives | drop | **yes** (Option A) | 14 (list below) |
+| Date archives | already absent | **yes** (v2 only) | 0 from sitemap; HTML still 200 |
+| Custom taxonomies | none live; v2 would drop any | **yes** via `is_tax()` | none today |
+
+Category URLs that leave the sitemap (and should be noindexed until a later
+content project gives a named slug a self-canonical, unique title, meta
+description, and H1 that is not `Category: {name}`):
+
+- `/category/vancouver-ai-ecosystem/`
+- `/category/ai-creatives/`
+- `/category/indigenous-reconciliation-in-tech/`
+- `/category/events-reports/`
+- `/category/conversations-interviews/`
+- `/category/ai-ethics-philosophy/`
+- `/category/ai-for-journalism-media/`
+- `/category/generative-ai-tools/`
+- `/category/field-notes/`
+- `/category/keynotes-speaking/`
+- `/category/responsible-ai-policy/`
+- `/category/creative-technology-making/`
+- `/category/photography-visual-storytelling/`
+- `/category/web-early-blog/`
+
+Issue #331's acceptance criteria still allow a curated category keep-list.
+The 2026-07-12 Growth Mirror rehearsal found 16 archive impressions and zero
+clicks; none of the 14 categories currently has a term description or
+canonical. **Option A (exclude all now)** is what v1 and v2 implement.
+Promoting a category later is a copy project plus a snippet change, not a
+reason to ship v1.
+
+Do **not** `Disallow` these paths in `robots.txt`. Google needs to crawl the
+`noindex`. Archives stay publicly reachable; links still pass.
+
+---
+
+## Apply (human-gated; do not run from this PR)
+
+1. Re-count live child sitemaps. Do not treat 1,668 / 1,019 as frozen.
+2. Snapshot the Code Snippets inventory outside the repo (same pattern as
+   `fixes/issue-706-script-diet.md`).
+3. Create an **inactive** snippet from v2, opening `<?php` stripped. Diff
+   the saved body against the repo file. `php -l` the body.
+4. Activate only after that diff, a PHP syntax check, and a named rollback
+   owner.
+5. Purge Pagely / Jetpack Boost cache.
+6. Readback:
+   - `/sitemap.xml` still `301` → `/wp-sitemap.xml`
+   - index contains post + page children only (no `users`, `category`,
+     `post_tag`, or other taxonomy children)
+   - post and page URL counts match the pre-deploy recount
+   - representative category, tag, author, **and date** archives, including
+     one `/page/2/`, return `200` with `noindex,follow`
+   - a control post and page still have a self-canonical and remain in their
+     sitemap children
+7. Search Console: read status at 24h and 72h. Do not resubmit in between.
+   Do not use temporary URL removals.
+
+---
+
+## Rollback
+
+Deactivate the snippet. Purge cache. Repeat the sitemap index plus the
+representative archive and post/page readback. Rollback restores prior
+provider and robots behavior. It must not edit content, terms, users,
+permalinks, redirects, `robots.txt`, or Search Console rows.

--- a/fixes/issue-331-archive-sitemap-policy-v2.php
+++ b/fixes/issue-331-archive-sitemap-policy-v2.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * KK archive sitemap and indexability policy v2 (#331).
+ *
+ * Deploy candidate. Supersedes fixes/issue-331-archive-sitemap-policy.php for
+ * any future Code Snippets activation. Keep the v1 file as the 2026-07-12
+ * receipt artifact; do not activate both. Function names are v2-prefixed so
+ * an accidental dual paste does not fatal, but only this file should be on.
+ *
+ * Why v2 exists (live readback 2026-08-16):
+ * - v1 would drop wp-sitemap-users-1.xml, the category child, and the tag
+ *   child. That part is correct and would close the sitemap half of #767.
+ * - v1 does not noindex date archives. Those URLs are absent from
+ *   /wp-sitemap.xml but still return 200 with only max-image-preview:large.
+ * - v1 leaves unknown public taxonomies in the sitemap. Live has none today
+ *   (only category and post_tag children). v2 drops leftovers so a future
+ *   public taxonomy does not reintroduce sitemap bloat.
+ *
+ * Policy (Option A from docs/current-state/SEO-ARCHIVE-INDEXABILITY-2026-08-02.md):
+ * exclude author, tag, and category archives from the core sitemap and emit
+ * noindex,follow on those archives plus date archives and any leftover custom
+ * taxonomy archives. Posts and pages are untouched. Do not change robots.txt
+ * or the /sitemap.xml → /wp-sitemap.xml handoff.
+ *
+ * REST /wp/v2/users and ?author=N probes are #767 / PR #793, not this file.
+ *
+ * When pasting into Code Snippets, remove the opening PHP tag.
+ * Do not activate without KK approval. See fixes/issue-331-apply.md.
+ *
+ * Rollback: deactivate this snippet, purge the approved production cache,
+ * and repeat the sitemap plus representative archive readback.
+ */
+
+/**
+ * Exclude author archives from the WordPress core sitemap registry.
+ *
+ * @param mixed  $provider Sitemap provider instance.
+ * @param string $name     Sitemap provider name.
+ * @return mixed
+ */
+function kk_archive_policy_v2_sitemap_provider( $provider, string $name ) {
+	if ( 'users' === $name ) {
+		return false;
+	}
+
+	return $provider;
+}
+add_filter( 'wp_sitemaps_add_provider', 'kk_archive_policy_v2_sitemap_provider', PHP_INT_MAX, 2 );
+
+/**
+ * Exclude every public taxonomy from WordPress core taxonomy sitemaps.
+ *
+ * Category and post_tag are named so the intent stays greppable. Any other
+ * public taxonomy is also dropped: live /wp-sitemap.xml has none today.
+ *
+ * @param array $taxonomies Public taxonomy objects keyed by taxonomy name.
+ * @return array
+ */
+function kk_archive_policy_v2_sitemap_taxonomies( array $taxonomies ): array {
+	unset( $taxonomies['category'], $taxonomies['post_tag'] );
+
+	return array();
+}
+add_filter( 'wp_sitemaps_taxonomies', 'kk_archive_policy_v2_sitemap_taxonomies', PHP_INT_MAX );
+
+/**
+ * Mark public author, tag, category, date, and custom-taxonomy archives
+ * noindex while retaining links.
+ *
+ * is_category(), is_tag(), is_author(), is_date(), and is_tax() are also
+ * true on their /page/N/ variants, so pagination inherits this policy.
+ *
+ * @param array $robots Existing robots directives.
+ * @return array
+ */
+function kk_archive_policy_v2_robots( array $robots ): array {
+	if ( ! is_author() && ! is_tag() && ! is_category() && ! is_date() && ! is_tax() ) {
+		return $robots;
+	}
+
+	unset( $robots['index'], $robots['nofollow'], $robots['none'] );
+	$robots['noindex'] = true;
+	$robots['follow']  = true;
+
+	return $robots;
+}
+add_filter( 'wp_robots', 'kk_archive_policy_v2_robots', PHP_INT_MAX );

--- a/scripts/tests/test_issue_331_archive_policy_v2.py
+++ b/scripts/tests/test_issue_331_archive_policy_v2.py
@@ -1,0 +1,166 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SNIPPET = ROOT / "fixes/issue-331-archive-sitemap-policy-v2.php"
+APPLY = ROOT / "fixes/issue-331-apply.md"
+V1 = ROOT / "fixes/issue-331-archive-sitemap-policy.php"
+
+
+class Issue331ArchivePolicyV2Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = SNIPPET.read_text(encoding="utf-8")
+        cls.apply = APPLY.read_text(encoding="utf-8")
+        cls.v1 = V1.read_text(encoding="utf-8")
+        cls.behavior = cls._run_php_harness()
+
+    @staticmethod
+    def _run_php_harness():
+        snippet_path = json.dumps(str(SNIPPET))
+        harness = f"""<?php
+$archive_context = 'single';
+
+function add_filter() {{
+    return true;
+}}
+
+function is_author() {{
+    global $archive_context;
+    return 'author' === $archive_context;
+}}
+
+function is_tag() {{
+    global $archive_context;
+    return 'tag' === $archive_context;
+}}
+
+function is_category() {{
+    global $archive_context;
+    return 'category' === $archive_context;
+}}
+
+function is_date() {{
+    global $archive_context;
+    return 'date' === $archive_context;
+}}
+
+function is_tax() {{
+    global $archive_context;
+    return 'tax' === $archive_context;
+}}
+
+require {snippet_path};
+
+$provider          = new stdClass();
+$users_result      = kk_archive_policy_v2_sitemap_provider($provider, 'users');
+$posts_result      = kk_archive_policy_v2_sitemap_provider($provider, 'posts');
+$taxonomies_result = kk_archive_policy_v2_sitemap_taxonomies(
+    array('category' => new stdClass(), 'post_tag' => new stdClass(), 'genre' => new stdClass())
+);
+
+$robots_results = array();
+foreach (array('author', 'tag', 'category', 'date', 'tax') as $context) {{
+    $archive_context = $context;
+    $robots_results[$context] = kk_archive_policy_v2_robots(
+        array(
+            'index'             => true,
+            'nofollow'          => true,
+            'none'              => true,
+            'max-image-preview' => 'large',
+        )
+    );
+}}
+
+$archive_context = 'single';
+$singular_robots = array('max-image-preview' => 'large');
+$singular_result = kk_archive_policy_v2_robots($singular_robots);
+
+echo json_encode(
+    array(
+        'sitemaps' => array(
+            'users_removed'   => false === $users_result,
+            'posts_preserved' => $provider === $posts_result,
+            'taxonomy_keys'   => array_keys($taxonomies_result),
+        ),
+        'robots' => array(
+            'archives'           => $robots_results,
+            'singular_unchanged' => $singular_robots === $singular_result,
+        ),
+    ),
+    JSON_THROW_ON_ERROR
+);
+"""
+        result = subprocess.run(
+            ["php"],
+            input=harness,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_snippet_has_valid_php_and_registers_only_narrow_filters(self):
+        result = subprocess.run(
+            ["php", "-l", str(SNIPPET)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        self.assertIn("No syntax errors detected", result.stdout)
+        self.assertEqual(3, self.source.count("add_filter("))
+        for registration in (
+            "add_filter( 'wp_sitemaps_add_provider', 'kk_archive_policy_v2_sitemap_provider', PHP_INT_MAX, 2 );",
+            "add_filter( 'wp_sitemaps_taxonomies', 'kk_archive_policy_v2_sitemap_taxonomies', PHP_INT_MAX );",
+            "add_filter( 'wp_robots', 'kk_archive_policy_v2_robots', PHP_INT_MAX );",
+        ):
+            self.assertIn(registration, self.source)
+        self.assertNotIn("template_redirect", self.source)
+        self.assertNotIn("wp_sitemaps_post_types", self.source)
+        self.assertNotIn("rest_endpoints", self.source)
+        self.assertNotIn("robots_txt", self.source)
+
+    def test_v1_is_preserved_and_does_not_cover_dates(self):
+        self.assertTrue(V1.is_file())
+        self.assertNotIn("is_date()", self.v1)
+        self.assertIn("is_date()", self.source)
+
+    def test_archive_providers_are_removed_without_touching_posts_or_pages(self):
+        sitemaps = self.behavior["sitemaps"]
+
+        self.assertTrue(sitemaps["users_removed"])
+        self.assertEqual([], sitemaps["taxonomy_keys"])
+        self.assertTrue(sitemaps["posts_preserved"])
+
+    def test_archive_robots_are_noindex_follow_without_conflicts(self):
+        for context, robots in self.behavior["robots"]["archives"].items():
+            with self.subTest(context=context):
+                self.assertIs(True, robots["noindex"])
+                self.assertIs(True, robots["follow"])
+                self.assertEqual("large", robots["max-image-preview"])
+                self.assertNotIn("index", robots)
+                self.assertNotIn("nofollow", robots)
+                self.assertNotIn("none", robots)
+
+        self.assertTrue(self.behavior["robots"]["singular_unchanged"])
+
+    def test_apply_note_locks_live_inventory_and_gates(self):
+        for expected in (
+            "1,668",
+            "973",
+            "633",
+            "wp-sitemap-users-1.xml",
+            "Option A",
+            "Do not change `robots.txt`",
+            "Deactivate the snippet",
+            "#767",
+        ):
+            self.assertIn(expected, self.apply)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Refs #331.

Prep-only. Nothing was activated, deployed, or written live. `robots.txt` is unchanged. REST/`?author=N` hardening stays on #767 / PR #793.

- Live `/wp-sitemap.xml` on 2026-08-16: 973 posts, 46 pages, 14 categories, 633 tags, 2 authors (1,668 URLs). No custom-taxonomy children. Author sitemap is still listed.
- Existing `fixes/issue-331-archive-sitemap-policy.php` is **not sufficient**: it would drop the author/tag/category sitemap children (including `wp-sitemap-users-1.xml`) and noindex those HTML archives, but date archives stay indexable and leftover public taxonomies would still get a sitemap child.
- New deploy candidate: `fixes/issue-331-archive-sitemap-policy-v2.php` (adds `is_date()` / `is_tax()` noindex and drops all taxonomy sitemap children). Apply/rollback: `fixes/issue-331-apply.md`.

## Test plan
- [x] `php -l` on the v2 snippet
- [x] `python3 -m unittest scripts.tests.test_issue_331_archive_policy_v2 scripts.tests.test_issue_331_archive_policy`
- [ ] KK reviews Option A (exclude all 14 categories now) vs a later curated keep-list
- [ ] Do **not** activate the snippet, purge cache, or touch Search Console from this PR


Made with [Cursor](https://cursor.com)