### PR TITLE
docs: 1.6.8 homepage closeout; live is 1.6.7

### DIFF
--- a/docs/current-state/AURORA-RELEASE-CHECKLIST.md
+++ b/docs/current-state/AURORA-RELEASE-CHECKLIST.md
@@ -41,7 +41,7 @@ Use this checklist for every manual `kk-aurora` production deploy on Pagely: wp-
 
 ## Current release note (2026-08-17)
 
-- Public `style.css` reports Aurora **1.6.5**. Source `main` is **1.6.6** (PR #751, undeployed). Open PR #789 cuts **1.6.7** for sitewide titles. Homepage cluster #411–#413 is **1.6.8** and stacks after #789 / 1.6.7. Do not treat 1.6.6 as live.
+- Public `style.css` reports Aurora **1.6.7** (readback 2026-08-17 04:23 UTC). Source `main` is **1.6.8** (PR #844 homepage cluster). Do not treat 1.6.8 as live. Pixel gate before SFTP.
 - The committed pre-deploy baseline manifest is `reports/visual-baseline/manifest-20260816T151617Z.json`. It captures `/` and `/speaking/` at 200 across mobile, tablet, and desktop.
 - `/marquee/` currently returns 404 and is not a valid live release gate. Verify the marquee archive copy in source; the visual runbook uses `/category/vancouver-ai-ecosystem/` as the live archive-template substitute until the marquee route exists.
 - A post-deploy candidate diff, cache purge, public 1.6.6 readback, rollback receipt, and Jetpack Boost regeneration are still required. This checklist and the repository merge do not authorize those actions.

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -14,7 +14,7 @@ Read these first:
 6. **[INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)**, slug/idempotency safety rules. Dated May, deliberately kept at top level: it is a standing safety rule, not a plan.
 7. **[../../.env.schema](../../.env.schema)** plus **[VARLOCK-ROLLOUT-2026-07-16.md](VARLOCK-ROLLOUT-2026-07-16.md)**, env contract (never read plaintext `.env`)
 
-**Live readback 2026-08-16:** WordPress `7.0.4`. Aurora **live is `1.6.5`**; repo `main` is **`1.6.7`** (PR #789, includes 1.6.6). That is deploy drift, not a surprise source fork. The public `style.css` readback remains authoritative for production theme state. Read back, do not assume, in either direction.
+**Live readback 2026-08-17:** WordPress last seen `7.0.4`. Aurora **live is `1.6.7`**; repo `main` is **`1.6.8`** (PR #844 homepage cluster). Title pipe + Krüg chrome is live. The 1.6.8 homepage bands are not. The public `style.css` readback remains authoritative for production theme state. Read back, do not assume, in either direction.
 
 ## Durable process docs (keep at top level)
 

--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -7,19 +7,20 @@
 
 ---
 
-## Verified state (2026-08-16 evening, public readbacks)
+## Verified state (2026-08-17 evening, public readbacks)
 
 | Signal | Value | Source |
 |---|---|---|
-| Aurora live | **1.6.5** | public `style.css` readback |
-| Aurora repo | **1.6.7** | `theme/kk-aurora/style.css` on `origin/main` (`59505f1`, PR #789) |
-| Deploy gap | **two versions** (1.6.6 + 1.6.7) | live vs repo |
+| Aurora live | **1.6.7** | public `style.css` 2026-08-17 04:23 UTC |
+| Aurora repo | **1.6.8** | `theme/kk-aurora/style.css` on `origin/main` (`17ae392`, PR #844) |
+| Deploy gap | **one version** (homepage cluster 1.6.8) | live vs repo |
 | WordPress | **7.0.4** | last status-readonly |
-| Open PRs | **0** after #839 and #824 | `gh pr list` |
-| Open issues | **47** | after 2026-08-17 merge wave |
-| Title format live | still `{EMDASH} Kris Krug \| …` on untitled posts | post 12653 `<title>` 2026-08-16 |
-| Post 12034 | still third person; `modified` 2026-08-01 | REST |
-| Post 12327 | still **21** em dashes; `Eth??s` | REST |
+| Open PRs | **0** | `gh pr list` 2026-08-17 |
+| Open issues | **40** | after homepage/alias/marker merge |
+| Origin heads | **`main` only** | leftover closed remotes deleted |
+| Title format live | `{title} \| Kris Krüg` on post 12653; homepage `Kris Krüg \| …` | public HTML 2026-08-17 |
+| Post 12034 | still third person; `modified` 2026-08-01 | REST 2026-08-16 |
+| Post 12327 | still **21** em dashes; `Eth??s` | REST 2026-08-16 |
 
 ## What just happened
 
@@ -29,14 +30,14 @@ False-closed or apply-still-owed (live evidence 2026-08-16):
 
 | Issue | GitHub | Live truth |
 |---|---|---|
-| #756 / 1.6.7 title fix | closed | em dash + ASCII Krug still in `<title>` — **not deployed** |
+| #756 / 1.6.7 title fix | closed | **live 2026-08-17**: pipe + Krüg on homepage and post 12653 |
 | #612 / #603 Zero to One | closed | still third person, mixed 130/$240 |
 | #764 Storyhive dashes | **open** | 21 dashes + `Eth??s` + 12032 `?p=11876` 404 |
 | #729 Futureproof copy | **open** | Aug 15 lines still live; payload is in merged PR #790 |
 | #602 / #635 deploys | closed | runbooks merged; live apply not verified here |
 | #122 undesigned pages | closed | closeout said **not** closeable; 24 pages still bare |
 
-Homepage redesign PRs #796 / #797 were **closed unmerged**. #411–#416 remain open with no landed code.
+Homepage #411–#416 landed on `main` as Aurora **1.6.8** (PR #844, stacked revive of closed #796/#797). #690 editor alias landed (PR #845). #745 markers parked without a cull (PR #846; issue stays open). **None of that is live.** Pixel gate still owed before any theme SFTP.
 
 ---
 
@@ -46,7 +47,7 @@ The bottleneck is **live apply + theme deploy**, not more inventories. No new au
 
 ### Gate 0 — KK at the keyboard (highest leverage)
 
-1. **Deploy Aurora 1.6.7** (contains 1.6.6 copy/orphan cleanup + #756 title pipe + Krüg). Pixel gate. Then **#731** Boost critical-CSS regen in the same window.
+1. **Deploy Aurora 1.6.8** (homepage #411–#416 cluster). Live is already **1.6.7**. Pixel gate. Then **#731** Boost critical-CSS regen in the same window.
 2. **Apply #764** — `content/drafts/2026-06-16-storyhive-haus-of-owl-jordan-dack/fix-764/APPLY.md`. Snapshot-first. Leave `Eth??s` for its own NCR pass.
 3. **Apply #729** — `content/drafts/2026-07-26-futureproof-festival-announcement/fix-729/PAYLOAD.md`. Close Call for Talks; Earlyworm through **Aug 31**.
 4. **Apply #612** even though GitHub closed it — payload from PR #803. First person, $340/year, 300 members.
@@ -65,18 +66,18 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ### Gate 2 — do not touch yet
 
-- Homepage #411–#416 until KK says whether to revive the closed PRs or start over.
+- Homepage #411–#416 **source is on main** (1.6.8). Do not restyle it until 1.6.8 is live and pixel-gated. Copy still needs KK confirm (labs list, ten-name client soup, real marks vs wordmarks).
 - Speaking W2/W3 (#640/#641) while #638-class decisions are still sticky.
 - `#481` class rename (blast-radius report now on main: live-DB landmine).
 - `#477` component migration epic.
-- `#745` slop batch (cull PR #810 was closed unmerged; nik-badminton already quarantined).
+- `#745` slop batch (markers on main via #846; 14 unpublished packages still in `content/drafts/`; cull still needs KK).
 - `#771` Gorgeous Ghost (needs publish-or-park ruling).
 - `#274` Search Console (human-only).
 - More visual-baseline PNG captures.
 
 ### Gate 3 — hygiene leftovers (low, after applies)
 
-#737 cached-rm of backup HTML (proposal on main), #738 remaining parked remotes (laptop worktrees cleared 2026-08-16), #742 script archive, #749 local PNG prune (already partly done), #690 cream aliases (PR #801 closed unmerged; re-open only if still true on 1.6.7).
+#737 cached-rm of backup HTML (proposal on main), #738 origin heads are now `main` only (other-session disk worktrees not touched), #742 script archive, #749 local PNG prune (already partly done). #740 remainder is the 26-file one-shot MOVE table; needs an explicit KK allow-list. #690 done on main (PR #845).
 
 ---
 
@@ -90,4 +91,4 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ---
 
-**Last verified:** 2026-08-16 evening (readbacks in the table). If you are reading this later, run `make status-readonly` and a public `style.css` readback before acting.
+**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.7**; repo `17ae392` **1.6.8**. Run `make status-readonly` and a public `style.css` readback before acting.

--- a/docs/current-state/reports/homepage-revive-closeout-2026-08-17.md
+++ b/docs/current-state/reports/homepage-revive-closeout-2026-08-17.md
@@ -1,0 +1,29 @@
+# Homepage revive closeout: 2026-08-17
+
+**Status:** source on `main`. **Not live.** No theme SFTP. No WordPress writes.
+
+## What shipped to `main`
+
+| PR | Commit | What |
+|---|---|---|
+| #846 | `f35db91` | #745 SHELVED/REWRITE/STATUS markers + proposed A5 list. Did not cull. |
+| #845 | `7347cd1` | #690 editor swatch name `Cream Elevated (same as Panel)`. Hex unchanged. |
+| #844 | `17ae392` | Aurora **1.6.8** homepage stack (#411–#416). CSS ratchet 6920→7489 lines, 169→173 `!important`. |
+
+Closed leftover remotes after the unique work was on `main` or in those PRs. Origin heads are now **`main` only**.
+
+#745 was auto-closed by the #846 merge and **reopened**. Cull of the 14 unpublished packages still needs KK.
+
+## Verify
+
+- Homepage unit tests, voice-gate, css-ratchet, and docs-truth-check were green locally 2026-08-17.
+- Live public `style.css` is **1.6.7** (2026-08-17 04:23 UTC). Repo is **1.6.8**.
+- Homepage HTML still has the TED/SXSW name strip. No `aurora-creative-labs` / `aurora-logo-soup` / `aurora-stages-band`. 1.6.8 is not live.
+- Title pipe + Krüg chrome from 1.6.7 is live (`AI Lands Inside Every Profession | Kris Krüg`; homepage `Kris Krüg | …`).
+- Pixel gate is still owed before any 1.6.8 deploy. Gate 0 in the day runbook is now "deploy 1.6.8" on top of live 1.6.7.
+
+## Left alone
+
+- Untracked `docs/current-state/reports/visual-baseline/{diff,manifest}-20260817T035118Z.json` (issue #473 capture from another session).
+- Other-session `/tmp/kriskrug-wp-*` dirs and `/Users/kk/Code/.worktrees/*`.
+- 14-draft cull, 26-file #740 archive, live apply (#764/#729/#612/#706).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only closeout after KK merged #844/#845/#846.

- Day runbook, current-state README, and Aurora release checklist now say repo **1.6.8** and live **1.6.7** (public `style.css` 2026-08-17 04:23 UTC).
- Homepage cluster is on `main`, not live (TED/SXSW strip still on `/`).
- Receipt: `docs/current-state/reports/homepage-revive-closeout-2026-08-17.md`.

Does not deploy. Does not cull #745. Leaves another session's untracked visual-baseline JSON alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

Made with [Cursor](https://cursor.com)