### PR TITLE
feat: add Dark Crystal and unofficial.city to the lab network

### DIFF
--- a/content/drafts/2026-06-18-creative-ai-human-lab-network/post.html
+++ b/content/drafts/2026-06-18-creative-ai-human-lab-network/post.html
@@ -127,6 +127,30 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Dark Crystal</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><a href="https://darkcrystal.app/">Dark Crystal</a> is the anti-slop machine: one being that holds chaos and refusal in the same stone.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>It reads what you feed it, grows wilder as it eats, then the facet that says no steps in. The gift is one clean human sentence. Not a productivity tool. A boundary you can demo.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">unofficial.city</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p><a href="https://unofficial.city/">unofficial.city</a> is MADE ON: a protest kit collection that cites its sources, shows its process, and names the numbers.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Everyone else made a souvenir. This one is the receipt. Stitched into the hem, not printed on a poster.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
 <h3 class="wp-block-heading">KrisKrug.co</h3>
 <!-- /wp:heading -->
 
@@ -135,7 +159,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>The standalone sites can each have their own physics. Skywhale should feel like a weird airport. Punk Rock AI should feel like zine paste and receipt paper. Gorgeous Ghost should feel like a transmission from somewhere expensive and impossible. Wedges should feel like a sharp tool left on the table. Ethos should feel like the room that made it. KrisKrug.co is where the threads can point back to each other without pretending they are the same project.</p>
+<p>The standalone sites can each have their own physics. Skywhale should feel like a weird airport. Punk Rock AI should feel like zine paste and receipt paper. Gorgeous Ghost should feel like a transmission from somewhere expensive and impossible. Wedges should feel like a sharp tool left on the table. Ethos should feel like the room that made it. Dark Crystal should feel like a boundary you can hold. unofficial.city should feel like a kit with receipts in the hem. KrisKrug.co is where the threads can point back to each other without pretending they are the same project.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:heading -->
@@ -237,6 +261,14 @@
 
 <!-- wp:list-item -->
 <li><a href="https://ethosblockparty.com/the-day">Ethos Lab Block Party</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://darkcrystal.app/">Dark Crystal</a></li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://unofficial.city/">unofficial.city</a></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 

--- a/content/drafts/2026-06-18-creative-ai-human-lab-network/post.html
+++ b/content/drafts/2026-06-18-creative-ai-human-lab-network/post.html
@@ -75,7 +75,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph -->
-<p><a href="https://ghost.radio.fm/">Ghost Radio</a> is the companion signal — the smaller, stranger broadcast surface in the same constellation.</p>
+<p><a href="https://ghost.radio.fm/">Ghost Radio</a> is the companion signal: the smaller, stranger broadcast surface in the same constellation.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->

--- a/content/drafts/2026-06-18-creative-ai-human-lab-network/post.md
+++ b/content/drafts/2026-06-18-creative-ai-human-lab-network/post.md
@@ -5,7 +5,7 @@ status: draft
 post_date: "2026-06-18"
 author: "Kris Krüg"
 author_wp_id: 1
-excerpt: "A field note on the Creative AI Human Lab: Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, and the Ethos Lab Block Party."
+excerpt: "A field note on the Creative AI Human Lab: Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, Dark Crystal, and unofficial.city."
 categories:
   - "AI for Creatives"
 tags:
@@ -18,9 +18,11 @@ tags:
   - "Wedges"
   - "Both Hands Full"
   - "Ethos Lab"
+  - "Dark Crystal"
+  - "unofficial.city"
 seo:
   meta_title: "What I’ve Been Making With Creative AI"
-  meta_description: "Kris Krüg maps the Creative AI Human Lab across Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, and Ethos Lab Block Party."
+  meta_description: "Kris Krüg maps the Creative AI Human Lab across Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, Dark Crystal, and unofficial.city."
 ---
 
 # What I’ve Been Making With Creative AI
@@ -87,11 +89,23 @@ Eleven people came to the block party and told me one true thing each. We turned
 
 That distinction is not decoration. It is the whole practice. Nothing public without consent. Minors first-name-only. No copying artists by name. No turning somebody else’s culture into a costume. The tech helped carry the songs through the door, but the people are the reason the songs exist.
 
+### Dark Crystal
+
+[Dark Crystal](https://darkcrystal.app/) is the anti-slop machine: one being that holds chaos and refusal in the same stone.
+
+It reads what you feed it, grows wilder as it eats, then the facet that says no steps in. The gift is one clean human sentence. Not a productivity tool. A boundary you can demo.
+
+### unofficial.city
+
+[unofficial.city](https://unofficial.city/) is MADE ON: a protest kit collection that cites its sources, shows its process, and names the numbers.
+
+Everyone else made a souvenir. This one is the receipt. Stitched into the hem, not printed on a poster.
+
 ### KrisKrug.co
 
 [KrisKrug.co Work](https://kriskrug.co/work/) is the hub.
 
-The standalone sites can each have their own physics. Skywhale should feel like a weird airport. Punk Rock AI should feel like zine paste and receipt paper. Gorgeous Ghost should feel like a transmission from somewhere expensive and impossible. Wedges should feel like a sharp tool left on the table. Ethos should feel like the room that made it. KrisKrug.co is where the threads can point back to each other without pretending they are the same project.
+The standalone sites can each have their own physics. Skywhale should feel like a weird airport. Punk Rock AI should feel like zine paste and receipt paper. Gorgeous Ghost should feel like a transmission from somewhere expensive and impossible. Wedges should feel like a sharp tool left on the table. Ethos should feel like the room that made it. Dark Crystal should feel like a boundary you can hold. unofficial.city should feel like a kit with receipts in the hem. KrisKrug.co is where the threads can point back to each other without pretending they are the same project.
 
 ## The Rules I Am Working By
 
@@ -135,5 +149,7 @@ Start anywhere:
 - [Wedges](https://wedges.dev/)
 - [Too Weird to Die](https://www.bothhandsfull.com/album/too-weird-to-die)
 - [Ethos Lab Block Party](https://ethosblockparty.com/the-day)
+- [Dark Crystal](https://darkcrystal.app/)
+- [unofficial.city](https://unofficial.city/)
 
 Bring both hands. Keep your taste on. Do not let the machine have the last word.

--- a/content/drafts/2026-06-18-creative-ai-human-lab-network/post.md
+++ b/content/drafts/2026-06-18-creative-ai-human-lab-network/post.md
@@ -63,7 +63,7 @@ It began as an AI film prompt challenge and grew teeth when the little film want
 
 ### Ghost Radio
 
-[Ghost Radio](https://ghost.radio.fm/) is the companion signal — the smaller, stranger broadcast surface in the same constellation.
+[Ghost Radio](https://ghost.radio.fm/) is the companion signal: the smaller, stranger broadcast surface in the same constellation.
 
 Not every artifact needs to explain itself like a case study. Sometimes the right move is to make a frequency, leave the light on, and let the thing be a little mysterious. Ghost Radio gives the network somewhere to breathe between the film, the songs, and the notes about how they got made.
 

--- a/content/drafts/2026-06-18-creative-ai-human-lab-network/seo-meta.md
+++ b/content/drafts/2026-06-18-creative-ai-human-lab-network/seo-meta.md
@@ -6,15 +6,15 @@
 
 **Status:** Draft-only. Do not publish without KK review.
 
-**Meta description:** Kris Krüg maps the Creative AI Human Lab across Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, and Ethos Lab Block Party.
+**Meta description:** Kris Krüg maps the Creative AI Human Lab across Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, Dark Crystal, and unofficial.city.
 
 **Focus keyword:** creative AI
 
-**Secondary keywords:** Creative AI Human Lab, Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, AI for creatives
+**Secondary keywords:** Creative AI Human Lab, Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, Dark Crystal, unofficial.city, AI for creatives
 
 **Open Graph**
 - og:title - What I’ve Been Making With Creative AI
 - og:description - A field note on the creative AI experiments Kris Krüg has been making lately: films, albums, portals, consent, taste, weirdness, and community.
 - og:image - Select after editorial review; candidate sources are Skywhale Airways key art, Too Weird to Die album art, or an original KrisKrug.co network graphic.
 
-**Internal/public links:** KrisKrug.co Work, Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party.
+**Internal/public links:** KrisKrug.co Work, Skywhale Airways, Punk Rock AI, Gorgeous Ghost, Ghost Radio, Wedges, Too Weird to Die, Ethos Lab Block Party, Dark Crystal, unofficial.city.

--- a/content/source-packs/content-architecture-2026/wp-payloads/work.html
+++ b/content/source-packs/content-architecture-2026/wp-payloads/work.html
@@ -72,12 +72,22 @@
       </a>
     </article>
     <article class="aurora-media-card">
-      <a href="https://vancouver-made.vercel.app/" style="text-decoration: none;" aria-label="Explore Ethos and MADE ON">
+      <a href="https://unofficial.city/" style="text-decoration: none;" aria-label="Explore unofficial.city">
         <img src="https://unofficial.city/og.jpg" width="1200" height="630" alt="MADE ON double silver graphic with the Nardwuar FC kit" loading="lazy" decoding="async">
         <span class="aurora-card-label">Local artifacts</span>
         <div>
-          <h3>Ethos and MADE ON</h3>
-          <p>Creative systems, Vancouver-made artifacts, and community-rooted experiments that keep the work local and alive.</p>
+          <h3>unofficial.city</h3>
+          <p>MADE ON: a protest kit collection that cites its sources, shows its process, and names the numbers.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://darkcrystal.app/" style="text-decoration: none;" aria-label="Explore Dark Crystal">
+        <img src="https://darkcrystal.app/lab/opengraph-image" width="1200" height="630" alt="Dark Crystal wordmark and anti-slop machine" loading="lazy" decoding="async">
+        <span class="aurora-card-label">Anti-slop machine</span>
+        <div>
+          <h3>Dark Crystal</h3>
+          <p>A live facet that eats slop, refuses at the edge, and hands back one clean human sentence.</p>
         </div>
       </a>
     </article>

--- a/content/source-packs/keynotes-2026/wp-payloads/work.html
+++ b/content/source-packs/keynotes-2026/wp-payloads/work.html
@@ -301,6 +301,22 @@
           <p>Eleven songs made from real conversations in one afternoon, with consent, first-name care, and the person as the hero.</p>
         </div>
       </article>
+      <article class="kk-card">
+        <img src="https://darkcrystal.app/lab/opengraph-image" alt="Dark Crystal wordmark and anti-slop machine" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Anti-slop machine</span>
+          <h3><a href="https://darkcrystal.app/">Dark Crystal</a></h3>
+          <p>A live facet that eats slop, refuses at the edge, and hands back one clean human sentence.</p>
+        </div>
+      </article>
+      <article class="kk-card">
+        <img src="https://unofficial.city/og.jpg" alt="MADE ON double silver graphic with the Nardwuar FC kit" loading="lazy" />
+        <div class="kk-card-body">
+          <span class="kk-tag">Local artifacts</span>
+          <h3><a href="https://unofficial.city/">unofficial.city</a></h3>
+          <p>MADE ON: a protest kit collection that cites its sources, shows its process, and names the numbers.</p>
+        </div>
+      </article>
     </div>
   </section>
 

--- a/theme/kk-aurora/CHANGELOG.md
+++ b/theme/kk-aurora/CHANGELOG.md
@@ -20,6 +20,10 @@ When you cut a new release, add a line here and follow
 
 ---
 
+## 1.6.9
+**Deployed:** On main
+Project footer: add Dark Crystal, retarget Vancouver Made to `https://unofficial.city/`, and keep BC + AI / Futureproof in the broader Projects list rather than the experiment webring.
+
 ## 1.6.8
 **Deployed:** LIVE (SFTP 2026-08-17, latest rollback `kk-aurora.bak-1786942075`; prior swap `kk-aurora.bak-1786942015`). Public `style.css` reads 1.6.8. Custom FSE `front-page` (wp_id 12661) was snapshotted then POSTed from theme `front-page.html` at 2026-08-17 04:51 UTC; homepage now renders labs / logo soup / stages / What People Say. Pixel vs pre-HTML 1.6.7 (`20260817T044445Z` → `20260817T045150Z`): homepage fail 55–62% (expected height + new bands); 29 other pairs pass; `/blog/` tablet warn 0.49%. Boost CSS bundle hash moved `d4faec73b4` → `0f9e6b2840`. Explicit #731 wp-admin regen still owed.
 Homepage cluster: rewrite the Join BC / Futureproof work-band copy, align the triptych, and quiet the card numerals (#411); restore a Creative Labs band with text-below-image cards (#412); bring back a monochrome interactive client logo soup (#413). Stages, What People Say, and newsletter follow in the same cut (#414–#416).

--- a/theme/kk-aurora/functions.php
+++ b/theme/kk-aurora/functions.php
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 /**
  * Theme version for cache busting
  */
-define('KK_AURORA_VERSION', '1.6.8');
+define('KK_AURORA_VERSION', '1.6.9');
 
 require_once get_template_directory() . '/inc/seo-title.php';
 require_once get_template_directory() . '/inc/seo-meta-rest.php';

--- a/theme/kk-aurora/parts/footer.html
+++ b/theme/kk-aurora/parts/footer.html
@@ -36,7 +36,8 @@
         <a href="https://gorgeousghost.com/">Gorgeous Ghost</a>
         <a href="https://ghost.radio.fm/">Ghost Radio</a>
         <a href="https://ethosblockparty.com/the-day">Ethọ́s Block Party</a>
-        <a href="https://vancouver-made.vercel.app">Vancouver Made</a>
+        <a href="https://darkcrystal.app/">Dark Crystal</a>
+        <a href="https://unofficial.city/">unofficial.city</a>
       </div>
     </nav>
 

--- a/theme/kk-aurora/readme.txt
+++ b/theme/kk-aurora/readme.txt
@@ -40,6 +40,9 @@ Built for Full Site Editing with WCAG 2.1 AA accessibility.
 
 == Changelog ==
 
+= 1.6.9 =
+* footer: add Dark Crystal and unofficial.city to Projects; drop the vancouver-made.vercel.app alias.
+
 = 1.6.8 =
 * homepage (#411): rewrite Join BC / Futureproof work-band copy; shared-grid alignment; quiet card numerals; hover and focus-visible states.
 * homepage (#412): restore Creative Labs (Vancouver AI, Punk Rock AI, Both Hands Full, AI Garden) with text below the photo.

--- a/theme/kk-aurora/style.css
+++ b/theme/kk-aurora/style.css
@@ -4,7 +4,7 @@ Theme URI: https://kriskrug.co
 Author: Kris Krug
 Author URI: https://kriskrug.co
 Description: A keynote-first WordPress block theme for Kris Krug, pairing media-led authority, authored judgment, and purposeful motion.
-Version: 1.6.8
+Version: 1.6.9
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 8.0


### PR DESCRIPTION
## Summary
- Add Dark Crystal (`https://darkcrystal.app/`) and unofficial.city (`https://unofficial.city/`) to the Creative AI Human Lab webring on the Work payloads, Projects footer, and the June 18 draft network post.
- Retarget Vancouver Made from `vancouver-made.vercel.app` to `https://unofficial.city/`.
- Keep BC + AI and Futureproof out of the experiment list (they stay on Projects / Featured systems).
- Theme bump 1.6.9 is **not live** until Pagely deploy. The live `/work/` page is WordPress DB page 2672; payloads here still need a content apply after review. The June 18 post stays draft. Do not publish.

## Test plan
- [ ] Work payload cards include Dark Crystal and unofficial.city
- [ ] Projects footer links Dark Crystal and `https://unofficial.city/`
- [ ] No `vancouver-made.vercel.app` in the webring
- [ ] Hub URL is `https://kriskrug.co/work/`
- [ ] Draft post membership list matches chrome; post remains unpublished