### PR TITLE
content(#745): park triage markers without culling drafts

### DIFF
--- a/content/drafts/2026-05-24-community-washed-capitalism-when-volunteering-becomes-unpaid-labor-at-scale/SHELVED.md
+++ b/content/drafts/2026-05-24-community-washed-capitalism-when-volunteering-becomes-unpaid-labor-at-scale/SHELVED.md
@@ -1,0 +1,9 @@
+# SHELVED
+
+**STATUS: shelved**. Do not publish.
+
+Real argument (AI Summit Vancouver 2025 steering-committee volunteer call; unpaid labor at scale). Reputational: publishing this unsigned and unhedged under KK's name torches the volunteer pipeline. Worth keeping. Not worth shipping without a KK rethink.
+
+Leave in `content/drafts/` so the source is findable. Do not treat this folder as a publish candidate.
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A4. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-gender-balance-email-post-vancouver-ai/SHELVED.md
+++ b/content/drafts/2026-05-24-gender-balance-email-post-vancouver-ai/SHELVED.md
@@ -1,0 +1,9 @@
+# SHELVED
+
+**STATUS: shelved**. Do not publish.
+
+Real KK voice, but it is an email draft plus a community post draft, not a blog post. References a specific call with Alexandra Samuel and a Jan 28 keynote. Needs KK's call on whether any of it goes public and in what form.
+
+Leave in `content/drafts/` so the source is findable. Do not let a publish run treat this as a post.
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A4. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-how-to-build-an-ungovernable-life-and-why-youd-want-to/SHELVED.md
+++ b/content/drafts/2026-05-24-how-to-build-an-ungovernable-life-and-why-youd-want-to/SHELVED.md
@@ -1,0 +1,9 @@
+# SHELVED
+
+**STATUS: shelved**. Do not publish.
+
+Best prose in the archive-import population, but it is a personal-brand manifesto with no dates, no names, no receipts, and a third-person bio sign-off. Overlaps heavily with the live `/about/` page. Only reopen if KK actively wants a manifesto post.
+
+Leave in `content/drafts/` so the source is findable. Do not treat this folder as queued work.
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A4. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-how-we-did-it-behind-the-scenes-of-the-sfu-siat-microcredential-project/STATUS.md
+++ b/content/drafts/2026-05-24-how-we-did-it-behind-the-scenes-of-the-sfu-siat-microcredential-project/STATUS.md
@@ -1,0 +1,9 @@
+# WITHDRAWN
+
+**Status:** WITHDRAWN. Confidential, do not publish.
+
+KK ruled 2026-06-14: DO NOT PUBLISH. The gate is permanently closed. Keep WP `12038` as an unpublished `draft`. Do not reopen this folder as a rewrite or publish candidate.
+
+This file is the folder-root marker matching the SUPERSEDED / publish-gate pattern. The same ruling is already in [`publish-gate.md`](publish-gate.md).
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A2. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-keynote-music-elevation-series-haus-of-owl/SHELVED.md
+++ b/content/drafts/2026-05-24-keynote-music-elevation-series-haus-of-owl/SHELVED.md
@@ -1,0 +1,9 @@
+# SHELVED
+
+**STATUS: shelved**. Do not publish.
+
+Not prose. A Fabric-style `extract_wisdom` dump (`## SUMMARY`, `## IDEAS`, `## QUOTES`) from a real Haus of Owl Music Elevation Series keynote. Source material for a future Haus of Owl piece, not a post. Pair with the already-live Haus of Owl material (WP 12327) if mined later.
+
+Leave in `content/drafts/` as a transcript extract. Do not treat this folder as a publish candidate.
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A4. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-kris-krugs-laws-of-digital-nomadism/SHELVED.md
+++ b/content/drafts/2026-05-24-kris-krugs-laws-of-digital-nomadism/SHELVED.md
@@ -1,0 +1,9 @@
+# SHELVED
+
+**STATUS: shelved**. Do not publish.
+
+Quote bank of 45 numbered aphorisms, not a post. A handful may be things KK actually says; most are fortune-cookie voice. Cull it as a post. Nobody should publish 45 AI-generated laws under KK's name.
+
+Leave in `content/drafts/` as a quote bank. Do not treat this folder as a publish candidate.
+
+Source of truth: [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) A4. Issue [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745).

--- a/content/drafts/2026-05-24-nobel-chemistry-foldit/REWRITE.md
+++ b/content/drafts/2026-05-24-nobel-chemistry-foldit/REWRITE.md
@@ -1,0 +1,15 @@
+# REWRITE
+
+**Status:** rewrite candidate. Do not publish this prose.
+
+This package stays in `content/drafts/` as a keeper. The current text is unpublishable (outline wearing a prose costume, slop lexicon, overclaim on the Foldit credit). **Discard 100% of the current prose.** Rewrite from scratch in a later scoped issue; this file is the marker, not the rewrite.
+
+**Keep (premise + receipts), per** [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) **A3:**
+
+- Foldit player participation that led to a collective "Foldit players" author credit in a Nature protein-folding paper
+- The line from that citizen-science work to David Baker's 2024 Nobel in Chemistry
+- The games / amateurs-beating-institutions frame
+
+**Gate before any rewrite ships:** verify the credit is the *collective* "Foldit players" author credit, not a personal byline. The current draft overclaims ("credited alongside lab-coat geniuses and computational wizards").
+
+Issue: [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745). KK ruling 2026-08-17: cull unpublished junk; rewrite keepers. Rewrite is not in this PR.

--- a/content/drafts/2026-05-24-smudging-the-lines-humanity-embodiment-and-ai-in-the-creative-process/REWRITE.md
+++ b/content/drafts/2026-05-24-smudging-the-lines-humanity-embodiment-and-ai-in-the-creative-process/REWRITE.md
@@ -1,0 +1,13 @@
+# REWRITE
+
+**Status:** rewrite candidate. Do not publish this prose.
+
+This package stays in `content/drafts/` as a keeper. The current file is a second-person writer brief, not a post. **Keep the premise and the three sources. Discard 100% of the current text.** Rewrite in a later scoped issue; this file is the marker, not the rewrite.
+
+**Keep, per** [`docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md`](../../../docs/current-state/reports/draft-triage-2026-05-24-batch-20260815.md) **A3:**
+
+- Premise: driving, working out why AI art feels like it is missing something, 20 years of photographic eye
+- Embodiment rather than ethics as the answer
+- Sources: Merleau-Ponty on embodiment, Benjamin on aura, Lanier
+
+Issue: [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745). KK ruling 2026-08-17: cull unpublished junk; rewrite keepers. Rewrite is not in this PR.

--- a/docs/current-state/reports/draft-cull-745-2026-08-17.md
+++ b/docs/current-state/reports/draft-cull-745-2026-08-17.md
@@ -1,0 +1,81 @@
+# Draft triage markers: #745 (parked cull)
+
+**Issue:** [#745](https://github.com/WalksWithASwagger/kriskrug-wp/issues/745)
+**Source of truth:** [`draft-triage-2026-05-24-batch-20260815.md`](draft-triage-2026-05-24-batch-20260815.md)
+**This PR:** park the triage as folder markers. **Does not cull.** **Does not close #745.** No live WordPress writes. No rewrite of keeper prose. No archive of Population A live-post folders.
+
+Closed PR #810 would have `git mv`'d 14 unpublished packages into `content/drafts/archive/`. KK only approved archiving `nik-badminton` (already on `main`). The 14 A5 packages stay in `content/drafts/` until KK says cull.
+
+---
+
+## Already archived
+
+`2026-05-24-nik-badminton-a-sassy-critique-setting-the-ai-record-straight` (2026-08-16). See [`content/drafts/archive/README.md`](../../../content/drafts/archive/README.md).
+
+---
+
+## Proposed A5 cull (not moved)
+
+These 14 still live under `content/drafts/`. Publishing scripts can still see them. Cull only after an explicit KK yes.
+
+| Package | Why (triage A5) |
+|---|---|
+| `2026-05-24-outline-for-droid-army-post` | Outline, not a post. Private chat-session URLs in the package. |
+| `2026-05-24-funding-for-journalism-startups-and-media-companies-in-2023` | 2023 generic filler. |
+| `2026-05-24-human-element-shane-loki-talk` | Sales-bro slop; no event detail. |
+| `2026-05-24-the-synthetic-renaissance-beyond-prompts-parameters` | LinkedIn post, not a blog post. |
+| `2026-05-24-finding-harmony-in-the-age-of-ai-a-digital-alchemists-guide-to-the-future` | Slop; Galiano origin already told in `2026-05-21-the-75-percent-rule`. |
+| `2026-05-24-guide-to-hacking-language-and-dismantling-colonialism` | Machine-written decolonization guidance; no consultation. |
+| `2026-05-24-why-100-young-canadians-are-writing-canadas-ai-future-and-why-bc-needs-to-show-up` | Time-expired calendar item. |
+| `2026-05-24-canada-media-fund-prototyping-spektorai` | Grant application, not a post. |
+| `2026-05-24-how-a-late-night-brain-dump-became-a-multimedia-thought-leadership-machine` | Writer brief, not a post. |
+| `2026-05-24-transmuting-words-into-gold-in-the-age-of-ai` | Duplicate outline; generic marketing. |
+| `2026-05-24-born-for-this-co-creative-age` | Bare scaffold. |
+| `2026-05-24-rewiring-education-hacking-the-system-for-an-ai-powered-future` | Outline only. |
+| `2026-05-24-future-proof-chaos-building-the-creative-tech-utopia` | Outline only. |
+| `2026-05-24-the-inside-out-evolution-how-ai-turned-this-old-dogs-brain-inside-out-and-why-youre-next` | Outline only. |
+
+---
+
+## Keepers marked (2). Prose not rewritten.
+
+| Folder | Marker |
+|---|---|
+| `2026-05-24-nobel-chemistry-foldit` | `REWRITE.md`: keep Foldit / Nature / Baker Nobel receipts; discard current prose; verify collective "Foldit players" credit before any rewrite. |
+| `2026-05-24-smudging-the-lines-humanity-embodiment-and-ai-in-the-creative-process` | `REWRITE.md`: keep premise + Merleau-Ponty / Benjamin / Lanier; discard 100% of current text. |
+
+Scoped rewrite issues are still owed (issue #745 AC). Not filed in this slice.
+
+---
+
+## A4 shelve markers (5). Left in `content/drafts/`.
+
+| Folder | Marker |
+|---|---|
+| `2026-05-24-community-washed-capitalism-when-volunteering-becomes-unpaid-labor-at-scale` | `SHELVED.md` |
+| `2026-05-24-gender-balance-email-post-vancouver-ai` | `SHELVED.md` |
+| `2026-05-24-kris-krugs-laws-of-digital-nomadism` | `SHELVED.md` |
+| `2026-05-24-keynote-music-elevation-series-haus-of-owl` | `SHELVED.md` |
+| `2026-05-24-how-to-build-an-ungovernable-life-and-why-youd-want-to` | `SHELVED.md` |
+
+Triage said leave these in the queue as source material, not posts. Markers only; no `git mv`.
+
+---
+
+## WITHDRAWN (left in place)
+
+`2026-05-24-how-we-did-it-behind-the-scenes-of-the-sfu-siat-microcredential-project` already had `Status: WITHDRAWN` in `publish-gate.md` (KK 2026-06-14, WP 12038 stays draft). Folder-root `STATUS.md` matches the SUPERSEDED pattern so a future pass cannot miss it. Not reopened.
+
+---
+
+## Population A live-post folders (5). Untouched.
+
+Per KK long-cut gate, **not archived, not marked, not edited:**
+
+| Folder | Live WP |
+|---|---|
+| `2026-05-24-agent-orchestrators-creative-insurgents-the-new-stack` | 12033 |
+| `2026-05-24-ai-wont-fix-your-broken-permit-process` | 12035 |
+| `2026-05-24-canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` | 12030 (local is the longer cut) |
+| `2026-05-24-what-would-chat-do-and-why-thats-the-wrong-question` | 12032 |
+| `2026-05-24-zero-to-one-from-meetup-to-movement-bc-ais-grassroots-journey` | 12034 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #745. Does **not** close it.

Cherry-pick of closed #810, shrunk. KK only approved archiving `nik-badminton` (already on main). This PR:

- Adds `SHELVED.md` / `REWRITE.md` / `STATUS.md` markers
- Parks the proposed A5 cull list in `docs/current-state/reports/draft-cull-745-2026-08-17.md`
- Leaves the 14 unpublished packages in `content/drafts/`
- Leaves Population A live-post folders untouched

No live WordPress writes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Made with [Cursor](https://cursor.com)