### PR TITLE
docs: record #706 PSI mobile rerun and #731 local Boost mode

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -51,7 +51,7 @@ The bottleneck is **live apply + theme deploy**, not more inventories. No new au
 2. **#764 live** (12327 dashes 0; 12032 dead link gone). `Eth??s Lab` still needs its own NCR pass.
 3. **#729 live** (Call for Talks closed; Earlyworm through Aug 31).
 4. **#612 live** (first person, `$340/year`, 300 members).
-5. **#706 live** (WPCode 7917 drafted; Code Snippets id 22 `KK Script Diet` active). Pixel ID `1720755522050230` is recorded for rollback only.
+5. **#706 live** (WPCode 7917 drafted; Code Snippets id 22 `KK Script Diet` active). PSI mobile 2026-08-16 10:59 PDT: TBT **10 ms** (was 160); Facebook gone; gtag still in the PSI trace (delay caveat). Pixel ID `1720755522050230` is recorded for rollback only.
 
 ### Gate 1 — agent crush (no live writes)
 
@@ -91,4 +91,4 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ---
 
-**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.8**. Gate 0 content + #706 origin greps live. #706 browser Network checks pass; PSI still owed (API 429). **#731 blocked** without wp-admin (critical CSS still has `--aurora-black:#030405`). Run `make status-readonly` and a public `style.css` readback before acting.
+**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.8**. Gate 0 content + #706 origin greps live. #706 Network + PSI captured (`psi-mobile-2026-08-16.md`). **#731 blocked**: Boost is local/free Critical CSS; app password 403s data-sync; inline snapshot still has `--aurora-black:#030405`. Next: KK Regenerates in Jetpack → Boost, or Gate 1 with no live writes. Run `make status-readonly` and a public `style.css` readback before acting.

--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -51,7 +51,7 @@ The bottleneck is **live apply + theme deploy**, not more inventories. No new au
 2. **#764 live** (12327 dashes 0; 12032 dead link gone). `Eth??s Lab` still needs its own NCR pass.
 3. **#729 live** (Call for Talks closed; Earlyworm through Aug 31).
 4. **#612 live** (first person, `$340/year`, 300 members).
-5. **#706 live** (WPCode 7917 drafted; Code Snippets id 22 `KK Script Diet` active). PSI mobile 2026-08-16 10:59 PDT: TBT **10 ms** (was 160); Facebook gone; gtag still in the PSI trace (delay caveat). Pixel ID `1720755522050230` is recorded for rollback only.
+5. **#706 live** (WPCode 7917 drafted; Code Snippets id 22 `KK Script Diet` active). PSI mobile 2026-08-16 11:59 PDT: TBT **10 ms** (was 160); Facebook gone; gtag still in the PSI trace (delay caveat). Pixel ID `1720755522050230` is recorded for rollback only.
 
 ### Gate 1 — agent crush (no live writes)
 

--- a/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
+++ b/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
@@ -1,6 +1,6 @@
 # #706 script diet apply receipt — 2026-08-17
 
-**Status:** live at origin on the main routes. PSI mobile rerun still owed (wait ≥30 min after purge).
+**Status:** live at origin on the main routes. PSI mobile rerun captured 2026-08-16 10:59 PDT (`qx4j9jir1j`).
 **Track:** Track A snippet/plugin surfaces. Not a theme deploy.
 **KK ruling (2026-08-10):** drop Facebook pixel `1720755522050230`; delay gtag to first interaction or 3 s idle.
 
@@ -51,7 +51,19 @@ Logged-out `https://kriskrug.co/?cb=…`. `#kk-gtag-delayed` 1, `#google_gtagjs-
 
 Pixel ID `1720755522050230` did not appear in the network log.
 
+## PSI mobile (2026-08-16 10:59 PDT)
+
+Report: [`psi-mobile-2026-08-16.md`](psi-mobile-2026-08-16.md) / [qx4j9jir1j](https://pagespeed.web.dev/analysis/https-kriskrug-co/qx4j9jir1j?form_factor=mobile).
+
+| #706 claim | Result |
+|---|---|
+| TBT should move | **160 ms → 10 ms** |
+| Facebook long tasks gone | **gone** |
+| gtag out of the PSI trace | **not gone** (176.9 KiB / 72.4 KiB unused; 1 long task). Matches the delay-from-`load` caveat. Network check still passes. |
+| LCP / CLS should not move | **they moved** (7.6 s → 3.9 s, 0.43 → 0). Do not credit the diet; 1.6.8 homepage landed the same evening. |
+
+Do not GitHub-close #706 until KK accepts the gtag-in-trace caveat.
+
 ## Still owed
 
-1. PSI mobile vs `docs/current-state/reports/psi-mobile-2026-08-10.md`. The unauthenticated PSI API returned **429** (`quota_limit_value: 0`). Run https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fkriskrug.co%2F Mobile. TBT / third-party should move. LCP and CLS should not. Do not close #706 without that report.
-2. #731 Jetpack Boost critical-CSS regen in wp-admin. Prep: `reports/issue-731-boost-critical-css-blocked-20260817.md`.
+1. #731 Jetpack Boost critical-CSS regen in wp-admin. Prep: `reports/issue-731-boost-critical-css-blocked-20260817.md`. Local/free module confirmed 2026-08-17; cloud regen is a no-op here.

--- a/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
+++ b/docs/current-state/reports/issue-706-script-diet-apply-20260817.md
@@ -1,6 +1,6 @@
 # #706 script diet apply receipt — 2026-08-17
 
-**Status:** live at origin on the main routes. PSI mobile rerun captured 2026-08-16 10:59 PDT (`qx4j9jir1j`).
+**Status:** live at origin on the main routes. PSI mobile rerun captured 2026-08-16 11:59 PDT (`qx4j9jir1j`).
 **Track:** Track A snippet/plugin surfaces. Not a theme deploy.
 **KK ruling (2026-08-10):** drop Facebook pixel `1720755522050230`; delay gtag to first interaction or 3 s idle.
 
@@ -51,7 +51,7 @@ Logged-out `https://kriskrug.co/?cb=…`. `#kk-gtag-delayed` 1, `#google_gtagjs-
 
 Pixel ID `1720755522050230` did not appear in the network log.
 
-## PSI mobile (2026-08-16 10:59 PDT)
+## PSI mobile (2026-08-16 11:59 PDT)
 
 Report: [`psi-mobile-2026-08-16.md`](psi-mobile-2026-08-16.md) / [qx4j9jir1j](https://pagespeed.web.dev/analysis/https-kriskrug-co/qx4j9jir1j?form_factor=mobile).
 

--- a/docs/current-state/reports/issue-731-boost-critical-css-blocked-20260817.md
+++ b/docs/current-state/reports/issue-731-boost-critical-css-blocked-20260817.md
@@ -1,6 +1,6 @@
 # Jetpack Boost critical CSS — #731 status 2026-08-17
 
-**Status:** still owed. App password cannot regenerate. wp-admin session is required.
+**Status:** still owed. App password cannot regenerate. Site is on **local/free** Critical CSS, not cloud. wp-admin session is required.
 **Live theme:** Aurora **1.6.8** (public `style.css`). Issue text still says 1.6.5; regenerate against **1.6.8**.
 
 ## Why this session could not click Regenerate
@@ -14,12 +14,13 @@
 | `GET /wp-json/jetpack-boost/v1/cloud-css/request-generate` | **404** (no cloud-css routes; manual Boost) |
 | `GET /wp-json/jetpack-boost/v1/list-source-providers` | **403** |
 | `GET /wp-json/jetpack-boost/v1/connection` | 200, `connected: true` |
+| One-shot mu-plugin `Modules_Setup::get_status()` | `critical_css: "1"`; **no `cloud_css`**. Cloud `regenerate_cloud_css()` skipped. Storage not cleared. Self-deleted. Report `wp-content/upgrade/kk-731-boost-regen.json` |
 
-Do not POST `set-provider-css` with hand-written CSS. That is not a regen.
+Do not POST `set-provider-css` with hand-written CSS. That is not a regen. Do not call `Regenerate::start()` on local mode from PHP: it would wipe `jb_store_css` and wait for the admin-page browser generator that we cannot run.
 
 ## Before-sample (canonical `/` and `/blog/`, 2026-08-17 05:47 UTC)
 
-Private full dump: `~/kk-snapshots/boost-critical-home-before-731-20260817T054734Z.css` (mode 0600).
+Private full dump: `~/kk-snapshots/boost-critical-home-before-731-20260817T054734Z.css` (mode 0600). `jb_store_css` edit snapshot: `~/kk-snapshots/jb_store_css-before-731-20260817T054800Z.json` (ids 12460 cornerstone, 12461 core_posts_page, both **modified 2026-07-01**).
 
 | Signal | `/` | `/blog/` |
 |---|---|---|

--- a/docs/current-state/reports/psi-mobile-2026-08-16.md
+++ b/docs/current-state/reports/psi-mobile-2026-08-16.md
@@ -1,0 +1,65 @@
+# PageSpeed Insights — kriskrug.co mobile — 2026-08-16 10:59 PDT
+
+Source: [PSI report `qx4j9jir1j`](https://pagespeed.web.dev/analysis/https-kriskrug-co/qx4j9jir1j?form_factor=mobile) (Lighthouse 13.4.1, emulated Moto G Power, slow 4G, HeadlessChromium 150). Captured in-session after #706 origin apply + Aurora **1.6.8**.
+Live state at capture: Aurora 1.6.8, WP 7.0.4, WPCode 7917 drafted, Code Snippets id 22 active.
+
+Baseline: [`psi-mobile-2026-08-10.md`](psi-mobile-2026-08-10.md) (Aurora 1.6.0, pixel + blocking gtag still on).
+
+## Scores
+
+| Category | 2026-08-10 | 2026-08-16 | Delta |
+|---|---:|---:|---|
+| Performance (mobile) | **43** | **84** | +41 |
+| Accessibility | 96 | 100 | +4 |
+| Best Practices | 100 | 100 | — |
+| SEO | 100 | 100 | — |
+| Agentic Browsing | 2/3 (CLS fail) | **3/3** | pass |
+
+## Metrics
+
+| Metric | 2026-08-10 | 2026-08-16 | #706 expected |
+|---|---|---|---|
+| First Contentful Paint | 3.4 s | 2.1 s | not claimed |
+| Largest Contentful Paint | **7.6 s** | **3.9 s** | should not move; **did** (1.6.8 homepage + other same-day work, not the diet) |
+| Total Blocking Time | 160 ms | **10 ms** | should move; **did** |
+| Cumulative Layout Shift | **0.43** | **0** (gauge) | should not move; **did** |
+| Speed Index | 5.6 s | 4.4 s | not claimed |
+
+Do not credit LCP or CLS to #706. The 1.6.8 front-page HTML write and cream theme landed the same evening. Layout-shift culprits (passed-audits drawer) still names `krug-1.jpg` (0.376) plus `#aurora-main`.
+
+## #706 script diet vs this report
+
+| Signal | 2026-08-10 | 2026-08-16 | Verdict |
+|---|---|---|---|
+| Facebook pixel (`fbevents`, id `1720755522050230`) | 176 KiB + 186 ms + two long tasks | **absent** | pass |
+| gtag `G-X7JE8B32L7` in the PSI trace | 178 KiB + 156 ms + two long tasks | **still present**: unused-JS 176.9 KiB transfer / 72.4 KiB unused; 1 long task on `/gtag/js` | expected caveat (delay is from `load`, not parse) |
+| Third-party long tasks from these origins | 4 | 1 (gtag only) | pixel half closed; gtag half is Network-pass, PSI-partial |
+| Efficient cache policy on fbevents | flagged (20 min TTL) | gone | pass |
+
+Logged-out browser Network (same evening, `issue-706-script-diet-apply-20260817.md`): 0 gtag requests for 2.5 s with no input; gtag on click; idle fire ~2.9 s after Playwright `load`. PSI still sees gtag because its trace outlasts that delay.
+
+## LCP breakdown (not #706)
+
+| Subpart | 2026-08-10 | 2026-08-16 |
+|---|---:|---:|
+| Time to first byte | 30 ms | 20 ms |
+| Resource load delay | 150 ms | 80 ms |
+| Resource load duration | 40 ms | 30 ms |
+| Element render delay | **2,110 ms** | **270 ms** |
+
+## Image delivery (est. 200 KiB; was 944 KiB)
+
+Theme assets are now WebP (`futureproof-salmon-starfield-600.webp`, `vancouver-ai-meetup-30-kris-community-600.webp`, `kriskrug-wordmark-*.webp`). Remaining waste is mostly i0.wp.com content JPEGs plus one pcdn WebP compression note (33.5 KiB).
+
+## Other findings
+
+- **Non-composited animations: 10 elements** (was 56).
+- **Forced reflow**: Boost bundle `1c4366cdd3.min.js` **103 ms** (was `7d33d1c7f5.min.js` 59 ms). Still #731 / Boost, not the diet.
+- **Best Practices trust suggestions (unscored)**: CSP, HSTS, COOP, XFO/frame-ancestors, Trusted Types — unchanged, owned by #709.
+- **Discover real-user data**: No Data.
+- Filmstrip still shows blank frames then a dark first paint of the cream homepage. That is the stale Boost critical-CSS snapshot (`--aurora-black:#030405`), owned by **#731**.
+
+## Do not close from this file alone
+
+- **#706** pixel half is done. Gtag half is done on origin HTML + Network. PSI still attributes gtag unused-JS / one long task. Close only if KK accepts the documented delay caveat.
+- **#731** is not done. Critical CSS rows are still 2026-07-01; wp-admin Regenerates is still required.

--- a/docs/current-state/reports/psi-mobile-2026-08-16.md
+++ b/docs/current-state/reports/psi-mobile-2026-08-16.md
@@ -1,4 +1,4 @@
-# PageSpeed Insights — kriskrug.co mobile — 2026-08-16 10:59 PDT
+# PageSpeed Insights — kriskrug.co mobile — 2026-08-16 11:59 PDT
 
 Source: [PSI report `qx4j9jir1j`](https://pagespeed.web.dev/analysis/https-kriskrug-co/qx4j9jir1j?form_factor=mobile) (Lighthouse 13.4.1, emulated Moto G Power, slow 4G, HeadlessChromium 150). Captured in-session after #706 origin apply + Aurora **1.6.8**.
 Live state at capture: Aurora 1.6.8, WP 7.0.4, WPCode 7917 drafted, Code Snippets id 22 active.


### PR DESCRIPTION
## Summary
- Record the 2026-08-16 PSI mobile rerun for #706 (`qx4j9jir1j`): TBT 160→10 ms, Facebook gone, gtag still in the PSI trace (documented delay caveat).
- Record that live Jetpack Boost is **local/free** Critical CSS, so cloud regen cannot close #731.
- Update the day runbook accordingly. No theme, plugin, or live WP writes.

## Test plan
- [x] Docs-only paths (`docs/current-state/**`)
- [x] PSI URL opens: https://pagespeed.web.dev/analysis/https-kriskrug-co/qx4j9jir1j?form_factor=mobile
- [x] No secrets in the new report (pixel ID is already public)
