### PR TITLE
content(#827): photography hub link payloads, not applied

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/APPLY.md
@@ -1,0 +1,138 @@
+# #827 APPLY: photography hub internal links
+
+**Prepared, not applied. Do not PATCH until #826 is live and KK says go.**
+Script is dry-run by default. `--apply` is the only write switch, and it refuses unless the five #826 category fixes are already live.
+
+Parent: #402. This is child 2 of 9. Child 1 (#826) still owns 1067 / 1063 / 1147. This pack does not recategorize or retitle them.
+
+Do not close #827 or #402 when this runbook merges.
+
+## Live reconfirm (logged-out + authenticated GET, 2026-08-17T06:35Z)
+
+No REST POST / PATCH / DELETE in this session. Public REST confirmed slug/ID pairs. Authenticated `context=edit` snapshotted `content.raw` into `before/` (repo pack, not `backup/` secrets).
+
+| ID | Kind | Slug | URL | HTTP | Internal body links | Notes |
+|---|---|---|---|---:|---:|---|
+| 12013 | page | `photography` | `/photography/` | 200 | **0** | Two Flickr exits only. Inline `<style>` still present. |
+| 1222 | post | `to-all-you-wannabe-fashion-photographers` | `/2007/04/27/to-all-you-wannabe-fashion-photographers/` | 200 | 2 (footer only) | No link to 1056. One baked `kk-collection-footer`. |
+| 1056 | post | `kk-on-modelmayhemcom` | `/2006/10/23/kk-on-modelmayhemcom/` | 200 | 2 (footer only) | Does not link `/photography/`. One baked footer. |
+
+Four target URLs were 200: `/photography/`, `/category/photography-visual-storytelling/`, `/2006/10/23/kk-on-modelmayhemcom/`, `/2007/04/27/to-all-you-wannabe-fashion-photographers/`.
+
+Page 12013 `modified_gmt` is `2026-08-17T05:30:00` (PressCACHE no-op title-save from #706). The coda text and the inline `<style>` are still the cream-pack body. #480 has not been applied.
+
+### Block recount (today's HTML, not the 2026-08-02 index)
+
+Walking `p / h2 / h3 / ul / ol / figure / blockquote` in `content.rendered`:
+
+- Block 21 is the `<h2>This is a fraction of it.</h2>`
+- Block 22 is the coda `<p>` that ends `lives on Flickr.`
+- There is no block 23. Insertion is by **text match** on `lives on Flickr.</p>`, not a stale index.
+
+Flickr stays. The archive link is a second link in that same closing paragraph. The Flickr control remains the existing `kkx-btn` (`See 144,000+ frames on Flickr ?`). Do not "fix" the `?`.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+| ID | Required slug |
+|---:|---|
+| 12013 | `photography` |
+| 1222 | `to-all-you-wannabe-fashion-photographers` |
+| 1056 | `kk-on-modelmayhemcom` |
+
+## What the script writes
+
+Content only. Titles, slugs, dates, status, featured media, tags, categories, and SEO meta stay untouched.
+
+| ID | Find (exactly once) | Inserted copy |
+|---|---|---|
+| 12013 | `lives on Flickr.</p>` | two sentences in the same `<p>`: exact anchors `the whole archive, twenty years of it` (row 11) and `the fashion and model years, 2006 to 2008` (row 12) |
+| 1222 | Megan Cole line, then the baked footer comment | trailing sentence before the footer: exact anchor `how I found those people in the first place` (row 13) |
+| 1056 | `I've met a couple cool peeps already.</p>` | new sentence after that line: exact anchor `where all of that ended up` (row 14) |
+
+Inserted copy is ASCII. No em dashes. No NCR needed in the new sentences. Existing latin1-unsafe characters in 12013 (em dashes, `ü`) and 1222 (`Â£`) stay as they are.
+
+Skip a row if that exact `href` + anchor already exists.
+
+## Must not
+
+- Link post 1210 or add checklist copy (rows 34-37 / #828).
+- Touch the inline `<style>` on 12013.
+- Remove or rewrite the Flickr exit.
+- Duplicate `kk-collection-footer`.
+- Recategorize 1067 / 1063 / 1147.
+- Run bulk `inject_links.py`.
+- Mix the #480 style-strip into this write.
+
+## #480 write-surface warning
+
+Page 12013 is also an #480 write surface. `content/source-packs/content-architecture-2026/issue-480-retire-inline-css/photography.html` is a full-page replacement **without** these two links. If that payload is applied after these links land, it will wipe them unless it is re-cut.
+
+Sequencing: **#826 live first, then #827, then re-cut the #480 photography payload if needed.** Do not apply #480 photography.html as it stands after this pack.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_827_photography_hub
+
+# Offline dry-run: rewrite the snapshotted before-files into after/. No network.
+python3 scripts/apply_issue_827_photography_hub.py --from-files
+
+# Live GET dry-run: authenticated context=edit + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py'
+
+# Apply only after #826 is live and KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --apply'
+```
+
+`--item-id 12013` limits to one object. Re-run after a successful apply prints `[SKIP]`.
+
+`--apply` GETs the five #826 posts and aborts unless 3814 is out of 1757 into 1678, 3330 is out of 1757 into 1676, and 1067 / 1063 / 1147 are out of their wrong buckets into 1756.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-827-photography-hub/rest-<page|post>-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --restore backup/issue-827-photography-hub/rest-page-12013-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --restore backup/issue-827-photography-hub/rest-page-12013-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the three IDs or a slug mismatch. Rollback body is the snapshotted `content.raw`.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/photography/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/category/photography-visual-storytelling/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/
+
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -F 'the whole archive, twenty years of it'
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -F 'the fashion and model years, 2006 to 2008'
+curl -sL "https://kriskrug.co/photography/?cb=$RANDOM" | grep -c 'checklist-of-model-photographer-negotiation-items'
+# last command must print 0 until child 3 / #828
+
+curl -sL "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/?cb=$RANDOM" \
+  | grep -F 'how I found those people in the first place'
+curl -sL "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/?cb=$RANDOM" \
+  | grep -F 'where all of that ended up'
+
+# footer count must match the pre-write snapshot (2 raw hits = comment + class)
+curl -sL "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/?cb=$RANDOM" \
+  | grep -c 'kk-collection-footer'
+curl -sL "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/?cb=$RANDOM" \
+  | grep -c 'kk-collection-footer'
+```
+
+Expect: 12013 body gains exactly two new internal `<a href>` (archive + 1056), not three. Flickr button still present. 1222 and 1056 footer counts unchanged. No 1210 href on 12013.
+
+## Out of payload
+
+- Post 1210 rewrite and checklist inbounds (#828)
+- Taxonomy repair on 1067 / 1063 / 1147 / 3814 / 3330 (#826)
+- Inline CSS retirement on 12013 (#480)
+- Hub cards on 12318 / 12316 / 12319
+- `inject_links.py`

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/page-12013-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/page-12013-content.raw.html
@@ -1,0 +1,158 @@
+<!-- wp:html -->
+<style>
+.kkx{
+  --ink:#171310;--ink-soft:rgba(23,19,16,.78);--muted:rgba(23,19,16,.55);
+  --paper:#efe6d2;--card:#e6dcc2;--line:rgba(23,19,16,.14);
+  --accent:#d94a1f;--accent-text:#b53c18;
+  --grad:linear-gradient(120deg,#d94a1f 0%,#e8b53a 45%,#1f8a86 100%);
+  color:var(--ink-soft); max-width:72rem;
+}
+.kkx *{box-sizing:border-box}
+.kkx a{color:var(--accent-text);text-decoration:none;font-weight:700}
+.kkx a:hover,.kkx a:focus-visible{color:var(--ink);text-decoration:underline;text-underline-offset:4px}
+.kkx :focus-visible{outline:2px solid var(--accent-text);outline-offset:3px;border-radius:2px}
+.kkx :where(p,li)::first-letter{
+  initial-letter:normal!important;font-size:inherit!important;font-weight:inherit!important;
+  float:none!important;margin:0!important;line-height:inherit!important;color:inherit!important;
+  background:transparent!important;
+}
+
+/* cinematic hero stays dark-on-photo */
+.kkx-hero{position:relative;min-height:clamp(560px,92vh,920px);display:grid;align-items:end;
+ margin:0 0 clamp(2rem,5vw,4rem);border-radius:2px;overflow:hidden;isolation:isolate;color:#efe6d2}
+.kkx-hero img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:-2;filter:saturate(1.05) contrast(1.03)}
+.kkx-hero::after{content:"";position:absolute;inset:0;z-index:-1;
+ background:linear-gradient(180deg,rgba(23,19,16,.22) 0%,rgba(23,19,16,.12) 38%,rgba(23,19,16,.9) 100%),
+ radial-gradient(120% 80% at 12% 105%,rgba(217,74,31,.2),transparent 60%)}
+.kkx-hero-inner{padding:clamp(1.5rem,5vw,4rem)}
+.kkx-eyebrow{margin:0 0 .8rem;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.68rem;font-weight:600;letter-spacing:.28em;text-transform:uppercase;color:#e8b53a}
+.kkx-hero h1,.kkx-hero h2{margin:0;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(2.6rem,8vw,6.4rem);font-weight:700;line-height:.94;letter-spacing:-.03em;max-width:16ch;text-wrap:balance;color:#efe6d2;text-shadow:0 2px 40px rgba(0,0,0,.5)}
+.kkx-lead{margin:1.2rem 0 0;max-width:46rem;font-size:clamp(1.05rem,1.6vw,1.25rem);line-height:1.6;color:rgba(239,230,210,.82)}
+.kkx-lead strong{color:#efe6d2}
+
+.kkx-intro{max-width:46rem;margin:0 auto clamp(2.5rem,6vw,4.5rem);font-size:1.18rem;line-height:1.7;color:var(--ink-soft)}
+.kkx-intro strong{color:var(--ink)}
+
+.kkx-masonry{columns:3;column-gap:1rem}
+@media(max-width:1000px){.kkx-masonry{columns:2}}
+@media(max-width:620px){.kkx-masonry{columns:1}}
+.kkx-shot{position:relative;break-inside:avoid;margin:0 0 1rem;border-radius:2px;overflow:hidden;
+ background:var(--card);border:1px solid var(--line);box-shadow:none;transform:translateZ(0)}
+.kkx-shot img{display:block;width:100%;height:auto;transition:transform .6s cubic-bezier(.2,.7,.2,1),filter .6s ease;filter:saturate(.96)}
+.kkx-shot figcaption{position:absolute;inset:auto 0 0 0;padding:2.4rem 1rem .95rem;color:#efe6d2;font-size:.95rem;line-height:1.35;
+ background:linear-gradient(180deg,transparent,rgba(23,19,16,.55) 30%,rgba(23,19,16,.92));
+ transform:translateY(8px);opacity:.9;transition:opacity .4s ease,transform .4s ease}
+.kkx-kicker{display:block;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.62rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;margin-bottom:.3rem;color:#e8b53a}
+@media(hover:hover){
+ .kkx-shot:hover img{transform:scale(1.05);filter:saturate(1.1)}
+ .kkx-shot:hover figcaption{opacity:1;transform:translateY(0)}
+ .kkx-shot::after{content:"";position:absolute;inset:0;pointer-events:none;border-radius:2px;opacity:0;transition:opacity .4s ease;
+  box-shadow:inset 0 0 0 1px rgba(217,74,31,.45)}
+ .kkx-shot:hover::after{opacity:1}
+}
+
+@supports (animation-timeline:view()){
+ @media(prefers-reduced-motion:no-preference){
+  .kkx-shot{animation:kkx-rise linear both;animation-timeline:view();animation-range:entry 0% entry 55%}
+  .kkx-intro,.kkx-hero-inner>*{animation:kkx-fade linear both;animation-timeline:view();animation-range:entry 0% cover 22%}
+ }
+}
+@keyframes kkx-rise{from{opacity:0;transform:translateY(34px) scale(.985)}to{opacity:1;transform:none}}
+@keyframes kkx-fade{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+
+.kkx-coda{margin:clamp(3rem,7vw,5rem) 0 0;padding:clamp(1.6rem,4vw,2.4rem);border-radius:2px;
+ border:1px solid var(--line);border-top:2px solid var(--accent);background:var(--card);box-shadow:none}
+.kkx-coda h2{margin:0 0 .5rem;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(1.4rem,3vw,2rem);font-weight:700;letter-spacing:-.02em;color:var(--ink)}
+.kkx-coda p{margin:0 0 1.1rem;color:var(--ink-soft);max-width:48rem;line-height:1.6}
+.kkx-btn{display:inline-block;padding:.75rem 1.2rem;border-radius:2px;border:1px solid var(--ink);background:var(--ink);color:var(--paper)!important;
+ font-size:.72rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;text-decoration:none!important;transition:background .15s ease,border-color .15s ease}
+.kkx-btn:hover{background:var(--accent);border-color:var(--accent);color:var(--paper)!important;text-decoration:none!important}
+</style>
+
+<div class="kkx kk-page">
+
+  <section class="kkx-hero">
+    <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" />
+    <div class="kkx-hero-inner">
+      <p class="kkx-eyebrow">Photography · 2004 – 2026</p>
+      <h2>Two decades in the room, with a camera.</h2>
+      <p class="kkx-lead">I didn't watch this century happen — I shot it. The <strong>TEDxOilSpill</strong> expedition into the Gulf after Deepwater Horizon. The <strong>Midway Journey</strong> to the most remote island on Earth, choked with our plastic. The <strong>2010 Vancouver Olympics</strong>. The Dalai Lama's Peace Summit. A decade of SXSW with Iggy Pop, Jack White, and Billy Bragg in the frame. 144,000+ exposures, all from inside the moment.</p>
+    </div>
+  </section>
+
+  <p class="kkx-intro">This is the consequential cut — <strong>the work that mattered</strong>, not selfies with famous people. Environmental photojournalism that traveled the world, the cultural and spiritual figures who shaped the conversation, and the music and film I shot on the floor. The full 144,000-frame archive lives on <a href="https://www.flickr.com/photos/kk/">Flickr</a>.</p>
+
+  <div class="kkx-masonry">
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-deepwater-horizon-oil-spill-gulf-of-mexico-1.jpg" alt="The Deepwater Horizon oil spill in the Gulf of Mexico, shot on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Deepwater Horizon — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-a-gulf-oil-rig.jpg" alt="A Gulf of Mexico oil rig, documented on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Gulf of Mexico — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554916809329-1.jpg" alt="Journey to Midway Island — documenting the most remote place on Earth and its ocean plastic, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554917413729.jpg" alt="Journey to Midway Island, Pacific — environmental documentary by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-amazed-the-dalai-lama-at-vancouver-with-a-badge-scaled.jpg" alt="His Holiness the Dalai Lama at the Vancouver Peace Summit, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama — Vancouver Peace Summit</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-eckhart-tolle2C-the-dalai-lama-and-ken-robinson-at-1-1.jpg" alt="Eckhart Tolle, the Dalai Lama and Sir Ken Robinson at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>Tolle, the Dalai Lama &amp; Ken Robinson</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-blessings-the-dalai-lama-at-vancouver.jpg" alt="The Dalai Lama offering blessings at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama, Vancouver</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Iggy Pop — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-jack-white-of-the-raconteurs-shot-by-kris-krug-scaled.jpg" alt="Jack White of the Raconteurs, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Jack White, the Raconteurs</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-billy-bragg-shot-by-kris-krug.jpg" alt="Billy Bragg, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Billy Bragg</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-alex-maas2C-the-black-angels2C-sxsw-2007-1.jpg" alt="Alex Maas of The Black Angels at SXSW 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>The Black Angels — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-all-your-base-are-belong-to-ilanaaq-281061547129.jpg" alt="Ilanaaq, the inukshuk emblem of the Vancouver 2010 Winter Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 — Ilanaaq</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-australia-womens-500m-speed-skating-richmond-o-scaled.jpg" alt="Women&#x27;s 500m speed skating, Richmond Olympic Oval, Vancouver 2010 Winter Olympics, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 Olympics</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-george-bush-at-the-2008-beijing-olympics-2827525797-1.jpg" alt="President George W. Bush at the 2008 Beijing Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Power</span>George W. Bush — Beijing 2008</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-jake-gyllenhaal-sxsw-2011.jpg" alt="Jake Gyllenhaal at SXSW 2011, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Jake Gyllenhaal — SXSW 2011</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-grace-park-28boomer29-on-battlestar-galactica-flic-1-scaled.jpg" alt="Grace Park on the set of Battlestar Galactica, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Grace Park — Battlestar Galactica</figcaption>
+      </figure>
+  </div>
+
+  <section class="kkx-coda">
+    <h2>This is a fraction of it.</h2>
+    <p>Twenty years, a hundred and forty thousand frames — environmental expeditions, Olympic Games, peace summits, festival floors, every one shot in the room. The deep archive, including the cross-processed portraits and the work that isn't here, lives on Flickr. Walk <a href="https://kriskrug.co/category/photography-visual-storytelling/">the whole archive, twenty years of it</a> on this site. For <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">the fashion and model years, 2006 to 2008</a>, start with the ModelMayhem note.</p>
+    <a class="kkx-btn" href="https://www.flickr.com/photos/kk/">See 144,000+ frames on Flickr ?</a>
+  </section>
+</div>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/post-1056-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/post-1056-content.raw.html
@@ -1,0 +1,5 @@
+<p class="link"><a href="http://www.modelmayhem.com/member.php?id=237347">kk+ on ModelMayhem.com</a></p><p class="extended">I joined this community site called Model Mayhem to hopefully to know some more photographers, stylists and models in the fashion photography industry. Please check me out over there and give me your feedback. I've met a couple cool peeps already. This is <a href="https://kriskrug.co/photography/">where all of that ended up</a>.</p> 
+
+<!-- wp:paragraph {"className":"kk-collection-footer"} -->
+<p class="kk-collection-footer">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/post-1222-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/after/post-1222-content.raw.html
@@ -1,0 +1,32 @@
+<a href="http://www.flickr.com/photos/megs_pics/213783586/"><img src="http://farm1.static.flickr.com/93/213783586_c263b3bbe5_m.jpg" alt="Fake it til you make it!" align="left" style="margin-right: 5px" /></a>In the past 2 years I've getting more and more into <a href="http://staticphotography.com">fashion photography</a>. I'm involved in a couple <a href="http://flickr.com">photography</a> and <a href="http://modelmayhem.com">fashion</a> online communities and subscribe to a few blogs and am generally trying to familiarize myself with the industry and scene. I go to meetups, look at other photographers work, assist different photographers when I can, but photography books and tear them apart, and book lots of lil creative shoots for practice and experience <a style="text-decoration: none" href="http://collegefootballpicks2014.com/"><font color="#555555">college football lines</font></a> . Anyway, today over a<a href="http://www.flickr.com/groups/fashionphotography/discuss/72157600009921568/">t Flickr in the Fashion Photographer's Discussion Forum</a> I came around this awesome post that I thought was so insightful that I wanted to copy it here to my blog.
+
+"there are few exceptionals for sure. but my "personal" experience are here:
+
+dont go to the expensive photography college,they are a ripoff for the posh kids. the most important thing i ve ever learned in college was the zone system, u can learn it in one week for under 20Â£. i spend hours and days in the darkroom. u can build a make shift darkroom for less than 300Â£. it cost me 6000Â£ in the end and delivering pizza with my lomo.
+
+dont assist (specially those famous one)photographer or you will be shooting like him, only if u like to be copycat , or a short cut to the dosh, but believe me u will never be happy( maybe assist several diferent photographes, but then when are you going to do your own stuff??).
+
+to learn how to light things up, just spend time dazing under the sun, you get a good idea about lighting for sure. the rest you will find a way to get it. i build a Â£50 kino flood or get a flood 500w tungsten light from a construction site, legally.
+
+dont buy any fancy equipments, my Â£10 seagull twin lens works great with landscape. digital camera and computer are terrible inventions if you dont have the discipline to use it. shoot film first, black and white film and make some mistakes. absolutely no retouching, buy a computer later when u have a client.
+
+have a very very good relationship with as many model agencies as you can.....be nice to your crews and let them create something for you as well. you should have a good feeling in the beginning who you are working with. feed them even just an apple and a banana. charismatic personality get you very far.
+
+dont copy trends or up and coming stuffs or u will always be the one catching up with everybody else. find inspiration in some unlikely resources. if i dont have to, i prefer not to use models, instead my fav. are dancers, actors.....but some great models just had it all...
+
+dont give a damn on what everybody said, photorgaphy comes first, fashion second then the model to fit in the shot, NOT vice verse, maybe equally important sometime but not more important than photography******(only if you want to create a picture with an unique signature of yourself and create a niche of fans and clients, then follow this path)
+
+these are everything i did for the last 8years, and i realized its a long(*)road( not so hard and painful if you are passionate about photography and have some nice pictures sometime) .
+
+make sure you have enough to pay your rent and food, or get your frineds and families to pay for it .... just for a while and dont piss them off, they are a life saver...
+
+and keep on shooting and no retirement plans. "
+
+Original post by <a href="http://www.flickr.com/photos/takkypictures/">takkytak</a>
+<a href="http://www.flickr.com/photos/megs_pics/213783586/">Photo by Megan Cole</a> 
+
+That is also <a href="https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/">how I found those people in the first place</a>.
+
+<!-- wp:paragraph {"className":"kk-collection-footer"} -->
+<p class="kk-collection-footer">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-content.raw.html
@@ -1,0 +1,158 @@
+<!-- wp:html -->
+<style>
+.kkx{
+  --ink:#171310;--ink-soft:rgba(23,19,16,.78);--muted:rgba(23,19,16,.55);
+  --paper:#efe6d2;--card:#e6dcc2;--line:rgba(23,19,16,.14);
+  --accent:#d94a1f;--accent-text:#b53c18;
+  --grad:linear-gradient(120deg,#d94a1f 0%,#e8b53a 45%,#1f8a86 100%);
+  color:var(--ink-soft); max-width:72rem;
+}
+.kkx *{box-sizing:border-box}
+.kkx a{color:var(--accent-text);text-decoration:none;font-weight:700}
+.kkx a:hover,.kkx a:focus-visible{color:var(--ink);text-decoration:underline;text-underline-offset:4px}
+.kkx :focus-visible{outline:2px solid var(--accent-text);outline-offset:3px;border-radius:2px}
+.kkx :where(p,li)::first-letter{
+  initial-letter:normal!important;font-size:inherit!important;font-weight:inherit!important;
+  float:none!important;margin:0!important;line-height:inherit!important;color:inherit!important;
+  background:transparent!important;
+}
+
+/* cinematic hero stays dark-on-photo */
+.kkx-hero{position:relative;min-height:clamp(560px,92vh,920px);display:grid;align-items:end;
+ margin:0 0 clamp(2rem,5vw,4rem);border-radius:2px;overflow:hidden;isolation:isolate;color:#efe6d2}
+.kkx-hero img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:-2;filter:saturate(1.05) contrast(1.03)}
+.kkx-hero::after{content:"";position:absolute;inset:0;z-index:-1;
+ background:linear-gradient(180deg,rgba(23,19,16,.22) 0%,rgba(23,19,16,.12) 38%,rgba(23,19,16,.9) 100%),
+ radial-gradient(120% 80% at 12% 105%,rgba(217,74,31,.2),transparent 60%)}
+.kkx-hero-inner{padding:clamp(1.5rem,5vw,4rem)}
+.kkx-eyebrow{margin:0 0 .8rem;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.68rem;font-weight:600;letter-spacing:.28em;text-transform:uppercase;color:#e8b53a}
+.kkx-hero h1,.kkx-hero h2{margin:0;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(2.6rem,8vw,6.4rem);font-weight:700;line-height:.94;letter-spacing:-.03em;max-width:16ch;text-wrap:balance;color:#efe6d2;text-shadow:0 2px 40px rgba(0,0,0,.5)}
+.kkx-lead{margin:1.2rem 0 0;max-width:46rem;font-size:clamp(1.05rem,1.6vw,1.25rem);line-height:1.6;color:rgba(239,230,210,.82)}
+.kkx-lead strong{color:#efe6d2}
+
+.kkx-intro{max-width:46rem;margin:0 auto clamp(2.5rem,6vw,4.5rem);font-size:1.18rem;line-height:1.7;color:var(--ink-soft)}
+.kkx-intro strong{color:var(--ink)}
+
+.kkx-masonry{columns:3;column-gap:1rem}
+@media(max-width:1000px){.kkx-masonry{columns:2}}
+@media(max-width:620px){.kkx-masonry{columns:1}}
+.kkx-shot{position:relative;break-inside:avoid;margin:0 0 1rem;border-radius:2px;overflow:hidden;
+ background:var(--card);border:1px solid var(--line);box-shadow:none;transform:translateZ(0)}
+.kkx-shot img{display:block;width:100%;height:auto;transition:transform .6s cubic-bezier(.2,.7,.2,1),filter .6s ease;filter:saturate(.96)}
+.kkx-shot figcaption{position:absolute;inset:auto 0 0 0;padding:2.4rem 1rem .95rem;color:#efe6d2;font-size:.95rem;line-height:1.35;
+ background:linear-gradient(180deg,transparent,rgba(23,19,16,.55) 30%,rgba(23,19,16,.92));
+ transform:translateY(8px);opacity:.9;transition:opacity .4s ease,transform .4s ease}
+.kkx-kicker{display:block;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.62rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;margin-bottom:.3rem;color:#e8b53a}
+@media(hover:hover){
+ .kkx-shot:hover img{transform:scale(1.05);filter:saturate(1.1)}
+ .kkx-shot:hover figcaption{opacity:1;transform:translateY(0)}
+ .kkx-shot::after{content:"";position:absolute;inset:0;pointer-events:none;border-radius:2px;opacity:0;transition:opacity .4s ease;
+  box-shadow:inset 0 0 0 1px rgba(217,74,31,.45)}
+ .kkx-shot:hover::after{opacity:1}
+}
+
+@supports (animation-timeline:view()){
+ @media(prefers-reduced-motion:no-preference){
+  .kkx-shot{animation:kkx-rise linear both;animation-timeline:view();animation-range:entry 0% entry 55%}
+  .kkx-intro,.kkx-hero-inner>*{animation:kkx-fade linear both;animation-timeline:view();animation-range:entry 0% cover 22%}
+ }
+}
+@keyframes kkx-rise{from{opacity:0;transform:translateY(34px) scale(.985)}to{opacity:1;transform:none}}
+@keyframes kkx-fade{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+
+.kkx-coda{margin:clamp(3rem,7vw,5rem) 0 0;padding:clamp(1.6rem,4vw,2.4rem);border-radius:2px;
+ border:1px solid var(--line);border-top:2px solid var(--accent);background:var(--card);box-shadow:none}
+.kkx-coda h2{margin:0 0 .5rem;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(1.4rem,3vw,2rem);font-weight:700;letter-spacing:-.02em;color:var(--ink)}
+.kkx-coda p{margin:0 0 1.1rem;color:var(--ink-soft);max-width:48rem;line-height:1.6}
+.kkx-btn{display:inline-block;padding:.75rem 1.2rem;border-radius:2px;border:1px solid var(--ink);background:var(--ink);color:var(--paper)!important;
+ font-size:.72rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;text-decoration:none!important;transition:background .15s ease,border-color .15s ease}
+.kkx-btn:hover{background:var(--accent);border-color:var(--accent);color:var(--paper)!important;text-decoration:none!important}
+</style>
+
+<div class="kkx kk-page">
+
+  <section class="kkx-hero">
+    <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" />
+    <div class="kkx-hero-inner">
+      <p class="kkx-eyebrow">Photography · 2004 – 2026</p>
+      <h2>Two decades in the room, with a camera.</h2>
+      <p class="kkx-lead">I didn't watch this century happen — I shot it. The <strong>TEDxOilSpill</strong> expedition into the Gulf after Deepwater Horizon. The <strong>Midway Journey</strong> to the most remote island on Earth, choked with our plastic. The <strong>2010 Vancouver Olympics</strong>. The Dalai Lama's Peace Summit. A decade of SXSW with Iggy Pop, Jack White, and Billy Bragg in the frame. 144,000+ exposures, all from inside the moment.</p>
+    </div>
+  </section>
+
+  <p class="kkx-intro">This is the consequential cut — <strong>the work that mattered</strong>, not selfies with famous people. Environmental photojournalism that traveled the world, the cultural and spiritual figures who shaped the conversation, and the music and film I shot on the floor. The full 144,000-frame archive lives on <a href="https://www.flickr.com/photos/kk/">Flickr</a>.</p>
+
+  <div class="kkx-masonry">
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-deepwater-horizon-oil-spill-gulf-of-mexico-1.jpg" alt="The Deepwater Horizon oil spill in the Gulf of Mexico, shot on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Deepwater Horizon — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-a-gulf-oil-rig.jpg" alt="A Gulf of Mexico oil rig, documented on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Gulf of Mexico — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554916809329-1.jpg" alt="Journey to Midway Island — documenting the most remote place on Earth and its ocean plastic, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554917413729.jpg" alt="Journey to Midway Island, Pacific — environmental documentary by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-amazed-the-dalai-lama-at-vancouver-with-a-badge-scaled.jpg" alt="His Holiness the Dalai Lama at the Vancouver Peace Summit, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama — Vancouver Peace Summit</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-eckhart-tolle2C-the-dalai-lama-and-ken-robinson-at-1-1.jpg" alt="Eckhart Tolle, the Dalai Lama and Sir Ken Robinson at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>Tolle, the Dalai Lama &amp; Ken Robinson</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-blessings-the-dalai-lama-at-vancouver.jpg" alt="The Dalai Lama offering blessings at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama, Vancouver</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Iggy Pop — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-jack-white-of-the-raconteurs-shot-by-kris-krug-scaled.jpg" alt="Jack White of the Raconteurs, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Jack White, the Raconteurs</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-billy-bragg-shot-by-kris-krug.jpg" alt="Billy Bragg, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Billy Bragg</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-alex-maas2C-the-black-angels2C-sxsw-2007-1.jpg" alt="Alex Maas of The Black Angels at SXSW 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>The Black Angels — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-all-your-base-are-belong-to-ilanaaq-281061547129.jpg" alt="Ilanaaq, the inukshuk emblem of the Vancouver 2010 Winter Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 — Ilanaaq</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-australia-womens-500m-speed-skating-richmond-o-scaled.jpg" alt="Women&#x27;s 500m speed skating, Richmond Olympic Oval, Vancouver 2010 Winter Olympics, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 Olympics</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-george-bush-at-the-2008-beijing-olympics-2827525797-1.jpg" alt="President George W. Bush at the 2008 Beijing Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Power</span>George W. Bush — Beijing 2008</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-jake-gyllenhaal-sxsw-2011.jpg" alt="Jake Gyllenhaal at SXSW 2011, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Jake Gyllenhaal — SXSW 2011</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img src="https://kriskrug.co/wp-content/uploads/2026/05/kkarchive-grace-park-28boomer29-on-battlestar-galactica-flic-1-scaled.jpg" alt="Grace Park on the set of Battlestar Galactica, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Grace Park — Battlestar Galactica</figcaption>
+      </figure>
+  </div>
+
+  <section class="kkx-coda">
+    <h2>This is a fraction of it.</h2>
+    <p>Twenty years, a hundred and forty thousand frames — environmental expeditions, Olympic Games, peace summits, festival floors, every one shot in the room. The deep archive, including the cross-processed portraits and the work that isn't here, lives on Flickr.</p>
+    <a class="kkx-btn" href="https://www.flickr.com/photos/kk/">See 144,000+ frames on Flickr ?</a>
+  </section>
+</div>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-content.rendered.html
@@ -1,0 +1,158 @@
+
+<style>
+.kkx{
+  --ink:#171310;--ink-soft:rgba(23,19,16,.78);--muted:rgba(23,19,16,.55);
+  --paper:#efe6d2;--card:#e6dcc2;--line:rgba(23,19,16,.14);
+  --accent:#d94a1f;--accent-text:#b53c18;
+  --grad:linear-gradient(120deg,#d94a1f 0%,#e8b53a 45%,#1f8a86 100%);
+  color:var(--ink-soft); max-width:72rem;
+}
+.kkx *{box-sizing:border-box}
+.kkx a{color:var(--accent-text);text-decoration:none;font-weight:700}
+.kkx a:hover,.kkx a:focus-visible{color:var(--ink);text-decoration:underline;text-underline-offset:4px}
+.kkx :focus-visible{outline:2px solid var(--accent-text);outline-offset:3px;border-radius:2px}
+.kkx :where(p,li)::first-letter{
+  initial-letter:normal!important;font-size:inherit!important;font-weight:inherit!important;
+  float:none!important;margin:0!important;line-height:inherit!important;color:inherit!important;
+  background:transparent!important;
+}
+
+/* cinematic hero stays dark-on-photo */
+.kkx-hero{position:relative;min-height:clamp(560px,92vh,920px);display:grid;align-items:end;
+ margin:0 0 clamp(2rem,5vw,4rem);border-radius:2px;overflow:hidden;isolation:isolate;color:#efe6d2}
+.kkx-hero img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;z-index:-2;filter:saturate(1.05) contrast(1.03)}
+.kkx-hero::after{content:"";position:absolute;inset:0;z-index:-1;
+ background:linear-gradient(180deg,rgba(23,19,16,.22) 0%,rgba(23,19,16,.12) 38%,rgba(23,19,16,.9) 100%),
+ radial-gradient(120% 80% at 12% 105%,rgba(217,74,31,.2),transparent 60%)}
+.kkx-hero-inner{padding:clamp(1.5rem,5vw,4rem)}
+.kkx-eyebrow{margin:0 0 .8rem;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.68rem;font-weight:600;letter-spacing:.28em;text-transform:uppercase;color:#e8b53a}
+.kkx-hero h1,.kkx-hero h2{margin:0;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(2.6rem,8vw,6.4rem);font-weight:700;line-height:.94;letter-spacing:-.03em;max-width:16ch;text-wrap:balance;color:#efe6d2;text-shadow:0 2px 40px rgba(0,0,0,.5)}
+.kkx-lead{margin:1.2rem 0 0;max-width:46rem;font-size:clamp(1.05rem,1.6vw,1.25rem);line-height:1.6;color:rgba(239,230,210,.82)}
+.kkx-lead strong{color:#efe6d2}
+
+.kkx-intro{max-width:46rem;margin:0 auto clamp(2.5rem,6vw,4.5rem);font-size:1.18rem;line-height:1.7;color:var(--ink-soft)}
+.kkx-intro strong{color:var(--ink)}
+
+.kkx-masonry{columns:3;column-gap:1rem}
+@media(max-width:1000px){.kkx-masonry{columns:2}}
+@media(max-width:620px){.kkx-masonry{columns:1}}
+.kkx-shot{position:relative;break-inside:avoid;margin:0 0 1rem;border-radius:2px;overflow:hidden;
+ background:var(--card);border:1px solid var(--line);box-shadow:none;transform:translateZ(0)}
+.kkx-shot img{display:block;width:100%;height:auto;transition:transform .6s cubic-bezier(.2,.7,.2,1),filter .6s ease;filter:saturate(.96)}
+.kkx-shot figcaption{position:absolute;inset:auto 0 0 0;padding:2.4rem 1rem .95rem;color:#efe6d2;font-size:.95rem;line-height:1.35;
+ background:linear-gradient(180deg,transparent,rgba(23,19,16,.55) 30%,rgba(23,19,16,.92));
+ transform:translateY(8px);opacity:.9;transition:opacity .4s ease,transform .4s ease}
+.kkx-kicker{display:block;font-family:"JetBrains Mono",ui-monospace,monospace;font-size:.62rem;font-weight:600;letter-spacing:.2em;text-transform:uppercase;margin-bottom:.3rem;color:#e8b53a}
+@media(hover:hover){
+ .kkx-shot:hover img{transform:scale(1.05);filter:saturate(1.1)}
+ .kkx-shot:hover figcaption{opacity:1;transform:translateY(0)}
+ .kkx-shot::after{content:"";position:absolute;inset:0;pointer-events:none;border-radius:2px;opacity:0;transition:opacity .4s ease;
+  box-shadow:inset 0 0 0 1px rgba(217,74,31,.45)}
+ .kkx-shot:hover::after{opacity:1}
+}
+
+@supports (animation-timeline:view()){
+ @media(prefers-reduced-motion:no-preference){
+  .kkx-shot{animation:kkx-rise linear both;animation-timeline:view();animation-range:entry 0% entry 55%}
+  .kkx-intro,.kkx-hero-inner>*{animation:kkx-fade linear both;animation-timeline:view();animation-range:entry 0% cover 22%}
+ }
+}
+@keyframes kkx-rise{from{opacity:0;transform:translateY(34px) scale(.985)}to{opacity:1;transform:none}}
+@keyframes kkx-fade{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:none}}
+
+.kkx-coda{margin:clamp(3rem,7vw,5rem) 0 0;padding:clamp(1.6rem,4vw,2.4rem);border-radius:2px;
+ border:1px solid var(--line);border-top:2px solid var(--accent);background:var(--card);box-shadow:none}
+.kkx-coda h2{margin:0 0 .5rem;font-family:"Space Grotesk",system-ui,sans-serif;font-size:clamp(1.4rem,3vw,2rem);font-weight:700;letter-spacing:-.02em;color:var(--ink)}
+.kkx-coda p{margin:0 0 1.1rem;color:var(--ink-soft);max-width:48rem;line-height:1.6}
+.kkx-btn{display:inline-block;padding:.75rem 1.2rem;border-radius:2px;border:1px solid var(--ink);background:var(--ink);color:var(--paper)!important;
+ font-size:.72rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;text-decoration:none!important;transition:background .15s ease,border-color .15s ease}
+.kkx-btn:hover{background:var(--accent);border-color:var(--accent);color:var(--paper)!important;text-decoration:none!important}
+</style>
+
+<div class="kkx kk-page">
+
+  <section class="kkx-hero">
+    <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg?ssl=1" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" />
+    <div class="kkx-hero-inner">
+      <p class="kkx-eyebrow">Photography · 2004 – 2026</p>
+      <h2>Two decades in the room, with a camera.</h2>
+      <p class="kkx-lead">I didn&#8217;t watch this century happen — I shot it. The <strong>TEDxOilSpill</strong> expedition into the Gulf after Deepwater Horizon. The <strong>Midway Journey</strong> to the most remote island on Earth, choked with our plastic. The <strong>2010 Vancouver Olympics</strong>. The Dalai Lama&#8217;s Peace Summit. A decade of SXSW with Iggy Pop, Jack White, and Billy Bragg in the frame. 144,000+ exposures, all from inside the moment.</p>
+    </div>
+  </section>
+
+  <p class="kkx-intro">This is the consequential cut — <strong>the work that mattered</strong>, not selfies with famous people. Environmental photojournalism that traveled the world, the cultural and spiritual figures who shaped the conversation, and the music and film I shot on the floor. The full 144,000-frame archive lives on <a href="https://www.flickr.com/photos/kk/">Flickr</a>.</p>
+
+  <div class="kkx-masonry">
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-deepwater-horizon-oil-spill-gulf-of-mexico-1.jpg?ssl=1" alt="The Deepwater Horizon oil spill in the Gulf of Mexico, shot on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Deepwater Horizon — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-a-gulf-oil-rig.jpg?ssl=1" alt="A Gulf of Mexico oil rig, documented on the TEDxOilSpill expedition by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>Gulf of Mexico — TEDxOilSpill</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554916809329-1.jpg?ssl=1" alt="Journey to Midway Island — documenting the most remote place on Earth and its ocean plastic, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-journey-to-midway-island-28554917413729.jpg?ssl=1" alt="Journey to Midway Island, Pacific — environmental documentary by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Climate</span>The Midway Journey</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-amazed-the-dalai-lama-at-vancouver-with-a-badge-scaled.jpg?ssl=1" alt="His Holiness the Dalai Lama at the Vancouver Peace Summit, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama — Vancouver Peace Summit</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-eckhart-tolle2C-the-dalai-lama-and-ken-robinson-at-1-1.jpg?ssl=1" alt="Eckhart Tolle, the Dalai Lama and Sir Ken Robinson at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>Tolle, the Dalai Lama &amp; Ken Robinson</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-blessings-the-dalai-lama-at-vancouver.jpg?ssl=1" alt="The Dalai Lama offering blessings at Vancouver, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Movements</span>The Dalai Lama, Vancouver</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-iggy-pop-at-south-by-southwest-2007-shot-by-kris-k.jpg?ssl=1" alt="Iggy Pop performing at South by Southwest, 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Iggy Pop — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-jack-white-of-the-raconteurs-shot-by-kris-krug-scaled.jpg?ssl=1" alt="Jack White of the Raconteurs, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Jack White, the Raconteurs</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-billy-bragg-shot-by-kris-krug.jpg?ssl=1" alt="Billy Bragg, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>Billy Bragg</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-alex-maas2C-the-black-angels2C-sxsw-2007-1.jpg?ssl=1" alt="Alex Maas of The Black Angels at SXSW 2007, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Music</span>The Black Angels — SXSW 2007</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-all-your-base-are-belong-to-ilanaaq-281061547129.jpg?ssl=1" alt="Ilanaaq, the inukshuk emblem of the Vancouver 2010 Winter Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 — Ilanaaq</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-australia-womens-500m-speed-skating-richmond-o-scaled.jpg?ssl=1" alt="Women&#x27;s 500m speed skating, Richmond Olympic Oval, Vancouver 2010 Winter Olympics, by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Sport</span>Vancouver 2010 Olympics</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-george-bush-at-the-2008-beijing-olympics-2827525797-1.jpg?ssl=1" alt="President George W. Bush at the 2008 Beijing Olympics, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Power</span>George W. Bush — Beijing 2008</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-jake-gyllenhaal-sxsw-2011.jpg?ssl=1" alt="Jake Gyllenhaal at SXSW 2011, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Jake Gyllenhaal — SXSW 2011</figcaption>
+      </figure>
+      <figure class="kkx-shot">
+        <img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kkarchive-grace-park-28boomer29-on-battlestar-galactica-flic-1-scaled.jpg?ssl=1" alt="Grace Park on the set of Battlestar Galactica, photographed by Kris Krüg" loading="lazy" />
+        <figcaption><span class="kkx-kicker">Film</span>Grace Park — Battlestar Galactica</figcaption>
+      </figure>
+  </div>
+
+  <section class="kkx-coda">
+    <h2>This is a fraction of it.</h2>
+    <p>Twenty years, a hundred and forty thousand frames — environmental expeditions, Olympic Games, peace summits, festival floors, every one shot in the room. The deep archive, including the cross-processed portraits and the work that isn&#8217;t here, lives on Flickr.</p>
+    <a class="kkx-btn" href="https://www.flickr.com/photos/kk/">See 144,000+ frames on Flickr ?</a>
+  </section>
+</div>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/page-12013-identity.json
@@ -1,0 +1,12 @@
+{
+  "id": 12013,
+  "slug": "photography",
+  "status": "publish",
+  "link": "https://kriskrug.co/photography/",
+  "modified": "2026-08-16T21:30:00",
+  "modified_gmt": "2026-08-17T05:30:00",
+  "type": "page",
+  "content_raw_bytes": 12841,
+  "content_raw_has_style": true,
+  "content_raw_has_footer": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-content.raw.html
@@ -1,0 +1,5 @@
+<p class="link"><a href="http://www.modelmayhem.com/member.php?id=237347">kk+ on ModelMayhem.com</a></p><p class="extended">I joined this community site called Model Mayhem to hopefully to know some more photographers, stylists and models in the fashion photography industry. Please check me out over there and give me your feedback. I've met a couple cool peeps already.</p> 
+
+<!-- wp:paragraph {"className":"kk-collection-footer"} -->
+<p class="kk-collection-footer">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-content.rendered.html
@@ -1,0 +1,4 @@
+<p class="link"><a href="http://www.modelmayhem.com/member.php?id=237347">kk+ on ModelMayhem.com</a></p><p class="extended">I joined this community site called Model Mayhem to hopefully to know some more photographers, stylists and models in the fashion photography industry. Please check me out over there and give me your feedback. I&#8217;ve met a couple cool peeps already.</p> 
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1056-identity.json
@@ -1,0 +1,12 @@
+{
+  "id": 1056,
+  "slug": "kk-on-modelmayhemcom",
+  "status": "publish",
+  "link": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+  "modified": "2026-06-14T21:20:28",
+  "modified_gmt": "2026-06-15T05:20:28",
+  "type": "post",
+  "content_raw_bytes": 877,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-content.raw.html
@@ -1,0 +1,30 @@
+<a href="http://www.flickr.com/photos/megs_pics/213783586/"><img src="http://farm1.static.flickr.com/93/213783586_c263b3bbe5_m.jpg" alt="Fake it til you make it!" align="left" style="margin-right: 5px" /></a>In the past 2 years I've getting more and more into <a href="http://staticphotography.com">fashion photography</a>. I'm involved in a couple <a href="http://flickr.com">photography</a> and <a href="http://modelmayhem.com">fashion</a> online communities and subscribe to a few blogs and am generally trying to familiarize myself with the industry and scene. I go to meetups, look at other photographers work, assist different photographers when I can, but photography books and tear them apart, and book lots of lil creative shoots for practice and experience <a style="text-decoration: none" href="http://collegefootballpicks2014.com/"><font color="#555555">college football lines</font></a> . Anyway, today over a<a href="http://www.flickr.com/groups/fashionphotography/discuss/72157600009921568/">t Flickr in the Fashion Photographer's Discussion Forum</a> I came around this awesome post that I thought was so insightful that I wanted to copy it here to my blog.
+
+"there are few exceptionals for sure. but my "personal" experience are here:
+
+dont go to the expensive photography college,they are a ripoff for the posh kids. the most important thing i ve ever learned in college was the zone system, u can learn it in one week for under 20Â£. i spend hours and days in the darkroom. u can build a make shift darkroom for less than 300Â£. it cost me 6000Â£ in the end and delivering pizza with my lomo.
+
+dont assist (specially those famous one)photographer or you will be shooting like him, only if u like to be copycat , or a short cut to the dosh, but believe me u will never be happy( maybe assist several diferent photographes, but then when are you going to do your own stuff??).
+
+to learn how to light things up, just spend time dazing under the sun, you get a good idea about lighting for sure. the rest you will find a way to get it. i build a Â£50 kino flood or get a flood 500w tungsten light from a construction site, legally.
+
+dont buy any fancy equipments, my Â£10 seagull twin lens works great with landscape. digital camera and computer are terrible inventions if you dont have the discipline to use it. shoot film first, black and white film and make some mistakes. absolutely no retouching, buy a computer later when u have a client.
+
+have a very very good relationship with as many model agencies as you can.....be nice to your crews and let them create something for you as well. you should have a good feeling in the beginning who you are working with. feed them even just an apple and a banana. charismatic personality get you very far.
+
+dont copy trends or up and coming stuffs or u will always be the one catching up with everybody else. find inspiration in some unlikely resources. if i dont have to, i prefer not to use models, instead my fav. are dancers, actors.....but some great models just had it all...
+
+dont give a damn on what everybody said, photorgaphy comes first, fashion second then the model to fit in the shot, NOT vice verse, maybe equally important sometime but not more important than photography******(only if you want to create a picture with an unique signature of yourself and create a niche of fans and clients, then follow this path)
+
+these are everything i did for the last 8years, and i realized its a long(*)road( not so hard and painful if you are passionate about photography and have some nice pictures sometime) .
+
+make sure you have enough to pay your rent and food, or get your frineds and families to pay for it .... just for a while and dont piss them off, they are a life saver...
+
+and keep on shooting and no retirement plans. "
+
+Original post by <a href="http://www.flickr.com/photos/takkypictures/">takkytak</a>
+<a href="http://www.flickr.com/photos/megs_pics/213783586/">Photo by Megan Cole</a> 
+
+<!-- wp:paragraph {"className":"kk-collection-footer"} -->
+<p class="kk-collection-footer">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>
+<!-- /wp:paragraph -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-content.rendered.html
@@ -1,0 +1,29 @@
+<a href="http://www.flickr.com/photos/megs_pics/213783586/"><img data-recalc-dims="1" decoding="async" src="https://i0.wp.com/farm1.static.flickr.com/93/213783586_c263b3bbe5_m.jpg" alt="Fake it til you make it!" align="left" style="margin-right: 5px" /></a>In the past 2 years I&#8217;ve getting more and more into <a href="http://staticphotography.com">fashion photography</a>. I&#8217;m involved in a couple <a href="http://flickr.com">photography</a> and <a href="http://modelmayhem.com">fashion</a> online communities and subscribe to a few blogs and am generally trying to familiarize myself with the industry and scene. I go to meetups, look at other photographers work, assist different photographers when I can, but photography books and tear them apart, and book lots of lil creative shoots for practice and experience <a style="text-decoration: none" href="http://collegefootballpicks2014.com/"><font color="#555555">college football lines</font></a> . Anyway, today over a<a href="http://www.flickr.com/groups/fashionphotography/discuss/72157600009921568/">t Flickr in the Fashion Photographer&#8217;s Discussion Forum</a> I came around this awesome post that I thought was so insightful that I wanted to copy it here to my blog.
+
+&#8220;there are few exceptionals for sure. but my &#8220;personal&#8221; experience are here:
+
+dont go to the expensive photography college,they are a ripoff for the posh kids. the most important thing i ve ever learned in college was the zone system, u can learn it in one week for under 20Â£. i spend hours and days in the darkroom. u can build a make shift darkroom for less than 300Â£. it cost me 6000Â£ in the end and delivering pizza with my lomo.
+
+dont assist (specially those famous one)photographer or you will be shooting like him, only if u like to be copycat , or a short cut to the dosh, but believe me u will never be happy( maybe assist several diferent photographes, but then when are you going to do your own stuff??).
+
+to learn how to light things up, just spend time dazing under the sun, you get a good idea about lighting for sure. the rest you will find a way to get it. i build a Â£50 kino flood or get a flood 500w tungsten light from a construction site, legally.
+
+dont buy any fancy equipments, my Â£10 seagull twin lens works great with landscape. digital camera and computer are terrible inventions if you dont have the discipline to use it. shoot film first, black and white film and make some mistakes. absolutely no retouching, buy a computer later when u have a client.
+
+have a very very good relationship with as many model agencies as you can&#8230;..be nice to your crews and let them create something for you as well. you should have a good feeling in the beginning who you are working with. feed them even just an apple and a banana. charismatic personality get you very far.
+
+dont copy trends or up and coming stuffs or u will always be the one catching up with everybody else. find inspiration in some unlikely resources. if i dont have to, i prefer not to use models, instead my fav. are dancers, actors&#8230;..but some great models just had it all&#8230;
+
+dont give a damn on what everybody said, photorgaphy comes first, fashion second then the model to fit in the shot, NOT vice verse, maybe equally important sometime but not more important than photography******(only if you want to create a picture with an unique signature of yourself and create a niche of fans and clients, then follow this path)
+
+these are everything i did for the last 8years, and i realized its a long(*)road( not so hard and painful if you are passionate about photography and have some nice pictures sometime) .
+
+make sure you have enough to pay your rent and food, or get your frineds and families to pay for it &#8230;. just for a while and dont piss them off, they are a life saver&#8230;
+
+and keep on shooting and no retirement plans. &#8221;
+
+Original post by <a href="http://www.flickr.com/photos/takkypictures/">takkytak</a>
+<a href="http://www.flickr.com/photos/megs_pics/213783586/">Photo by Megan Cole</a> 
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/category/photography-visual-storytelling/">Photography and Visual Storytelling</a> collection. See also: <a href="https://kriskrug.co/2023/10/23/embarking-on-a-media-revolution-my-participation-in-the-google-news-initiative-pre-launch-lab/">Embarking on a Media Revolution: My Participation in the Google News Initiative Pre-launch Lab</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/before/post-1222-identity.json
@@ -1,0 +1,12 @@
+{
+  "id": 1222,
+  "slug": "to-all-you-wannabe-fashion-photographers",
+  "status": "publish",
+  "link": "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/",
+  "modified": "2026-07-11T11:48:05",
+  "modified_gmt": "2026-07-11T19:48:05",
+  "type": "post",
+  "content_raw_bytes": 4495,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-827/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-827/targets.json
@@ -1,0 +1,104 @@
+{
+  "issue": 827,
+  "parent": 402,
+  "blocked_by": 826,
+  "live_reconfirm": "2026-08-17T06:35:00Z",
+  "status": "prepared_not_applied",
+  "style_sha256_12013": "23dc2ddaf20ffda0f94f619e9ade0068d3a9a0c5fdb38563538b6542a34c69b3",
+  "forbidden_href_substrings": [
+    "checklist-of-model-photographer-negotiation-items"
+  ],
+  "flickr_exit": "https://www.flickr.com/photos/kk/",
+  "flickr_button": "See 144,000+ frames on Flickr ?",
+  "child1_gate": [
+    {
+      "id": 3814,
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "from_category": 1757,
+      "to_category": 1678
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "from_category": 1757,
+      "to_category": 1676
+    },
+    {
+      "id": 1067,
+      "slug": "hardcore-superstar-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1063,
+      "slug": "made-in-vancouver-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1147,
+      "slug": "fashion-photoshoot-for-discollection",
+      "from_category": 1665,
+      "to_category": 1756
+    }
+  ],
+  "items": [
+    {
+      "id": 12013,
+      "kind": "pages",
+      "slug": "photography",
+      "url": "https://kriskrug.co/photography/",
+      "modified_gmt_at_reconfirm": "2026-08-17T05:30:00",
+      "find": "lives on Flickr.</p>",
+      "replace": "lives on Flickr. Walk <a href=\"https://kriskrug.co/category/photography-visual-storytelling/\">the whole archive, twenty years of it</a> on this site. For <a href=\"https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/\">the fashion and model years, 2006 to 2008</a>, start with the ModelMayhem note.</p>",
+      "anchors": [
+        {
+          "row": 11,
+          "text": "the whole archive, twenty years of it",
+          "href": "https://kriskrug.co/category/photography-visual-storytelling/"
+        },
+        {
+          "row": 12,
+          "text": "the fashion and model years, 2006 to 2008",
+          "href": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/"
+        }
+      ],
+      "preserve_style": true,
+      "preserve_flickr": true
+    },
+    {
+      "id": 1222,
+      "kind": "posts",
+      "slug": "to-all-you-wannabe-fashion-photographers",
+      "url": "https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/",
+      "modified_gmt_at_reconfirm": "2026-07-11T19:48:05",
+      "find": "<a href=\"http://www.flickr.com/photos/megs_pics/213783586/\">Photo by Megan Cole</a> \n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->",
+      "replace": "<a href=\"http://www.flickr.com/photos/megs_pics/213783586/\">Photo by Megan Cole</a> \n\nThat is also <a href=\"https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/\">how I found those people in the first place</a>.\n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->",
+      "anchors": [
+        {
+          "row": 13,
+          "text": "how I found those people in the first place",
+          "href": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/"
+        }
+      ],
+      "preserve_footer": true
+    },
+    {
+      "id": 1056,
+      "kind": "posts",
+      "slug": "kk-on-modelmayhemcom",
+      "url": "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+      "modified_gmt_at_reconfirm": "2026-06-15T05:20:28",
+      "find": "I've met a couple cool peeps already.</p>",
+      "replace": "I've met a couple cool peeps already. This is <a href=\"https://kriskrug.co/photography/\">where all of that ended up</a>.</p>",
+      "anchors": [
+        {
+          "row": 14,
+          "text": "where all of that ended up",
+          "href": "https://kriskrug.co/photography/"
+        }
+      ],
+      "preserve_footer": true
+    }
+  ]
+}

--- a/docs/current-state/reports/issue-827-apply-ready-20260817.md
+++ b/docs/current-state/reports/issue-827-apply-ready-20260817.md
@@ -1,0 +1,76 @@
+# Issue #827 apply-ready readback (2026-08-17)
+
+**Status:** PREPARED, NOT APPLIED. Content-only payloads for page 12013 and posts 1222 / 1056. No live WordPress write.
+**Issue:** [#827](https://github.com/WalksWithASwagger/kriskrug-wp/issues/827) (child 2 of [#402](https://github.com/WalksWithASwagger/kriskrug-wp/issues/402)).
+**Pack:** [`content/drafts/2026-08-02-seo-authority-hubs/fix-827/`](../../../content/drafts/2026-08-02-seo-authority-hubs/fix-827/)
+**Blocker:** [#826](https://github.com/WalksWithASwagger/kriskrug-wp/issues/826) taxonomy repair is not live.
+
+Do not close #827 or #402.
+
+## Method
+
+Logged-out HTTP + public REST, then authenticated GET `context=edit` for `content.raw` only. Fetch stamp `2026-08-17T06:29Z` (public) and `2026-08-17T06:35Z` (raw). No POST / PATCH / DELETE. No `.env*` reads. No PNG captures.
+
+## Slug / ID pairs (public REST, then raw GET)
+
+| ID | Kind | Slug | Link | `modified_gmt` | HTTP |
+|---:|---|---|---|---|---:|
+| 12013 | page | `photography` | https://kriskrug.co/photography/ | 2026-08-17T05:30:00 | 200 |
+| 1222 | post | `to-all-you-wannabe-fashion-photographers` | https://kriskrug.co/2007/04/27/to-all-you-wannabe-fashion-photographers/ | 2026-07-11T19:48:05 | 200 |
+| 1056 | post | `kk-on-modelmayhemcom` | https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/ | 2026-06-15T05:20:28 | 200 |
+
+Also 200: https://kriskrug.co/category/photography-visual-storytelling/
+
+Page 12013 `modified_gmt` matches the #706 PressCACHE no-op title-save recorded in the #480 reconfirm. Body and inline `<style>` are unchanged cream-pack. #480 has not been applied.
+
+## Live link counts (body `content.rendered`, not chrome)
+
+| ID | Internal `<a href>` | External `<a href>` | `kk-collection-footer` in raw | Planned anchors present |
+|---:|---:|---:|---:|---|
+| 12013 | **0** | 2 (both Flickr) | 0 | none of rows 11-12 |
+| 1222 | 2 (footer pillar + sibling) | 8 | 2 string hits (comment + class) | row 13 absent |
+| 1056 | 2 (footer pillar + sibling) | 1 (ModelMayhem) | 2 string hits | row 14 absent; no `/photography/` in body |
+
+Post 1056 still does not link `/photography/`. Page 12013 still has zero internal links in the page body. Nav chrome on the public HTML does include `/photography/`; that is not page content.
+
+## Block recount on 12013
+
+Hub-plan "block 23" is stale. Today's rendered body has **22** block-level tags (`p`, `h2`, `figure`):
+
+- 21 = `<h2>This is a fraction of it.</h2>`
+- 22 = coda `<p>` ending `lives on Flickr.`
+
+The helper inserts on that text, not on an index.
+
+## Exact payload anchors
+
+| Row | Source | Anchor | Target |
+|---:|---|---|---|
+| 11 | 12013 coda `<p>` | `the whole archive, twenty years of it` | `/category/photography-visual-storytelling/` |
+| 12 | same `<p>`, new sentence | `the fashion and model years, 2006 to 2008` | post 1056 |
+| 13 | 1222, before footer | `how I found those people in the first place` | post 1056 |
+| 14 | 1056, after the peeps line | `where all of that ended up` | `/photography/` |
+
+Flickr button text on 12013 is `See 144,000+ frames on Flickr ?`. Left alone. Inline `<style>` sha256 `23dc2ddaf20ffda0f94f619e9ade0068d3a9a0c5fdb38563538b6542a34c69b3`. No 1210 / checklist href.
+
+## #826 still blocking live apply
+
+Public REST 2026-08-17T06:32Z:
+
+| ID | Slug | Live categories | Needed after #826 |
+|---:|---|---|---|
+| 3814 | `the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things` | `[1757]` | `[1678]` |
+| 3330 | `the-future-called-i-answered` | `[1757]` | `[1676]` |
+| 1067 | `hardcore-superstar-photoshoot` | `[1662]` | `[1756]` |
+| 1063 | `made-in-vancouver-photoshoot` | `[1662]` | `[1756]` |
+| 1147 | `fashion-photoshoot-for-discollection` | `[1665]` | `[1756]` |
+
+`--apply` on the #827 helper aborts until those five swaps are live.
+
+## #480 sequencing
+
+Page 12013 is a shared write surface with #480. The current #480 `photography.html` is a full-page replace without rows 11-12. If it is applied after #827, it wipes these links. Sequence: #826, then #827, then re-cut #480 photography if the style-strip still needs to land.
+
+## Not applied
+
+This report is public readback plus a repo payload pack. Live HTML still has zero of the four anchors. KK approval is still required after #826.

--- a/scripts/apply_issue_827_photography_hub.py
+++ b/scripts/apply_issue_827_photography_hub.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Issue #827: wire photography hub links on page 12013 and posts 1222 / 1056.
+
+Dry-run by default. Writes are gated on ID->slug match, exact text-match
+insertion, child-1 (#826) category proof, and a fresh context=edit snapshot.
+
+    python3 scripts/apply_issue_827_photography_hub.py --from-files
+    make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py'
+    make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-827"
+TARGETS_PATH = PACK / "targets.json"
+BEFORE_DIR = PACK / "before"
+AFTER_DIR = PACK / "after"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-827-photography-hub"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+STYLE_OPEN = "<style>"
+STYLE_CLOSE = "</style>"
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-827"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def style_block(body: str) -> str:
+    start = body.find(STYLE_OPEN)
+    end = body.find(STYLE_CLOSE)
+    if start < 0 or end < 0 or end < start:
+        raise ValueError("inline <style> block missing")
+    return body[start : end + len(STYLE_CLOSE)]
+
+
+def style_sha256(body: str) -> str:
+    return hashlib.sha256(style_block(body).encode("utf-8")).hexdigest()
+
+
+def already_applied(body: str, spec: dict) -> bool:
+    return all(
+        f'<a href="{row["href"]}">{row["text"]}</a>' in body for row in spec["anchors"]
+    )
+
+
+def inserted_fragment(spec: dict) -> str:
+    find = spec["find"]
+    replace = spec["replace"]
+    prefix = os.path.commonprefix([find, replace])
+    find_rest = find[len(prefix) :]
+    replace_rest = replace[len(prefix) :]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
+    if already_applied(body, spec):
+        return None
+    find = spec["find"]
+    replace = spec["replace"]
+    count = body.count(find)
+    if count != 1:
+        raise ValueError(
+            f"{spec['id']}: find needle occurs {count} times; expected 1. "
+            "Insert by text match, not a stale block index."
+        )
+    added = inserted_fragment(spec)
+    if "\u2014" in added or "\u2013" in added:
+        raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
+    if any(ord(char) > 127 for char in added):
+        raise ValueError(f"{spec['id']}: inserted copy is not ASCII; use NCR")
+    rewritten = body.replace(find, replace, 1)
+    if spec.get("preserve_style"):
+        if style_sha256(body) != targets["style_sha256_12013"]:
+            raise ValueError(f"{spec['id']}: live <style> hash drifted; abort")
+        if style_sha256(rewritten) != style_sha256(body):
+            raise ValueError(f"{spec['id']}: rewrite touched the <style> block")
+    if spec.get("preserve_flickr"):
+        if body.count(targets["flickr_exit"]) != rewritten.count(
+            targets["flickr_exit"]
+        ):
+            raise ValueError(f"{spec['id']}: Flickr exit count changed")
+        if targets["flickr_button"] not in rewritten:
+            raise ValueError(f"{spec['id']}: Flickr button text missing")
+    if spec.get("preserve_footer"):
+        if body.count(FOOTER_SENTINEL) != rewritten.count(FOOTER_SENTINEL):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+    for forbidden in targets["forbidden_href_substrings"]:
+        if forbidden in rewritten and forbidden not in body:
+            raise ValueError(f"{spec['id']}: forbidden href {forbidden} was added")
+    for row in spec["anchors"]:
+        needle = f'<a href="{row["href"]}">{row["text"]}</a>'
+        if rewritten.count(needle) != 1:
+            raise ValueError(f"{spec['id']}: expected one {needle!r}")
+    return rewritten
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    if live.get("id") != spec["id"]:
+        sys.exit(f"[ABORT] {spec['id']}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: slug is {live.get('slug')!r}, "
+            f"expected {spec['slug']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def child1_is_live(header: str, targets: dict) -> tuple[bool, list[str]]:
+    notes: list[str] = []
+    ready = True
+    for row in targets["child1_gate"]:
+        live = request(
+            f"{BASE_URL}/wp-json/wp/v2/posts/{row['id']}?_fields=id,slug,categories",
+            header,
+        )
+        if live.get("slug") != row["slug"]:
+            ready = False
+            notes.append(f"{row['id']} slug {live.get('slug')!r}")
+            continue
+        cats = list(live.get("categories") or [])
+        if row["to_category"] not in cats or row["from_category"] in cats:
+            ready = False
+            notes.append(f"{row['id']} categories {cats}")
+        else:
+            notes.append(f"{row['id']} ok {cats}")
+    return ready, notes
+
+
+def plan_item(spec: dict, body: str, targets: dict) -> dict | None:
+    try:
+        rewritten = rewrite_body(body, spec, targets)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: exact href+anchor already present.")
+        return None
+    return {"spec": spec, "before": body, "after": rewritten}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for row in spec["anchors"]:
+        print(f"        row {row['row']}: {row['text']!r} -> {row['href']}")
+
+
+def write_after_files(planned: list[dict]) -> None:
+    AFTER_DIR.mkdir(parents=True, exist_ok=True)
+    for item in planned:
+        spec = item["spec"]
+        path = AFTER_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+        path.write_text(item["after"], encoding="utf-8")
+        print(f"[AFTER] {path}")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    print_plan(item)
+    if not do_apply:
+        return
+    spec = item["spec"]
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_item(spec, raw_body(live), load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    allowed = {row["id"] for row in load_targets()["items"]}
+    post_id = snapshot.get("id")
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #827 set.")
+    spec = next(row for row in load_targets()["items"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(live, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def load_before_body(spec: dict) -> str:
+    path = BEFORE_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+    if not path.is_file():
+        sys.exit(f"[ABORT] missing before-file {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #827 photography hub links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-files", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    parser.add_argument(
+        "--allow-before-826",
+        action="store_true",
+        help="Unsafe. Bypass the child-1 category gate. Do not use on production.",
+    )
+    args = parser.parse_args()
+    targets = load_targets()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, auth_header(), args.apply)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id:
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+
+    if args.from_files:
+        planned = []
+        for spec in rows:
+            try:
+                item = plan_item(spec, load_before_body(spec), targets)
+            except ValueError as exc:
+                sys.exit(f"[ABORT] {exc}")
+            if item is not None:
+                planned.append(item)
+                print_plan(item)
+        if not planned:
+            print("[OK] nothing pending.")
+            return 0
+        write_after_files(planned)
+        print("[FROM-FILES] wrote after/ payloads. No WordPress writes.")
+        return 0
+
+    header = auth_header()
+    if args.apply and not args.allow_before_826:
+        ready, notes = child1_is_live(header, targets)
+        for note in notes:
+            print(f"[826] {note}")
+        if not ready:
+            sys.exit(
+                "[ABORT] #826 category fixes are not live. Do not PATCH 12013/1222/1056 yet."
+            )
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_item(spec, raw_body(live), targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            item["live"] = live
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Pass --apply after #826 is live and KK approves."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_827_photography_hub.py
+++ b/scripts/tests/test_apply_issue_827_photography_hub.py
@@ -1,0 +1,277 @@
+"""Offline safety tests for the issue #827 photography hub helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_827_photography_hub.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_827_photography_hub", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def before_body(item_id: int) -> str:
+    spec = spec_by_id(item_id)
+    return (
+        MODULE.BEFORE_DIR / f"{spec['kind'][:-1]}-{item_id}-content.raw.html"
+    ).read_text(encoding="utf-8")
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    return {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else before_body(spec["id"])},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_827_photography_hub.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue827PhotographyHubTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+        self.gate = {
+            row["id"]: {
+                "id": row["id"],
+                "slug": row["slug"],
+                "categories": [row["from_category"]],
+            }
+            for row in TARGETS["child1_gate"]
+        }
+
+    def _patch_request(self, calls, *, gate_ready=False):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/posts/" in url and "context=edit" not in url:
+                post_id = int(url.split("/posts/")[1].split("?")[0])
+                live = json.loads(json.dumps(self.gate[post_id]))
+                if gate_ready:
+                    spec = next(
+                        row for row in TARGETS["child1_gate"] if row["id"] == post_id
+                    )
+                    live["categories"] = [spec["to_category"]]
+                return live
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_rows_11_through_14(self):
+        ids = [row["id"] for row in TARGETS["items"]]
+        self.assertEqual(ids, [12013, 1222, 1056])
+        self.assertEqual(spec_by_id(12013)["slug"], "photography")
+        self.assertEqual(
+            spec_by_id(1222)["slug"], "to-all-you-wannabe-fashion-photographers"
+        )
+        self.assertEqual(spec_by_id(1056)["slug"], "kk-on-modelmayhemcom")
+        anchors = [
+            (row["row"], row["text"], row["href"])
+            for spec in TARGETS["items"]
+            for row in spec["anchors"]
+        ]
+        self.assertEqual(
+            anchors,
+            [
+                (
+                    11,
+                    "the whole archive, twenty years of it",
+                    "https://kriskrug.co/category/photography-visual-storytelling/",
+                ),
+                (
+                    12,
+                    "the fashion and model years, 2006 to 2008",
+                    "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+                ),
+                (
+                    13,
+                    "how I found those people in the first place",
+                    "https://kriskrug.co/2006/10/23/kk-on-modelmayhemcom/",
+                ),
+                (
+                    14,
+                    "where all of that ended up",
+                    "https://kriskrug.co/photography/",
+                ),
+            ],
+        )
+
+    def test_rewrite_12013_adds_two_links_and_keeps_style_and_flickr(self):
+        spec = spec_by_id(12013)
+        before = before_body(12013)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertEqual(before.count("<style>"), 1)
+        self.assertEqual(MODULE.style_sha256(before), TARGETS["style_sha256_12013"])
+        self.assertEqual(MODULE.style_sha256(after), MODULE.style_sha256(before))
+        self.assertEqual(
+            before.count(TARGETS["flickr_exit"]), after.count(TARGETS["flickr_exit"])
+        )
+        self.assertIn(TARGETS["flickr_button"], after)
+        self.assertNotIn("checklist-of-model-photographer-negotiation-items", after)
+        self.assertEqual(after.count("the whole archive, twenty years of it"), 1)
+        self.assertEqual(after.count("the fashion and model years, 2006 to 2008"), 1)
+        self.assertNotIn("\u2014", MODULE.inserted_fragment(spec))
+
+    def test_rewrite_1222_inserts_before_footer_and_does_not_duplicate_it(self):
+        spec = spec_by_id(1222)
+        before = before_body(1222)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        self.assertLess(
+            after.find("how I found those people in the first place"),
+            after.find("kk-collection-footer"),
+        )
+        self.assertNotIn("1210", after)
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_1056_follows_the_peeps_line(self):
+        spec = spec_by_id(1056)
+        before = before_body(1056)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        peeps = after.find("I've met a couple cool peeps already.")
+        hub = after.find("where all of that ended up")
+        footer = after.find("kk-collection-footer")
+        self.assertGreater(hub, peeps)
+        self.assertGreater(footer, hub)
+        self.assertIn('href="https://kriskrug.co/photography/"', after)
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+
+    def test_stale_block_index_is_ignored_text_match_wins(self):
+        spec = spec_by_id(12013)
+        before = before_body(12013)
+        self.assertIn("This is a fraction of it", before)
+        self.assertIn(spec["find"], before)
+        self.assertEqual(before.count(spec["find"]), 1)
+
+    def test_missing_needle_aborts(self):
+        spec = spec_by_id(1056)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>no peeps</p>", spec, TARGETS)
+
+    def test_from_files_writes_after_payloads_and_does_not_call_wordpress(self):
+        calls = []
+        after_dir = self.tmp_path / "after"
+        with (
+            mock.patch.object(MODULE, "AFTER_DIR", after_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--from-files"))
+        self.assertEqual(calls, [])
+        self.assertTrue((after_dir / "page-12013-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-1222-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-1056-content.raw.html").is_file())
+
+    def test_live_dry_run_performs_no_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12013]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--allow-before-826", "--item-id", "12013")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_refuses_when_826_is_not_live(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "1056")
+        self.assertIn("#826", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE,
+                "request",
+                side_effect=self._patch_request(calls, gate_ready=True),
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "1056"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn("where all of that ended up", writes[0]["content"])
+        self.assertIn("kk-collection-footer", writes[0]["content"])
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("#480", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #827", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Prepared, **not applied** content-only payloads that wire rows 11-14 on page 12013 and posts 1222 / 1056.
- Live GET readback: 12013 still has **zero** internal body links; 1056 still does not link `/photography/`. Insertion is by text match (coda is block 22 today, not 23).
- Does **not** close #827 or #402. Live apply stays blocked on #826. Page 12013 is also an #480 write surface; if `photography.html` lands after these links, recut it.

Refs #827

## Test plan
- [x] `python3 -m unittest scripts.tests.test_apply_issue_827_photography_hub`
- [x] `python3 scripts/apply_issue_827_photography_hub.py --from-files` (offline; no WordPress writes)
- [ ] After #826 is live and KK approves: dry-run `make varlock-run CMD='python3 scripts/apply_issue_827_photography_hub.py'`, then `--apply`
- [ ] After-apply greps in `fix-827/APPLY.md` (two new 12013 anchors, no 1210 href, footer counts unchanged)


Made with [Cursor](https://cursor.com)