### PR TITLE
docs: drop the stale functions.php voice waiver after 1.6.7

### DIFF
--- a/.voice-waivers.json
+++ b/.voice-waivers.json
@@ -19,13 +19,6 @@
   ],
   "waivers": [
     {
-      "path": "theme/kk-aurora/functions.php",
-      "sha256": "0ac137f73b21b3d1b902471f83437888dd5816e3f10c282bc6701b8b460322fb",
-      "rules": ["em-dash"],
-      "issue": "#756",
-      "reason": "TEMPORARY exact baseline for the confirmed theme-owned document title separator. PR #751 changes only the 1.6.6 cache-busting constant in this file; #756 remains decision and deploy gated."
-    },
-    {
       "path": "content/drafts/2026-07-26-client-logo-soup/copy.md",
       "sha256": "6fcd2d521bb9cc6b6c114b9d475a2753f93044a719055ab4a19bdd46394a103f",
       "rules": ["slop:delve"],


### PR DESCRIPTION
Refs #756.

The #756 functions.php waiver was SHA-pinned to the pre-1.6.7 file. PR #789 changed that file, so the waiver no longer matched and was already inert. This removes the leftover entry. Voice-check still passes.

No theme or WordPress change.

Made with [Cursor](https://cursor.com)