### PR TITLE
content(#827): apply-ready photography hub links

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/1056-sentence.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/1056-sentence.html
@@ -1,0 +1,1 @@
+ Here is <a href="https://kriskrug.co/photography/">where all of that ended up</a>.

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/12013-coda-inserts.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/12013-coda-inserts.html
@@ -1,0 +1,1 @@
+ The on-site version is <a href="https://kriskrug.co/category/photography-visual-storytelling/">the whole archive, twenty years of it</a>. Start with <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">the fashion and model years, 2006 to 2008</a>.

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/1222-sentence.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/1222-sentence.html
@@ -1,0 +1,1 @@
+<p>The year before this rant I posted <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">how I found those people in the first place</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/APPLY.md
@@ -1,0 +1,101 @@
+# #827 APPLY: wire internal links on /photography/
+
+**Prepared, not applied. Do not PATCH until KK says go.**
+Script is dry-run by default. `--apply` is the only write switch.
+
+Parent: #402. This is child 2 of 9. **Live apply waits for KK and should follow #826 apply.** Child 1 is prepared on `main` and is not live: public REST on 2026-08-17T06:32Z still has 1067/1063 in `[1662]` and 1147 in `[1665]`. Do not recategorize those posts here. 1056 and 1222 are already in `photography-visual-storytelling` (`[1756]`); this child still must not PATCH them until KK approves, after #826.
+
+## Live reconfirm (logged-out, 2026-08-17T06:32Z)
+
+Public GET only. No REST POST/PATCH/DELETE. `inject_links.py` was not run.
+
+| URL | HTTP | Identity |
+|---|---|---|
+| `https://kriskrug.co/photography/` | 200 | page 12013, slug `photography`, `modified_gmt` 2026-08-17T05:30:00 |
+| `https://kriskrug.co/category/photography-visual-storytelling/` | 200 | term archive |
+| `https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/` | 200 | post 1056, slug `kk-on-modelmayhemcom`, cats `[1756]` |
+| `https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/` | 200 | post 1222, slug `to-all-you-wannabe-fashion-photographers`, cats `[1756]` |
+
+Page 12013 `content.rendered` still has **zero** internal `href`s. The two body links are both `https://www.flickr.com/photos/kk/` (intro + coda button). Exact anchors for rows 11-14 are absent. `checklist-of-model-photographer-negotiation-items` is absent. Inline `<style>` is present (5039 chars, sha256 `23dc2ddaf20ffda0f94f619e9ade0068d3a9a0c5fdb38563538b6542a34c69b3` of the rendered `<style>` block). Do not touch it.
+
+Post 1056 body still does not contain `/photography/` or `kriskrug.co/photography`. It still has one `kk-collection-footer`. The peeps line is `I&#8217;ve met a couple cool peeps already.`
+
+Post 1222 body still does not contain the row 13 anchor. Footer count is 1. No link to post 1210.
+
+Block recount on today's 12013 rendered HTML (walk `p`/`h2`/`h3`/`ul`/`ol`/`figure`/`blockquote`): **22** blocks. `This is a fraction of it` is the coda `h2` (block 21). The closing paragraph is block **22**, not stale index 23. Insert by that text match.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Page 12013 uses `/wp/v2/pages/12013`. Posts 1222 and 1056 use `/wp/v2/posts/<id>`. Never PATCH on ID alone.
+
+## What the script writes
+
+Content-only. No `categories`. No titles, slugs, dates, status, featured media, tags, or SEO meta.
+
+| ID | Rows | REST body |
+|---|---|---|
+| 12013 | 11, 12 | Insert two sentences at the end of the coda `<p>` after `This is a fraction of it`. Archive link, then fashion-years link to 1056. Flickr button stays. `<style>` must be byte-identical. |
+| 1222 | 13 | One paragraph before the existing `kk-collection-footer`. Footer count stays 1. |
+| 1056 | 14 | One sentence after the peeps line, still inside that paragraph. Footer count stays 1. |
+
+Skip a row if that exact `href` + anchor already exists. Do not add data rows 34-37. Do not link post 1210.
+
+Inserted copy (also in the snippet files):
+
+- 12013: ` The on-site version is <a href="https://kriskrug.co/category/photography-visual-storytelling/">the whole archive, twenty years of it</a>. Start with <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">the fashion and model years, 2006 to 2008</a>.`
+- 1222: `<p>The year before this rant I posted <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">how I found those people in the first place</a>.</p>`
+- 1056: ` Here is <a href="https://kriskrug.co/photography/">where all of that ended up</a>.`
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_827_photography_hub
+
+# Dry run: authenticated GET + printed plan. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py'
+
+# Apply only after KK approves that diff, and after #826 is live.
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --apply'
+```
+
+`--id 12013` limits to one target. Re-run after a successful apply prints `[SKIP]`.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-827-photography-hub/rest-{pages|posts}-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --restore backup/issue-827-photography-hub/rest-pages-12013-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --restore backup/issue-827-photography-hub/rest-pages-12013-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the three IDs or a slug mismatch. Restore writes `content` only.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/photography/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/category/photography-visual-storytelling/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/
+
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -F 'the whole archive, twenty years of it'
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -F 'the fashion and model years, 2006 to 2008'
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -c 'checklist-of-model-photographer-negotiation-items'
+# last command must print 0 until child 3
+
+curl -sL "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/?cb=$RANDOM" \
+  | grep -F 'how I found those people in the first place'
+curl -sL "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/?cb=$RANDOM" \
+  | grep -F 'where all of that ended up'
+```
+
+Expect: 12013 body gains exactly two internal links (archive + 1056), Flickr remains, no 1210. 1222 and 1056 `kk-collection-footer` counts unchanged from the pre-write snapshot.
+
+## Out of payload
+
+- Post 1210 ModelMayhem 404 rewrite and data rows 34-37 (#828)
+- Recategorizing 1067 / 1063 / 1147 (#826)
+- Hub cards on 12318 / 12316 / 12319
+- Regenerating `/photography/` or stripping its inline CSS
+- Closing #402

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/targets.json
@@ -1,0 +1,75 @@
+{
+  "issue": 827,
+  "parent_issue": 402,
+  "live_reconfirm": "2026-08-17T06:32:00Z",
+  "child_826_must_precede_apply": true,
+  "flickr_href": "https://www.flickr.com/photos/kk/",
+  "locate_12013": "This is a fraction of it",
+  "coda_must_contain": "lives on Flickr",
+  "peeps_line": "I've met a couple cool peeps already.",
+  "forbidden_href_needles": [
+    "checklist-of-model-photographer-negotiation-items"
+  ],
+  "out_of_payload_ids": [1210, 1067, 1063, 1147],
+  "targets": [
+    {
+      "id": 12013,
+      "rest": "pages",
+      "slug": "photography",
+      "url": "https://kriskrug.co/photography/",
+      "kind": "coda_page",
+      "keep_style": true,
+      "keep_flickr": true,
+      "modified_gmt_at_reconfirm": "2026-08-17T05:30:00",
+      "rows": [
+        {
+          "row": 11,
+          "href": "https://kriskrug.co/category/photography-visual-storytelling/",
+          "anchor": "the whole archive, twenty years of it",
+          "prefix": " The on-site version is ",
+          "suffix": "."
+        },
+        {
+          "row": 12,
+          "href": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+          "anchor": "the fashion and model years, 2006 to 2008",
+          "prefix": " Start with ",
+          "suffix": "."
+        }
+      ]
+    },
+    {
+      "id": 1222,
+      "rest": "posts",
+      "slug": "to-all-you-wannabe-fashion-photographers",
+      "url": "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/",
+      "kind": "before_footer",
+      "modified_gmt_at_reconfirm": "2026-07-11T19:48:05",
+      "rows": [
+        {
+          "row": 13,
+          "href": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+          "anchor": "how I found those people in the first place",
+          "paragraph": "<p>The year before this rant I posted <a href=\"https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/\">how I found those people in the first place</a>.</p>"
+        }
+      ]
+    },
+    {
+      "id": 1056,
+      "rest": "posts",
+      "slug": "kk-on-modelmayhemcom",
+      "url": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+      "kind": "after_peeps",
+      "modified_gmt_at_reconfirm": "2026-06-15T05:20:28",
+      "rows": [
+        {
+          "row": 14,
+          "href": "https://kriskrug.co/photography/",
+          "anchor": "where all of that ended up",
+          "prefix": " Here is ",
+          "suffix": "."
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/apply_issue_827_photography_hub.py
+++ b/scripts/apply_issue_827_photography_hub.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Issue #827: wire internal links on /photography/ (page 12013) plus posts 1222 and 1056.
+
+Dry-run by default. Writes are gated on ID→slug match, a text-match insert
+(not a stale block index), skip-if-exact-href+anchor, and a fresh
+context=edit snapshot before each POST.
+
+    make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py'
+    make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TARGETS_PATH = (
+    REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-827/targets.json"
+)
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-827-photography-hub"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+STYLE_RE = re.compile(r"<style\b[^>]*>.*?</style>", re.I | re.S)
+PEEPS_RE = re.compile(
+    r"I(?:'|&#8217;|&rsquo;|&apos;|&#x2019;|\u2019)ve met a couple cool peeps already\."
+)
+FOOTER_MARKERS = (
+    '<!-- wp:paragraph {"className":"kk-collection-footer"} -->',
+    "<p class=\"kk-collection-footer",
+)
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-827"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def rest_url(spec: dict, item_id: int | None = None) -> str:
+    collection = spec["rest"]
+    target_id = spec["id"] if item_id is None else item_id
+    return f"{BASE_URL}/wp-json/wp/v2/{collection}/{target_id}?context=edit"
+
+
+def write_snapshot(item: dict, spec: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    path = SNAPSHOT_DIR / f"rest-{spec['rest']}-{spec['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    item_id = spec["id"]
+    if live.get("id") != item_id:
+        sys.exit(f"[ABORT] {item_id}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {item_id}: slug is {live.get('slug')!r}, expected {spec['slug']!r}."
+        )
+
+
+def exact_link(href: str, anchor: str) -> str:
+    return f'<a href="{href}">{anchor}</a>'
+
+
+def style_blocks(raw: str) -> list[str]:
+    return STYLE_RE.findall(raw)
+
+
+def footer_count(raw: str) -> int:
+    return raw.count(FOOTER_SENTINEL)
+
+
+def assert_payload_safe(raw: str, spec: dict, targets: dict, original: str) -> None:
+    for needle in targets["forbidden_href_needles"]:
+        if needle in raw:
+            raise ValueError(f"{spec['id']}: forbidden href {needle!r} present")
+    if spec.get("keep_style") and style_blocks(raw) != style_blocks(original):
+        raise ValueError(f"{spec['id']}: inline <style> block changed")
+    if spec.get("keep_flickr"):
+        flickr = targets["flickr_href"]
+        if raw.count(flickr) < original.count(flickr):
+            raise ValueError(f"{spec['id']}: Flickr href count dropped")
+    if spec["kind"] in {"before_footer", "after_peeps"}:
+        if footer_count(raw) != footer_count(original):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+
+
+def coda_paragraph_close(raw: str, locate: str, must_contain: str) -> int:
+    if raw.count(locate) != 1:
+        raise ValueError(
+            f"locate {locate!r} occurs {raw.count(locate)} times; expected 1"
+        )
+    loc = raw.find(locate)
+    p_start = raw.find("<p", loc)
+    if p_start < 0:
+        raise ValueError("no <p> after locate text")
+    p_close = raw.find("</p>", p_start)
+    if p_close < 0:
+        raise ValueError("coda <p> is unclosed")
+    styles = list(STYLE_RE.finditer(raw))
+    if styles and p_start < styles[-1].end():
+        raise ValueError("coda paragraph resolved inside the style block")
+    paragraph = raw[p_start:p_close]
+    if must_contain not in paragraph:
+        raise ValueError(f"coda <p> does not contain {must_contain!r}")
+    return p_close
+
+
+def rewrite_coda_page(raw: str, spec: dict, targets: dict) -> tuple[str | None, list[str]]:
+    notes: list[str] = []
+    close_at = coda_paragraph_close(
+        raw, targets["locate_12013"], targets["coda_must_contain"]
+    )
+    new = raw
+    offset = 0
+    for row in spec["rows"]:
+        link = exact_link(row["href"], row["anchor"])
+        if link in new:
+            notes.append(f"row {row['row']} already present")
+            continue
+        insert = f"{row['prefix']}{link}{row['suffix']}"
+        at = close_at + offset
+        new = new[:at] + insert + new[at:]
+        offset += len(insert)
+        notes.append(f"row {row['row']} insert")
+    if new == raw:
+        return None, notes
+    assert_payload_safe(new, spec, targets, raw)
+    return new, notes
+
+
+def footer_insert_index(raw: str) -> int:
+    found = [raw.find(marker) for marker in FOOTER_MARKERS if marker in raw]
+    if not found:
+        raise ValueError("kk-collection-footer marker not found")
+    return min(found)
+
+
+def rewrite_before_footer(raw: str, spec: dict, targets: dict) -> tuple[str | None, list[str]]:
+    notes: list[str] = []
+    if footer_count(raw) < 1:
+        raise ValueError("kk-collection-footer is missing")
+    row = spec["rows"][0]
+    link = exact_link(row["href"], row["anchor"])
+    if link in raw:
+        notes.append(f"row {row['row']} already present")
+        return None, notes
+    paragraph = row["paragraph"]
+    if link not in paragraph or not paragraph.startswith("<p>") or not paragraph.endswith("</p>"):
+        raise ValueError("before_footer paragraph payload is malformed")
+    idx = footer_insert_index(raw)
+    prefix = raw[:idx]
+    if not prefix.endswith("\n"):
+        prefix += "\n"
+    if not prefix.endswith("\n\n"):
+        prefix += "\n"
+    new = prefix + paragraph + "\n\n" + raw[idx:]
+    notes.append(f"row {row['row']} insert")
+    assert_payload_safe(new, spec, targets, raw)
+    return new, notes
+
+
+def rewrite_after_peeps(raw: str, spec: dict, targets: dict) -> tuple[str | None, list[str]]:
+    notes: list[str] = []
+    matches = list(PEEPS_RE.finditer(raw))
+    if len(matches) != 1:
+        raise ValueError(f"peeps line occurs {len(matches)} times; expected 1")
+    row = spec["rows"][0]
+    link = exact_link(row["href"], row["anchor"])
+    if link in raw:
+        notes.append(f"row {row['row']} already present")
+        return None, notes
+    insert = f"{row['prefix']}{link}{row['suffix']}"
+    at = matches[0].end()
+    new = raw[:at] + insert + raw[at:]
+    notes.append(f"row {row['row']} insert")
+    assert_payload_safe(new, spec, targets, raw)
+    return new, notes
+
+
+REWRITERS = {
+    "coda_page": rewrite_coda_page,
+    "before_footer": rewrite_before_footer,
+    "after_peeps": rewrite_after_peeps,
+}
+
+
+def plan_target(spec: dict, live: dict, targets: dict) -> dict | None:
+    body = raw_body(live)
+    rewriter = REWRITERS.get(spec["kind"])
+    if rewriter is None:
+        raise ValueError(f"{spec['id']}: unknown kind {spec['kind']!r}")
+    rewritten, notes = rewriter(body, spec, targets)
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: {'; '.join(notes) or 'nothing to do'}.")
+        return None
+    return {
+        "spec": spec,
+        "live": live,
+        "payload": {"content": rewritten},
+        "notes": notes,
+    }
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    payload = item["payload"]
+    print(f"[PLAN] {spec['rest']}/{spec['id']} {spec['slug']}: {'; '.join(item['notes'])}")
+    old = raw_body(item["live"])
+    new = payload["content"]
+    print(f"        content.raw {len(old)} chars -> {len(new)} chars")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    spec = item["spec"]
+    print_plan(item)
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_target(spec, live, load_targets())
+    if replanned is None:
+        return
+    if set(replanned["payload"]) != {"content"}:
+        sys.exit(f"[ABORT] {spec['id']}: payload is not content-only.")
+    write_snapshot(live, spec, stamp)
+    updated = request(rest_url(spec), header, replanned["payload"])
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    item_id = snapshot.get("id")
+    targets = load_targets()
+    allowed = {row["id"]: row for row in targets["targets"]}
+    if item_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {item_id} is not in the #827 set.")
+    spec = allowed[item_id]
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {item_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(
+        live, spec, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    )
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {item_id} restored")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #827 photography hub internal links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--id", type=int, dest="target_id")
+    parser.add_argument("--restore", type=Path)
+    args = parser.parse_args()
+    header = auth_header()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, header, args.apply)
+        return 0
+
+    targets = load_targets()
+    rows = targets["targets"]
+    if args.target_id:
+        rows = [row for row in rows if row["id"] == args.target_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --id {args.target_id}")
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_target(spec, live, targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print("[DRY-RUN] no WordPress writes. Pass --apply after KK approves.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_827_photography_hub.py
+++ b/scripts/tests/test_apply_issue_827_photography_hub.py
@@ -1,0 +1,356 @@
+"""Offline safety tests for the issue #827 photography hub apply helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_827_photography_hub.py"
+SPEC = importlib.util.spec_from_file_location(
+    "apply_issue_827_photography_hub", SCRIPT
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+FIX_DIR = (
+    MODULE.REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-827"
+)
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["targets"] if row["id"] == item_id)
+
+
+def exact(row: dict) -> str:
+    return MODULE.exact_link(row["href"], row["anchor"])
+
+
+def coda_fixture(*, figures: int = 16, already: str = "") -> str:
+    shots = "\n".join(f"<figure>shot {i}</figure>" for i in range(figures))
+    return (
+        "<style>.kkx{color:#171310}</style>\n"
+        "<div class=\"kkx\">\n"
+        "  <p class=\"kkx-intro\">The full archive lives on "
+        f"<a href=\"{TARGETS['flickr_href']}\">Flickr</a>.</p>\n"
+        f"  <div>{shots}</div>\n"
+        "  <section class=\"kkx-coda\">\n"
+        "    <h2>This is a fraction of it.</h2>\n"
+        "    <p>Twenty years of frames. The deep archive, including the "
+        "cross-processed portraits and the work that isn't here, lives on Flickr."
+        f"{already}</p>\n"
+        f"    <a class=\"kkx-btn\" href=\"{TARGETS['flickr_href']}\">"
+        "See 144,000+ frames on Flickr</a>\n"
+        "  </section>\n"
+        "</div>\n"
+    )
+
+
+def footer_block() -> str:
+    return (
+        '<!-- wp:paragraph {"className":"kk-collection-footer"} -->\n'
+        '<p class="kk-collection-footer wp-block-paragraph">Part of the '
+        '<a href="https://kriskrug.co/category/photography-visual-storytelling/">'
+        "Photography and Visual Storytelling</a> collection. See also: "
+        '<a href="https://kriskrug.co/example/">Sibling</a>.</p>\n'
+        "<!-- /wp:paragraph -->"
+    )
+
+
+def fake_item(spec: dict, *, raw: str | None = None) -> dict:
+    if raw is not None:
+        body = raw
+    elif spec["kind"] == "coda_page":
+        body = coda_fixture()
+    elif spec["kind"] == "before_footer":
+        body = "<p>Fashion rant body.</p>\n\n" + footer_block()
+    else:
+        body = (
+            '<p class="extended">I joined Model Mayhem. '
+            "I've met a couple cool peeps already.</p>\n\n" + footer_block()
+        )
+    return {
+        "id": spec["id"],
+        "slug": spec["slug"],
+        "content": {"raw": body},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_827_photography_hub.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue827PhotographyHubTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["targets"]}
+
+    def _patch_request(self, calls):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_issue_rows_11_to_14(self):
+        ids = [row["id"] for row in TARGETS["targets"]]
+        self.assertEqual(ids, [12013, 1222, 1056])
+        self.assertEqual(spec_by_id(12013)["rest"], "pages")
+        self.assertEqual(spec_by_id(12013)["slug"], "photography")
+        rows = {
+            item["row"]: item
+            for spec in TARGETS["targets"]
+            for item in spec["rows"]
+        }
+        self.assertEqual(
+            rows[11]["anchor"], "the whole archive, twenty years of it"
+        )
+        self.assertEqual(
+            rows[11]["href"],
+            "https://kriskrug.co/category/photography-visual-storytelling/",
+        )
+        self.assertEqual(
+            rows[12]["anchor"], "the fashion and model years, 2006 to 2008"
+        )
+        self.assertEqual(
+            rows[12]["href"],
+            "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+        )
+        self.assertEqual(
+            rows[13]["anchor"], "how I found those people in the first place"
+        )
+        self.assertEqual(rows[14]["anchor"], "where all of that ended up")
+        self.assertEqual(rows[14]["href"], "https://kriskrug.co/photography/")
+        self.assertNotIn(1210, ids)
+        self.assertTrue(
+            set(TARGETS["out_of_payload_ids"]).isdisjoint(ids)
+        )
+
+    def test_payload_snippets_match_targets(self):
+        coda = (FIX_DIR / "12013-coda-inserts.html").read_text(encoding="utf-8")
+        self.assertIn(exact(spec_by_id(12013)["rows"][0]), coda)
+        self.assertIn(exact(spec_by_id(12013)["rows"][1]), coda)
+        self.assertNotIn("checklist-of-model-photographer-negotiation-items", coda)
+        para = (FIX_DIR / "1222-sentence.html").read_text(encoding="utf-8").strip()
+        self.assertEqual(para, spec_by_id(1222)["rows"][0]["paragraph"])
+        peeps = (FIX_DIR / "1056-sentence.html").read_text(encoding="utf-8")
+        self.assertIn(exact(spec_by_id(1056)["rows"][0]), peeps)
+
+    def test_coda_insert_is_text_match_not_stale_block_index(self):
+        spec = spec_by_id(12013)
+        for figure_count in (0, 3, 16, 40):
+            raw = coda_fixture(figures=figure_count)
+            rewritten, notes = MODULE.rewrite_coda_page(raw, spec, TARGETS)
+            self.assertIsNotNone(rewritten)
+            self.assertIn("row 11 insert", notes)
+            self.assertIn("row 12 insert", notes)
+            self.assertIn(exact(spec["rows"][0]), rewritten)
+            self.assertIn(exact(spec["rows"][1]), rewritten)
+            self.assertEqual(
+                MODULE.style_blocks(raw), MODULE.style_blocks(rewritten)
+            )
+            self.assertEqual(
+                rewritten.count(TARGETS["flickr_href"]),
+                raw.count(TARGETS["flickr_href"]),
+            )
+            self.assertNotIn(
+                "checklist-of-model-photographer-negotiation-items", rewritten
+            )
+
+    def test_coda_skips_a_row_when_exact_href_and_anchor_exist(self):
+        spec = spec_by_id(12013)
+        row11 = exact(spec["rows"][0])
+        raw = coda_fixture(already=f" The on-site version is {row11}.")
+        rewritten, notes = MODULE.rewrite_coda_page(raw, spec, TARGETS)
+        self.assertIsNotNone(rewritten)
+        self.assertIn("row 11 already present", notes)
+        self.assertIn("row 12 insert", notes)
+        self.assertEqual(rewritten.count(row11), 1)
+        self.assertIn(exact(spec["rows"][1]), rewritten)
+
+    def test_coda_aborts_if_locate_text_missing_or_duplicated(self):
+        spec = spec_by_id(12013)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_coda_page("<p>no coda</p>", spec, TARGETS)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_coda_page(
+                coda_fixture() + "<h2>This is a fraction of it.</h2>",
+                spec,
+                TARGETS,
+            )
+
+    def test_coda_aborts_if_paragraph_resolves_inside_style(self):
+        spec = spec_by_id(12013)
+        poisoned = (
+            "<style>This is a fraction of it. <p>lives on Flickr</p></style>"
+            "<p>body</p>"
+        )
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_coda_page(poisoned, spec, TARGETS)
+
+    def test_1222_inserts_before_footer_and_keeps_count(self):
+        spec = spec_by_id(1222)
+        raw = fake_item(spec)["content"]["raw"]
+        rewritten, _notes = MODULE.rewrite_before_footer(raw, spec, TARGETS)
+        self.assertIsNotNone(rewritten)
+        self.assertIn(exact(spec["rows"][0]), rewritten)
+        self.assertLess(
+            rewritten.find(exact(spec["rows"][0])),
+            rewritten.find(MODULE.FOOTER_SENTINEL),
+        )
+        self.assertEqual(MODULE.footer_count(raw), MODULE.footer_count(rewritten))
+        self.assertIn("Sibling", rewritten)
+
+    def test_1056_inserts_after_entity_encoded_peeps_line(self):
+        spec = spec_by_id(1056)
+        raw = (
+            '<p class="extended">I joined. I&#8217;ve met a couple cool peeps '
+            "already.</p>\n\n" + footer_block()
+        )
+        rewritten, _notes = MODULE.rewrite_after_peeps(raw, spec, TARGETS)
+        self.assertIsNotNone(rewritten)
+        self.assertIn("I&#8217;ve met a couple cool peeps already. Here is ", rewritten)
+        self.assertIn(exact(spec["rows"][0]), rewritten)
+        self.assertEqual(MODULE.footer_count(raw), MODULE.footer_count(rewritten))
+
+    def test_dry_run_performs_no_local_or_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertTrue(any("/pages/12013" in url for url, _ in calls))
+        self.assertTrue(any("/posts/1222" in url for url, _ in calls))
+        self.assertTrue(any("/posts/1056" in url for url, _ in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12013]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--id", "12013")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--id", "12013"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn(exact(spec_by_id(12013)["rows"][0]), writes[0]["content"])
+        self.assertIn(exact(spec_by_id(12013)["rows"][1]), writes[0]["content"])
+        self.assertEqual(
+            MODULE.style_blocks(self.lives[12013]["content"]["raw"]),
+            MODULE.style_blocks(coda_fixture()),
+        )
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+        self.assertIn("pages-12013", snapshots[0].name)
+
+    def test_apply_all_three_targets_is_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(3, len(writes))
+        for body in writes:
+            self.assertEqual(set(body), {"content"})
+            self.assertNotIn("categories", body)
+
+    def test_skip_when_already_applied(self):
+        spec = spec_by_id(1222)
+        applied, _notes = MODULE.rewrite_before_footer(
+            fake_item(spec)["content"]["raw"], spec, TARGETS
+        )
+        self.lives[1222] = fake_item(spec, raw=applied)
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            self.assertEqual(0, run_main("--apply", "--id", "1222"))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_restore_refuses_ids_outside_the_allowlist(self):
+        snapshot = self.tmp_path / "rest-posts-1067-before.json"
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "id": 1067,
+                    "slug": "hardcore-superstar-photoshoot",
+                    "content": {"raw": "<p>nope</p>"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with mock.patch.object(MODULE, "request", side_effect=self._patch_request([])):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--restore", str(snapshot))
+        self.assertIn("not in the #827 set", str(caught.exception))
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (FIX_DIR / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("follow #826", apply_md)
+        self.assertIn("zero", apply_md.lower())
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #402", apply_md)
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn("inject_links", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #827.

## Summary

Gate 1 of the 2026-08-17 work plan: apply-ready payloads and a dry-run-default helper to wire internal links on `/photography/` (page 12013) and posts 1222 + 1056 (data rows 11-14). **No WordPress write in this PR.**

Live GET 2026-08-17T06:32Z:
- Page 12013 `content.rendered` still has **zero** internal hrefs (Flickr only).
- Post 1056 still does not link `/photography/`.
- All four target URLs return HTTP 200.
- Child 1 (#826) is prepared on main and not live. Live apply of this child waits for KK and should follow #826.

Inserts are by text match (`This is a fraction of it`), not stale block index 23. Exact anchors from the issue. Skip a row if that exact href+anchor already exists. Flickr exit and the inline `<style>` on 12013 stay. No rows 34-37, no post 1210, no recategorize of 1067/1063/1147.

## Related Issue

Refs #827 (parent #402 stays open). Do not close on merge of prep.

## Changes

- `content/drafts/2026-08-02-seo-authority-hubs/fix-827/` — APPLY.md, targets.json, insert snippets
- `scripts/apply_issue_827_photography_hub.py` — dry-run by default; slug/ID check; snapshot before write; `--apply` gated
- `scripts/tests/test_apply_issue_827_photography_hub.py`

## Type of Change

- [x] SEO improvement
- [x] Content update
- [x] Documentation update

## Testing

- [x] `python3 -m unittest scripts.tests.test_apply_issue_827_photography_hub`
- [x] Logged-out curls: `/photography/`, the photography archive, and post 1056 all 200; row 11-12 anchors absent; checklist grep count 0
- [ ] Do not run `--apply` until KK approves the dry-run diff, after #826 is live

## Deployment Notes

- [x] Requires KK approval before any live PATCH
- Content-only REST body. Restore is dry-run by default from `backup/issue-827-photography-hub/`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84a230e5-5184-48aa-832c-5e1157038f01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84a230e5-5184-48aa-832c-5e1157038f01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

