### PR TITLE
docs: close out Gate 1 swarm on the 2026-08-17 runbook

### DIFF
--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -14,7 +14,7 @@ Read these first:
 6. **[INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)**, slug/idempotency safety rules. Dated May, deliberately kept at top level: it is a standing safety rule, not a plan.
 7. **[../../.env.schema](../../.env.schema)** plus **[VARLOCK-ROLLOUT-2026-07-16.md](VARLOCK-ROLLOUT-2026-07-16.md)**, env contract (never read plaintext `.env`)
 
-**Live readback 2026-08-17 05:30 UTC:** WordPress last seen `7.0.4`. Aurora **live is `1.6.8`**. Content applies #764 / #729 / #612 are live. #706 script diet is live at origin (Code Snippets id 22; pixel markers 0 on `/` and `/about/`). PSI rerun still owed. Receipts: [`reports/gate0-content-apply-20260817.md`](reports/gate0-content-apply-20260817.md), [`reports/aurora-168-live-deploy-20260817.md`](reports/aurora-168-live-deploy-20260817.md). The public `style.css` readback remains authoritative for production theme state.
+**Live readback 2026-08-17 06:43 UTC:** WordPress last seen `7.0.4`. Aurora **live is `1.6.8`**. Content applies #764 / #729 / #612 are live. #706 script diet is live at origin (Code Snippets id 22; pixel markers 0 on `/` and `/about/`). PSI mobile 2026-08-16 11:59 PDT is in [`reports/psi-mobile-2026-08-16.md`](reports/psi-mobile-2026-08-16.md) (TBT 10 ms; gtag still in the PSI trace). Gate 1 prep is on `main` and not applied. Receipts: [`reports/gate0-content-apply-20260817.md`](reports/gate0-content-apply-20260817.md), [`reports/aurora-168-live-deploy-20260817.md`](reports/aurora-168-live-deploy-20260817.md). The public `style.css` readback remains authoritative for production theme state.
 
 ## Durable process docs (keep at top level)
 

--- a/docs/current-state/WORK-PLAN-2026-08-17.md
+++ b/docs/current-state/WORK-PLAN-2026-08-17.md
@@ -15,9 +15,9 @@
 | Aurora repo | **1.6.8** | `theme/kk-aurora/style.css` on `main` |
 | Deploy gap | **none** for theme files/homepage template | pixel `20260817T044445Z` → `20260817T045150Z` |
 | WordPress | **7.0.4** | last status-readonly |
-| Open PRs | **0** | `gh pr list` 2026-08-17 |
-| Open issues | **40** | after homepage/alias/marker merge |
-| Origin heads | **`main` only** | leftover closed remotes deleted |
+| Open PRs | **0** | `gh pr list` 2026-08-17 06:43 UTC |
+| Open issues | **34** | `make status-readonly` 2026-08-17 06:43 UTC |
+| Origin heads | **`main` only** | Gate 1 swarm remotes pruned 2026-08-17 06:44 UTC |
 | Title format live | `{title} \| Kris Krüg` on post 12653; homepage `Kris Krüg \| …` | public HTML 2026-08-17 |
 | Post 12034 | first person; `$340/year` + 300 members | REST + public HTML 2026-08-17 05:05 UTC |
 | Post 12327 | **0** body em dashes; `Eth??s` still 1 | REST + public HTML 2026-08-17 05:03 UTC |
@@ -53,16 +53,20 @@ The bottleneck is **live apply + theme deploy**, not more inventories. No new au
 4. **#612 live** (first person, `$340/year`, 300 members).
 5. **#706 live** (WPCode 7917 drafted; Code Snippets id 22 `KK Script Diet` active). PSI mobile 2026-08-16 11:59 PDT: TBT **10 ms** (was 160); Facebook gone; gtag still in the PSI trace (delay caveat). Pixel ID `1720755522050230` is recorded for rollback only.
 
-### Gate 1 — agent crush (no live writes)
+### Gate 1 — landed on `main`, not applied (2026-08-17 swarm)
 
-Only if Gate 0 is moving. One worktree per lane. Draft PRs.
+Repo-only. No live WordPress writes. Issues stay open.
 
-| Lane | Issue | What |
-|---|---|---|
-| B | **#826** | Taxonomy repair (first #402 child; unblocks the other hubs) |
-| C | **#827** | Wire internal links on `/photography/` |
-| D | **#480** | Apply-ready check of the inline-CSS retirement payloads (PR #794 merged); do not PATCH |
-| E | **#767** | REST/author-probe hardening is drafted (PR #793 merged); confirm it is still apply-ready, do not enable live |
+| Lane | Issue | PR | Live |
+|---|---|---|---|
+| B | **#826** | [#857](https://github.com/WalksWithASwagger/kriskrug-wp/pull/857) | Defects unchanged. Dry-run planned six writes. **KK must approve `--apply`.** |
+| C | **#827** | [#860](https://github.com/WalksWithASwagger/kriskrug-wp/pull/860) | Payloads ready. `--apply` aborts until #826 categories are live. |
+| D | **#480** | [#858](https://github.com/WalksWithASwagger/kriskrug-wp/pull/858) | Six routes still have page-content CSS. Cream-pack still not live. **Nothing apply-now.** Recut `photography.html` after #827 if that style-strip still lands. |
+| E | **#767** | [#853](https://github.com/WalksWithASwagger/kriskrug-wp/pull/853) | Check script 0/4 PASS. Snippets unchanged, not enabled. Needs KK rulings (host-admin, sitemap scope, author-archive 404s). |
+
+Receipts: `reports/issue-826-apply-ready-20260817.md`, `issue-827-apply-ready-20260817.md`, `issue-480-apply-ready-20260817.md`, `issue-767-apply-ready-20260817.md`.
+
+**Do not swarm more reports.** First live apply, when KK says go, is **#826**. Then #827. Then recut #480 photography if needed. #767 stays prep until the three rulings.
 
 ### Gate 2 — do not touch yet
 
@@ -91,4 +95,4 @@ Only if Gate 0 is moving. One worktree per lane. Draft PRs.
 
 ---
 
-**Last verified:** 2026-08-17 evening. Live `style.css` **1.6.8**. Gate 0 content + #706 origin greps live. #706 Network + PSI captured (`psi-mobile-2026-08-16.md`). **#731 blocked**: Boost is local/free Critical CSS; app password 403s data-sync; inline snapshot still has `--aurora-black:#030405`. Next: KK Regenerates in Jetpack → Boost, or Gate 1 with no live writes. Run `make status-readonly` and a public `style.css` readback before acting.
+**Last verified:** 2026-08-17 06:43 UTC. Live `style.css` **1.6.8**. Gate 0 content + #706 origin greps live. #706 Network + PSI captured (`psi-mobile-2026-08-16.md`). Gate 1 prep is on `main` (#853, #857, #858, #860) and **not applied**. **#731 blocked**: Boost is local/free Critical CSS; app password 403s data-sync; inline snapshot still has `--aurora-black:#030405`. Next: KK Regenerates in Jetpack → Boost, and/or `--apply` #826. Run `make status-readonly` and a public `style.css` readback before acting.


### PR DESCRIPTION
## Summary
- Gate 1 swarm is on `main` and was not applied: #826 #857, #827 #860, #480 #858, #767 #853.
- Front door: PSI captured; first live apply is #826 when KK says go.
- Swarm remotes pruned; origin heads are `main` only.

## Test plan
- [x] `make docs-truth-check`
- [x] `python3 -m unittest scripts.tests.test_apply_issue_826_taxonomy scripts.tests.test_apply_issue_827_photography_hub` (23 OK, mocked)
- [x] public `style.css` Version 1.6.8
- [x] `make status-readonly` (WP 7.0.4, 0 open PRs, 34 open issues)

Does not close #826 #827 #480 #767 #731 #706.

Made with [Cursor](https://cursor.com)