### PR TITLE
content(#635): snapshot-gate runbook for events page 2250

### DIFF
--- a/content/drafts/2026-08-16-events-hero-backfill/APPLY-RUNBOOK.md
+++ b/content/drafts/2026-08-16-events-hero-backfill/APPLY-RUNBOOK.md
@@ -1,0 +1,297 @@
+# Apply + rollback runbook: WP page 2250 events hero backfill (#635)
+
+**PREPARE, DO NOT APPLY.** This PR ships the procedure and a 2026-08-16 live
+diff. It does not PATCH WordPress, upload media, or write the catalog. Live
+apply waits on an explicit KK approval comment on
+[#635](https://github.com/WalksWithASwagger/kriskrug-wp/issues/635) naming the
+hero set.
+
+Live target:
+
+- ID **2250**
+- slug **`events`**
+- URL https://kriskrug.co/events/
+- Field written: **`content` only**. Do not send title, slug, excerpt, or meta.
+
+Payload sources (already on `main` via PRs #647 / #648 / the catalog):
+
+- `scripts/events_page/heroes/LEDGER-2024-2025.md`
+- `scripts/events_page/heroes/LEDGER-2026-MEETUP.md`
+- `scripts/events_page/events-catalog.yaml` (SSOT; mutate only approved `image` fields)
+- Generator: `scripts/events_page/render_events_page.py` →
+  gitignored `scripts/events_page/out/events-2250.generated.html`
+
+There is **no** pre-baked HTML that already contains the new heroes. The apply
+session must: restrict to KK-approved rows → stage local files or attach
+existing media IDs → `sync_event_media.py` → re-render → eyeball → snapshot →
+POST. See [`live-vs-payload-2026-08-16.md`](./live-vs-payload-2026-08-16.md).
+
+This is an UPDATE of a published page. The 2026-05-15 overwrite incident
+applies: slug match before POST, snapshot before write, dry-run first, rollback
+file on disk before the write returns.
+
+#635 inherits #592 exclusivity. No other open issue may mutate the catalog,
+upload event media, or write page 2250. Do **not** run concurrently with
+testimonials (#602) or speaking live writes.
+
+Do **not** use `backup/20260801-events-backfill-ship/` as the restore snapshot.
+That tree is the #592 body. Live `modified` is `2026-08-10T10:38:46` after the
+IIDA Coffee card. Use a fresh dated dir so both remain intact.
+
+## Current truth — verified 2026-08-16 (public REST + cache-bypass HTML)
+
+Do not close #635. Live does **not** carry the ledger heroes.
+
+| Check | Live 2250 |
+|---|---|
+| REST `modified` | `2026-08-10T10:38:46` |
+| Public cards | 66 `data-event-id` |
+| Compact empty media | **49** `aurora-event-compact-media--empty` (2026-08-02 baseline was **48**) |
+| Event `<img>` | 16, all HTTP 200 |
+| `file:///` | 0 |
+| TruNorth | not on the public page |
+
+## Still gated on KK (do not apply without these)
+
+1. Named row set. Default exclude every `NO SOURCE — needs KK` row. Do not
+   improvise an image.
+2. Photographer courtesy checks in `LEDGER-2026-MEETUP.md`: Peter Holst, Aaron
+   Hockenstein, Tristan Brand. Michelle Diamond already has live precedent
+   (media 12663).
+3. Series-fallback ruling for `van-ai-meetup-01/03/06/07/08/09` (labelled 2024
+   frames vs stay empty).
+4. `van-ai-meetup-24` credit + date conflict; TED2025 fetch path; AEFL Morten
+   wrong-night photo.
+5. TruNorth stays art-free unless the organizer grants an image. No speaking
+   claim.
+6. Every `PROVISIONAL` alt rewritten against the actual frame at upload.
+7. Fresh snapshot + dry-run render eyeballed in the apply session.
+
+Repo-side blockers #631 / #632 / #633 are closed. The `blocked` label is stale
+as a code dependency; this remains human-gated.
+
+## Identity gate (hard abort if any fail)
+
+Public (no secrets):
+
+1. `GET https://kriskrug.co/wp-json/wp/v2/pages/2250` returns `id == 2250`.
+2. That object has `slug == events` and `status == publish`.
+3. `GET https://kriskrug.co/wp-json/wp/v2/pages?slug=events` returns exactly one
+   page, and that page's `id` is 2250.
+4. Title is still `Events`. If it is not, stop. Do not "fix forward."
+
+Authenticated (`context=edit`), immediately before write:
+
+5. Same ID/slug/status.
+6. If `modified` is no longer `2026-08-10T10:38:46`, stop and re-diff against
+   live. Someone else wrote 2250. Reconcile; do not POST over an unexpected body.
+
+If slug or ID disagree, you are about to write the wrong page. Stop.
+
+## Pre-flight (no live write)
+
+```bash
+scripts/notion-to-wp/.venv/bin/python -m unittest \
+  scripts.tests.test_events_render_contract -v
+```
+
+Must be green. That suite is the guard against re-shipping `file:///`.
+
+Confirm every asset in the approved set has a recorded rights basis. Skip gaps.
+
+Suggested first wave after a narrow KK comment (attach existing library IDs;
+confirm each ID via authenticated `GET /wp/v2/media/<id>` before catalog write):
+
+- `2025-03-20-data-storytelling-hackathon` → 8675
+- `bcama-vision-conference-panel-2024` → 5740
+- `enya-liftoff-keynote-2024` → 6964
+- `innovate-west-keynote-2024` → 5360
+
+Do not upload for those four if the media object is the intended file. Write
+`image.media_id` + `image.url` + a frame-checked `alt`, then re-render.
+
+For rows that need a new file: download the ledger URL to
+`scripts/events_page/heroes/` (keep each file under 1 MB; R2 `large` is often
+too big — prefer `grid` or resize), set `image.path` to
+`repo:scripts/events_page/heroes/…`, never a hotlink and never a `file://` src.
+
+## Snapshot (before any media upload or page POST)
+
+Authenticated, via Varlock. Do not print secrets.
+
+```bash
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+SNAPDIR="backup/${STAMP}-events-hero-backfill/page-snapshots"
+mkdir -p -m 700 "$SNAPDIR"
+```
+
+Capture `content.raw` before any write:
+
+```bash
+make varlock-run CMD="python3 -c \"
+import json, os, urllib.request, base64, pathlib
+user = os.environ['WP_USER']
+pw = os.environ['WP_APP_PASSWORD']
+auth = 'Basic ' + base64.b64encode(f'{user}:{pw}'.encode()).decode()
+url = 'https://kriskrug.co/wp-json/wp/v2/pages/2250?context=edit'
+req = urllib.request.Request(url, headers={'Authorization': auth, 'User-Agent': 'kriskrug-ops/635'})
+with urllib.request.urlopen(req, timeout=90) as resp:
+    data = json.load(resp)
+path = pathlib.Path('$SNAPDIR/page-2250-events-before.json')
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + '\n', encoding='utf-8')
+raw = data['content']['raw']
+pathlib.Path('$SNAPDIR/2250-before-content.raw.html').write_text(raw, encoding='utf-8')
+print('id', data['id'], 'slug', data['slug'], 'modified', data['modified'], 'raw_bytes', len(raw.encode('utf-8')))
+\""
+```
+
+Also save a logged-out rendered page:
+
+```bash
+curl -sS -o "$SNAPDIR/page-2250-events-before.html" \
+  "https://kriskrug.co/events/?cb=$RANDOM$RANDOM"
+```
+
+Public REST does not return `content.raw`. The apply session must use
+`context=edit` for the rollback file.
+
+Write the rollback manifest **before** any `--execute` or POST:
+
+```json
+{
+  "page_id": 2250,
+  "slug": "events",
+  "url": "https://kriskrug.co/events/",
+  "before_snapshot_json": "backup/<STAMP>-events-hero-backfill/page-snapshots/page-2250-events-before.json"
+}
+```
+
+Save it as `backup/<STAMP>-events-hero-backfill/rollback-events-2250.json`.
+
+Restore (content only; no title/slug/date):
+
+```bash
+jq -r '.content.raw' \
+  "$SNAPDIR/page-2250-events-before.json" \
+  > /tmp/events-2250-rollback.html
+
+make varlock-run CMD="python3 -c \"
+import json, os, urllib.request, base64, pathlib
+user = os.environ['WP_USER']
+pw = os.environ['WP_APP_PASSWORD']
+body = pathlib.Path('/tmp/events-2250-rollback.html').read_text(encoding='utf-8')
+payload = json.dumps({'content': body}).encode()
+auth = 'Basic ' + base64.b64encode(f'{user}:{pw}'.encode()).decode()
+url = 'https://kriskrug.co/wp-json/wp/v2/pages/2250?_fields=id,slug,modified,status,link'
+req = urllib.request.Request(url, data=payload, method='POST',
+    headers={'Authorization': auth, 'Content-Type': 'application/json', 'User-Agent': 'kriskrug-ops/635-rollback'})
+with urllib.request.urlopen(req, timeout=90) as resp:
+    print(resp.read().decode())
+\""
+```
+
+## Dry-run media + render (still no page POST)
+
+```bash
+scripts/notion-to-wp/.venv/bin/python scripts/events_page/sync_event_media.py
+scripts/notion-to-wp/.venv/bin/python scripts/events_page/render_events_page.py
+```
+
+Eyeball `scripts/events_page/out/events-2250.generated.html` before any POST:
+
+- `file://` count is 0
+- no `/Users/` in any `src`
+- every approved row that should have art now has an `https://` `src`
+- skipped `NO SOURCE` rows still use `aurora-event-compact-media--empty`
+- `data-event-id` set still matches the 66 live ids (do not retitle or redate)
+- TruNorth still absent
+- `compact-empty` count is **lower than 49** (issue bar: drop vs the 2026-08-02
+  baseline of 48 — today's live is 49 because IIDA Coffee is heroless)
+
+Diff generated vs the snapshot raw:
+
+```bash
+diff -u \
+  "$SNAPDIR/2250-before-content.raw.html" \
+  scripts/events_page/out/events-2250.generated.html
+```
+
+Show that diff to Kris. Do not POST.
+
+## Apply (only after KK comment-approves on #635)
+
+Re-check identity against the snapshot just taken. Abort if `modified` drifted.
+
+1. `sync_event_media.py --execute` **only** for ledger-approved local files.
+   Log the new media ID range. Do not upload skipped rows.
+2. Re-render. Re-run `test_events_render_contract`. Abort on fail.
+3. POST **content only** from the generated HTML (already wrapped in
+   `<!-- wp:html -->` by `shell-events-2250.html`):
+
+```bash
+make varlock-run CMD="python3 -c \"
+import json, os, urllib.request, base64, pathlib
+user = os.environ['WP_USER']
+pw = os.environ['WP_APP_PASSWORD']
+body = pathlib.Path('scripts/events_page/out/events-2250.generated.html').read_text(encoding='utf-8')
+payload = json.dumps({'content': body}).encode()
+auth = 'Basic ' + base64.b64encode(f'{user}:{pw}'.encode()).decode()
+url = 'https://kriskrug.co/wp-json/wp/v2/pages/2250?_fields=id,slug,modified,status,link'
+req = urllib.request.Request(url, data=payload, method='POST',
+    headers={'Authorization': auth, 'Content-Type': 'application/json', 'User-Agent': 'kriskrug-ops/635'})
+with urllib.request.urlopen(req, timeout=90) as resp:
+    print(resp.read().decode())
+\""
+```
+
+4. Save `$SNAPDIR/page-2250-events-after.json` (`context=edit` GET).
+
+## Verify (logged out, cache-bypassed)
+
+```bash
+curl -sS -o /tmp/2250-after.html \
+  "https://kriskrug.co/events/?cb=$RANDOM$RANDOM"
+```
+
+Must all be true:
+
+- HTTP 200, id/slug still 2250 / `events`
+- `file:///` count is 0
+- every `<img>` on `/events/` that is an event hero returns HTTP 200
+- `aurora-event-compact-media--empty` is measurably below **49** (and below the
+  2026-08-02 baseline of **48** if the approved set is large enough)
+- every dated card still has `data-event-end`; upcoming/past buckets still
+  sensible (IIDA / Pitch Night / Sep 30 / Futureproof remain the upcoming set
+  until those dates roll)
+- no TruNorth speaking claim
+- 66 public `data-event-id` values unless KK approved adding/removing a card
+  (this issue's default is heroes only)
+
+Purge Pagely cache for `/events/` if the readback is stale. Re-fetch with a
+new `cb`.
+
+Comment on #635: media ID range, before/after empty-media counts, rollback path.
+
+## Rollback
+
+If anything is wrong, restore `content` from the snapshot taken immediately
+before the write using the restore commands in the Snapshot section above. Do
+not reconstruct from memory. Do not use the 2026-08-01 #592 backup if the
+fresh `$SNAPDIR` snapshot exists. Purge cache and cache-bypass confirm the
+pre-apply empty-media count and card set are back, then stop and report.
+
+New media objects can stay in the library; they are unused if the page rolls
+back. Do not bulk-delete media in the same session.
+
+## Explicit non-actions
+
+- Do not PATCH any page other than 2250.
+- Do not retitle or redate events.
+- Do not deploy theme files.
+- Do not run the Notion connector.
+- Do not change the slug, title, or excerpt.
+- Do not upload `NO SOURCE` rows or hotlink Luma/R2 URLs on the live page.
+- Do not merge this PR as a substitute for the live write.
+- Do not apply from `backup/20260801-events-backfill-ship/` "after" JSON.
+  That is the #592 body, not current live.

--- a/content/drafts/2026-08-16-events-hero-backfill/live-content-rendered-2026-08-16.html
+++ b/content/drafts/2026-08-16-events-hero-backfill/live-content-rendered-2026-08-16.html
@@ -1,0 +1,899 @@
+
+<div class="aurora-events-page">
+  <section class="aurora-speaking-hero" aria-labelledby="aurora-events-title">
+    <div class="aurora-speaking-hero-copy">
+      <p class="aurora-kicker">Events I build, host &amp; speak at</p>
+      <h2 id="aurora-events-title">I don&#8217;t just attend the AI conversation. I host the room.</h2>
+      <p>From a monthly Vancouver meetup to film-club screenings, weekly office hours, and keynote stages from São Paulo to Whistler. These are the rooms where BC&#8217;s AI community actually shows up, argues, makes things, and leaves braver. Most run on Luma; come find the next one.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">Follow on Luma</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book Kris to speak</a>
+      </div>
+    </div>
+  </section>
+
+
+<!-- EVENTS_DYNAMIC_START -->
+
+<style>
+  /* Dated event cards on /events/: rich Upcoming + dense Past archive */
+  .aurora-events-page .aurora-proof-media--portrait img {
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    object-position: center top;
+  }
+  .aurora-events-page [data-events-bucket][data-events-empty="true"] {
+    display: none;
+  }
+  .aurora-events-page .aurora-event-cta-past {
+    display: none;
+  }
+  .aurora-events-page [data-events-grid="past"] .aurora-event-cta-upcoming {
+    display: none;
+  }
+  .aurora-events-page [data-events-grid="past"] .aurora-event-cta-past {
+    display: flex;
+  }
+  .aurora-events-page .aurora-event-status-note {
+    font-size: 0.9em;
+    opacity: 0.8;
+  }
+
+  /* Past archive: dense 3 / 2 / 1 grid */
+  .aurora-events-page [data-events-grid="past"] {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem 1rem;
+  }
+  @media (max-width: 900px) {
+    .aurora-events-page [data-events-grid="past"] {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  @media (max-width: 560px) {
+    .aurora-events-page [data-events-grid="past"] {
+      grid-template-columns: 1fr;
+    }
+  }
+  .aurora-events-page .aurora-event-card--compact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin: 0;
+  }
+  .aurora-events-page .aurora-event-compact-media {
+    margin: 0;
+    overflow: hidden;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.04);
+  }
+  .aurora-events-page .aurora-event-compact-media img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
+    object-position: center;
+  }
+  .aurora-events-page .aurora-event-compact-media--empty {
+    aspect-ratio: 16 / 10;
+    background: linear-gradient(135deg, rgba(0,0,0,0.06), rgba(0,0,0,0.02));
+  }
+  .aurora-events-page .aurora-event-compact-body h3 {
+    font-size: 1.05rem;
+    margin: 0.15rem 0 0.35rem;
+    line-height: 1.25;
+  }
+  .aurora-events-page .aurora-event-compact-link {
+    font-size: 0.9rem;
+  }
+
+  /* Upcoming stays on the existing proof-grid / rich module rhythm */
+  .aurora-events-page [data-events-grid="upcoming"] .aurora-event-card--rich {
+    /* inherits .aurora-proof-module */
+  }
+</style>
+
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-upcoming" data-events-bucket="upcoming" data-events-empty="false">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Upcoming</p>
+      <h2 id="aurora-events-upcoming">On the calendar.</h2>
+      <p>Stages, festivals, and the next rooms. Register and come say hi.</p>
+    </div>
+    <div class="aurora-proof-grid" data-events-grid="upcoming">
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-08-13T11:00:00-07:00" data-event-id="iida-thermador-coffee-conversations-2026">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Thursday, Aug 13 · 9–11am · Thermador Experience &amp; Design Centre</p>
+          <h3>Coffee Conversations #1: The Impact of AI</h3>
+          <p>Invited guest at the first Coffee Conversations breakfast: an intimate small-room conversation about AI&#8217;s impact on the evolution of design, with IIDA Northern Pacific&#8217;s Vancouver community and Thermador.</p>
+          <div class="aurora-proof-tags"><span>Invited guest</span><span>AI + Design</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://www.iida-northernpacific.org/vancouverbc">IIDA Vancouver</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://www.iida-northernpacific.org/vancouverbc">IIDA Vancouver</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-09-08T21:00:00-07:00" data-event-id="how-can-we-help-pitch-night-2026">
+        <figure class="aurora-proof-media aurora-proof-media--portrait">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/2026-09-08-how-can-we-help-pitch-night-social-promo.jpg?ssl=1" alt="Panelist social graphic for Brands for Better Foundation How Can We Help? Pitch Night featuring Kris Krüg, Tuesday September 8 at BCIT Tech Collider" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Tuesday, Sept 8 · 6–9pm · BCIT Tech Collider</p>
+          <h3>How Can We Help? Pitch Night</h3>
+          <p>Panelist for Brands for Better Foundation: connecting nonprofits with skilled professionals for skills-based volunteering. Bringing a BC + AI Ecosystem perspective on practical knowledge-sharing and responsible tech in service of community.</p>
+          <div class="aurora-proof-tags"><span>Panelist</span><span>Vancouver</span><span>Nonprofits</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://www.eventbrite.ca/e/how-can-we-help-pitch-night-use-your-skills-to-support-nonprofits-tickets-1992057314051">Register on Eventbrite</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://www.eventbrite.ca/e/how-can-we-help-pitch-night-use-your-skills-to-support-nonprofits-tickets-1992057314051">Event details</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-09-30T22:00:00-07:00" data-event-id="vancouver-ai-meetup-2026-09-30">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Wed, Sept 30 · Space Centre</p>
+          <h3>Vancouver AI Community Meetup</h3>
+          <p>Next Vancouver AI Community Meetup on Wednesday, September 30. Hosted monthly at the H.R. MacMillan Space Centre.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Monthly</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://luma.com/sept-ai">Register on Luma</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://luma.com/sept-ai">Event details</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-10-30T22:00:00-07:00" data-event-id="futureproof-festival-2026">
+        <figure class="aurora-proof-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/futureproof-salmon-starfield-share-20260527.jpg?ssl=1" alt="Futureproof Festival salmon-starfield share graphic" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Oct 28–30 · H.R. MacMillan Space Centre</p>
+          <h3>Futureproof Festival</h3>
+          <p>Inaugural Futureproof Festival at the H.R. MacMillan Space Centre, Oct 28–30, 2026. The rooms, screenings, and conversations BC + AI has been building toward.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Festival</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://futureproof.website/">Save the date</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://futureproof.website/">Festival site</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-past" data-events-bucket="past" data-events-empty="false">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Archive</p>
+      <h2 id="aurora-events-past">Past rooms.</h2>
+      <p>Every Vancouver AI meetup edition plus dated stages that have rolled off Upcoming.</p>
+    </div>
+    <div class="aurora-proof-grid" data-events-grid="past">
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-29T22:00:00-07:00" data-event-id="van-ai-meetup-31">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/09-veggie-skewers-michelle-diamond.jpg?ssl=1" alt="Vancouver AI Meetup #31 (photo: Michelle Diamond / Diamond's Edge Photography)" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #31 · Jul 2026</p>
+          <h3>Vancouver AI Meetup #31</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/july-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-09T22:00:00-07:00" data-event-id="2026-07-09-bc-ai-film-club-july-idea-lab">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · Multimodal Media Lab · Host</p>
+          <h3>BC + AI Film Club July: Idea Lab</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/summertime">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-09T21:00:00-07:00" data-event-id="2026-07-09-sfu-ai-panel">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · SFU · Panelist</p>
+          <h3>SFU AI panel</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-08T21:00:00-07:00" data-event-id="2026-07-08-ai-ethical-futures-lab-morten">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · Vancouver · Host</p>
+          <h3>AI Ethical Futures Lab w/ Morten Rand-Hendriksen</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-06-24T22:00:00-07:00" data-event-id="van-ai-meetup-30">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/13-meetup-30-full-lineup-hero.png?ssl=1" alt="Vancouver AI Meetup #30" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #30 · Jun 2026</p>
+          <h3>Vancouver AI Meetup #30</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/june-vanai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-05-27T22:00:00-07:00" data-event-id="van-ai-meetup-29">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #29 · May 2026</p>
+          <h3>Vancouver AI Meetup #29</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vanai-may">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-05-01T12:00:00-07:00" data-event-id="creativemornings-perils-parallels-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/punk-rock-ai-creative-mornings.jpg?ssl=1" alt="Kris Krüg speaking at CreativeMornings Vancouver in front of a Stop Saying Bias slide" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 1, 2026 · Vancouver</p>
+          <h3>CreativeMornings: Perils &amp; Parallels</h3>
+          <a class="aurora-event-compact-link" href="https://creativemornings.com/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-29T22:00:00-07:00" data-event-id="van-ai-meetup-28">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/9-6bf27e0d-957a-4c79-b2bf-90349fecbf45.jpg?ssl=1" alt="Vancouver AI Meetup #28" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #28 · Apr 2026</p>
+          <h3>Vancouver AI Meetup #28</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vanai-april">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-12T19:30:00-07:00" data-event-id="2026-04-12-yvr-ai-welcome-salon-ted2026">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2026 · Alibi Room, Gastown · Host</p>
+          <h3>YVR AI Welcome Salon (TED2026 week)</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-01T11:50:00-07:00" data-event-id="2026-04-01-global-ai-summit-vancouver-panel">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2026 · UBC Robson Square · Moderator</p>
+          <h3>Global AI Summit Vancouver panel</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-03-31T11:50:00-07:00" data-event-id="2026-03-31-sea-to-sky-gondola-ai-ethics-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">March 2026 · Squamish · Workshop lead</p>
+          <h3>Sea to Sky Gondola AI-ethics workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-03-25T22:00:00-07:00" data-event-id="van-ai-meetup-27">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #27 · Mar 2026</p>
+          <h3>Vancouver AI Meetup #27</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-26T21:00:00-03:00" data-event-id="waiff-sao-paulo-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/press-2026-02-09-tela-viva-context-v2-1.jpg?ssl=1" alt="Tela Viva press coverage of WAIFF 2026, the World AI Film Festival in Brazil" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2026 · São Paulo · Keynote</p>
+          <h3>World AI Film Festival Brasil</h3>
+          <a class="aurora-event-compact-link" href="/speaking/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-25T22:00:00-07:00" data-event-id="van-ai-meetup-26">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #26 · Feb 2026</p>
+          <h3>Vancouver AI Meetup #26</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/deepdive">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-01T21:00:00-08:00" data-event-id="2026-02-01-vibe-working-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2026 · Vancouver · Workshop lead</p>
+          <h3>Vibe Working Workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-31T21:00:00-08:00" data-event-id="2026-01-31-first-tech-challenge-think-award">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2026 · Port Moody · Judge</p>
+          <h3>FIRST Tech Challenge: Think Award</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-28T22:00:00-07:00" data-event-id="van-ai-meetup-25">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #25 · Jan 2026</p>
+          <h3>Vancouver AI Meetup #25</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/liftoff">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-14T20:00:00-07:00" data-event-id="lasalle-college-keynote-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/lasalle-college-graduation.jpg?ssl=1" alt="Kris Krüg on stage at LaSalle College Vancouver asking what you would never give up to AI" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2026 · Vancouver · Keynote</p>
+          <h3>LaSalle College Vancouver</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=-c7mgY2aSgM">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-12-18T22:00:00-07:00" data-event-id="van-ai-meetup-24">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #24 · Dec 2025</p>
+          <h3>Vancouver AI Meetup #24</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/awards">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-11-26T22:00:00-07:00" data-event-id="van-ai-meetup-23">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #23 · Nov 2025</p>
+          <h3>Vancouver AI Meetup #23</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai23">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-29T22:00:00-07:00" data-event-id="van-ai-meetup-22">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #22 · Oct 2025</p>
+          <h3>Vancouver AI Meetup #22 (First Annual BC + AI Film Festival)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai22">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-24T21:00:00-07:00" data-event-id="2025-10-24-munda-mennuie-residency">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Oct 2025 · Vancouver · Host</p>
+          <h3>Munda M&#8217;ennuie Residency</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/arthurkuhn">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-22T21:00:00-07:00" data-event-id="2025-10-22-dama-day-ai-for-nonprofits-keynote">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Oct 2025 · Deloitte Summit · Keynote</p>
+          <h3>DAMA Day Vancouver: AI for Non-Profits</h3>
+          <a class="aurora-event-compact-link" href="https://damavancouverbcchapter.wildapricot.org/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-24T22:00:00-07:00" data-event-id="van-ai-meetup-21">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #21 · Sep 2025</p>
+          <h3>Vancouver AI Meetup #21</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai21">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-02T21:00:00-07:00" data-event-id="2025-09-02-amd-media-copilot-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2025 · Virtual · Workshop</p>
+          <h3>AMD Media CoPilot AI Workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-01T21:00:00-07:00" data-event-id="2025-09-01-ea-creative-innovation-keynote">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2025 · EA HQ Burnaby · Keynote</p>
+          <h3>Electronic Arts Creative Innovation Keynote</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-08-27T22:00:00-07:00" data-event-id="van-ai-meetup-20">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #20 · Aug 2025</p>
+          <h3>Vancouver AI Meetup #20</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai20">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-08-10T21:00:00-07:00" data-event-id="2025-08-10-calm-before-storm-siggraph">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Aug 2025 · Alibi Room · Host</p>
+          <h3>Calm Before the Storm #SIGGRAPH</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/siggraph2025">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-07-30T22:00:00-07:00" data-event-id="van-ai-meetup-19">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #19 · Jul 2025</p>
+          <h3>Vancouver AI Meetup #19</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/julio">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-07-11T21:00:00-07:00" data-event-id="2025-07-11-bass-coast-brain-stage">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/2025-07-11-bass-coast-brain-stage-youtube.jpg?ssl=1" alt="Kris Krug speaking on the Bass Coast Brain Stage, Synthetic Consciousness / Dear AI talk thumbnail" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2025 · Bass Coast, Merritt · Workshop</p>
+          <h3>Bass Coast Brain Stage: Dear AI</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=owtSPcpRinI">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-06-25T22:00:00-07:00" data-event-id="van-ai-meetup-18">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/surrey-ai-meetup-june-2025-080.jpg?ssl=1" alt="Vancouver AI Meetup #18" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #18 · Jun 2025</p>
+          <h3>Vancouver AI Meetup #18</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI18">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-06-03T18:00:00-07:00" data-event-id="channelnext-2025">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/channel-next.jpg?ssl=1" alt="ChannelNext keynote video thumbnail: Krüg on AI and who owns the future" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">June 2025 · Conference · Keynote</p>
+          <h3>ChannelNext</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=1OcC-0X6Nb8">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-28T22:00:00-07:00" data-event-id="van-ai-meetup-17">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/surrey-ai-meetup-may-2025-027.jpg?ssl=1" alt="Vancouver AI Meetup #17 (#WebSummit special edition)" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #17 · May 2025</p>
+          <h3>Vancouver AI Meetup #17 (#WebSummit special edition)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/websummit-vancouver">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-27T21:00:00-07:00" data-event-id="2025-05-27-web-summit-indigenomics-ai">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Web Summit Vancouver · Panelist</p>
+          <h3>Web Summit: Indigenomics AI</h3>
+          <a class="aurora-event-compact-link" href="https://vancouver.websummit.com/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-25T21:00:00-07:00" data-event-id="2025-05-25-calm-before-storm-websummit">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Alibi Room · Host</p>
+          <h3>Calm Before the Storm: Web Summit</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/LocalsOnly">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-06T21:00:00-07:00" data-event-id="2025-05-06-bc-ai-ecosystem-launch">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Zoom · Host</p>
+          <h3>BC + AI Ecosystem Launch Session</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/BCai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-04-30T22:00:00-07:00" data-event-id="van-ai-meetup-16">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #16 · Apr 2025</p>
+          <h3>Vancouver AI Meetup #16</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI16">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-04-09T20:00:00-07:00" data-event-id="2025-04-09-ted2025-community-meetup">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Apr 2025 · Vancouver · Host</p>
+          <h3>TED2025 Community Meetup</h3>
+          <a class="aurora-event-compact-link" href="https://web.archive.org/web/20250324140102/https://lu.ma/TED-Vancouver">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-03-26T22:00:00-07:00" data-event-id="van-ai-meetup-15">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #15 · Mar 2025</p>
+          <h3>Vancouver AI Meetup #15</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI15">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-03-20T21:00:00-07:00" data-event-id="2025-03-20-data-storytelling-hackathon">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Mar 2025 · Vancouver · Host</p>
+          <h3>Data Storytelling Hackathon</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2025/03/20/is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-02-26T22:00:00-07:00" data-event-id="van-ai-meetup-14">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-feb-2025-072-scaled.jpg?ssl=1" alt="Vancouver AI Meetup #14" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #14 · Feb 2025</p>
+          <h3>Vancouver AI Meetup #14</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI14">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-02-05T21:00:00-08:00" data-event-id="2025-02-05-thinking-game-premiere">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2025 · Vancouver · Host</p>
+          <h3>The Thinking Game Premiere</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/thinking">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-01-29T22:00:00-07:00" data-event-id="van-ai-meetup-13">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #13 · Jan 2025</p>
+          <h3>Vancouver AI Meetup #13</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI13">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-01-23T20:00:00-07:00" data-event-id="whistler-institute-2025">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/whistler-institute.jpg?ssl=1" alt="Whistler Institute talk video thumbnail: Building the Creative Technology Future" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2025 · Whistler</p>
+          <h3>Whistler Institute Global Speaker Series</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=-XEsqsEbpoo">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-12-15T22:00:00-07:00" data-event-id="van-ai-meetup-12">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #12 · Dec 2024</p>
+          <h3>Vancouver AI Meetup #12 (#NeurIPS special edition)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/NeurIPS2024">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-12-04T21:00:00-08:00" data-event-id="dot-summit-autoloom-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Dec 2024 (day approx) · Wosk Centre, Vancouver · Host</p>
+          <h3>Dialogue on Technology (DoT) Summit</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.beehiiv.com/p/vancouver-ai-revolution">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-11-27T22:00:00-07:00" data-event-id="van-ai-meetup-11">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-november-2024-162-scaled.jpg?ssl=1" alt="Vancouver AI Meetup #11" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #11 · Nov 2024</p>
+          <h3>Vancouver AI Meetup #11</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VanAI-11">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-11-22T21:00:00-08:00" data-event-id="adplist-fireside-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Nov 22, 2024 · Vancouver · Fireside</p>
+          <h3>ADPList Vancouver Fireside</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/ai-chat">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-10-30T22:00:00-07:00" data-event-id="van-ai-meetup-10">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #10 · Oct 2024</p>
+          <h3>Vancouver AI Meetup #10</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/letsgo">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-09-25T22:00:00-07:00" data-event-id="van-ai-meetup-09">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #9 · Sep 2024</p>
+          <h3>Vancouver AI Meetup #9</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-09-11T21:00:00-07:00" data-event-id="enya-liftoff-keynote-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2024 (day approx) · Wosk Centre, Vancouver · Keynote</p>
+          <h3>ENYA Liftoff</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/09/11/the-human-algorithm-enya-learning-keynote/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-08-28T22:00:00-07:00" data-event-id="van-ai-meetup-08">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #8 · Aug 2024</p>
+          <h3>Vancouver AI Meetup #8</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-07-31T22:00:00-07:00" data-event-id="van-ai-meetup-07">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #7 · Jul 2024</p>
+          <h3>Vancouver AI Meetup #7</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-06-26T22:00:00-07:00" data-event-id="van-ai-meetup-06">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #6 · Jun 2024</p>
+          <h3>Vancouver AI Meetup #6</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-29T22:00:00-07:00" data-event-id="van-ai-meetup-05">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #5 · May 2024</p>
+          <h3>Vancouver AI Meetup #5</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-27T21:00:00-07:00" data-event-id="bcama-vision-conference-panel-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2024 (day approx) · Vancouver · Moderator</p>
+          <h3>BCAMA Vision Conference</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-24T14:45:00-06:00" data-event-id="yorkton-film-festival-panel-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 24, 2024 · Yorkton, SK · Panel</p>
+          <h3>Yorkton Film Festival</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/05/25/ai-in-filmmaking-at-the-yorkton-film-festival/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-04-24T22:00:00-07:00" data-event-id="van-ai-meetup-04">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-april-2024-112.jpg?ssl=1" alt="Vancouver AI Meetup #4" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #4 · Apr 2024</p>
+          <h3>Vancouver AI Meetup #4</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-04-20T21:00:00-07:00" data-event-id="innovate-west-keynote-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2024 (day approx) · Vancouver · Keynote</p>
+          <h3>Innovate West</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/04/20/ai-mindset-keynote-at-innovate-west-2024-in-vancouver/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-03-27T22:00:00-07:00" data-event-id="van-ai-meetup-03">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #3 · Mar 2024</p>
+          <h3>Vancouver AI Meetup #3</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-02-28T22:00:00-07:00" data-event-id="van-ai-meetup-02">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #2 · Feb 2024</p>
+          <h3>Vancouver AI Meetup #2</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-01-31T22:00:00-07:00" data-event-id="van-ai-meetup-01">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #1 · Jan 2024</p>
+          <h3>Vancouver AI Meetup #1</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+    </div>
+  </section>
+
+<script>
+(function () {
+  var page = document.querySelector('.aurora-events-page');
+  if (!page) return;
+
+  function parseEnd(iso) {
+    var t = Date.parse(iso);
+    return Number.isFinite(t) ? t : NaN;
+  }
+
+  function syncBuckets() {
+    var now = Date.now();
+    var upcomingGrid = page.querySelector('[data-events-grid="upcoming"]');
+    var pastGrid = page.querySelector('[data-events-grid="past"]');
+    var upcomingBucket = page.querySelector('[data-events-bucket="upcoming"]');
+    var pastBucket = page.querySelector('[data-events-bucket="past"]');
+    if (!upcomingGrid || !pastGrid || !upcomingBucket || !pastBucket) return;
+
+    var cards = Array.prototype.slice.call(page.querySelectorAll('[data-event-end]'));
+    cards.sort(function (a, b) {
+      return parseEnd(b.getAttribute('data-event-end')) - parseEnd(a.getAttribute('data-event-end'));
+    });
+
+    cards.forEach(function (card) {
+      var end = parseEnd(card.getAttribute('data-event-end'));
+      if (!Number.isFinite(end)) return;
+      var target = end <= now ? pastGrid : upcomingGrid;
+      if (card.parentElement !== target) target.appendChild(card);
+    });
+
+    upcomingBucket.setAttribute('data-events-empty', upcomingGrid.children.length ? 'false' : 'true');
+    pastBucket.setAttribute('data-events-empty', pastGrid.children.length ? 'false' : 'true');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncBuckets);
+  } else {
+    syncBuckets();
+  }
+})();
+</script>
+
+<!-- EVENTS_DYNAMIC_END -->
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-host">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Series I produce &amp; host</p>
+      <h2 id="aurora-events-host">The rooms I build and keep building.</h2>
+      <p>Not one-off panels. Recurring rituals with their own crowds, collaborators, and momentum.</p>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Monthly · Vancouver</p>
+          <h3>Vancouver AI Community Meetup</h3>
+          <p>The flagship night I host and curate: builders, artists, founders, and the curious in one room every month. Demos, talks, arguments, and the occasional Squatchie Award. The heartbeat of the local scene.</p>
+          <div class="aurora-proof-tags"><span>Host &amp; curator</span><span>Monthly</span><span>Community</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">See upcoming meetups</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Weekly · Online</p>
+          <h3>BC + AI Office Hours</h3>
+          <p>Every Friday, an open working session for the BC + AI ecosystem: questions, show-and-tell, and practical help moving real AI work forward. The connective tissue between the big monthly rooms.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Weekly</span><span>Members</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/bcai">Join BC + AI on Luma</a>
+            <a class="aurora-button aurora-button-secondary" href="https://bc-ai.ca/">About BC + AI</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Monthly · Multimodal Media Lab</p>
+          <h3>AI Film Club</h3>
+          <p>Co-led with <strong>Kevin Friel</strong> and <strong>Luke Minaker</strong>: monthly screenings and hands-on accelerators for filmmakers staying human while the tools get good at everything. Building toward the 2nd Annual BC + AI Film Festival in October 2026.</p>
+          <div class="aurora-proof-tags"><span>Co-host</span><span>Screenings</span><span>Accelerators</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/film">See film events</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Ongoing · BC + AI</p>
+          <h3>The special-interest groups</h3>
+          <p>The deeper-end rooms inside the ecosystem: Mind, AI &amp; Consciousness (MAC) deepdives, the AI + Education SIG, and the AI Ethical Futures Lab, plus regional chapters spinning up beyond Vancouver.</p>
+          <div class="aurora-proof-tags"><span>MAC deepdives</span><span>AI + Education</span><span>Ethical Futures</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="https://bc-ai.ca/">Explore BC + AI</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-stages">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Stages I speak on</p>
+      <h2 id="aurora-events-stages">Keynotes, festivals, and the rooms that travel.</h2>
+      <p>A few recent ones, several with the full talk on tape.</p>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">São Paulo · Keynote</p>
+          <h3>World AI Film Festival Brasil</h3>
+          <p>Opening keynote: "How to keep our souls intact when the machines get really good at making everything." The Both Hands Full framework for filmmakers, students, and creative technologists.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="/speaking/">See speaking topics</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Vancouver · Keynote</p>
+          <h3>LaSalle College</h3>
+          <p>"Both Hands Full: what creatives actually need to know about AI." A graduation-season keynote on staying human, useful, and employable as the tools accelerate.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=-c7mgY2aSgM">Watch the keynote</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Whistler · Speaker series</p>
+          <h3>Whistler Institute Global Speaker Series</h3>
+          <p>"Inside Vancouver's AI Boom": the local scene as a case study in building AI culture that's practical, ethical, and alive instead of hype-driven.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=-XEsqsEbpoo">Watch the talk</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Conference · Keynote</p>
+          <h3>ChannelNext</h3>
+          <p>"The future of humanity: chaos &amp; creativity", a keynote that ends in a live, on-stage AI synthesis of the whole conference. The kind of risk that only works live.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=1OcC-0X6Nb8">Watch the keynote</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Web Summit Vancouver</p>
+          <h3>Calm Before the Storm</h3>
+          <p>The community night I host on the eve of the big conferences (Web Summit, SIGGRAPH), so the locals own the room before the circus arrives.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="https://lu.ma/websummit-vancouver">See the next one</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-signature">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Signature moments</p>
+      <h2 id="aurora-events-signature">The nights people still talk about.</h2>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>The Thinking Game premiere</h3>
+          <p>A documentary night at the Space Centre theatre with the AI Salon: big screen, bigger conversation.</p>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>The Squatchie Awards</h3>
+          <p>The community's tongue-in-cheek year-end recognition: Vancouver AI's answer to an awards show.</p>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>Holiday Social / BC + AI Festivus</h3>
+          <p>The end-of-year gathering where the whole ecosystem (and a birthday or two) collides.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-final-cta" aria-labelledby="aurora-events-cta">
+    <p class="aurora-kicker">Bring me to your stage, or your city</p>
+    <h2 id="aurora-events-cta">Come to a room, or let's build one.</h2>
+    <p>Follow along on Luma for what's next, or bring a keynote, workshop, or community build to your event.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">Follow on Luma</a>
+      <a class="aurora-button aurora-button-secondary" href="/speaking/">Book Kris to speak</a>
+    </div>
+  </section>
+</div>
+

--- a/content/drafts/2026-08-16-events-hero-backfill/live-vs-payload-2026-08-16.md
+++ b/content/drafts/2026-08-16-events-hero-backfill/live-vs-payload-2026-08-16.md
@@ -1,0 +1,81 @@
+# Live vs prepared payload — page 2250 `/events/` (2026-08-16)
+
+Read-only diagnosis for [#635](https://github.com/WalksWithASwagger/kriskrug-wp/issues/635).
+**No live write.** Do **not** close #635: the hero backfill has not shipped.
+
+Fetched 2026-08-16 (logged out):
+
+- `GET https://kriskrug.co/wp-json/wp/v2/pages/2250` → id **2250**, slug `events`, status `publish`, `modified` **`2026-08-10T10:38:46`** (`2026-08-10T18:38:46Z`)
+- `GET https://kriskrug.co/wp-json/wp/v2/pages?slug=events` → exactly one page, id 2250
+- Cache-bypass HTML `https://kriskrug.co/events/?cb=…` HTTP **200**
+- Live theme `style.css` Version **1.6.5** (repo `main` may differ; do not treat repo Version as production proof)
+- Public REST rendered body: [`live-content-rendered-2026-08-16.html`](./live-content-rendered-2026-08-16.html)
+  (diagnosis only; not a restore source — public REST has no `content.raw`)
+
+## What the “prepared payload” actually is
+
+There is **no** ready-to-POST HTML that already contains the ledger heroes.
+
+| Artifact | Role | Shipped to live? |
+|---|---|---|
+| `scripts/events_page/events-catalog.yaml` | SSOT for dated cards | **Yes** — 66 public ids match live, same order |
+| `scripts/events_page/render_events_page.py` + `shell-events-2250.html` | Page generator | **Yes** — dry-run HTML matches live cards/images/empties |
+| `scripts/events_page/heroes/LEDGER-2024-2025.md` (#632, merged PR #647) | Research ledger, 16 one-off rows | **No uploads** |
+| `scripts/events_page/heroes/LEDGER-2026-MEETUP.md` (#633, merged PR #648) | Research ledger, 34 meetup/one-off rows | **No uploads** |
+| `scripts/events_page/out/events-2250.generated.html` | Gitignored dry-run of *current* catalog | Matches live; **does not** include ledger heroes |
+
+#592 (archive backfill) closed complete on 2026-08-02. This issue is the **hero** successor. Catalog facts are live. Card art from the ledgers is not.
+
+## Live vs current catalog render (2026-08-16)
+
+Same 66 `data-event-id` values, same order. Generated HTML from `main` and live REST body agree on every id, every empty card, and every image card. The remaining work is **not** a body-swap of a finished file; it is media + catalog `image.media_id` + re-render + POST.
+
+| Check | Live 2250 | Current catalog render | Ledger-backed ship (not rendered yet) |
+|---|---|---|---|
+| REST `modified` | `2026-08-10T10:38:46` (IIDA Coffee add) | n/a | n/a |
+| Public dated cards | **66** | **66** (`trunorth-ai-leadership-summit-2026` stays `proposed`, skipped) | same ids; more `<img>` |
+| `aurora-event-compact-media--empty` | **49** | **49** | must drop vs 2026-08-02 baseline of **48** (today is *up* one) |
+| Cards with an `<img>` | **16** | **16** | 16 + approved ledger attaches/uploads |
+| `file:///` | **0** | **0** | must stay 0 |
+| TruNorth speaking claim | **absent** (row not public) | skipped | stay skipped / art-free |
+| Upcoming ids | IIDA Coffee, Pitch Night, Sep 30 meetup, Futureproof | same four | Sep 30 may gain a Luma cover if KK approves |
+| All 16 live event `<img>` URLs | HTTP **200** | same 16 media ids | new uploads must 200 after apply |
+
+`data-event-end` substring count on the rendered body is **70** because the rolloff script mentions the attribute; there are **66** dated cards, each with the attribute.
+
+## Already shipped (do not redo)
+
+- #592 archive backfill: 66 public cards, no `file://`, no TruNorth claim
+- Render-contract tests (#631, closed 2026-08-03): 32/32 pass on this session
+- Hero *research* ledgers (#632 / #633, both closed 2026-08-03)
+- 16 catalog rows that already have `image.media_id` (12660–12716 range plus Pitch Night 12660) and matching live `<img>`s
+- 2026-08-10 exclusive write of `iida-thermador-coffee-conversations-2026` onto page 2250 (`modified` 2026-08-10). That is a catalog-card add, **not** the hero backfill. Do **not** restore from `backup/20260801-events-backfill-ship/` as if it were current live.
+
+## Still waiting (this issue)
+
+Live-empty cards that already have a **sourced** ledger candidate (21 from the 2026 ledger headings, plus the 11 sourced 2024/2025 one-offs). None of those candidates are on live.
+
+Lowest-risk attach-only rows (existing kriskrug.co media, confirm ID before writing catalog):
+
+| Event id | Probable media ID (from public post HTML; confirm via REST) |
+|---|---|
+| `2025-03-20-data-storytelling-hackathon` | 8675 |
+| `bcama-vision-conference-panel-2024` | 5740 |
+| `enya-liftoff-keynote-2024` | 6964 |
+| `innovate-west-keynote-2024` | 5360 |
+| `yorkton-film-festival-panel-2024` | weak `og:image` template; look at media 5682–5687 first |
+
+Skip until KK says otherwise (`NO SOURCE` / no license / TruNorth):
+
+- 2024/2025: Indigenomics, EA keynote, AMD workshop, DAMA Day, ADPList (organizer art, no license)
+- 2026: TruNorth, FIRST Tech Challenge, Vibe Working, Sea to Sky gondola, Global AI Summit panel, YVR Welcome Salon, SFU AI panel
+
+KK decision gates that still block a full empty-count drop are listed in `LEDGER-2026-MEETUP.md` § “Blockers and decision gates” (photographer courtesy checks, series-fallback 2024 frames, meetup #24 credit/date, TED2025 fetch path, AEFL wrong-night photo, provisional alts).
+
+## `blocked` label
+
+Repo dependencies named on the issue (#631, #632, #633) are **closed**. The label is stale as a *code* blocker. The remaining gate is KK approval of the hero set, which #635 already records. Keep the issue **open**. Swap `blocked` for human-gated review if the board uses that signal; do not treat the issue as closeable.
+
+## Recommendation
+
+Keep #635 open. Run [`APPLY-RUNBOOK.md`](./APPLY-RUNBOOK.md) only after KK comments the approved row set (and the photographer / series-fallback rulings). Closing now would strand the ledgers with no live apply owner.

--- a/scripts/events_page/README.md
+++ b/scripts/events_page/README.md
@@ -61,7 +61,7 @@ scripts/notion-to-wp/.venv/bin/python scripts/events_page/render_events_page.py
 # → scripts/events_page/out/events-2250.generated.html
 ```
 
-5. **Apply to live** (separate phase — snapshot page 2250 first, KK approval): POST the generated HTML to WP page **2250**. Do not skip rollback snapshot.
+5. **Apply to live** (separate phase — snapshot page 2250 first, KK approval on #635): follow [`content/drafts/2026-08-16-events-hero-backfill/APPLY-RUNBOOK.md`](../../content/drafts/2026-08-16-events-hero-backfill/APPLY-RUNBOOK.md). POST the generated HTML to WP page **2250**. Do not skip rollback snapshot. Do not treat a merged runbook PR as the live write.
 
 ## Harvest merge
 


### PR DESCRIPTION
## Summary
- Read-only 2026-08-16 diff of live WP page **2250** (`/events/`) vs the catalog renderer and hero ledgers on `main` (PRs #647 / #648). Live still has **49** empty compact cards (2026-08-02 baseline was 48) and the same **16** images as the catalog. Do **not** close #635.
- Adds a snapshot-first apply/rollback runbook. No live PATCH, no media upload, no catalog write in this PR. Apply waits on KK naming the approved hero set on #635.
- Repo blockers #631 / #632 / #633 are closed. The `blocked` label is stale as a code dependency; the remaining gate is KK approval. There is no pre-baked HTML payload with new heroes.

Refs #635. Successor to #592 (archive backfill, already shipped).

## Test plan
- [x] Public REST `GET /wp-json/wp/v2/pages/2250` → id 2250, slug `events`, `modified` 2026-08-10T10:38:46
- [x] Cache-bypass `/events/` HTTP 200; 66 `data-event-id`; 49 `aurora-event-compact-media--empty`; 0 `file://`; no TruNorth
- [x] All 16 live event `<img>` URLs HTTP 200
- [x] `python3 -m unittest scripts.tests.test_events_render_contract` (32 tests, OK)
- [ ] KK names the approved ledger rows (skip every `NO SOURCE` row)
- [ ] After approval: follow `content/drafts/2026-08-16-events-hero-backfill/APPLY-RUNBOOK.md` (snapshot → media sync → render → POST content only)
- [ ] Do not merge this PR as a substitute for the live write


Made with [Cursor](https://cursor.com)