### PR TITLE
theme(#690): honest Cream Elevated alias (no CSS, no version bump)

### DIFF
--- a/scripts/tests/test_aurora_contrast_tokens.py
+++ b/scripts/tests/test_aurora_contrast_tokens.py
@@ -33,6 +33,17 @@ class AuroraContrastTokenTests(unittest.TestCase):
         theme = json.loads((THEME_DIR / "theme.json").read_text(encoding="utf-8"))
         palette = theme["settings"]["color"]["palette"]
         self.colors = {entry["slug"]: entry["color"] for entry in palette}
+        self.names = {entry["slug"]: entry["name"] for entry in palette}
+
+    def test_surface_and_elevated_preset_slugs_are_kept(self):
+        """#690: never delete these slugs; live editor/content may reference them."""
+        self.assertIn("surface", self.colors)
+        self.assertIn("elevated", self.colors)
+        self.assertEqual(self.colors["surface"].lower(), "#e6dcc2")
+        self.assertEqual(
+            self.colors["elevated"].lower(), self.colors["surface"].lower()
+        )
+        self.assertIn("same as Panel", self.names["elevated"])
 
     def test_text_tokens_meet_wcag_aa_on_dark_surfaces(self):
         foregrounds = ("text-primary", "text-secondary", "text-muted", "signal")

--- a/theme/kk-aurora/theme.json
+++ b/theme/kk-aurora/theme.json
@@ -33,7 +33,7 @@
         },
         {
           "slug": "elevated",
-          "name": "Cream Elevated",
+          "name": "Cream Elevated (same as Panel)",
           "color": "#e6dcc2"
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #690.

Cherry-pick of closed #801, shrunk. Editor swatch name becomes **Cream Elevated (same as Panel)**. Hex stays `#e6dcc2`. Both slugs kept. No `02-tokens.css` comment bloat, no Aurora version bump.

Track B, but this is a palette *name* only. No visual change. Closed #801 blew css-ratchet on extra comments and assumed a 1.6.9 cut on top of unmerged homepage work.
<!-- CURSOR_AGENT_PR_BODY_END -->

Made with [Cursor](https://cursor.com)