### PR TITLE
docs: record #731 Boost block and #706 browser checks

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -47,7 +47,7 @@ The bottleneck is **live apply + theme deploy**, not more inventories. No new au
 
 ### Gate 0 — KK at the keyboard (highest leverage)
 
-1. **Aurora 1.6.8 is live.** Still owed: **#731** Boost critical-CSS regen in wp-admin.
+1. **Aurora 1.6.8 is live.** **#731** Boost critical-CSS regen still needs wp-admin. App password 403s the Boost data store. Dark tokens still in the inline snapshot.
 2. **#764 live** (12327 dashes 0; 12032 dead link gone). `Eth??s Lab` still needs its own NCR pass.
 3. **#729 live** (Call for Talks closed; Earlyworm through Aug 31).
 4. **#612 live** (first person, `$340/year`, 300 members).
@@ -91,4 +91,4 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ---
 
-**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.8**. Gate 0 #764/#729/#612/#706 live at origin. #706 PSI rerun still owed. Next: #731 Boost in wp-admin. Run `make status-readonly` and a public `style.css` readback before acting.
+**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.8**. Gate 0 content + #706 origin greps live. #706 browser Network checks pass; PSI still owed (API 429). **#731 blocked** without wp-admin (critical CSS still has `--aurora-black:#030405`). Run `make status-readonly` and a public `style.css` readback before acting.

--- a/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
+++ b/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
@@ -39,8 +39,19 @@ Page edit snapshots `~/kk-snapshots/page-*-before-706-purge-*.json` for the no-o
 - Pixel: reactivate WPCode 7917. Do not invent a Code Snippets pixel id.
 - Then cache-bust. PressCACHE/Atomic if the canonical URL stays stale.
 
+## Browser Network (Playwright, Chrome for Testing, 390×844, 2026-08-17 05:49 UTC)
+
+Logged-out `https://kriskrug.co/?cb=…`. `#kk-gtag-delayed` 1, `#google_gtagjs-js` 0.
+
+| Path | Facebook / fbevents | gtag |
+|---|---|---|
+| Load + 2.5 s, no input | **0** requests | **0** requests |
+| Then a click | 0 | **1** `gtag/js?id=G-X7JE8B32L7` |
+| Separate idle run, no input | **0** | first `gtag/js` at **2874 ms** after Playwright `load` (3 s timer is from the document `load` event, which fires slightly before Playwright's callback) |
+
+Pixel ID `1720755522050230` did not appear in the network log.
+
 ## Still owed
 
-1. Browser/GA4 checks from the runbook (Network: no `googletagmanager` during load; click then `gtag/js?id=G-X7JE8B32L7`; idle path after 3 s).
-2. PSI mobile vs `docs/current-state/reports/psi-mobile-2026-08-10.md`. TBT / third-party should move. LCP and CLS should not. Do not close #706 on HTML greps alone.
-3. #731 Jetpack Boost critical-CSS regen in wp-admin.
+1. PSI mobile vs `docs/current-state/reports/psi-mobile-2026-08-10.md`. The unauthenticated PSI API returned **429** (`quota_limit_value: 0`). Run https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fkriskrug.co%2F Mobile. TBT / third-party should move. LCP and CLS should not. Do not close #706 without that report.
+2. #731 Jetpack Boost critical-CSS regen in wp-admin. Prep: `reports/issue-731-boost-critical-css-blocked-20260817.md`.

--- a/docs/current-state/reports/issue-731-boost-critical-css-blocked-20260817.md
+++ b/docs/current-state/reports/issue-731-boost-critical-css-blocked-20260817.md
@@ -1,0 +1,45 @@
+# Jetpack Boost critical CSS — #731 status 2026-08-17
+
+**Status:** still owed. App password cannot regenerate. wp-admin session is required.
+**Live theme:** Aurora **1.6.8** (public `style.css`). Issue text still says 1.6.5; regenerate against **1.6.8**.
+
+## Why this session could not click Regenerate
+
+| Probe | Result |
+|---|---|
+| `WP_AUTH_MODE=login` | RuntimeError: login did not produce an admin session (application password is not a wp-admin password) |
+| `GET /wp-json/jetpack-boost-ds/critical-css-state` | **403** `rest_forbidden` |
+| `GET .../critical-css-suggest-regenerate` | **403** |
+| `POST .../critical-css-state/action/request-regenerate` | not attempted after GET 403 |
+| `GET /wp-json/jetpack-boost/v1/cloud-css/request-generate` | **404** (no cloud-css routes; manual Boost) |
+| `GET /wp-json/jetpack-boost/v1/list-source-providers` | **403** |
+| `GET /wp-json/jetpack-boost/v1/connection` | 200, `connected: true` |
+
+Do not POST `set-provider-css` with hand-written CSS. That is not a regen.
+
+## Before-sample (canonical `/` and `/blog/`, 2026-08-17 05:47 UTC)
+
+Private full dump: `~/kk-snapshots/boost-critical-home-before-731-20260817T054734Z.css` (mode 0600).
+
+| Signal | `/` | `/blog/` |
+|---|---|---|
+| `<style id="jetpack-boost-critical-css">` | present, 7474 bytes | present, 15332 bytes |
+| `--aurora-black:#030405` | **1** | **1** |
+| `--aurora-ink:#f7f7f2` | **1** | **1** |
+| `--revive-surface` | 0 | — |
+| `aurora-creative-labs` / `aurora-logo-soup` | **0** (1.6.8 bands not in snapshot) | n/a |
+| Boost CSS bundle hash | `0f9e6b2840` | — |
+
+The 1.6.8 homepage HTML is live; the inlined critical snapshot is still the pre-cream / pre-labs first paint. After the full sheet loads, cream `!important` wins. That is the #731 FOUC, not a theme-file miss.
+
+## What KK does in wp-admin
+
+1. Jetpack → Boost (`admin.php?page=jetpack-boost`).
+2. Optimize Critical CSS Loading → **Regenerate**. Stay on the page. Prior hangs are documented in `PERFORMANCE-RECOVERY-2026-07-01.md`.
+3. If it hangs, leave #731 open and paste the UI state.
+
+After success, a public grep should show `--aurora-black:#030405` **0** on `/` and `/blog/`, and homepage critical CSS should mention the 1.6.8 bands or at least drop the dark tokens. Record the new inline length + a short before/after excerpt in this reports folder. Homepage CLS spot-check vs `psi-mobile-2026-08-10.md` (CLS 0.43). Keep the #701 geometry guard.
+
+## Out of scope here
+
+PSI mobile API returned **429** without a key (`quota_limit_value: 0`). #706 browser Network checks are in `issue-706-script-diet-apply-20260817.md`.


### PR DESCRIPTION
## Summary
- **#731** still needs wp-admin. Boost data-store GET is 403. Live critical CSS still has \`--aurora-black:#030405\` on \`/\` and \`/blog/\`.
- **#706** Playwright Network: no fbevents/gtag for 2.5s after load; click fetches \`gtag/js?id=G-X7JE8B32L7\`. PSI API 429, issue stays open.

## Test plan
- [x] Public grep of \`jetpack-boost-critical-css\` dark tokens
- [x] Playwright click vs idle gtag
- [ ] PSI mobile in the browser (pagespeed.web.dev)
- [ ] Boost Regenerates in wp-admin

Made with [Cursor](https://cursor.com)