### PR TITLE
docs(#331): reconfirm live sitemap inventory before the v2 apply

### DIFF
--- a/fixes/issue-331-apply.md
+++ b/fixes/issue-331-apply.md
@@ -1,11 +1,16 @@
 # Archive sitemap policy — apply / rollback (#331)
 
-Prepared 2026-08-16. **Nothing here has been applied.** Activating this snippet
-is a live write and stays KK-gated. Do not change `robots.txt`. Do not submit,
-resubmit, or remove anything in Search Console from this lane.
+Prepared 2026-08-16. Reconfirmed the same evening (logged-out curl,
+2026-08-16 19:28 PT). **Nothing here has been applied.** Activating this
+snippet is a live write and stays KK-gated. Do not change `robots.txt`. Do
+not submit, resubmit, or remove anything in Search Console from this lane.
 
 REST `/wp/v2/users` and `/?author=N` probes are **not** this packet. Those
-are #767 / draft PR #793.
+are #767 / merged PR #793. This lane does not edit those files.
+
+v2 PHP is unchanged: the evening readback matched the earlier 2026-08-16
+inventory, so `fixes/issue-331-archive-sitemap-policy-v2.php` remains the
+deploy candidate. Do not activate both v1 and v2.
 
 ---
 
@@ -28,10 +33,17 @@ No custom-taxonomy child sitemap exists. Public REST taxonomies are
 `category`, `post_tag`, `nav_menu`, and `wp_pattern_category`. Only the first
 two appear in `/wp-sitemap.xml`.
 
-Sampled archives (category, tag, both authors, year/month/day) all return
-`200`, emit `meta robots=max-image-preview:large` only, and have **no**
-canonical. A control post still has a self-canonical. Date archives are
+Sampled archives (category, tag, both authors, year/month/day, plus
+`/category/vancouver-ai-ecosystem/page/2/`) all return `200`, emit
+`meta robots=max-image-preview:large` only, and have **no** canonical. A
+control post and `/about/` still have a self-canonical. Date archives are
 **not** in the sitemap and are still indexable.
+
+Evening reconfirm (2026-08-16 19:28 PT): child counts still 973 / 46 / 14 /
+633 / 2. Same 14 category slugs. `/sitemap.xml` still `301`s with
+`x-redirect-by: WordPress`. REST `/wp/v2/users` still returns `200` with
+`x-wp-total: 2` (out of scope; #767 / PR #793). No v3 snippet: v2 still
+covers the live surface.
 
 ---
 

--- a/scripts/tests/test_issue_331_archive_policy_v2.py
+++ b/scripts/tests/test_issue_331_archive_policy_v2.py
@@ -158,6 +158,8 @@ echo json_encode(
             "Do not change `robots.txt`",
             "Deactivate the snippet",
             "#767",
+            "merged PR #793",
+            "2026-08-16 19:28 PT",
         ):
             self.assertIn(expected, self.apply)
 


### PR DESCRIPTION
## Summary
Refs #331.

Prep-only. Nothing was activated, deployed, or written live. `robots.txt` is unchanged. REST/`?author=N` hardening stays on #767 / merged PR #793 (those files were not touched). `fixes/README.md` was not touched.

- Live `/wp-sitemap.xml` on 2026-08-16 19:28 PT: 973 posts, 46 pages, 14 categories, 633 tags, 2 authors (1,668 URLs). No custom-taxonomy children. Author sitemap is still listed, so v1/v2 are still not live.
- Existing `fixes/issue-331-archive-sitemap-policy.php` is **not sufficient**: activating it would drop `wp-sitemap-users-1.xml` plus the category and tag children and noindex those HTML archives, but date archives stay indexable and leftover public taxonomies would still get a sitemap child.
- Deploy candidate is unchanged: `fixes/issue-331-archive-sitemap-policy-v2.php` (already on `main` via #807). No v3 file — evening counts matched the earlier inventory.
- Apply/rollback note updated in `fixes/issue-331-apply.md`.

## Test plan
- [x] Logged-out curl of `/sitemap.xml`, `/wp-sitemap.xml`, and each child sitemap
- [x] Sampled category/tag/author/date archives plus one `/page/2/` still emit only `max-image-preview:large`
- [x] `php -l` on v1 and v2 snippets
- [x] `python3 -m unittest scripts.tests.test_issue_331_archive_policy_v2 scripts.tests.test_issue_331_archive_policy`
- [ ] KK reviews Option A (exclude all 14 categories now) vs a later curated keep-list
- [ ] Do **not** activate the snippet, purge cache, or touch Search Console from this PR


Made with [Cursor](https://cursor.com)