### PR TITLE
docs: archive superseded 08-09/15/16 work plans

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,7 +14,7 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 |---|---|
 | [`current-state/README.md`](current-state/README.md) | Index; front door pointers |
 | [`current-state/CURRENT-STATE-2026-07-30.md`](current-state/CURRENT-STATE-2026-07-30.md) | Declared snapshot for drift checks (WP 7.0.4; Aurora live and repo `main` in sync at 1.6.5, readback 2026-08-15) |
-| [`current-state/WORK-PLAN-2026-08-16.md`](current-state/WORK-PLAN-2026-08-16.md) | **Active day runbook** (supersedes 2026-08-15) |
+| [`current-state/WORK-PLAN-2026-08-17.md`](current-state/WORK-PLAN-2026-08-17.md) | **Active day runbook** (supersedes 2026-08-16) |
 | [`current-state/MASTER-PLAN-2026-07-30.md`](current-state/MASTER-PLAN-2026-07-30.md) | Truth → reclaim → product lanes |
 | [`current-state/TWO-TRACK-MODEL.md`](current-state/TWO-TRACK-MODEL.md) | Active Track A / Track B decision rule |
 | [`current-state/ACCESS_CHANNELS.md`](current-state/ACCESS_CHANNELS.md) | MCP / REST / Chrome / SSH — what works today |

--- a/docs/current-state/CURRENT-STATE-2026-07-30.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-30.md
@@ -6,7 +6,7 @@
 
 This file is the declared snapshot for `make current-state-drift-check` / `make morning-truth` / `make status-readonly` (via `WORK_PLAN` / `WORK_PLAN_DEFAULT`).
 
-Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Latest dated runbook: [`WORK-PLAN-2026-08-16.md`](WORK-PLAN-2026-08-16.md).
+Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Latest dated runbook: [`WORK-PLAN-2026-08-17.md`](WORK-PLAN-2026-08-17.md).
 
 ## Verified State
 

--- a/docs/current-state/MASTER-PLAN-2026-07-30.md
+++ b/docs/current-state/MASTER-PLAN-2026-07-30.md
@@ -4,7 +4,7 @@
 **Lane:** Docs / ops first; then Track A or Track B — never interleaved in one commit.
 **Does not authorize** live WordPress writes, theme deploys, or history rewrite.
 
-Day runbook: [`WORK-PLAN-2026-08-16.md`](WORK-PLAN-2026-08-16.md). Declared snapshot: [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+Day runbook: [`WORK-PLAN-2026-08-17.md`](WORK-PLAN-2026-08-17.md). Declared snapshot: [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
 
 ## Goal
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -14,7 +14,7 @@ Read these first:
 6. **[INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)**, slug/idempotency safety rules. Dated May, deliberately kept at top level: it is a standing safety rule, not a plan.
 7. **[../../.env.schema](../../.env.schema)** plus **[VARLOCK-ROLLOUT-2026-07-16.md](VARLOCK-ROLLOUT-2026-07-16.md)**, env contract (never read plaintext `.env`)
 
-**Live readback 2026-08-16:** WordPress `7.0.4`. Aurora **live is `1.6.5`**; repo `main` is **`1.6.6`** (PR #751, `dcb7ff4`). That is deploy drift, not a surprise source fork. The public `style.css` readback remains authoritative for production theme state. Read back, do not assume, in either direction.
+**Live readback 2026-08-16:** WordPress `7.0.4`. Aurora **live is `1.6.5`**; repo `main` is **`1.6.7`** (PR #789, includes 1.6.6). That is deploy drift, not a surprise source fork. The public `style.css` readback remains authoritative for production theme state. Read back, do not assume, in either direction.
 
 ## Durable process docs (keep at top level)
 
@@ -64,6 +64,9 @@ Every file below carries a `STATUS: Historical` banner in its first lines pointi
 - [WORK-PLAN-2026-07-19.md](archive/WORK-PLAN-2026-07-19.md)
 - [WORK-PLAN-2026-07-25.md](archive/WORK-PLAN-2026-07-25.md)
 - [WORK-PLAN-2026-07-26.md](archive/WORK-PLAN-2026-07-26.md)
+- [WORK-PLAN-2026-08-09.md](archive/WORK-PLAN-2026-08-09.md)
+- [WORK-PLAN-2026-08-15.md](archive/WORK-PLAN-2026-08-15.md)
+- [WORK-PLAN-2026-08-16.md](archive/WORK-PLAN-2026-08-16.md)
 
 ## Archive (#549 close-out, verified 2026-08-02)
 

--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -1,6 +1,6 @@
 # Work Plan — 2026-08-17 — Apply what is prepared
 
-**Status:** active day runbook. **Supersedes** [`WORK-PLAN-2026-08-16.md`](WORK-PLAN-2026-08-16.md) (leftover swarm produced reports and payloads; several issues were then closed on merge of *prep*, not live apply).
+**Status:** active day runbook. **Supersedes** [`WORK-PLAN-2026-08-16.md`](archive/WORK-PLAN-2026-08-16.md) (leftover swarm produced reports and payloads; several issues were then closed on merge of *prep*, not live apply).
 **Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
 **Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
 **Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
@@ -76,7 +76,7 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ### Gate 3 — hygiene leftovers (low, after applies)
 
-#737 cached-rm of backup HTML (proposal on main), #738 remaining worktrees, #742 script archive, #749 local PNG prune (already partly done), #690 cream aliases (PR #801 closed unmerged — re-open only if still true on 1.6.7).
+#737 cached-rm of backup HTML (proposal on main), #738 remaining parked remotes (laptop worktrees cleared 2026-08-16), #742 script archive, #749 local PNG prune (already partly done), #690 cream aliases (PR #801 closed unmerged; re-open only if still true on 1.6.7).
 
 ---
 

--- a/docs/current-state/archive/WORK-PLAN-2026-08-09.md
+++ b/docs/current-state/archive/WORK-PLAN-2026-08-09.md
@@ -1,8 +1,8 @@
 # Work Plan — 2026-08-09
 
 **Status:** SUPERSEDED by [`WORK-PLAN-2026-08-15.md`](WORK-PLAN-2026-08-15.md) (lanes closed or absorbed; the 2026-08-15 audit round took over). Historical below. **Superseded** `WORK-PLAN-2026-08-05.md` (deploy window never opened; gap widened to three versions; new critical repo-integrity lane).
-**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
-**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md) (counts drifted — see verified state below).
+**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](../MASTER-PLAN-2026-07-30.md).
+**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](../CURRENT-STATE-2026-07-30.md) (counts drifted — see verified state below).
 **Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
 
 ---

--- a/docs/current-state/archive/WORK-PLAN-2026-08-15.md
+++ b/docs/current-state/archive/WORK-PLAN-2026-08-15.md
@@ -1,8 +1,8 @@
 # Work Plan — 2026-08-15 — Audit Round
 
 **Status:** SUPERSEDED by [`WORK-PLAN-2026-08-16.md`](WORK-PLAN-2026-08-16.md) (Round 1 repo work landed; leftover agent-safe slices and the 1.6.6 deploy gate moved to the 16th). Historical below. **Supersedes** `WORK-PLAN-2026-08-09.md` (its lanes closed or absorbed: gitdir rescue done, truth re-baselined, the 1.6.1–1.6.4 deploy window executed, hygiene swept).
-**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
-**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](../MASTER-PLAN-2026-07-30.md).
+**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](../CURRENT-STATE-2026-07-30.md).
 **Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
 
 ---
@@ -30,7 +30,7 @@ The 2026-08-15 full-project audit (code, docs, brand, voice, deadlines) produced
 
 ## Round 1 — launch now (all `agent:ready` + `swarm-ready`, no KK input required)
 
-Concurrency rules: **one worktree per lane** (multiple sessions often share this tree), lane-scoped commits, PRs start as drafts. Content/docs PRs may use the `agent-safe-merge` path per [`AGENT-MERGE-PATH-2026-07-26.md`](AGENT-MERGE-PATH-2026-07-26.md); theme PRs merge only with KK approval.
+Concurrency rules: **one worktree per lane** (multiple sessions often share this tree), lane-scoped commits, PRs start as drafts. Content/docs PRs may use the `agent-safe-merge` path per [`AGENT-MERGE-PATH-2026-07-26.md`](../AGENT-MERGE-PATH-2026-07-26.md); theme PRs merge only with KK approval.
 
 | Lane | Issues (in order) | Notes |
 |---|---|---|

--- a/docs/current-state/archive/WORK-PLAN-2026-08-16.md
+++ b/docs/current-state/archive/WORK-PLAN-2026-08-16.md
@@ -1,8 +1,8 @@
 # Work Plan — 2026-08-16 — Swarm the leftover stack
 
-**Status:** SUPERSEDED by [`WORK-PLAN-2026-08-17.md`](WORK-PLAN-2026-08-17.md) (prep merged; next round is live apply + 1.6.7 deploy). Historical below. **Supersedes** [`WORK-PLAN-2026-08-15.md`](WORK-PLAN-2026-08-15.md) (its Round 1 repo work is on `main`; #733/#743 stay open only for the 1.6.6 deploy gate).
-**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
-**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+**Status:** SUPERSEDED by [`WORK-PLAN-2026-08-17.md`](../WORK-PLAN-2026-08-17.md) (prep merged; next round is live apply + 1.6.7 deploy). Historical below. **Supersedes** [`WORK-PLAN-2026-08-15.md`](WORK-PLAN-2026-08-15.md) (its Round 1 repo work is on `main`; #733/#743 stay open only for the 1.6.6 deploy gate).
+**Plan of record:** [`MASTER-PLAN-2026-07-30.md`](../MASTER-PLAN-2026-07-30.md).
+**Declared snapshot:** [`CURRENT-STATE-2026-07-30.md`](../CURRENT-STATE-2026-07-30.md).
 **Does not authorize** any live WordPress write. Dry-run, slug/ID checks, snapshots, and KK approval still apply.
 
 ---

--- a/docs/current-state/reports/hygiene-738-740-2026-08-16.md
+++ b/docs/current-state/reports/hygiene-738-740-2026-08-16.md
@@ -1,0 +1,30 @@
+# Hygiene receipt — 2026-08-16 evening (#738 / #740)
+
+**Mode:** repo hygiene only. No live WordPress writes. No theme deploy.
+
+## #738 branches and worktrees
+
+Laptop `git worktree list` is back to the primary checkout on `main`. The 2026-08-16 leftover `/private/tmp/kriskrug-wp-*` and `/Users/kk/Code/.worktrees/*` checkouts are gone.
+
+`origin` heads that remain are parked on purpose, not merge candidates:
+
+| Remote | Why it stays |
+|---|---|
+| `cursor/publications-aurora-tearsheet` | SHA recovery ref. Content blobs already match `main`. |
+| `cursor/homepage-411-412-413-e0bc` | Closed PR #796. CI red (css-ratchet). Revive after a CSS-budget waiver, stacked on 1.6.7. |
+| `cursor/homepage-414-415-416-34d1` | Closed PR #797. Same CSS-budget hold. Stack after #796. |
+| `cursor/issue-745-cull-516c` | Closed PR #810. KK only approved the nik-badminton archive. |
+| `cursor/hygiene-execute-740-738-516c` | Closed PR #795. 26-file archive is wider than the approved plan list. |
+| `theme/690-cream-elevated-alias` | Closed PR #801. Tiny later PR after 1.6.7 is live. |
+
+Do not raw-merge any of those heads.
+
+## #740 docs archive (this PR)
+
+Moved only the three superseded day runbooks into `docs/current-state/archive/`:
+
+- `WORK-PLAN-2026-08-09.md`
+- `WORK-PLAN-2026-08-15.md`
+- `WORK-PLAN-2026-08-16.md`
+
+Front door now points at `WORK-PLAN-2026-08-17.md`. The 26-file durable-doc archive from PR #795 stays unmerged.

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -126,9 +126,7 @@ ACTIVE_GUIDANCE_PATHS = {
     Path("README.md"),
     Path("docs/INDEX.md"),
     Path("docs/current-state/README.md"),
-    Path("docs/current-state/WORK-PLAN-2026-08-09.md"),
-    Path("docs/current-state/WORK-PLAN-2026-08-15.md"),
-    Path("docs/current-state/WORK-PLAN-2026-08-16.md"),
+    Path("docs/current-state/WORK-PLAN-2026-08-17.md"),
     Path("docs/current-state/MASTER-PLAN-2026-07-30.md"),
 }
 

--- a/scripts/tests/test_docs_truth_check.py
+++ b/scripts/tests/test_docs_truth_check.py
@@ -13,7 +13,7 @@ class EphemeralMorningTruthGuidanceTests(unittest.TestCase):
     def test_active_guidance_rejects_routine_report_commit_flow(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            work_plan = repo_root / "docs/current-state/WORK-PLAN-2026-08-09.md"
+            work_plan = repo_root / "docs/current-state/WORK-PLAN-2026-08-17.md"
             work_plan.parent.mkdir(parents=True)
             work_plan.write_text(
                 "1. `make morning-truth` while online.\n"


### PR DESCRIPTION
Refs #740. Refs #738.

## What
`git mv` the three superseded day runbooks into `docs/current-state/archive/`. Front door, INDEX, MASTER-PLAN, CURRENT-STATE, and the docs-truth-check active-guidance list now point at `WORK-PLAN-2026-08-17.md`.

## What this is not
- Not the 26-file durable-doc archive from closed PR #795 (wider than the approved plan list).
- Not a merge of parked remotes: homepage #796/#797, #745 cull, #690 cream aliases, publications tearsheet.

Laptop worktrees from the #738 sweep are already gone. Remaining remotes are parked on purpose.

No live WordPress writes. No theme deploy.

Made with [Cursor](https://cursor.com)