### PR TITLE
docs: 2026-08-17 apply-round work plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 
 1. [`docs/current-state/README.md`](docs/current-state/README.md) — current-state front door; run `make status-readonly` for live counters
 2. [`docs/current-state/CURRENT-STATE-2026-07-30.md`](docs/current-state/CURRENT-STATE-2026-07-30.md) — declared snapshot for drift/morning-truth (Makefile default)
-3. [`docs/current-state/WORK-PLAN-2026-08-16.md`](docs/current-state/WORK-PLAN-2026-08-16.md) — **day runbook** (2026-08-16 leftover swarm: #742 #744 #738 #740 #749 #759; 1.6.6 deploy still owed; supersedes 2026-08-15)
+3. [`docs/current-state/WORK-PLAN-2026-08-17.md`](docs/current-state/WORK-PLAN-2026-08-17.md) — **day runbook** (apply prepared payloads + deploy 1.6.7; supersedes 2026-08-16)
 4. [`docs/current-state/MASTER-PLAN-2026-07-30.md`](docs/current-state/MASTER-PLAN-2026-07-30.md) — hygiene + lane sequencing plan of record
 5. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 6. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
@@ -45,7 +45,7 @@ Legacy branch split context is in [`TWO-TRACK-MODEL.md`](docs/current-state/TWO-
 - **`.github/workflows/test-pr.yml`** — still active PR validation. Do not describe all workflows as dormant.
 - **`docs/architecture.md`, `docs/automation-guide.md`** — reference docs for the dormant swarm.
 - **`docs/cloudways-setup.md`, `docs/local-development-setup.md`, `.claude/context/wordpress-setup.md`** — Cloudways dev-server setup that was never used as planned. Relevant if/when Track B needs staging, otherwise ignore.
-- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `CURRENT-STATE-2026-07-30.md`, `WORK-PLAN-2026-08-16.md`, `MASTER-PLAN-2026-07-30.md`, and a fresh `make status-readonly` run for current truth. May–June handoffs live under `docs/current-state/archive/`.
+- **`docs/vision.md`, `docs/roadmap.md`** — early planning docs. Use `CURRENT-STATE-2026-07-30.md`, `WORK-PLAN-2026-08-17.md`, `MASTER-PLAN-2026-07-30.md`, and a fresh `make status-readonly` run for current truth. May–June handoffs live under `docs/current-state/archive/`.
 
 Anything banner-tagged `STATUS: Historical` at the top is reference-only.
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -6,7 +6,7 @@ Ops truth for [kriskrug.co](https://kriskrug.co/). Every May and June 2026 plan 
 
 Read these first:
 
-1. **[WORK-PLAN-2026-08-16.md](WORK-PLAN-2026-08-16.md)**, latest dated runbook (supersedes 2026-08-15; use `make status-readonly` for live counters)
+1. **[WORK-PLAN-2026-08-17.md](WORK-PLAN-2026-08-17.md)**, latest dated runbook (supersedes 2026-08-16; use `make status-readonly` for live counters)
 2. **[CURRENT-STATE-2026-07-30.md](CURRENT-STATE-2026-07-30.md)**, declared snapshot for morning-truth drift checks (compare it with a fresh `make status-readonly` run)
 3. **[MASTER-PLAN-2026-07-30.md](MASTER-PLAN-2026-07-30.md)**, truth then reclaim then product lanes (hygiene phases complete)
 4. Run `make status-readonly` for current signals; use the newest **[reports/morning-truth-*.md](reports/)** only as durable checkpoint evidence

--- a/docs/current-state/WORK-PLAN-2026-08-16.md
+++ b/docs/current-state/WORK-PLAN-2026-08-16.md
@@ -1,6 +1,6 @@
 # Work Plan — 2026-08-16 — Swarm the leftover stack
 
-**Status:** active day runbook. **Supersedes** [`WORK-PLAN-2026-08-15.md`](WORK-PLAN-2026-08-15.md) (its Round 1 repo work is on `main`; #733/#743 stay open only for the 1.6.6 deploy gate).
+**Status:** SUPERSEDED by [`WORK-PLAN-2026-08-17.md`](WORK-PLAN-2026-08-17.md) (prep merged; next round is live apply + 1.6.7 deploy). Historical below. **Supersedes** [`WORK-PLAN-2026-08-15.md`](WORK-PLAN-2026-08-15.md) (its Round 1 repo work is on `main`; #733/#743 stay open only for the 1.6.6 deploy gate).
 **Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
 **Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
 **Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.

--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -1,0 +1,94 @@
+# Work Plan — 2026-08-17 — Apply what is prepared
+
+**Status:** active day runbook. **Supersedes** [`WORK-PLAN-2026-08-16.md`](WORK-PLAN-2026-08-16.md) (leftover swarm produced reports and payloads; several issues were then closed on merge of *prep*, not live apply).
+**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
+**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+**Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
+
+---
+
+## Verified state (2026-08-16 evening, public readbacks)
+
+| Signal | Value | Source |
+|---|---|---|
+| Aurora live | **1.6.5** | public `style.css` readback |
+| Aurora repo | **1.6.7** | `theme/kk-aurora/style.css` on `origin/main` (`59505f1`, PR #789) |
+| Deploy gap | **two versions** (1.6.6 + 1.6.7) | live vs repo |
+| WordPress | **7.0.4** | last status-readonly |
+| Open PRs | **1** — #824 (python-tests failing; hold) | `gh pr list` |
+| Open issues | **47** | after 2026-08-17 merge wave |
+| Title format live | still `{EMDASH} Kris Krug \| …` on untitled posts | post 12653 `<title>` 2026-08-16 |
+| Post 12034 | still third person; `modified` 2026-08-01 | REST |
+| Post 12327 | still **21** em dashes; `Eth??s` | REST |
+
+## What just happened
+
+A review+merge pass landed 17 docs/runbook/payload PRs onto `main` (#812–#823, #825, #835–#838). Prep is now in the repo. **Closing an issue because the runbook merged is not the same as the live site changing.** Treat GitHub state as a hint; trust public readback.
+
+False-closed or apply-still-owed (live evidence 2026-08-16):
+
+| Issue | GitHub | Live truth |
+|---|---|---|
+| #756 / 1.6.7 title fix | closed | em dash + ASCII Krug still in `<title>` — **not deployed** |
+| #612 / #603 Zero to One | closed | still third person, mixed 130/$240 |
+| #764 Storyhive dashes | **open** | 21 dashes + `Eth??s` + 12032 `?p=11876` 404 |
+| #729 Futureproof copy | **open** | Aug 15 lines still live; payload is in merged PR #790 |
+| #602 / #635 deploys | closed | runbooks merged; live apply not verified here |
+| #122 undesigned pages | closed | closeout said **not** closeable; 24 pages still bare |
+
+Homepage redesign PRs #796 / #797 were **closed unmerged**. #411–#416 remain open with no landed code.
+
+---
+
+## Round next — do not swarm more reports
+
+The bottleneck is **live apply + theme deploy**, not more inventories. No new audit issues. No new remainder reports for work that already has an APPLY.md.
+
+### Gate 0 — KK at the keyboard (highest leverage)
+
+1. **Deploy Aurora 1.6.7** (contains 1.6.6 copy/orphan cleanup + #756 title pipe + Krüg). Pixel gate. Then **#731** Boost critical-CSS regen in the same window.
+2. **Apply #764** — `content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/fix-764/APPLY.md`. Snapshot-first. Leave `Eth??s` for its own NCR pass.
+3. **Apply #729** — `content/drafts/2026-07-26-futureproof-festival-announcement/fix-729/PAYLOAD.md`. Close Call for Talks; Earlyworm through **Aug 31**.
+4. **Apply #612** even though GitHub closed it — payload from PR #803. First person, $340/year, 300 members.
+5. **Apply #706** in **WPCode Lite** (not Code Snippets). Runbook is on PR **#824**, which is **not merged** (python-tests fail). Fix tests, merge, then apply. Pixel ID `1720755522050230`.
+
+### Gate 1 — agent crush (no live writes)
+
+Only if Gate 0 is moving. One worktree per lane. Draft PRs.
+
+| Lane | Issue | What |
+|---|---|---|
+| A | **#824** | Fix the python-tests failure and merge the #706 runbook |
+| B | **#826** | Taxonomy repair (first #402 child; unblocks the other hubs) |
+| C | **#827** | Wire internal links on `/photography/` |
+| D | **#480** | Apply-ready check of the inline-CSS retirement payloads (PR #794 merged); do not PATCH |
+| E | **#767** | REST/author-probe hardening is drafted (PR #793 merged); confirm it is still apply-ready, do not enable live |
+
+### Gate 2 — do not touch yet
+
+- Homepage #411–#416 until KK says whether to revive the closed PRs or start over.
+- Speaking W2/W3 (#640/#641) while #638-class decisions are still sticky.
+- `#481` class rename (blast-radius report now on main: live-DB landmine).
+- `#477` component migration epic.
+- `#745` slop batch (cull PR #810 was closed unmerged; nik-badminton already quarantined).
+- `#771` Gorgeous Ghost (needs publish-or-park ruling).
+- `#274` Search Console (human-only).
+- More visual-baseline PNG captures.
+
+### Gate 3 — hygiene leftovers (low, after applies)
+
+#737 cached-rm of backup HTML (proposal on main), #738 remaining worktrees, #742 script archive, #749 local PNG prune (already partly done), #690 cream aliases (PR #801 closed unmerged — re-open only if still true on 1.6.7).
+
+---
+
+## Launch prompt (Gate 1 only)
+
+> Swarm Gate 1 of WORK-PLAN-2026-08-17.md: fix #824 python-tests, then #826 taxonomy repair, #827 photography hub links, #480 apply-readiness, #767 apply-readiness. Draft PRs, no live writes, one worktree per lane. Do not file more audit issues.
+
+## Launch prompt (Gate 0, credentialed session)
+
+> Apply #764 then #729 then #612 per their APPLY.md/PAYLOAD.md on main. Snapshot-first, slug/ID check, no extra copy. Then stop for readback.
+
+---
+
+**Last verified:** 2026-08-16 evening (readbacks in the table). If you are reading this later, run `make status-readonly` and a public `style.css` readback before acting.


### PR DESCRIPTION
Opens WORK-PLAN-2026-08-17.md. Points AGENTS.md and the current-state front door at it. Banners 08-16 SUPERSEDED.

Next round is live apply + 1.6.7 deploy. Several GitHub closes were prep-only; live readbacks still fail for #612/#756/#764/#729.

Made with [Cursor](https://cursor.com)