### PR TITLE
content(#826): apply-ready taxonomy repair + 2819 contact href

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-826/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-826/APPLY.md
@@ -1,0 +1,86 @@
+# #826 APPLY: taxonomy repair + post 2819 contact href
+
+**Prepared, not applied. Do not PATCH until KK says go.**
+Script is dry-run by default. `--apply` is the only write switch.
+
+Parent: #402. This is child 1 of 9. Later hub children edit the same posts, so this lands first.
+
+## Live reconfirm (logged-out, 2026-08-17T03:30Z)
+
+Term IDs still match `scripts/seo-backfill/linkinject_lib.py`. `/contact/` returns 200.
+
+| ID | Slug | Live categories | Defect |
+|---|---|---|---|
+| 3814 | `the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things` | `[1757]` web-early-blog | 2023 MBO essay footers into the 2005 archive |
+| 3330 | `the-future-called-i-answered` | `[1757]` web-early-blog | 2023 DENT writeup in the early-blog bucket. **No baked `kk-collection-footer` today.** |
+| 1067 | `hardcore-superstar-photoshoot` | `[1662]` vancouver-ai-ecosystem | 2006 valet shoot footers into The Long Road to Futureproof |
+| 1063 | `made-in-vancouver-photoshoot` | `[1662]` vancouver-ai-ecosystem | same |
+| 1147 | `fashion-photoshoot-for-discollection` | `[1665]` ai-creatives | 2007 fashion shoot in the creatives collection |
+| 2819 | `exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out` | `[1680]` (unchanged) | one `http://www.kriskrug.com/contact` href. Categories stay. |
+
+The 2026-06 link-inject wave baked `kk-collection-footer` into `post_content` on 3814, 1067, 1063, and 1147. Recategorizing those four without a content edit would leave the old collection sentence in the body. The script swaps that one pillar `<a>` and leaves the "See also" sibling alone.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+## What the script writes
+
+| ID | REST body |
+|---|---|
+| 3814, 3330, 1067, 1063, 1147 | `categories` (replace listed primary, keep extras). Content only if a baked footer still names the old collection. |
+| 2819 | `content` only: `http://www.kriskrug.com/contact` → `https://kriskrug.co/contact/`. One occurrence. Anchor text stays "connect with me". |
+
+Titles, slugs, dates, status, featured media, tags, and SEO meta stay untouched. No Cyber Love Garden sentence on 2819 (that is #830). No MBO spokes on 3814 (that is #833).
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_826_taxonomy
+
+# Dry run: authenticated GET + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py'
+
+# Apply only after KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py --apply'
+```
+
+`--post-id 1067` limits to one post. Re-run after a successful apply prints `[SKIP]`.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-826-taxonomy/rest-post-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py --restore backup/issue-826-taxonomy/rest-post-<id>-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py --restore backup/issue-826-taxonomy/rest-post-<id>-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the six IDs or a slug mismatch.
+
+## After-apply logged-out gates
+
+```bash
+for id in 3814 3330 1067 1063 1147 2819; do
+  curl -s "https://kriskrug.co/wp-json/wp/v2/posts/${id}?_fields=id,slug,categories"
+done
+
+curl -sL "https://kriskrug.co/2006/11/15/hardcore-superstar-photoshoot/?cb=$RANDOM" \
+  | grep -o 'kk-collection-footer[^<]*'
+curl -sL "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/?cb=$RANDOM" \
+  | grep -o 'kk-collection-footer[^<]*'
+
+curl -sL "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/?cb=$RANDOM" \
+  | grep -o 'href="[^"]*contact[^"]*"'
+```
+
+Expect: 3814 categories `[1678]`; 3330 `[1676]`; 1067/1063/1147 `[1756]`; 2819 still `[1680]`. 1067 footer names Photography and Visual Storytelling, not Vancouver AI. 2819 href is `https://kriskrug.co/contact/` and has no `kriskrug.com`.
+
+## Out of payload
+
+- Post 1210 ModelMayhem 404 (#828)
+- Hub cards on 12013 / 12318 / 12316 / 12319 (#827, #829, #830, #831)
+- Meetup recaps → `/events/` (#832)
+- Page 2250 (#635)
+- `reassign_categories.py` (that is the #223 Misc classifier)

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-826/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-826/targets.json
@@ -1,0 +1,89 @@
+{
+  "issue": 826,
+  "live_reconfirm": "2026-08-17T03:30:00Z",
+  "contact_find": "http://www.kriskrug.com/contact",
+  "contact_replace": "https://kriskrug.co/contact/",
+  "term_ids": {
+    "web-early-blog": 1757,
+    "ai-ethics-philosophy": 1678,
+    "events-reports": 1676,
+    "vancouver-ai-ecosystem": 1662,
+    "ai-creatives": 1665,
+    "photography-visual-storytelling": 1756
+  },
+  "pillars": {
+    "1678": {
+      "url": "https://kriskrug.co/ai-ethics/",
+      "label": "AI Ethics and Philosophy"
+    },
+    "1676": {
+      "url": "https://kriskrug.co/ai-events/",
+      "label": "Events and Reports"
+    },
+    "1756": {
+      "url": "https://kriskrug.co/category/photography-visual-storytelling/",
+      "label": "Photography and Visual Storytelling"
+    }
+  },
+  "posts": [
+    {
+      "id": 3814,
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "url": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+      "from_category": "web-early-blog",
+      "to_category": "ai-ethics-philosophy",
+      "old_pillar_href": "https://kriskrug.co/category/web-early-blog/",
+      "old_pillar_label": "Web and Early Blog archive",
+      "modified_gmt_at_reconfirm": "2026-06-28T20:37:13"
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "url": "https://kriskrug.co/2023/09/29/the-future-called-i-answered/",
+      "from_category": "web-early-blog",
+      "to_category": "events-reports",
+      "old_pillar_href": null,
+      "old_pillar_label": null,
+      "modified_gmt_at_reconfirm": "2026-06-14T16:57:04"
+    },
+    {
+      "id": 1067,
+      "slug": "hardcore-superstar-photoshoot",
+      "url": "https://kriskrug.co/2006/11/15/hardcore-superstar-photoshoot/",
+      "from_category": "vancouver-ai-ecosystem",
+      "to_category": "photography-visual-storytelling",
+      "old_pillar_href": "https://kriskrug.co/vancouver-ai/",
+      "old_pillar_label": "Vancouver AI Ecosystem",
+      "modified_gmt_at_reconfirm": "2026-07-11T11:49:15"
+    },
+    {
+      "id": 1063,
+      "slug": "made-in-vancouver-photoshoot",
+      "url": "https://kriskrug.co/2006/11/13/made-in-vancouver-photoshoot/",
+      "from_category": "vancouver-ai-ecosystem",
+      "to_category": "photography-visual-storytelling",
+      "old_pillar_href": "https://kriskrug.co/vancouver-ai/",
+      "old_pillar_label": "Vancouver AI Ecosystem",
+      "modified_gmt_at_reconfirm": "2026-07-11T11:49:39"
+    },
+    {
+      "id": 1147,
+      "slug": "fashion-photoshoot-for-discollection",
+      "url": "https://kriskrug.co/2007/02/06/fashion-photoshoot-for-discollection/",
+      "from_category": "ai-creatives",
+      "to_category": "photography-visual-storytelling",
+      "old_pillar_href": "https://kriskrug.co/ai-for-creatives/",
+      "old_pillar_label": "AI for Creatives",
+      "modified_gmt_at_reconfirm": "2026-07-11T11:49:01"
+    },
+    {
+      "id": 2819,
+      "slug": "exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out",
+      "url": "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/",
+      "from_category": null,
+      "to_category": null,
+      "href_repair": true,
+      "modified_gmt_at_reconfirm": "2026-06-28T20:39:19"
+    }
+  ]
+}

--- a/scripts/apply_issue_826_taxonomy.py
+++ b/scripts/apply_issue_826_taxonomy.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Issue #826: recategorize five posts and repair the dead contact href on 2819.
+
+Dry-run by default. Writes are gated on ID→slug match, live category (or href)
+still matching the recorded defect, and a fresh context=edit snapshot before
+each POST.
+
+    make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py'
+    make varlock-run CMD='python3 scripts/apply_issue_826_taxonomy.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TARGETS_PATH = (
+    REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-826/targets.json"
+)
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-826-taxonomy"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-826"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(post: dict, post_id: int, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    path = SNAPSHOT_DIR / f"rest-post-{post_id}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(post, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != post:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(post: dict) -> str:
+    content = post.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {post.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    post_id = spec["id"]
+    if live.get("id") != post_id:
+        sys.exit(f"[ABORT] {post_id}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {post_id}: slug is {live.get('slug')!r}, expected {spec['slug']!r}."
+        )
+
+
+def swap_primary_category(
+    live_categories: list[int], from_id: int, to_id: int
+) -> list[int] | None:
+    if from_id not in live_categories:
+        if to_id in live_categories:
+            return None
+        raise ValueError(
+            f"live categories {live_categories} do not contain from_id {from_id}"
+        )
+    if to_id in live_categories:
+        raise ValueError(
+            f"live categories {live_categories} already contain to_id {to_id} "
+            f"and still contain from_id {from_id}"
+        )
+    return [to_id if cat == from_id else cat for cat in live_categories]
+
+
+def rewrite_footer_pillar(
+    raw: str, old_href: str, old_label: str, new_href: str, new_label: str
+) -> str | None:
+    if FOOTER_SENTINEL not in raw:
+        return None
+    needle = f'<a href="{old_href}">{old_label}</a>'
+    already = f'<a href="{new_href}">{new_label}</a>'
+    count = raw.count(needle)
+    if count == 0:
+        if already in raw:
+            return None
+        raise ValueError(
+            "baked footer present but neither the old nor the new pillar <a> was found"
+        )
+    if count != 1:
+        raise ValueError(f"old pillar <a> occurs {count} times; expected 1")
+    return raw.replace(needle, already, 1)
+
+
+def plan_post(spec: dict, live: dict, targets: dict) -> dict | None:
+    post_id = spec["id"]
+    term_ids = targets["term_ids"]
+    payload: dict = {}
+    notes: list[str] = []
+
+    if spec.get("href_repair"):
+        body = raw_body(live)
+        find = targets["contact_find"]
+        replace = targets["contact_replace"]
+        count = body.count(find)
+        if count == 0 and replace in body:
+            notes.append("contact href already repaired")
+        elif count != 1:
+            raise ValueError(
+                f"{post_id}: {find!r} occurs {count} times in content.raw; expected 1"
+            )
+        else:
+            payload["content"] = body.replace(find, replace, 1)
+            notes.append("href repair")
+    else:
+        from_id = term_ids[spec["from_category"]]
+        to_id = term_ids[spec["to_category"]]
+        live_cats = list(live.get("categories") or [])
+        new_cats = swap_primary_category(live_cats, from_id, to_id)
+        if new_cats is None:
+            notes.append("category already swapped")
+        else:
+            payload["categories"] = new_cats
+            notes.append(f"categories {live_cats} -> {new_cats}")
+
+        old_href = spec.get("old_pillar_href")
+        old_label = spec.get("old_pillar_label")
+        if old_href and old_label:
+            pillar = targets["pillars"][str(to_id)]
+            body = raw_body(live)
+            try:
+                rewritten = rewrite_footer_pillar(
+                    body, old_href, old_label, pillar["url"], pillar["label"]
+                )
+            except ValueError as exc:
+                raise ValueError(f"{post_id}: {exc}") from exc
+            if rewritten is None:
+                notes.append("no footer rewrite needed")
+            else:
+                payload["content"] = rewritten
+                notes.append("footer pillar swap")
+
+    if not payload:
+        print(f"[SKIP] {post_id}: {'; '.join(notes) or 'nothing to do'}.")
+        return None
+    return {"spec": spec, "live": live, "payload": payload, "notes": notes}
+
+
+def fetch_live(post_id: int, header: str) -> dict:
+    return request(f"{BASE_URL}/wp-json/wp/v2/posts/{post_id}?context=edit", header)
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    payload = item["payload"]
+    print(f"[PLAN] {spec['id']} {spec['slug']}: {'; '.join(item['notes'])}")
+    if "categories" in payload:
+        print(f"        categories -> {payload['categories']}")
+    if "content" in payload:
+        old = raw_body(item["live"])
+        new = payload["content"]
+        print(f"        content.raw {len(old)} chars -> {len(new)} chars")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    spec = item["spec"]
+    post_id = spec["id"]
+    print_plan(item)
+    if not do_apply:
+        return
+    live = fetch_live(post_id, header)
+    validate_identity(live, spec)
+    replanned = plan_post(spec, live, load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, post_id, stamp)
+    updated = request(
+        f"{BASE_URL}/wp-json/wp/v2/posts/{post_id}?context=edit",
+        header,
+        replanned["payload"],
+    )
+    validate_identity(updated, spec)
+    print(f"[WROTE] {post_id}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    post_id = snapshot.get("id")
+    allowed = {row["id"] for row in load_targets()["posts"]}
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #826 set.")
+    spec = next(row for row in load_targets()["posts"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {
+        "categories": snapshot.get("categories"),
+        "content": raw_body(snapshot),
+    }
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(post_id, header)
+    validate_identity(live, spec)
+    write_snapshot(live, post_id, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(f"{BASE_URL}/wp-json/wp/v2/posts/{post_id}?context=edit", header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply issue #826 taxonomy repair.")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--post-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    args = parser.parse_args()
+    header = auth_header()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, header, args.apply)
+        return 0
+
+    targets = load_targets()
+    rows = targets["posts"]
+    if args.post_id:
+        rows = [row for row in rows if row["id"] == args.post_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --post-id {args.post_id}")
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec["id"], header)
+        validate_identity(live, spec)
+        try:
+            item = plan_post(spec, live, targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print("[DRY-RUN] no WordPress writes. Pass --apply after KK approves.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_826_taxonomy.py
+++ b/scripts/tests/test_apply_issue_826_taxonomy.py
@@ -1,0 +1,262 @@
+"""Offline safety tests for the issue #826 taxonomy apply helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_826_taxonomy.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_826_taxonomy", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(post_id: int) -> dict:
+    return next(row for row in TARGETS["posts"] if row["id"] == post_id)
+
+
+def fake_post(spec: dict, *, categories=None, raw: str | None = None) -> dict:
+    if spec.get("href_repair"):
+        body = raw or (
+            '<p>If this resonates, <a href="http://www.kriskrug.com/contact">'
+            "connect with me</a>.</p>"
+        )
+        cats = categories if categories is not None else [1680]
+    else:
+        from_id = TARGETS["term_ids"][spec["from_category"]]
+        cats = categories if categories is not None else [from_id]
+        if raw is not None:
+            body = raw
+        elif spec.get("old_pillar_href"):
+            body = (
+                '<!-- wp:paragraph {"className":"kk-collection-footer"} -->\n'
+                f'<p class="kk-collection-footer">Part of the '
+                f'<a href="{spec["old_pillar_href"]}">{spec["old_pillar_label"]}</a> '
+                "collection. See also: "
+                '<a href="https://kriskrug.co/example/">Sibling</a>.</p>\n'
+                "<!-- /wp:paragraph -->"
+            )
+        else:
+            body = "<p>No collection footer on this post.</p>"
+    return {
+        "id": spec["id"],
+        "slug": spec["slug"],
+        "categories": cats,
+        "content": {"raw": body},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_826_taxonomy.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue826TaxonomyTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_post(row) for row in TARGETS["posts"]}
+
+    def _patch_request(self, calls):
+        def fake_request(url, _header, body=None):
+            post_id = int(url.split("/posts/")[1].split("?")[0])
+            calls.append((url, body))
+            live = json.loads(json.dumps(self.lives[post_id]))
+            if body is not None:
+                if "categories" in body:
+                    live["categories"] = body["categories"]
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[post_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_the_live_reconfirm_table(self):
+        ids = [row["id"] for row in TARGETS["posts"]]
+        self.assertEqual(ids, [3814, 3330, 1067, 1063, 1147, 2819])
+        self.assertEqual(TARGETS["term_ids"]["web-early-blog"], 1757)
+        self.assertEqual(TARGETS["term_ids"]["photography-visual-storytelling"], 1756)
+        self.assertEqual(TARGETS["contact_find"], "http://www.kriskrug.com/contact")
+        self.assertEqual(TARGETS["contact_replace"], "https://kriskrug.co/contact/")
+        self.assertTrue(spec_by_id(2819).get("href_repair"))
+        self.assertIsNone(spec_by_id(3330)["old_pillar_href"])
+
+    def test_swap_primary_preserves_extra_terms(self):
+        self.assertEqual(
+            MODULE.swap_primary_category([1757, 99], 1757, 1678),
+            [1678, 99],
+        )
+        self.assertIsNone(MODULE.swap_primary_category([1678], 1757, 1678))
+        with self.assertRaises(ValueError):
+            MODULE.swap_primary_category([1662], 1757, 1678)
+
+    def test_footer_rewrite_keeps_the_see_also_sibling(self):
+        spec = spec_by_id(1067)
+        pillar = TARGETS["pillars"]["1756"]
+        raw = fake_post(spec)["content"]["raw"]
+        rewritten = MODULE.rewrite_footer_pillar(
+            raw,
+            spec["old_pillar_href"],
+            spec["old_pillar_label"],
+            pillar["url"],
+            pillar["label"],
+        )
+        self.assertIsNotNone(rewritten)
+        self.assertIn(pillar["url"], rewritten)
+        self.assertIn(pillar["label"], rewritten)
+        self.assertIn("https://kriskrug.co/example/", rewritten)
+        self.assertIn("Sibling", rewritten)
+        self.assertNotIn("vancouver-ai", rewritten)
+        self.assertIsNone(
+            MODULE.rewrite_footer_pillar(
+                rewritten,
+                spec["old_pillar_href"],
+                spec["old_pillar_label"],
+                pillar["url"],
+                pillar["label"],
+            )
+        )
+
+    def test_dry_run_performs_no_local_or_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[1067]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--post-id", "1067")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_snapshots_then_posts_categories_and_footer(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--post-id", "1067"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(writes[0]["categories"], [1756])
+        self.assertIn("photography-visual-storytelling", writes[0]["content"])
+        self.assertIn("Sibling", writes[0]["content"])
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_3330_is_category_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--post-id", "3330"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(writes[0], {"categories": [1676]})
+
+    def test_2819_replaces_exactly_one_dead_href_and_leaves_categories(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--post-id", "2819"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertNotIn("categories", writes[0])
+        self.assertEqual(
+            writes[0]["content"].count("http://www.kriskrug.com/contact"), 0
+        )
+        self.assertEqual(writes[0]["content"].count("https://kriskrug.co/contact/"), 1)
+        self.assertIn("connect with me", writes[0]["content"])
+
+    def test_2819_aborts_if_the_dead_href_is_missing_or_duplicated(self):
+        self.lives[2819]["content"]["raw"] = "<p>no contact link</p>"
+        with mock.patch.object(MODULE, "request", side_effect=self._patch_request([])):
+            with self.assertRaises(SystemExit):
+                run_main("--post-id", "2819")
+        self.lives[2819] = fake_post(
+            spec_by_id(2819),
+            raw=(
+                '<a href="http://www.kriskrug.com/contact">a</a>'
+                '<a href="http://www.kriskrug.com/contact">b</a>'
+            ),
+        )
+        with mock.patch.object(MODULE, "request", side_effect=self._patch_request([])):
+            with self.assertRaises(SystemExit):
+                run_main("--post-id", "2819")
+
+    def test_skip_when_already_applied(self):
+        spec = spec_by_id(3814)
+        pillar = TARGETS["pillars"]["1678"]
+        self.lives[3814] = fake_post(
+            spec,
+            categories=[1678],
+            raw=fake_post(spec)["content"]["raw"].replace(
+                f'<a href="{spec["old_pillar_href"]}">{spec["old_pillar_label"]}</a>',
+                f'<a href="{pillar["url"]}">{pillar["label"]}</a>',
+            ),
+        )
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            self.assertEqual(0, run_main("--apply", "--post-id", "3814"))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (
+            MODULE.REPO_ROOT
+            / "content/drafts/2026-08-02-seo-authority-hubs/fix-826/APPLY.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #826.

## Summary
- Live reconfirm 2026-08-17: posts 3814, 3330, 1067, 1063, 1147 are still in the wrong category. Post 2819 still has one `http://www.kriskrug.com/contact` href. `/contact/` returns 200.
- Apply helper is dry-run by default. It swaps the listed primary category (keeps extras), rewrites the baked `kk-collection-footer` pillar `<a>` on the four posts that have one, and does a one-occurrence href replace on 2819. Slug check + snapshot before every POST.
- 3330 has no baked footer today, so it is category-only.
- **No WordPress write in this PR.** Unblocks #827 and the other #402 hub children after KK applies.

## Test plan
- [x] `python3 -m unittest scripts.tests.test_apply_issue_826_taxonomy`
- [x] Logged-out REST: term IDs and the six slugs still match `targets.json`
- [ ] Do not run `--apply` until KK approves the dry-run diff
- [ ] After apply: cache-busted footer greps on 1067 and 3814; 2819 href is `https://kriskrug.co/contact/`

Made with [Cursor](https://cursor.com)