### PR TITLE
content(#829): apply-ready You Can't Drink Data hub links, not applied

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/APPLY.md
@@ -1,0 +1,162 @@
+# #829 APPLY: You Can't Drink Data on the /ai-ethics/ hub
+
+**Prepared, not applied. Do not PATCH until #826 is live and KK says go.**
+Script is dry-run by default. `--apply` is the only write switch, and it refuses unless the five #826 category fixes are already live.
+
+Parent: #402. This is child 4 of 9. Child 1 (#826) still owns the taxonomy pass. This pack does not recategorize or retitle anything.
+
+Do not close #829 or #402 when this runbook merges.
+
+## Live reconfirm (logged-out public GET, 2026-08-19T23:23Z)
+
+No REST POST / PATCH / DELETE in this session. `WP_USER` and `WP_APP_PASSWORD` were unset, so there is no fresh `context=edit` `content.raw` from this run. Public REST confirmed slug/ID pairs and snapshotted `content.rendered` into `before/`.
+
+`content.raw` is present only where a historical authenticated snapshot still matches live `modified_gmt`:
+
+| ID | Raw source | Matches live modified_gmt? |
+|---|---|---|
+| 12318 | `backup/20260701T202734Z-content-architecture/page-snapshots/page-12318-ai-ethics-after.json` | yes (`2026-07-01T20:27:51`) |
+| 12030 | `backup/20260801-voice-sweep/canada-12030/after.json` | yes (`2026-08-01T19:57:26`) |
+| 6144 | none | no raw fetched |
+| 11882 | none. A 2026-06-23 draft snapshot exists with slug `both-hands-full-vancouver-ai-march-2026` and older `modified_gmt`. Not used. | no raw fetched |
+| 11936 | read-only identity only. Body not snapshotted and not in the write set. | n/a |
+
+| ID | Kind | Slug | URL | HTTP | Notes |
+|---|---|---|---|---:|---|
+| 12318 | page | `ai-ethics` | `/ai-ethics/` | 200 | Source trail = Punk Rock AI + RAP + archive. **No** You Can't Drink Data card. `you-cant-drink-data` href count = 0. |
+| 12030 | post | `canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` | `/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/` | 200 | First compute paragraph ends `We lack consent architecture.` Body has **0** `/about/` hrefs (row 32 / #834 stays off this pack). No 11936 link. |
+| 6144 | post | `ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence` | `/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/` | 200 | Final paragraph ends `Peace out! ???`. One baked `kk-collection-footer`. No 11936 link. |
+| 11882 | post | `we-trained-ai-on-stolen-work` | `/2026/05/19/we-trained-ai-on-stolen-work/` | 200 | Already has two 11936 hrefs under other anchors (`environmental cost` and the Related list). Exact row-10 guild anchor is **absent**. Skip rule is href+anchor, so this row still inserts. |
+| 11936 | post | `you-cant-drink-data` | `/2026/05/23/you-cant-drink-data/` | 200 | Read-only. Already links BC AI, Punk Rock AI, Both Hands Full, Your Taste Is Your Moat. Do not edit. |
+
+Four target URLs plus the hub post were 200. Public HTML greps matched the REST table: no new card, no three new anchors.
+
+### Block recount (today's HTML, not the 2026-08-02 index)
+
+Walking `p / h2 / h3 / ul / ol / figure / blockquote` is not how this pack inserts. Insertion is by **text match**:
+
+- 12318: the existing Punk Rock AI Source trail card, not a stale card index.
+- 12030: `We lack consent architecture.</p>` (first compute / infrastructure-cost paragraph). The closing `just a faster leak` paragraph is left for #834.
+- 6144: `Peace out! ???</p>` immediately before `kk-collection-footer`.
+- 11882: `training material without consent.</p>` (creative-labour paragraph).
+
+Existing Punk Rock AI, RAP, and AI ethics archive cards stay. This is an insert, not a rebuild.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+| ID | Required slug |
+|---:|---|
+| 12318 | `ai-ethics` |
+| 12030 | `canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one` |
+| 6144 | `ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence` |
+| 11882 | `we-trained-ai-on-stolen-work` |
+
+## What the script writes
+
+Content only. Titles, slugs, dates, status, featured media, tags, categories, and SEO meta stay untouched.
+
+| ID | Find (exactly once) | Inserted copy |
+|---|---|---|
+| 12318 | Punk Rock AI `<article class="aurora-media-card">` opener | new first card titled `You Can't Drink Data` (row 7), blurb exactly `A thousand people on Granville Street, and the AI guy standing in the middle of them.` |
+| 12030 | `We lack consent architecture.</p>` | trailing sentence: exact anchor `what the water math looks like from street level` (row 8) |
+| 6144 | `Peace out! ???</p>` | trailing sentence before the footer: exact anchor `two years later I went to the protest and wrote down what the signs said` (row 9) |
+| 11882 | `training material without consent.</p>` | trailing sentence: exact anchor `the march where the illustrators showed up as a guild` (row 10) |
+
+Inserted copy is ASCII. No em dashes. No NCR needed in the new sentences. Existing encoded apostrophes in 12030 / 6144 / 11882 stay as they are.
+
+Skip a row if that exact `href` + anchor already exists.
+
+## Must not
+
+- Touch post 11936 body (no spoke out; already linked).
+- Touch post 11929.
+- Touch `/about/` (#249 / #339).
+- Edit the 12030 closing paragraph (row 32 / #834).
+- Add rows 1-6 (MBO) or the MBO sentence on 11936 (child 8 / #833).
+- Duplicate `kk-collection-footer`.
+- Rebuild the 12318 Source trail or drop the Punk Rock AI / RAP / archive cards.
+- Run bulk `inject_links.py`.
+- Mix theme, schema, or title edits.
+
+## Shared-surface warnings
+
+Page 12318 is also the topic-hub payload `content/source-packs/content-architecture-2026/wp-payloads/topic-hubs/ai-ethics.html`. That file is a full-page replacement **without** this card. If it is applied after these links land, it will wipe the card unless it is re-cut.
+
+Post 12030 is also an #834 write surface (row 32, `/about/` in the closing paragraph). Sequencing: **#826 live first, then #829, then #834.** Do not apply the #834 `/about/` sentence in this pack.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_829_ai_ethics_hub
+
+# Offline dry-run: rewrite the snapshotted before-files into after/. No network.
+python3 scripts/apply_issue_829_ai_ethics_hub.py --from-files
+
+# Live GET dry-run: authenticated context=edit + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py'
+
+# Apply only after #826 is live and KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py --apply'
+```
+
+`--item-id 12318` limits to one object. Re-run after a successful apply prints `[SKIP]`.
+
+`--from-files` uses `before/*-content.raw.html` when present, else the public `before/*-content.rendered.html`. Live `--apply` always GETs `context=edit` `content.raw` and still requires the slug check.
+
+`--apply` GETs the five #826 posts and aborts unless 3814 is out of 1757 into 1678, 3330 is out of 1757 into 1676, and 1067 / 1063 / 1147 are out of their wrong buckets into 1756.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-829-ai-ethics-hub/rest-<page|post>-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py --restore backup/issue-829-ai-ethics-hub/rest-page-12318-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py --restore backup/issue-829-ai-ethics-hub/rest-page-12318-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the four IDs or a slug mismatch. Rollback body is the snapshotted `content.raw`.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/ai-ethics/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2026/05/23/you-cant-drink-data/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2026/05/19/we-trained-ai-on-stolen-work/
+
+curl -sL "https://kriskrug.co/ai-ethics/?cb=$RANDOM" | grep -n 'you-cant-drink-data'
+curl -sL "https://kriskrug.co/ai-ethics/?cb=$RANDOM" | grep -F "You Can't Drink Data"
+curl -sL "https://kriskrug.co/ai-ethics/?cb=$RANDOM" | grep -F 'A thousand people on Granville Street, and the AI guy standing in the middle of them.'
+# You Can't Drink Data card must appear before the Punk Rock AI card
+
+curl -sL "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/?cb=$RANDOM" \
+  | grep -F 'what the water math looks like from street level'
+# 12030 closing paragraph must still have no /about/ from this child
+curl -sL "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/?cb=$RANDOM" \
+  | grep -F 'just a faster leak'
+
+curl -sL "https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/?cb=$RANDOM" \
+  | grep -F 'two years later I went to the protest and wrote down what the signs said'
+curl -sL "https://kriskrug.co/2026/05/19/we-trained-ai-on-stolen-work/?cb=$RANDOM" \
+  | grep -F 'the march where the illustrators showed up as a guild'
+
+# footer count on 6144 must match the pre-write snapshot (1 rendered hit)
+curl -sL "https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/?cb=$RANDOM" \
+  | grep -c 'kk-collection-footer'
+```
+
+Expect: 12318 Source trail gains exactly one new 11936 card, still ahead of Punk Rock AI. 12030 / 6144 / 11882 each gain the named anchor once. 12030 closing paragraph unchanged. 6144 footer count unchanged. 11882 keeps its two older 11936 hrefs.
+
+## Out of payload
+
+- Taxonomy repair on 3814 / 3330 / 1067 / 1063 / 1147 / 2819 (#826)
+- Photography hub wiring (#827)
+- Post 1210 checklist rewrite (#828)
+- Cyber Love Garden / Matt McKenna / meetup / MBO / brand-nav children (#830-#834)
+- `/about/` sentence on 12030 (#834)
+- Spoke out from 11936
+- `inject_links.py`

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/page-12318-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/page-12318-content.raw.html
@@ -1,0 +1,81 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-ethics -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI ethics</p>
+  <h2 class="aurora-display-heading">Responsible AI needs practice, not slogans.</h2>
+  <p class="aurora-page-lead">This hub gathers Kris Krug's writing and teaching on bias, data, provenance, labor, authorship, open source, sovereignty, and the uncomfortable parts of deploying AI in real communities.</p>
+  <p>The working posture is practical: name the tradeoffs, keep people in the loop, and refuse systems that make humans smaller.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Questions worth keeping in the room</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Who benefits?</h3>
+      <p>AI strategy should make power visible: who gains capacity, who loses agency, and who is being asked to absorb the risk?</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What data is being used?</h3>
+      <p>Bias, consent, privacy, provenance, and data quality are not side quests. They shape the system before anyone sees the interface.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What remains human?</h3>
+      <p>Judgment, accountability, relationship, care, taste, and refusal are not bugs to automate away.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>How do teams practice?</h3>
+      <p>Responsible AI becomes real through workflows, review rituals, escalation paths, training, and visible accountability.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Source trail</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/7674-granville-march.jpg?resize=640,400&amp;ssl=1" alt="The march fills two lanes heading down Granville Street under a grey Vancouver sky" loading="lazy"/>
+        <div>
+          <h3>You Can't Drink Data</h3>
+          <p>A thousand people on Granville Street, and the AI guy standing in the middle of them.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/04/punk-rock-ai/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?resize=640,400&amp;ssl=1" alt="Punk Rock AI keynote graphic" loading="lazy"/>
+        <div>
+          <h3>Punk Rock AI</h3>
+          <p>A culture-first way to use powerful systems without becoming obedient to them.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/04/rap-faces.png?resize=640,400&amp;ssl=1" alt="Responsible AI Professional faces graphic" loading="lazy"/>
+        <div>
+          <h3>Responsible AI Professional</h3>
+          <p>A practical certification path for teams turning ethics into operating practice.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-ethics-philosophy/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/02/01-the-word-bias-dissolving.png?resize=640,400&amp;ssl=1" alt="The word bias dissolving in an AI ethics graphic" loading="lazy"/>
+        <div>
+          <h3>AI ethics archive</h3>
+          <p>Posts on bias, open systems, data, creative labor, and the politics inside the tools.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Turn responsibility into practice</h2>
+    <p>For training, talks, or applied AI governance that people can actually use, start with the decisions your team is making now.</p>
+    <p><a class="aurora-button" href="/responsible-ai-professional/">Explore RAP</a> <a class="aurora-button" href="/speaking/">Book an ethics talk</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-11882-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-11882-content.raw.html
@@ -1,0 +1,48 @@
+<p>The AI debate is exhausted because too much of it is pretending to be brave while refusing the actual contradiction.</p>
+<p>The boosters want a clean story where the tools will save us if everyone just gets with the program. The doomers want a clean story where refusing the tools is the only ethical position left.</p>
+<blockquote class="wp-block-quote is-style-large">
+<p>Neither story is big enough.</p>
+</blockquote>
+<p>At the Vancouver AI March 2026 meetup, I tried to say the thing as plainly as I could: these systems are compromised, and they are powerful. They are built on extraction, and they are expanding what small creative teams can do. They carry bias, <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">environmental cost</a>, labor risk, and cultural danger, and they are also helping people learn, make, organize, imagine, and build.</p>
+<p>That is not a contradiction to solve with a slogan.</p>
+<p>That is the work.</p>
+<h2>Both Hands Full Is A Community Practice</h2>
+<p><code>Both Hands Full</code> is not just a keynote title. It is how our community has learned to stand inside this moment.</p>
+<p>One hand has to hold the hard stuff: stolen work, permission, copyright, bias, misinformation, environmental pressure, platform power, labor disruption, and the very real grief artists feel when their work becomes training material without consent. I also saw <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">the march where the illustrators showed up as a guild</a>.</p>
+<p>The other hand has to hold the equally real creative explosion: new tools, new access, new workflows, new forms of learning, new capacity for individuals and small teams, and new ways for people to build things that used to require institutions.</p>
+<blockquote class="wp-block-quote is-style-large">
+<p>If you drop either hand, you start lying.</p>
+</blockquote>
+<h2>Why Vancouver AI Matters</h2>
+<p>Vancouver AI is useful because it gives people a room where they do not have to pick a lazy team.</p>
+<p>Artists can sit beside engineers. Founders can hear from educators. Policy people can hear from builders. Curious beginners can ask the question that everyone else is pretending they already understand.</p>
+<p>That is where the good AI conversation happens: in community, under enough trust that people can admit uncertainty without being punished for it.</p>
+<p>The meetup is not just an audience for my talks. It is one of the places the ideas get stress-tested. People push back. People bring edge cases. People bring lived experience from classrooms, studios, startups, nonprofits, and big organizations.</p>
+<p>That makes the talk better. It makes the whole community smarter.</p>
+<h2>The Middle Path Is Not Neutral</h2>
+<p>Some people hear &#8220;middle path&#8221; and think it means splitting the difference.</p>
+<p>That is not what I mean.</p>
+<p>The middle path is not passive. It is not polite mush. It is active stewardship. It asks better questions:</p>
+<ul>
+<li>Who benefits from this system?</li>
+<li>Whose work made it possible?</li>
+<li>What data should never go into it?</li>
+<li>What kind of creative practice becomes stronger with AI?</li>
+<li>What kind of human relationship gets weaker if we automate it?</li>
+<li>What should communities build for themselves instead of waiting for platforms?</li>
+</ul>
+<p>Those questions are harder than cheerleading. They are also harder than refusal.</p>
+<h2>Watch The Talk</h2>
+<figure class="wp-block-embed is-type-video is-provider-youtube">
+<div class="wp-block-embed__wrapper">https://www.youtube.com/watch?v=T5ANAthZewE</div>
+</figure>
+<h2>Related</h2>
+<ul>
+<li><a href="https://kriskrug.co/speaking/">AI keynote speaking</a></li>
+<li><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></li>
+<li><a href="https://www.bothhandsfull.com/">Both Hands Full</a></li>
+<li><a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">You Can&#8217;t Drink Data: notes from my first AI protest</a></li>
+<li><a href="https://kriskrug.co/2026/05/23/data-center-protest-signs/">Both Hands Full at the Data Center: protest signs</a></li>
+<li><a href="https://kriskrug.co/podcast-guesting-page-epk/">Podcast guesting and media EPK</a></li>
+</ul>
+<p><em>Source note: this draft is based on the public Vancouver AI March 2026 video and the local 2026 keynote source pack. Final publication should review ethical claims, audience references, and image choice before WordPress publishing.</em></p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-12030-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-12030-content.raw.html
@@ -1,0 +1,360 @@
+<!-- wp:paragraph -->
+<p>Rainy Vancouver night. Somebody's laptop is open. Somebody else is asking the kind of question that makes a room go quiet: <em>Who owns the data in an AI future?</em> Not "who stores it" or "who can query it," but who actually holds the power to say yes, to say no, to set the terms, to change them later, to benefit when value is created.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the part of the AI conversation Canada keeps dodging: we don't just lack compute. We lack consent architecture. I already wrote <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">what the water math looks like from street level</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Meanwhile, Maxime C. Cohen drops a clean, sharp white paper that basically says: Canada is in trouble. Not vibes-trouble. Measurable-trouble. His warning is blunt: we've been "too slow, too fragmented, and too modest in scale."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He's not wrong.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen's paper is one of the most coherent "Canada must get its act together" documents I've seen. It lays out the structural hits: compute scarcity, weak commercialization, adoption lag, and a real brain drain pipeline that keeps dumping Canadian talent into U.S. gravity wells. He cites a study where "two-thirds of Canadian software engineering students" from a cohort ended up in the U.S. within 5 years.  He points at a 46% compensation premium for U.S. tech workers over Canada, and the practical effect that has on retention.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>On compute, Cohen highlights Canada's share of global AI compute capacity as 0.7%.  That number isn't just a flex metric. It's an indicator of who gets to do frontier-scale experiments, who gets to train, who gets to iterate, who gets to publish, and who gets to set standards by sheer repetition.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>On adoption, he cites an AI adoption rate of 12.2% for Canadian enterprises and frames it as a competitiveness problem, especially for SMEs.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Then he does what policy people do when they're being serious: he proposes infrastructure and governance that match the size of the problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He calls for national GPU superclusters in the 10,000-50,000+ range.  He wants a national compute governance body and emphasizes "low-carbon infrastructure."  He proposes a CAD $1-2B commercialization fund to deal with the scale-up gap.  He wants industry acting as "anchor customers" and procurement that actually scales Canadian startups.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And he wants a "strong, active National AI Governance Council with a real mandate and accountability."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So yeah. Diagnosis is solid.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Now the hard part: Cohen's paper is necessary, but it's not sufficient.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Because the thing Cohen barely touches is the thing BC keeps tripping over (and learning from) in real-time: if we scale AI without stewardship, we just build a more efficient extraction machine.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The part Cohen nails (and we should steal shamelessly)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">1) Publish the feature: "We Agree on the Diagnosis. Our Cure Is Different."</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This long-form piece: Canada doesn't win a compute war by pretending compute doesn't matter.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen is correct that "sovereign compute" is not optional if you want domestic research capacity, domestic products, and domestic sovereignty over sensitive workloads.  Without it, you become what he warns against: "a research supplier to other nations."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He also correctly calls for coordination across governments, industry, and researchers, plus faster commercialization mechanics. His recommendations are built for execution, not for panel discussions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC + AI should take those tools and upgrade them with our missing ingredient: <em>governance that doesn't treat community wellbeing as an afterthought.</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The part Cohen misses: trust is the limiting reagent</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen's paper is framed like a national competition problem. But in BC, we're living inside a trust problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And trust is not a PR issue. It's an adoption ceiling.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC public opinion research from SFU's Morris J. Wosk Centre for Dialogue says three-quarters of British Columbians do not trust tech companies to manage and develop AI carefully and with public wellbeing in mind. Two-thirds don't trust government or NGOs either. Academic institutions do better, but even there it's split.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the social reality any "national AI strategy" has to operate inside. If you try to force adoption without rebuilding trust, you don't get acceleration. You get backlash, refusal, and quiet sabotage.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The same report says 82% feel "nervous" about AI in society, 86% worry about losing personal agency if companies and governments use AI to make decisions affecting their lives, and 56% don't believe benefits outweigh risks.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And here's the kicker: despite low trust in government, BC residents still want regulation. 74% want government to impose regulations on companies developing or using generative AI systems to address false or misleading information.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So if we're designing a future AI economy, we're not optimizing for "compute first." We're optimizing for "trust and consent first," because without that, compute just scales conflict.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What BC+AI has that Cohen's framework doesn't: a proven community engine</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen is solving for institutions. BC+AI has been solving for people.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The Vancouver AI Community Meetup case study in <em>BC Studies</em> describes something most policy frameworks can't see: a grassroots practice community that becomes infrastructure.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>They reported "an average audience size… around 150 people," with total attendance "around 2,400" in 2024, and "the community built itself without corporate sponsorship or government funding."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>It's also not just quantity. It's format: open mic, demos, rapid iteration, "digital platforms," and "dedicated physical spaces" where people keep showing up.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's not a meetup anecdote. That's an adoption mechanism. It's how SMEs actually move: seeing real workflows, talking to peers, stealing patterns, trying again next week.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen's procurement reforms and commercialization funds become radically more effective when there's already a living lab generating demand and talent attachment.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The Indigenous governance gap is not "inclusion." It's strategy.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here's where BC's West Coast model stops being "nice" and becomes <em>nationally differentiating</em>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The BC AI Symposium Final Report explicitly calls out Indigenous rights and governance frameworks as real components of responsible AI. It notes that participants underscored the need to integrate "Indigenous rights and governance principles in AI development," including UNDRIP and OCAP.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The report also flags the environmental footprint of compute, calling for greener infrastructure and "green data centers," and explicitly ties that to the "increasing computational power needed by AI systems."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And it doesn't stop at principles. It points at practical governance and procurement problems: if we don't build best practices and accountability frameworks, we get a "move fast and break things" import with a Canadian flag sticker slapped on top.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the missing layer in Cohen's blueprint: <strong>stewardship</strong>. Not "ethics as a PDF," but enforceable consent, reciprocal benefit, and governance with teeth.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The BC AI JEDI Report uses a metaphor that's almost too perfect: building the ecosystem as a "mycorrhizal web," where exchange is mutual and regenerative, not extractive. It also names "<a href="https://kriskrug.co/indigenous-ai/">Indigenous data sovereignty and stewardship</a>" as a core necessity.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's not a vibe. That's the blueprint for how Canada becomes globally distinctive without trying to out-America America.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">So what do we do with Cohen's paper?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>We don't dunk on it. We remix it into something Canada can own.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs scale. I'm saying: fine, but only with stewardship.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs compute. I'm saying: fine, but only with consent, climate discipline, and value staying local.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs governance. I'm saying: fine, but governance must include Indigenous jurisdiction and community accountability, or it's just a nicer-looking extraction layer.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's the synthesis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The plan: a concrete "West Coast Response" that can ship</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here's what I'd publish, and how I'd execute it, fast.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">1) Publish the feature: "We Agree on the Diagnosis. Our Cure Is Different."</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This long-form piece (the thing you're reading) becomes the public-facing bridge: respectful to Cohen's rigor, brutally honest about what's missing.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include short direct quotes from Cohen (no cherry-picking). Example: Canada has been "too slow, too fragmented, and too modest in scale."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include real BC receipts: Vancouver AI's scale and independence.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include the trust reality: three-quarters don't trust tech companies.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">2) Convene a national "Stewardship + Scale" roundtable (not a conference)</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>60-90 days. One day. No panels. Just working sessions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Invite Cohen. Invite Indigenous data governance leaders. Invite BC Hydro or energy system folks. Invite SMEs. Invite labour.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Output is not a "statement." Output is a draft spec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Deliverable: <strong>The Stewarded Compute Accord (v0.1)</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>A short, enforceable set of requirements for any publicly supported AI compute capacity in Canada:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>OCAP/UNDRIP-aligned data governance pathways for sensitive datasets. Low-carbon infrastructure requirements (Cohen already flags low-carbon compute as a priority).Public reporting on access, usage, and benefit distribution.Clear "no extractive deals" clauses for public assets.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">3) Build a BC pilot: "Compute Commons + Consent Commons"</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>If Cohen wants 10,000-50,000 GPU superclusters, BC can pilot the governance model for how that compute gets used.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>In 6-12 months:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Stand up a small "Compute Commons" allocation model (even if the hardware is modest at first).Pair it with a "Consent Commons" toolkit: reusable legal templates, data-sharing agreements, and audit patterns aligned to OCAP/UNDRIP principles referenced in the symposium report.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This turns "responsible AI" from branding into operational controls.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">4) SME adoption: copy Cohen's speed, use BC's community engine</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen emphasizes procurement and pilots that scale.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC's move:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Run 90-day "SME AI Sprints" that start in community (meetups, practice labs) and end in procurement-ready outputs.Use the Vancouver AI pattern: live demos, open mic, show your work.Track outcomes: time saved, error rates, employee satisfaction, risk incidents, and whether value stayed local.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">5) Trust rebuilding isn't optional. It's a parallel workstream.</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>The SFU public opinion report literally says any action will be "severely hampered" by lack of trust and will require "trust re-building" efforts.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So we treat trust like infrastructure:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>publish plain-language model cards for <a href="https://kriskrug.co/ai-tools/">community-built tools</a>,publish impact assessments for pilots,run public "AI office hours" in multiple regions,measure sentiment quarterly, not annually.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">6) Capital stack: take Cohen's money, change the rules</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen proposes a CAD $1-2B national commercialization fund.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC's demand should be: if public money builds capacity, public benefit must be contractually real.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>revenue-share or equity-return terms that recycle value into regional capacity,cooperative options for SMEs (shared infrastructure, shared governance),open-source requirements where appropriate (JEDI's ecosystem logic explicitly pushes open, collaborative building).</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Closing: Canada's real advantage is not speed. It's legitimacy.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>The U.S. can brute-force frontier scale. The EU can brute-force regulation. Canada's best move is neither. Canada's best move is to build AI that people will actually consent to live with.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen is building the scaffolding: compute, commercialization, coordination.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC+AI is building the missing organs: community practice, Indigenous governance, trust repair, non-extractive value flow.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Put them together and Canada stops copying Silicon Valley's worst habits with a polite smile. We become the place that figured out how to scale AI without hollowing out the people it claims to serve.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's the West Coast contribution: scale, yes. But stewarded. Or it's not progress, it's just a faster leak.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Public source checks</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item -->
+<li><a href="https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all">Canada's National Artificial Intelligence Strategy: AI for All</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://ised-isde.canada.ca/site/ised/en/artificial-intelligence-ecosystem/overview-canadas-national-artificial-intelligence-strategy">Overview of Canada's National Artificial Intelligence Strategy</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://www.sfu.ca/dialogue/what-we-do/initiatives/dot.html">SFU Dialogue on Technology Project</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://indigenousinitiatives.ctlt.ubc.ca/2025/11/19/ai-reflections-indigenous-data-sovereignty-and-artificial-intelligence/">Indigenous data sovereignty and AI reflection</a></li>
+<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-6144-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/after/post-6144-content.raw.html
@@ -1,0 +1,383 @@
+
+<h2 class="wp-block-heading">Insights from Morten Rand-Hendriksen&#8217;s &#8216;Demythifying AI&#8217; Talk at GDG Burnaby &#8220;Build With AI&#8221; Event</h2>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Yo, future-proofed creators! Today I’m dropping some insights from <a href="https://mor10.com/">Morten Rand-Hendriksen&#8217;</a>s talk at <a href="https://gdg.community.dev/gdg-burnaby/">GDG Burnaby</a>. This dude, a senior staff instructor at <a href="https://www.linkedin.com/in/mortenrandhendriksen?originalSubdomain=ca">LinkedIn Learning</a>, just blew the roof off with his no-BS take on AI. Buckle up, &#8217;cause we&#8217;re about to get real about the AI hype machine and what it means for us as creators and innovators.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0b62c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0b62c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6148" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Cutting Through the AI BS</h2>
+
+
+
+<p class="wp-block-paragraph">First things first, let&#8217;s talk about the elephant in the room: the way we talk about AI is often misleading. Morten hit us with this gem: &#8220;The language we use about AI creates pictures in our heads.&#8221; And boy, are those pictures sometimes way off base.</p>
+
+
+
+<p class="wp-block-paragraph">We&#8217;ve been sold this idea of AI as some kind of digital BFF or a new species. But here&#8217;s the truth bomb: AI is primarily tools and materials, not your next drinking buddy or the evolution of humanity. It&#8217;s time we reassessed the anthropomorphic language and saw AI for what it really is – powerful tech that we can shape and use, while also acknowledging its potential for significant impact.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Real Talk on AI Capabilities</h2>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s get down to the nitty-gritty of what AI can actually do. Morten laid it out straight:</p>
+
+
+
+<ol class="wp-block-list">
+<li>AI systems are probabilistic and non-deterministic. In plain English? They can be unpredictable, which poses challenges for devs trying to build reliable systems.</li>
+
+
+
+<li>These systems have limited memory within each interaction. They&#8217;re like that friend who needs constant reminders.</li>
+
+
+
+<li>They don&#8217;t have knowledge in the human sense; they&#8217;re pattern recognition machines on steroids.</li>
+
+
+
+<li>It&#8217;s all about language modeling and data processing, not human-like intelligence.</li>
+</ol>
+
+
+
+<p class="wp-block-paragraph">The key takeaway? Context is crucial. Without it, AI can struggle. To make AI work for us, we need to feed it the right data and ask the right questions. But let&#8217;s not forget – when we do this right, the results can be pretty damn impressive.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0bf54&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0bf54" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6149" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">AI: The UX Layer of the Future</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s where it gets interesting. Morten dropped this bomb: generative AI is just the tip of the iceberg. It&#8217;s the sexy, public-facing part of a much bigger AI world. But get this – it&#8217;s essentially a UX layer for more complex AI systems.</p>
+
+
+
+<p class="wp-block-paragraph">Think about it like this: generative AI is the cool interface that lets us mere mortals interact with the hardcore AI stuff underneath. It&#8217;s like the sleek app on your phone that&#8217;s powered by some serious backend magic. And this interface? It&#8217;s opening up new possibilities for creativity and innovation that we&#8217;re only beginning to explore.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0c68e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0c68e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6151" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Enterprise AI Struggle Is Real (But Worth It)</h2>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s talk about the corporate world trying to jump on the AI bandwagon. It&#8217;s like watching your dad try to use <a href="https://www.tiktok.com/@kriskrug">TikTok</a> – awkward at first, but give it time, and you might be surprised. Companies are integrating AI into everything, expecting big changes. And while Morten&#8217;s right that &#8220;If you just bolt generative AI on top of something, it does not work,&#8221; we&#8217;re seeing some companies nail it and reap major benefits.</p>
+
+
+
+<p class="wp-block-paragraph">The real challenge is restructuring entire systems and data to work with AI. It&#8217;s not a quick fix; it&#8217;s a total overhaul. But for those who get it right? They&#8217;re seeing increased efficiency, innovation, and even new job creation. It&#8217;s a tough journey, but the destination could be worth it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0cdb6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0cdb6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6152" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Ethical AI: Not Just a Buzzword</h2>
+
+
+
+<p class="wp-block-paragraph">Alright, let&#8217;s get serious for a sec. AI harms are real, and we can&#8217;t ignore them. We&#8217;re talking environmental impact, societal issues, and decision-making that affects real people. But let&#8217;s also recognize the flip side – AI&#8217;s potential to solve major global challenges.</p>
+
+
+
+<p class="wp-block-paragraph">Morten challenged us to justify every kilowatt-hour we use with AI. That&#8217;s some heavy stuff, but it&#8217;s crucial. We&#8217;ve got to think about the impact of our tech, not just the cool factor. At the same time, let&#8217;s consider how AI might help us solve energy crises or climate change. It&#8217;s a balancing act, folks.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0d508&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0d508" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6153" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Building a Future We Actually Want</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s where we, as creators and innovators, come in. Morten hit us with this truth bomb: &#8220;The future is not an inevitable thing that happens to us. It is something we build ourselves.&#8221; Boom! That&#8217;s the kind of empowerment we need.</p>
+
+
+
+<p class="wp-block-paragraph">So, how do we use AI to build a kickass future?</p>
+
+
+
+<ol class="wp-block-list">
+<li>Explore new ways of doing old things. Challenge the status quo, baby!</li>
+
+
+
+<li>Tackle those &#8220;impossible&#8221; problems. AI gives us new tools to iterate and innovate.</li>
+
+
+
+<li>Use AI to empower people, not replace them. Think augmented intelligence, not artificial intelligence.</li>
+
+
+
+<li>Apply AI where it makes sense, not just because it&#8217;s trendy.</li>
+
+
+
+<li>Focus on solving real problems for real people. Don&#8217;t get caught up in the money-making hype, but don&#8217;t ignore the economic potential either.</li>
+</ol>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0dd42&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0dd42" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6154" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">The KK Take: A Deeper Dive into AI&#8217;s Impact</h3>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s take a moment to zoom out and look at the bigger picture. While Morten&#8217;s talk gave us a much-needed reality check on AI hype, it&#8217;s worth diving deeper into the nuances of AI&#8217;s impact on society and individuals.</p>
+
+
+
+<h4 class="wp-block-heading">Creativity and Productivity Explosion</h4>
+
+
+
+<p class="wp-block-paragraph">First off, let&#8217;s acknowledge that AI isn&#8217;t all doom and gloom. We&#8217;re witnessing a creativity and productivity explosion that&#8217;s hard to ignore. New jobs are being created, groundbreaking scientific discoveries are being made, and innovations are happening at breakneck speed. AI is helping us design new molecules, compounds, and materials that could revolutionize medicine, energy, and more.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0e59e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0e59e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6155" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">Trust and Potential Harm</h4>
+
+
+
+<p class="wp-block-paragraph">However, Morten&#8217;s concerns about trust and potential harm are valid. The question isn&#8217;t whether AI can be trusted in general, but rather for what specific tasks and under what conditions. The &#8220;infinite blast radius&#8221; he mentions might be an extreme metaphor, but it points to a real issue: the far-reaching and sometimes unpredictable consequences of AI decisions.</p>
+
+
+
+<h4 class="wp-block-heading">Energy Use and Efficiency</h4>
+
+
+
+<p class="wp-block-paragraph">When it comes to energy use, it&#8217;s true that AI systems are power-hungry beasts. But let&#8217;s not forget that they&#8217;re also being used to optimize energy grids, improve renewable energy sources, and tackle climate change. The key is to weigh the energy cost against the potential benefits and constantly strive for more efficient AI systems.</p>
+
+
+
+<h4 class="wp-block-heading">Corporate Hype and Genuine Innovation</h4>
+
+
+
+<p class="wp-block-paragraph">Is corporate hype the only driver behind AI development? Not entirely. While big tech certainly plays a significant role, there&#8217;s also genuine scientific curiosity, a desire to solve complex problems, and yes, economic incentives at play. It&#8217;s a complex ecosystem of motivations and actors.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0f172&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0f172" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6156" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">Capitalism and AI Development</h4>
+
+
+
+<p class="wp-block-paragraph">Morten&#8217;s anti-capitalist and anti-authoritarian views resonate with many of us who are wary of unchecked corporate power. But it&#8217;s worth noting that not everyone sees our current system as a &#8220;capitalist hellscape.&#8221; Many see opportunities for positive change within existing structures, while others advocate for more radical overhauls.</p>
+
+
+
+<h3 class="wp-block-heading">Embracing the Complexity</h3>
+
+
+
+<p class="wp-block-paragraph">The path forward isn&#8217;t black and white. It&#8217;s a winding road full of gray areas, unexpected turns, and tough decisions. As we navigate this AI-infused future, we need to hold onto our critical thinking skills, our ethical compass, and our ability to see both the forest and the trees.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Conclusion</h3>
+
+
+
+<p class="wp-block-paragraph">So, future-proofers, let&#8217;s embrace the complexity. Let&#8217;s be excited about AI&#8217;s potential while remaining clear-eyed about its risks. Let&#8217;s push for responsible innovation that benefits not just shareholders, but society as a whole. The future is ours to shape, and AI is just one of many tools we have at our disposal. Use it wisely, creatively, and always with an eye towards the greater good.</p>
+
+
+
+<p class="wp-block-paragraph">Now go forth and future-proof, you beautiful, complex creators! The world is waiting for your nuanced, AI-augmented brilliance. Peace out! ??? And <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">two years later I went to the protest and wrote down what the signs said</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0f996&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0f996" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6157" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-for-creatives/">AI for Creatives</a> collection. See also: <a href="https://kriskrug.co/2024/08/12/llms-and-beyond-reframing-the-future-of-artificial-intelligence/">LLMs and Beyond: Reframing the Future of Artificial Intelligence</a> and <a href="https://kriskrug.co/2026/06/04/ai-keynote-slides-visual-workflow/">AI Keynote Slides Need Taste Before Prompts</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-content.raw.html
@@ -1,0 +1,72 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-ethics -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI ethics</p>
+  <h2 class="aurora-display-heading">Responsible AI needs practice, not slogans.</h2>
+  <p class="aurora-page-lead">This hub gathers Kris Krug's writing and teaching on bias, data, provenance, labor, authorship, open source, sovereignty, and the uncomfortable parts of deploying AI in real communities.</p>
+  <p>The working posture is practical: name the tradeoffs, keep people in the loop, and refuse systems that make humans smaller.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Questions worth keeping in the room</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Who benefits?</h3>
+      <p>AI strategy should make power visible: who gains capacity, who loses agency, and who is being asked to absorb the risk?</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What data is being used?</h3>
+      <p>Bias, consent, privacy, provenance, and data quality are not side quests. They shape the system before anyone sees the interface.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What remains human?</h3>
+      <p>Judgment, accountability, relationship, care, taste, and refusal are not bugs to automate away.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>How do teams practice?</h3>
+      <p>Responsible AI becomes real through workflows, review rituals, escalation paths, training, and visible accountability.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Source trail</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/04/punk-rock-ai/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?resize=640,400&amp;ssl=1" alt="Punk Rock AI keynote graphic" loading="lazy"/>
+        <div>
+          <h3>Punk Rock AI</h3>
+          <p>A culture-first way to use powerful systems without becoming obedient to them.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/04/rap-faces.png?resize=640,400&amp;ssl=1" alt="Responsible AI Professional faces graphic" loading="lazy"/>
+        <div>
+          <h3>Responsible AI Professional</h3>
+          <p>A practical certification path for teams turning ethics into operating practice.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-ethics-philosophy/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/02/01-the-word-bias-dissolving.png?resize=640,400&amp;ssl=1" alt="The word bias dissolving in an AI ethics graphic" loading="lazy"/>
+        <div>
+          <h3>AI ethics archive</h3>
+          <p>Posts on bias, open systems, data, creative labor, and the politics inside the tools.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Turn responsibility into practice</h2>
+    <p>For training, talks, or applied AI governance that people can actually use, start with the decisions your team is making now.</p>
+    <p><a class="aurora-button" href="/responsible-ai-professional/">Explore RAP</a> <a class="aurora-button" href="/speaking/">Book an ethics talk</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-content.rendered.html
@@ -1,0 +1,72 @@
+
+<!-- content-architecture-2026:topic-ai-ethics -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI ethics</p>
+  <h2 class="aurora-display-heading">Responsible AI needs practice, not slogans.</h2>
+  <p class="aurora-page-lead">This hub gathers Kris Krug&#8217;s writing and teaching on bias, data, provenance, labor, authorship, open source, sovereignty, and the uncomfortable parts of deploying AI in real communities.</p>
+  <p>The working posture is practical: name the tradeoffs, keep people in the loop, and refuse systems that make humans smaller.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Questions worth keeping in the room</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Who benefits?</h3>
+      <p>AI strategy should make power visible: who gains capacity, who loses agency, and who is being asked to absorb the risk?</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What data is being used?</h3>
+      <p>Bias, consent, privacy, provenance, and data quality are not side quests. They shape the system before anyone sees the interface.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What remains human?</h3>
+      <p>Judgment, accountability, relationship, care, taste, and refusal are not bugs to automate away.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>How do teams practice?</h3>
+      <p>Responsible AI becomes real through workflows, review rituals, escalation paths, training, and visible accountability.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Source trail</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/04/punk-rock-ai/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/kk-cmvan-keynote-header.png?resize=640,400&amp;ssl=1" alt="Punk Rock AI keynote graphic" loading="lazy"/>
+        <div>
+          <h3>Punk Rock AI</h3>
+          <p>A culture-first way to use powerful systems without becoming obedient to them.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/04/rap-faces.png?resize=640,400&amp;ssl=1" alt="Responsible AI Professional faces graphic" loading="lazy"/>
+        <div>
+          <h3>Responsible AI Professional</h3>
+          <p>A practical certification path for teams turning ethics into operating practice.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-ethics-philosophy/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/02/01-the-word-bias-dissolving.png?resize=640,400&amp;ssl=1" alt="The word bias dissolving in an AI ethics graphic" loading="lazy"/>
+        <div>
+          <h3>AI ethics archive</h3>
+          <p>Posts on bias, open systems, data, creative labor, and the politics inside the tools.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Turn responsibility into practice</h2>
+    <p>For training, talks, or applied AI governance that people can actually use, start with the decisions your team is making now.</p>
+    <p><a class="aurora-button" href="/responsible-ai-professional/">Explore RAP</a> <a class="aurora-button" href="/speaking/">Book an ethics talk</a></p>
+  </div>
+</section>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/page-12318-identity.json
@@ -1,0 +1,20 @@
+{
+  "id": 12318,
+  "slug": "ai-ethics",
+  "status": "publish",
+  "link": "https://kriskrug.co/ai-ethics/",
+  "modified": "2026-07-01T12:27:51",
+  "modified_gmt": "2026-07-01T20:27:51",
+  "type": "page",
+  "title_rendered": "AI Ethics &#038; Philosophy",
+  "content_rendered_bytes": 3755,
+  "content_rendered_sha256": "a1990a2cfc8c9b1d857e657d0af6b97541bea97dbd0cde21da477f005a8347db",
+  "content_raw_bytes": 3731,
+  "content_raw_sha256": "12b30e9340336176659ff44c44e8dde4d4a48c1f0c5789465861be95e57d946e",
+  "content_raw_has_footer": false,
+  "snapshot_at": "2026-08-19T23:23:05Z",
+  "snapshot_auth": false,
+  "snapshot_source_rendered": "public REST content.rendered (WP_USER/WP_APP_PASSWORD unset)",
+  "snapshot_source_raw": "historical authenticated context=edit from 2026-07-01 content-architecture apply; modified_gmt matches live",
+  "you_cant_drink_data_href_count": 0
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11882-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11882-content.rendered.html
@@ -1,0 +1,48 @@
+<p>The AI debate is exhausted because too much of it is pretending to be brave while refusing the actual contradiction.</p>
+<p>The boosters want a clean story where the tools will save us if everyone just gets with the program. The doomers want a clean story where refusing the tools is the only ethical position left.</p>
+<blockquote class="wp-block-quote is-style-large">
+<p>Neither story is big enough.</p>
+</blockquote>
+<p>At the Vancouver AI March 2026 meetup, I tried to say the thing as plainly as I could: these systems are compromised, and they are powerful. They are built on extraction, and they are expanding what small creative teams can do. They carry bias, <a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">environmental cost</a>, labor risk, and cultural danger, and they are also helping people learn, make, organize, imagine, and build.</p>
+<p>That is not a contradiction to solve with a slogan.</p>
+<p>That is the work.</p>
+<h2>Both Hands Full Is A Community Practice</h2>
+<p><code>Both Hands Full</code> is not just a keynote title. It is how our community has learned to stand inside this moment.</p>
+<p>One hand has to hold the hard stuff: stolen work, permission, copyright, bias, misinformation, environmental pressure, platform power, labor disruption, and the very real grief artists feel when their work becomes training material without consent.</p>
+<p>The other hand has to hold the equally real creative explosion: new tools, new access, new workflows, new forms of learning, new capacity for individuals and small teams, and new ways for people to build things that used to require institutions.</p>
+<blockquote class="wp-block-quote is-style-large">
+<p>If you drop either hand, you start lying.</p>
+</blockquote>
+<h2>Why Vancouver AI Matters</h2>
+<p>Vancouver AI is useful because it gives people a room where they do not have to pick a lazy team.</p>
+<p>Artists can sit beside engineers. Founders can hear from educators. Policy people can hear from builders. Curious beginners can ask the question that everyone else is pretending they already understand.</p>
+<p>That is where the good AI conversation happens: in community, under enough trust that people can admit uncertainty without being punished for it.</p>
+<p>The meetup is not just an audience for my talks. It is one of the places the ideas get stress-tested. People push back. People bring edge cases. People bring lived experience from classrooms, studios, startups, nonprofits, and big organizations.</p>
+<p>That makes the talk better. It makes the whole community smarter.</p>
+<h2>The Middle Path Is Not Neutral</h2>
+<p>Some people hear &#8220;middle path&#8221; and think it means splitting the difference.</p>
+<p>That is not what I mean.</p>
+<p>The middle path is not passive. It is not polite mush. It is active stewardship. It asks better questions:</p>
+<ul>
+<li>Who benefits from this system?</li>
+<li>Whose work made it possible?</li>
+<li>What data should never go into it?</li>
+<li>What kind of creative practice becomes stronger with AI?</li>
+<li>What kind of human relationship gets weaker if we automate it?</li>
+<li>What should communities build for themselves instead of waiting for platforms?</li>
+</ul>
+<p>Those questions are harder than cheerleading. They are also harder than refusal.</p>
+<h2>Watch The Talk</h2>
+<figure class="wp-block-embed is-type-video is-provider-youtube">
+<div class="wp-block-embed__wrapper">https://www.youtube.com/watch?v=T5ANAthZewE</div>
+</figure>
+<h2>Related</h2>
+<ul>
+<li><a href="https://kriskrug.co/speaking/">AI keynote speaking</a></li>
+<li><a href="https://bc-ai.ca/">BC + AI Ecosystem</a></li>
+<li><a href="https://www.bothhandsfull.com/">Both Hands Full</a></li>
+<li><a href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">You Can&#8217;t Drink Data: notes from my first AI protest</a></li>
+<li><a href="https://kriskrug.co/2026/05/23/data-center-protest-signs/">Both Hands Full at the Data Center: protest signs</a></li>
+<li><a href="https://kriskrug.co/podcast-guesting-page-epk/">Podcast guesting and media EPK</a></li>
+</ul>
+<p><em>Source note: this draft is based on the public Vancouver AI March 2026 video and the local 2026 keynote source pack. Final publication should review ethical claims, audience references, and image choice before WordPress publishing.</em></p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11882-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11882-identity.json
@@ -1,0 +1,20 @@
+{
+  "id": 11882,
+  "slug": "we-trained-ai-on-stolen-work",
+  "status": "publish",
+  "link": "https://kriskrug.co/2026/05/19/we-trained-ai-on-stolen-work/",
+  "modified": "2026-06-24T10:20:09",
+  "modified_gmt": "2026-06-24T18:20:09",
+  "type": "post",
+  "title_rendered": "We Trained AI On Stolen Work. I Am More Creative Than Ever.",
+  "content_rendered_bytes": 4344,
+  "content_rendered_sha256": "b8c68561fc2d3a902d6cc065c8d342a0f2a47a75552686d224242e7af5480131",
+  "content_raw_bytes": null,
+  "content_raw_sha256": null,
+  "content_raw_has_footer": false,
+  "snapshot_at": "2026-08-19T23:23:05Z",
+  "snapshot_auth": false,
+  "snapshot_source_rendered": "public REST content.rendered (WP_USER/WP_APP_PASSWORD unset)",
+  "snapshot_source_raw": null,
+  "you_cant_drink_data_href_count": 2
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11936-identity-readonly.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-11936-identity-readonly.json
@@ -1,0 +1,12 @@
+{
+  "id": 11936,
+  "slug": "you-cant-drink-data",
+  "status": "publish",
+  "link": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+  "modified_gmt": "2026-08-11T02:24:37",
+  "type": "post",
+  "title_rendered": "You Can&#8217;t Drink Data",
+  "role": "read_only_not_in_write_set",
+  "snapshot_at": "2026-08-19T23:23:05Z",
+  "snapshot_source": "public REST identity fields only; body not snapshotted"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-content.raw.html
@@ -1,0 +1,360 @@
+<!-- wp:paragraph -->
+<p>Rainy Vancouver night. Somebody's laptop is open. Somebody else is asking the kind of question that makes a room go quiet: <em>Who owns the data in an AI future?</em> Not "who stores it" or "who can query it," but who actually holds the power to say yes, to say no, to set the terms, to change them later, to benefit when value is created.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the part of the AI conversation Canada keeps dodging: we don't just lack compute. We lack consent architecture.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Meanwhile, Maxime C. Cohen drops a clean, sharp white paper that basically says: Canada is in trouble. Not vibes-trouble. Measurable-trouble. His warning is blunt: we've been "too slow, too fragmented, and too modest in scale."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He's not wrong.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen's paper is one of the most coherent "Canada must get its act together" documents I've seen. It lays out the structural hits: compute scarcity, weak commercialization, adoption lag, and a real brain drain pipeline that keeps dumping Canadian talent into U.S. gravity wells. He cites a study where "two-thirds of Canadian software engineering students" from a cohort ended up in the U.S. within 5 years.  He points at a 46% compensation premium for U.S. tech workers over Canada, and the practical effect that has on retention.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>On compute, Cohen highlights Canada's share of global AI compute capacity as 0.7%.  That number isn't just a flex metric. It's an indicator of who gets to do frontier-scale experiments, who gets to train, who gets to iterate, who gets to publish, and who gets to set standards by sheer repetition.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>On adoption, he cites an AI adoption rate of 12.2% for Canadian enterprises and frames it as a competitiveness problem, especially for SMEs.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Then he does what policy people do when they're being serious: he proposes infrastructure and governance that match the size of the problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He calls for national GPU superclusters in the 10,000-50,000+ range.  He wants a national compute governance body and emphasizes "low-carbon infrastructure."  He proposes a CAD $1-2B commercialization fund to deal with the scale-up gap.  He wants industry acting as "anchor customers" and procurement that actually scales Canadian startups.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And he wants a "strong, active National AI Governance Council with a real mandate and accountability."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So yeah. Diagnosis is solid.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Now the hard part: Cohen's paper is necessary, but it's not sufficient.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Because the thing Cohen barely touches is the thing BC keeps tripping over (and learning from) in real-time: if we scale AI without stewardship, we just build a more efficient extraction machine.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The part Cohen nails (and we should steal shamelessly)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">1) Publish the feature: "We Agree on the Diagnosis. Our Cure Is Different."</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This long-form piece: Canada doesn't win a compute war by pretending compute doesn't matter.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen is correct that "sovereign compute" is not optional if you want domestic research capacity, domestic products, and domestic sovereignty over sensitive workloads.  Without it, you become what he warns against: "a research supplier to other nations."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>He also correctly calls for coordination across governments, industry, and researchers, plus faster commercialization mechanics. His recommendations are built for execution, not for panel discussions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC + AI should take those tools and upgrade them with our missing ingredient: <em>governance that doesn't treat community wellbeing as an afterthought.</em></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The part Cohen misses: trust is the limiting reagent</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen's paper is framed like a national competition problem. But in BC, we're living inside a trust problem.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And trust is not a PR issue. It's an adoption ceiling.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC public opinion research from SFU's Morris J. Wosk Centre for Dialogue says three-quarters of British Columbians do not trust tech companies to manage and develop AI carefully and with public wellbeing in mind. Two-thirds don't trust government or NGOs either. Academic institutions do better, but even there it's split.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the social reality any "national AI strategy" has to operate inside. If you try to force adoption without rebuilding trust, you don't get acceleration. You get backlash, refusal, and quiet sabotage.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The same report says 82% feel "nervous" about AI in society, 86% worry about losing personal agency if companies and governments use AI to make decisions affecting their lives, and 56% don't believe benefits outweigh risks.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And here's the kicker: despite low trust in government, BC residents still want regulation. 74% want government to impose regulations on companies developing or using generative AI systems to address false or misleading information.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So if we're designing a future AI economy, we're not optimizing for "compute first." We're optimizing for "trust and consent first," because without that, compute just scales conflict.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">What BC+AI has that Cohen's framework doesn't: a proven community engine</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen is solving for institutions. BC+AI has been solving for people.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The Vancouver AI Community Meetup case study in <em>BC Studies</em> describes something most policy frameworks can't see: a grassroots practice community that becomes infrastructure.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>They reported "an average audience size… around 150 people," with total attendance "around 2,400" in 2024, and "the community built itself without corporate sponsorship or government funding."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>It's also not just quantity. It's format: open mic, demos, rapid iteration, "digital platforms," and "dedicated physical spaces" where people keep showing up.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's not a meetup anecdote. That's an adoption mechanism. It's how SMEs actually move: seeing real workflows, talking to peers, stealing patterns, trying again next week.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen's procurement reforms and commercialization funds become radically more effective when there's already a living lab generating demand and talent attachment.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The Indigenous governance gap is not "inclusion." It's strategy.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here's where BC's West Coast model stops being "nice" and becomes <em>nationally differentiating</em>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The BC AI Symposium Final Report explicitly calls out Indigenous rights and governance frameworks as real components of responsible AI. It notes that participants underscored the need to integrate "Indigenous rights and governance principles in AI development," including UNDRIP and OCAP.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The report also flags the environmental footprint of compute, calling for greener infrastructure and "green data centers," and explicitly ties that to the "increasing computational power needed by AI systems."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>And it doesn't stop at principles. It points at practical governance and procurement problems: if we don't build best practices and accountability frameworks, we get a "move fast and break things" import with a Canadian flag sticker slapped on top.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is the missing layer in Cohen's blueprint: <strong>stewardship</strong>. Not "ethics as a PDF," but enforceable consent, reciprocal benefit, and governance with teeth.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>The BC AI JEDI Report uses a metaphor that's almost too perfect: building the ecosystem as a "mycorrhizal web," where exchange is mutual and regenerative, not extractive. It also names "<a href="https://kriskrug.co/indigenous-ai/">Indigenous data sovereignty and stewardship</a>" as a core necessity.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's not a vibe. That's the blueprint for how Canada becomes globally distinctive without trying to out-America America.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">So what do we do with Cohen's paper?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>We don't dunk on it. We remix it into something Canada can own.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs scale. I'm saying: fine, but only with stewardship.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs compute. I'm saying: fine, but only with consent, climate discipline, and value staying local.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen says Canada needs governance. I'm saying: fine, but governance must include Indigenous jurisdiction and community accountability, or it's just a nicer-looking extraction layer.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's the synthesis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">The plan: a concrete "West Coast Response" that can ship</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Here's what I'd publish, and how I'd execute it, fast.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">1) Publish the feature: "We Agree on the Diagnosis. Our Cure Is Different."</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>This long-form piece (the thing you're reading) becomes the public-facing bridge: respectful to Cohen's rigor, brutally honest about what's missing.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include short direct quotes from Cohen (no cherry-picking). Example: Canada has been "too slow, too fragmented, and too modest in scale."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include real BC receipts: Vancouver AI's scale and independence.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Include the trust reality: three-quarters don't trust tech companies.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">2) Convene a national "Stewardship + Scale" roundtable (not a conference)</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>60-90 days. One day. No panels. Just working sessions.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Invite Cohen. Invite Indigenous data governance leaders. Invite BC Hydro or energy system folks. Invite SMEs. Invite labour.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Output is not a "statement." Output is a draft spec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Deliverable: <strong>The Stewarded Compute Accord (v0.1)</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>A short, enforceable set of requirements for any publicly supported AI compute capacity in Canada:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>OCAP/UNDRIP-aligned data governance pathways for sensitive datasets. Low-carbon infrastructure requirements (Cohen already flags low-carbon compute as a priority).Public reporting on access, usage, and benefit distribution.Clear "no extractive deals" clauses for public assets.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">3) Build a BC pilot: "Compute Commons + Consent Commons"</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>If Cohen wants 10,000-50,000 GPU superclusters, BC can pilot the governance model for how that compute gets used.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>In 6-12 months:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Stand up a small "Compute Commons" allocation model (even if the hardware is modest at first).Pair it with a "Consent Commons" toolkit: reusable legal templates, data-sharing agreements, and audit patterns aligned to OCAP/UNDRIP principles referenced in the symposium report.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This turns "responsible AI" from branding into operational controls.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">4) SME adoption: copy Cohen's speed, use BC's community engine</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen emphasizes procurement and pilots that scale.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC's move:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Run 90-day "SME AI Sprints" that start in community (meetups, practice labs) and end in procurement-ready outputs.Use the Vancouver AI pattern: live demos, open mic, show your work.Track outcomes: time saved, error rates, employee satisfaction, risk incidents, and whether value stayed local.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">5) Trust rebuilding isn't optional. It's a parallel workstream.</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>The SFU public opinion report literally says any action will be "severely hampered" by lack of trust and will require "trust re-building" efforts.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>So we treat trust like infrastructure:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>publish plain-language model cards for <a href="https://kriskrug.co/ai-tools/">community-built tools</a>,publish impact assessments for pilots,run public "AI office hours" in multiple regions,measure sentiment quarterly, not annually.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">6) Capital stack: take Cohen's money, change the rules</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Cohen proposes a CAD $1-2B national commercialization fund.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC's demand should be: if public money builds capacity, public benefit must be contractually real.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>revenue-share or equity-return terms that recycle value into regional capacity,cooperative options for SMEs (shared infrastructure, shared governance),open-source requirements where appropriate (JEDI's ecosystem logic explicitly pushes open, collaborative building).</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Closing: Canada's real advantage is not speed. It's legitimacy.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>The U.S. can brute-force frontier scale. The EU can brute-force regulation. Canada's best move is neither. Canada's best move is to build AI that people will actually consent to live with.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Cohen is building the scaffolding: compute, commercialization, coordination.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>BC+AI is building the missing organs: community practice, Indigenous governance, trust repair, non-extractive value flow.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Put them together and Canada stops copying Silicon Valley's worst habits with a polite smile. We become the place that figured out how to scale AI without hollowing out the people it claims to serve.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>That's the West Coast contribution: scale, yes. But stewarded. Or it's not progress, it's just a faster leak.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Public source checks</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item -->
+<li><a href="https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all">Canada's National Artificial Intelligence Strategy: AI for All</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://ised-isde.canada.ca/site/ised/en/artificial-intelligence-ecosystem/overview-canadas-national-artificial-intelligence-strategy">Overview of Canada's National Artificial Intelligence Strategy</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://www.sfu.ca/dialogue/what-we-do/initiatives/dot.html">SFU Dialogue on Technology Project</a></li>
+<!-- /wp:list-item -->
+<!-- wp:list-item -->
+<li><a href="https://indigenousinitiatives.ctlt.ubc.ca/2025/11/19/ai-reflections-indigenous-data-sovereignty-and-artificial-intelligence/">Indigenous data sovereignty and AI reflection</a></li>
+<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-content.rendered.html
@@ -1,0 +1,360 @@
+
+<p class="wp-block-paragraph">Rainy Vancouver night. Somebody&#8217;s laptop is open. Somebody else is asking the kind of question that makes a room go quiet: <em>Who owns the data in an AI future?</em> Not &#8220;who stores it&#8221; or &#8220;who can query it,&#8221; but who actually holds the power to say yes, to say no, to set the terms, to change them later, to benefit when value is created.</p>
+
+
+
+<p class="wp-block-paragraph">This is the part of the AI conversation Canada keeps dodging: we don&#8217;t just lack compute. We lack consent architecture.</p>
+
+
+
+<p class="wp-block-paragraph">Meanwhile, Maxime C. Cohen drops a clean, sharp white paper that basically says: Canada is in trouble. Not vibes-trouble. Measurable-trouble. His warning is blunt: we&#8217;ve been &#8220;too slow, too fragmented, and too modest in scale.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">He&#8217;s not wrong.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen&#8217;s paper is one of the most coherent &#8220;Canada must get its act together&#8221; documents I&#8217;ve seen. It lays out the structural hits: compute scarcity, weak commercialization, adoption lag, and a real brain drain pipeline that keeps dumping Canadian talent into U.S. gravity wells. He cites a study where &#8220;two-thirds of Canadian software engineering students&#8221; from a cohort ended up in the U.S. within 5 years.  He points at a 46% compensation premium for U.S. tech workers over Canada, and the practical effect that has on retention.</p>
+
+
+
+<p class="wp-block-paragraph">On compute, Cohen highlights Canada&#8217;s share of global AI compute capacity as 0.7%.  That number isn&#8217;t just a flex metric. It&#8217;s an indicator of who gets to do frontier-scale experiments, who gets to train, who gets to iterate, who gets to publish, and who gets to set standards by sheer repetition.</p>
+
+
+
+<p class="wp-block-paragraph">On adoption, he cites an AI adoption rate of 12.2% for Canadian enterprises and frames it as a competitiveness problem, especially for SMEs.</p>
+
+
+
+<p class="wp-block-paragraph">Then he does what policy people do when they&#8217;re being serious: he proposes infrastructure and governance that match the size of the problem.</p>
+
+
+
+<p class="wp-block-paragraph">He calls for national GPU superclusters in the 10,000-50,000+ range.  He wants a national compute governance body and emphasizes &#8220;low-carbon infrastructure.&#8221;  He proposes a CAD $1-2B commercialization fund to deal with the scale-up gap.  He wants industry acting as &#8220;anchor customers&#8221; and procurement that actually scales Canadian startups.</p>
+
+
+
+<p class="wp-block-paragraph">And he wants a &#8220;strong, active National AI Governance Council with a real mandate and accountability.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">So yeah. Diagnosis is solid.</p>
+
+
+
+<p class="wp-block-paragraph">Now the hard part: Cohen&#8217;s paper is necessary, but it&#8217;s not sufficient.</p>
+
+
+
+<p class="wp-block-paragraph">Because the thing Cohen barely touches is the thing BC keeps tripping over (and learning from) in real-time: if we scale AI without stewardship, we just build a more efficient extraction machine.</p>
+
+
+
+<h2 class="wp-block-heading">The part Cohen nails (and we should steal shamelessly)</h2>
+
+
+
+<h3 class="wp-block-heading">1) Publish the feature: &#8220;We Agree on the Diagnosis. Our Cure Is Different.&#8221;</h3>
+
+
+
+<p class="wp-block-paragraph">This long-form piece: Canada doesn&#8217;t win a compute war by pretending compute doesn&#8217;t matter.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen is correct that &#8220;sovereign compute&#8221; is not optional if you want domestic research capacity, domestic products, and domestic sovereignty over sensitive workloads.  Without it, you become what he warns against: &#8220;a research supplier to other nations.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">He also correctly calls for coordination across governments, industry, and researchers, plus faster commercialization mechanics. His recommendations are built for execution, not for panel discussions.</p>
+
+
+
+<p class="wp-block-paragraph">BC + AI should take those tools and upgrade them with our missing ingredient: <em>governance that doesn&#8217;t treat community wellbeing as an afterthought.</em></p>
+
+
+
+<h2 class="wp-block-heading">The part Cohen misses: trust is the limiting reagent</h2>
+
+
+
+<p class="wp-block-paragraph">Cohen&#8217;s paper is framed like a national competition problem. But in BC, we&#8217;re living inside a trust problem.</p>
+
+
+
+<p class="wp-block-paragraph">And trust is not a PR issue. It&#8217;s an adoption ceiling.</p>
+
+
+
+<p class="wp-block-paragraph">BC public opinion research from SFU&#8217;s Morris J. Wosk Centre for Dialogue says three-quarters of British Columbians do not trust tech companies to manage and develop AI carefully and with public wellbeing in mind. Two-thirds don&#8217;t trust government or NGOs either. Academic institutions do better, but even there it&#8217;s split.</p>
+
+
+
+<p class="wp-block-paragraph">This is the social reality any &#8220;national AI strategy&#8221; has to operate inside. If you try to force adoption without rebuilding trust, you don&#8217;t get acceleration. You get backlash, refusal, and quiet sabotage.</p>
+
+
+
+<p class="wp-block-paragraph">The same report says 82% feel &#8220;nervous&#8221; about AI in society, 86% worry about losing personal agency if companies and governments use AI to make decisions affecting their lives, and 56% don&#8217;t believe benefits outweigh risks.</p>
+
+
+
+<p class="wp-block-paragraph">And here&#8217;s the kicker: despite low trust in government, BC residents still want regulation. 74% want government to impose regulations on companies developing or using generative AI systems to address false or misleading information.</p>
+
+
+
+<p class="wp-block-paragraph">So if we&#8217;re designing a future AI economy, we&#8217;re not optimizing for &#8220;compute first.&#8221; We&#8217;re optimizing for &#8220;trust and consent first,&#8221; because without that, compute just scales conflict.</p>
+
+
+
+<h2 class="wp-block-heading">What BC+AI has that Cohen&#8217;s framework doesn&#8217;t: a proven community engine</h2>
+
+
+
+<p class="wp-block-paragraph">Cohen is solving for institutions. BC+AI has been solving for people.</p>
+
+
+
+<p class="wp-block-paragraph">The Vancouver AI Community Meetup case study in <em>BC Studies</em> describes something most policy frameworks can&#8217;t see: a grassroots practice community that becomes infrastructure.</p>
+
+
+
+<p class="wp-block-paragraph">They reported &#8220;an average audience size… around 150 people,&#8221; with total attendance &#8220;around 2,400&#8221; in 2024, and &#8220;the community built itself without corporate sponsorship or government funding.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">It&#8217;s also not just quantity. It&#8217;s format: open mic, demos, rapid iteration, &#8220;digital platforms,&#8221; and &#8220;dedicated physical spaces&#8221; where people keep showing up.</p>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s not a meetup anecdote. That&#8217;s an adoption mechanism. It&#8217;s how SMEs actually move: seeing real workflows, talking to peers, stealing patterns, trying again next week.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen&#8217;s procurement reforms and commercialization funds become radically more effective when there&#8217;s already a living lab generating demand and talent attachment.</p>
+
+
+
+<h2 class="wp-block-heading">The Indigenous governance gap is not &#8220;inclusion.&#8221; It&#8217;s strategy.</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s where BC&#8217;s West Coast model stops being &#8220;nice&#8221; and becomes <em>nationally differentiating</em>.</p>
+
+
+
+<p class="wp-block-paragraph">The BC AI Symposium Final Report explicitly calls out Indigenous rights and governance frameworks as real components of responsible AI. It notes that participants underscored the need to integrate &#8220;Indigenous rights and governance principles in AI development,&#8221; including UNDRIP and OCAP.</p>
+
+
+
+<p class="wp-block-paragraph">The report also flags the environmental footprint of compute, calling for greener infrastructure and &#8220;green data centers,&#8221; and explicitly ties that to the &#8220;increasing computational power needed by AI systems.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">And it doesn&#8217;t stop at principles. It points at practical governance and procurement problems: if we don&#8217;t build best practices and accountability frameworks, we get a &#8220;move fast and break things&#8221; import with a Canadian flag sticker slapped on top.</p>
+
+
+
+<p class="wp-block-paragraph">This is the missing layer in Cohen&#8217;s blueprint: <strong>stewardship</strong>. Not &#8220;ethics as a PDF,&#8221; but enforceable consent, reciprocal benefit, and governance with teeth.</p>
+
+
+
+<p class="wp-block-paragraph">The BC AI JEDI Report uses a metaphor that&#8217;s almost too perfect: building the ecosystem as a &#8220;mycorrhizal web,&#8221; where exchange is mutual and regenerative, not extractive. It also names &#8220;<a href="https://kriskrug.co/indigenous-ai/">Indigenous data sovereignty and stewardship</a>&#8221; as a core necessity.</p>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s not a vibe. That&#8217;s the blueprint for how Canada becomes globally distinctive without trying to out-America America.</p>
+
+
+
+<h2 class="wp-block-heading">So what do we do with Cohen&#8217;s paper?</h2>
+
+
+
+<p class="wp-block-paragraph">We don&#8217;t dunk on it. We remix it into something Canada can own.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen says Canada needs scale. I&#8217;m saying: fine, but only with stewardship.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen says Canada needs compute. I&#8217;m saying: fine, but only with consent, climate discipline, and value staying local.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen says Canada needs governance. I&#8217;m saying: fine, but governance must include Indigenous jurisdiction and community accountability, or it&#8217;s just a nicer-looking extraction layer.</p>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s the synthesis.</p>
+
+
+
+<h2 class="wp-block-heading">The plan: a concrete &#8220;West Coast Response&#8221; that can ship</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s what I&#8217;d publish, and how I&#8217;d execute it, fast.</p>
+
+
+
+<h3 class="wp-block-heading">1) Publish the feature: &#8220;We Agree on the Diagnosis. Our Cure Is Different.&#8221;</h3>
+
+
+
+<p class="wp-block-paragraph">This long-form piece (the thing you&#8217;re reading) becomes the public-facing bridge: respectful to Cohen&#8217;s rigor, brutally honest about what&#8217;s missing.</p>
+
+
+
+<p class="wp-block-paragraph">Include short direct quotes from Cohen (no cherry-picking). Example: Canada has been &#8220;too slow, too fragmented, and too modest in scale.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph">Include real BC receipts: Vancouver AI&#8217;s scale and independence.</p>
+
+
+
+<p class="wp-block-paragraph">Include the trust reality: three-quarters don&#8217;t trust tech companies.</p>
+
+
+
+<h3 class="wp-block-heading">2) Convene a national &#8220;Stewardship + Scale&#8221; roundtable (not a conference)</h3>
+
+
+
+<p class="wp-block-paragraph">60-90 days. One day. No panels. Just working sessions.</p>
+
+
+
+<p class="wp-block-paragraph">Invite Cohen. Invite Indigenous data governance leaders. Invite BC Hydro or energy system folks. Invite SMEs. Invite labour.</p>
+
+
+
+<p class="wp-block-paragraph">Output is not a &#8220;statement.&#8221; Output is a draft spec.</p>
+
+
+
+<p class="wp-block-paragraph">Deliverable: <strong>The Stewarded Compute Accord (v0.1)</strong></p>
+
+
+
+<p class="wp-block-paragraph">A short, enforceable set of requirements for any publicly supported AI compute capacity in Canada:</p>
+
+
+
+<p class="wp-block-paragraph">OCAP/UNDRIP-aligned data governance pathways for sensitive datasets. Low-carbon infrastructure requirements (Cohen already flags low-carbon compute as a priority).Public reporting on access, usage, and benefit distribution.Clear &#8220;no extractive deals&#8221; clauses for public assets.</p>
+
+
+
+<h3 class="wp-block-heading">3) Build a BC pilot: &#8220;Compute Commons + Consent Commons&#8221;</h3>
+
+
+
+<p class="wp-block-paragraph">If Cohen wants 10,000-50,000 GPU superclusters, BC can pilot the governance model for how that compute gets used.</p>
+
+
+
+<p class="wp-block-paragraph">In 6-12 months:</p>
+
+
+
+<p class="wp-block-paragraph">Stand up a small &#8220;Compute Commons&#8221; allocation model (even if the hardware is modest at first).Pair it with a &#8220;Consent Commons&#8221; toolkit: reusable legal templates, data-sharing agreements, and audit patterns aligned to OCAP/UNDRIP principles referenced in the symposium report.</p>
+
+
+
+<p class="wp-block-paragraph">This turns &#8220;responsible AI&#8221; from branding into operational controls.</p>
+
+
+
+<h3 class="wp-block-heading">4) SME adoption: copy Cohen&#8217;s speed, use BC&#8217;s community engine</h3>
+
+
+
+<p class="wp-block-paragraph">Cohen emphasizes procurement and pilots that scale.</p>
+
+
+
+<p class="wp-block-paragraph">BC&#8217;s move:</p>
+
+
+
+<p class="wp-block-paragraph">Run 90-day &#8220;SME AI Sprints&#8221; that start in community (meetups, practice labs) and end in procurement-ready outputs.Use the Vancouver AI pattern: live demos, open mic, show your work.Track outcomes: time saved, error rates, employee satisfaction, risk incidents, and whether value stayed local.</p>
+
+
+
+<h3 class="wp-block-heading">5) Trust rebuilding isn&#8217;t optional. It&#8217;s a parallel workstream.</h3>
+
+
+
+<p class="wp-block-paragraph">The SFU public opinion report literally says any action will be &#8220;severely hampered&#8221; by lack of trust and will require &#8220;trust re-building&#8221; efforts.</p>
+
+
+
+<p class="wp-block-paragraph">So we treat trust like infrastructure:</p>
+
+
+
+<p class="wp-block-paragraph">publish plain-language model cards for <a href="https://kriskrug.co/ai-tools/">community-built tools</a>,publish impact assessments for pilots,run public &#8220;AI office hours&#8221; in multiple regions,measure sentiment quarterly, not annually.</p>
+
+
+
+<h3 class="wp-block-heading">6) Capital stack: take Cohen&#8217;s money, change the rules</h3>
+
+
+
+<p class="wp-block-paragraph">Cohen proposes a CAD $1-2B national commercialization fund.</p>
+
+
+
+<p class="wp-block-paragraph">BC&#8217;s demand should be: if public money builds capacity, public benefit must be contractually real.</p>
+
+
+
+<p class="wp-block-paragraph">revenue-share or equity-return terms that recycle value into regional capacity,cooperative options for SMEs (shared infrastructure, shared governance),open-source requirements where appropriate (JEDI&#8217;s ecosystem logic explicitly pushes open, collaborative building).</p>
+
+
+
+<h2 class="wp-block-heading">Closing: Canada&#8217;s real advantage is not speed. It&#8217;s legitimacy.</h2>
+
+
+
+<p class="wp-block-paragraph">The U.S. can brute-force frontier scale. The EU can brute-force regulation. Canada&#8217;s best move is neither. Canada&#8217;s best move is to build AI that people will actually consent to live with.</p>
+
+
+
+<p class="wp-block-paragraph">Cohen is building the scaffolding: compute, commercialization, coordination.</p>
+
+
+
+<p class="wp-block-paragraph">BC+AI is building the missing organs: community practice, Indigenous governance, trust repair, non-extractive value flow.</p>
+
+
+
+<p class="wp-block-paragraph">Put them together and Canada stops copying Silicon Valley&#8217;s worst habits with a polite smile. We become the place that figured out how to scale AI without hollowing out the people it claims to serve.</p>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s the West Coast contribution: scale, yes. But stewarded. Or it&#8217;s not progress, it&#8217;s just a faster leak.</p>
+
+
+
+<h2 class="wp-block-heading">Public source checks</h2>
+
+
+
+<ul class="wp-block-list">
+
+<li><a href="https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all">Canada&#8217;s National Artificial Intelligence Strategy: AI for All</a></li>
+
+
+<li><a href="https://ised-isde.canada.ca/site/ised/en/artificial-intelligence-ecosystem/overview-canadas-national-artificial-intelligence-strategy">Overview of Canada&#8217;s National Artificial Intelligence Strategy</a></li>
+
+
+<li><a href="https://www.sfu.ca/dialogue/what-we-do/initiatives/dot.html">SFU Dialogue on Technology Project</a></li>
+
+
+<li><a href="https://indigenousinitiatives.ctlt.ubc.ca/2025/11/19/ai-reflections-indigenous-data-sovereignty-and-artificial-intelligence/">Indigenous data sovereignty and AI reflection</a></li>
+
+</ul>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-12030-identity.json
@@ -1,0 +1,20 @@
+{
+  "id": 12030,
+  "slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+  "status": "publish",
+  "link": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+  "modified": "2026-08-01T11:57:26",
+  "modified_gmt": "2026-08-01T19:57:26",
+  "type": "post",
+  "title_rendered": "Canada Doesn&#8217;t Need a Bigger AI Machine. It Needs a Better One.",
+  "content_rendered_bytes": 16804,
+  "content_rendered_sha256": "849d8c3cd06f4ff71fce841254750df93958b296217f552385dbf25af7bc430a",
+  "content_raw_bytes": 17824,
+  "content_raw_sha256": "6f9d3386819d707dec6ff34fbffe070eb194e1303e0e90a94b4b251cec0abc7d",
+  "content_raw_has_footer": false,
+  "snapshot_at": "2026-08-19T23:23:05Z",
+  "snapshot_auth": false,
+  "snapshot_source_rendered": "public REST content.rendered (WP_USER/WP_APP_PASSWORD unset)",
+  "snapshot_source_raw": "historical authenticated context=edit from 2026-08-01 voice sweep; modified_gmt matches live",
+  "you_cant_drink_data_href_count": 0
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-6144-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-6144-content.rendered.html
@@ -1,0 +1,383 @@
+
+<h2 class="wp-block-heading">Insights from Morten Rand-Hendriksen&#8217;s &#8216;Demythifying AI&#8217; Talk at GDG Burnaby &#8220;Build With AI&#8221; Event</h2>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Yo, future-proofed creators! Today I’m dropping some insights from <a href="https://mor10.com/">Morten Rand-Hendriksen&#8217;</a>s talk at <a href="https://gdg.community.dev/gdg-burnaby/">GDG Burnaby</a>. This dude, a senior staff instructor at <a href="https://www.linkedin.com/in/mortenrandhendriksen?originalSubdomain=ca">LinkedIn Learning</a>, just blew the roof off with his no-BS take on AI. Buckle up, &#8217;cause we&#8217;re about to get real about the AI hype machine and what it means for us as creators and innovators.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0b62c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0b62c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6148" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Cybernetic_Mindscape_-_A_futuristic_mental_landscape_8998621a-1e55-4d16-9021-79c87d3841aa_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Cutting Through the AI BS</h2>
+
+
+
+<p class="wp-block-paragraph">First things first, let&#8217;s talk about the elephant in the room: the way we talk about AI is often misleading. Morten hit us with this gem: &#8220;The language we use about AI creates pictures in our heads.&#8221; And boy, are those pictures sometimes way off base.</p>
+
+
+
+<p class="wp-block-paragraph">We&#8217;ve been sold this idea of AI as some kind of digital BFF or a new species. But here&#8217;s the truth bomb: AI is primarily tools and materials, not your next drinking buddy or the evolution of humanity. It&#8217;s time we reassessed the anthropomorphic language and saw AI for what it really is – powerful tech that we can shape and use, while also acknowledging its potential for significant impact.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Real Talk on AI Capabilities</h2>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s get down to the nitty-gritty of what AI can actually do. Morten laid it out straight:</p>
+
+
+
+<ol class="wp-block-list">
+<li>AI systems are probabilistic and non-deterministic. In plain English? They can be unpredictable, which poses challenges for devs trying to build reliable systems.</li>
+
+
+
+<li>These systems have limited memory within each interaction. They&#8217;re like that friend who needs constant reminders.</li>
+
+
+
+<li>They don&#8217;t have knowledge in the human sense; they&#8217;re pattern recognition machines on steroids.</li>
+
+
+
+<li>It&#8217;s all about language modeling and data processing, not human-like intelligence.</li>
+</ol>
+
+
+
+<p class="wp-block-paragraph">The key takeaway? Context is crucial. Without it, AI can struggle. To make AI work for us, we need to feed it the right data and ask the right questions. But let&#8217;s not forget – when we do this right, the results can be pretty damn impressive.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0bf54&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0bf54" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6149" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_1.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">AI: The UX Layer of the Future</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s where it gets interesting. Morten dropped this bomb: generative AI is just the tip of the iceberg. It&#8217;s the sexy, public-facing part of a much bigger AI world. But get this – it&#8217;s essentially a UX layer for more complex AI systems.</p>
+
+
+
+<p class="wp-block-paragraph">Think about it like this: generative AI is the cool interface that lets us mere mortals interact with the hardcore AI stuff underneath. It&#8217;s like the sleek app on your phone that&#8217;s powered by some serious backend magic. And this interface? It&#8217;s opening up new possibilities for creativity and innovation that we&#8217;re only beginning to explore.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0c68e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0c68e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6151" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_cc825650-0334-4901-ae67-42cb980e39ec_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Enterprise AI Struggle Is Real (But Worth It)</h2>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s talk about the corporate world trying to jump on the AI bandwagon. It&#8217;s like watching your dad try to use <a href="https://www.tiktok.com/@kriskrug">TikTok</a> – awkward at first, but give it time, and you might be surprised. Companies are integrating AI into everything, expecting big changes. And while Morten&#8217;s right that &#8220;If you just bolt generative AI on top of something, it does not work,&#8221; we&#8217;re seeing some companies nail it and reap major benefits.</p>
+
+
+
+<p class="wp-block-paragraph">The real challenge is restructuring entire systems and data to work with AI. It&#8217;s not a quick fix; it&#8217;s a total overhaul. But for those who get it right? They&#8217;re seeing increased efficiency, innovation, and even new job creation. It&#8217;s a tough journey, but the destination could be worth it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0cdb6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0cdb6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6152" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_7e269df0-0032-4a79-a223-5807a4bda580_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Ethical AI: Not Just a Buzzword</h2>
+
+
+
+<p class="wp-block-paragraph">Alright, let&#8217;s get serious for a sec. AI harms are real, and we can&#8217;t ignore them. We&#8217;re talking environmental impact, societal issues, and decision-making that affects real people. But let&#8217;s also recognize the flip side – AI&#8217;s potential to solve major global challenges.</p>
+
+
+
+<p class="wp-block-paragraph">Morten challenged us to justify every kilowatt-hour we use with AI. That&#8217;s some heavy stuff, but it&#8217;s crucial. We&#8217;ve got to think about the impact of our tech, not just the cool factor. At the same time, let&#8217;s consider how AI might help us solve energy crises or climate change. It&#8217;s a balancing act, folks.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0d508&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0d508" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6153" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_0.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Building a Future We Actually Want</h2>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s where we, as creators and innovators, come in. Morten hit us with this truth bomb: &#8220;The future is not an inevitable thing that happens to us. It is something we build ourselves.&#8221; Boom! That&#8217;s the kind of empowerment we need.</p>
+
+
+
+<p class="wp-block-paragraph">So, how do we use AI to build a kickass future?</p>
+
+
+
+<ol class="wp-block-list">
+<li>Explore new ways of doing old things. Challenge the status quo, baby!</li>
+
+
+
+<li>Tackle those &#8220;impossible&#8221; problems. AI gives us new tools to iterate and innovate.</li>
+
+
+
+<li>Use AI to empower people, not replace them. Think augmented intelligence, not artificial intelligence.</li>
+
+
+
+<li>Apply AI where it makes sense, not just because it&#8217;s trendy.</li>
+
+
+
+<li>Focus on solving real problems for real people. Don&#8217;t get caught up in the money-making hype, but don&#8217;t ignore the economic potential either.</li>
+</ol>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0dd42&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0dd42" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6154" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_01a98906-20e2-420b-96c5-3f9311dee2c7_1.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">The KK Take: A Deeper Dive into AI&#8217;s Impact</h3>
+
+
+
+<p class="wp-block-paragraph">Now, let&#8217;s take a moment to zoom out and look at the bigger picture. While Morten&#8217;s talk gave us a much-needed reality check on AI hype, it&#8217;s worth diving deeper into the nuances of AI&#8217;s impact on society and individuals.</p>
+
+
+
+<h4 class="wp-block-heading">Creativity and Productivity Explosion</h4>
+
+
+
+<p class="wp-block-paragraph">First off, let&#8217;s acknowledge that AI isn&#8217;t all doom and gloom. We&#8217;re witnessing a creativity and productivity explosion that&#8217;s hard to ignore. New jobs are being created, groundbreaking scientific discoveries are being made, and innovations are happening at breakneck speed. AI is helping us design new molecules, compounds, and materials that could revolutionize medicine, energy, and more.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0e59e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0e59e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6155" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_httpss.mj_.run4WlY1UxwXU8_httpss.mj_.runfCWXbRe30bU_ht_74a8ca6d-2804-4de9-a4ef-5c58b339a6db_0.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">Trust and Potential Harm</h4>
+
+
+
+<p class="wp-block-paragraph">However, Morten&#8217;s concerns about trust and potential harm are valid. The question isn&#8217;t whether AI can be trusted in general, but rather for what specific tasks and under what conditions. The &#8220;infinite blast radius&#8221; he mentions might be an extreme metaphor, but it points to a real issue: the far-reaching and sometimes unpredictable consequences of AI decisions.</p>
+
+
+
+<h4 class="wp-block-heading">Energy Use and Efficiency</h4>
+
+
+
+<p class="wp-block-paragraph">When it comes to energy use, it&#8217;s true that AI systems are power-hungry beasts. But let&#8217;s not forget that they&#8217;re also being used to optimize energy grids, improve renewable energy sources, and tackle climate change. The key is to weigh the energy cost against the potential benefits and constantly strive for more efficient AI systems.</p>
+
+
+
+<h4 class="wp-block-heading">Corporate Hype and Genuine Innovation</h4>
+
+
+
+<p class="wp-block-paragraph">Is corporate hype the only driver behind AI development? Not entirely. While big tech certainly plays a significant role, there&#8217;s also genuine scientific curiosity, a desire to solve complex problems, and yes, economic incentives at play. It&#8217;s a complex ecosystem of motivations and actors.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0f172&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0f172" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6156" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Generative_Reality_Warp_-_An_ever-evolving_reality_c_12e393a2-266e-49bc-9c88-8b1ef27bde7c_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">Capitalism and AI Development</h4>
+
+
+
+<p class="wp-block-paragraph">Morten&#8217;s anti-capitalist and anti-authoritarian views resonate with many of us who are wary of unchecked corporate power. But it&#8217;s worth noting that not everyone sees our current system as a &#8220;capitalist hellscape.&#8221; Many see opportunities for positive change within existing structures, while others advocate for more radical overhauls.</p>
+
+
+
+<h3 class="wp-block-heading">Embracing the Complexity</h3>
+
+
+
+<p class="wp-block-paragraph">The path forward isn&#8217;t black and white. It&#8217;s a winding road full of gray areas, unexpected turns, and tough decisions. As we navigate this AI-infused future, we need to hold onto our critical thinking skills, our ethical compass, and our ability to see both the forest and the trees.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Conclusion</h3>
+
+
+
+<p class="wp-block-paragraph">So, future-proofers, let&#8217;s embrace the complexity. Let&#8217;s be excited about AI&#8217;s potential while remaining clear-eyed about its risks. Let&#8217;s push for responsible innovation that benefits not just shareholders, but society as a whole. The future is ours to shape, and AI is just one of many tools we have at our disposal. Use it wisely, creatively, and always with an eye towards the greater good.</p>
+
+
+
+<p class="wp-block-paragraph">Now go forth and future-proof, you beautiful, complex creators! The world is waiting for your nuanced, AI-augmented brilliance. Peace out! ???</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863adb0f996&quot;}" data-wp-interactive="core/image" data-wp-key="6a863adb0f996" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-6157" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/kriskrug_Transcendent_Data_Pulse_-_The_rhythmic_flow_of_data__c1938c54-2b22-47ec-a7c3-e7ec45711e2a_3.png?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-for-creatives/">AI for Creatives</a> collection. See also: <a href="https://kriskrug.co/2024/08/12/llms-and-beyond-reframing-the-future-of-artificial-intelligence/">LLMs and Beyond: Reframing the Future of Artificial Intelligence</a> and <a href="https://kriskrug.co/2026/06/04/ai-keynote-slides-visual-workflow/">AI Keynote Slides Need Taste Before Prompts</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-6144-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/before/post-6144-identity.json
@@ -1,0 +1,20 @@
+{
+  "id": 6144,
+  "slug": "ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence",
+  "status": "publish",
+  "link": "https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/",
+  "modified": "2026-06-28T20:33:43",
+  "modified_gmt": "2026-06-29T04:33:43",
+  "type": "post",
+  "title_rendered": "AI is Not Your Friend: Why We Need to Rethink Our Relationship with Artificial Intelligence",
+  "content_rendered_bytes": 36872,
+  "content_rendered_sha256": "1dca71d2f318a167dfa8b1eaf13721c3cbd838598afb84a0b45e3f25ec2b395d",
+  "content_raw_bytes": null,
+  "content_raw_sha256": null,
+  "content_raw_has_footer": true,
+  "snapshot_at": "2026-08-19T23:23:05Z",
+  "snapshot_auth": false,
+  "snapshot_source_rendered": "public REST content.rendered (WP_USER/WP_APP_PASSWORD unset)",
+  "snapshot_source_raw": null,
+  "you_cant_drink_data_href_count": 0
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-829/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-829/targets.json
@@ -1,0 +1,126 @@
+{
+  "issue": 829,
+  "parent": 402,
+  "blocked_by": 826,
+  "live_reconfirm": "2026-08-19T23:23:05Z",
+  "status": "prepared_not_applied",
+  "snapshot_auth": false,
+  "forbidden_href_substrings": [
+    "/about/"
+  ],
+  "preserved_closing_needles": [
+    "just a faster leak"
+  ],
+  "card_blurb": "A thousand people on Granville Street, and the AI guy standing in the middle of them.",
+  "existing_source_trail_hrefs": [
+    "https://kriskrug.co/2026/05/04/punk-rock-ai/",
+    "https://kriskrug.co/2026/04/17/applied-ethical-ai-responsible-ai-professional-certification-rap/",
+    "https://kriskrug.co/category/ai-ethics-philosophy/"
+  ],
+  "child1_gate": [
+    {
+      "id": 3814,
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "from_category": 1757,
+      "to_category": 1678
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "from_category": 1757,
+      "to_category": 1676
+    },
+    {
+      "id": 1067,
+      "slug": "hardcore-superstar-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1063,
+      "slug": "made-in-vancouver-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1147,
+      "slug": "fashion-photoshoot-for-discollection",
+      "from_category": 1665,
+      "to_category": 1756
+    }
+  ],
+  "items": [
+    {
+      "id": 12318,
+      "kind": "pages",
+      "slug": "ai-ethics",
+      "url": "https://kriskrug.co/ai-ethics/",
+      "modified_gmt_at_reconfirm": "2026-07-01T20:27:51",
+      "find": "    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/2026/05/04/punk-rock-ai/\">",
+      "replace": "    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/05/7674-granville-march.jpg?resize=640,400&amp;ssl=1\" alt=\"The march fills two lanes heading down Granville Street under a grey Vancouver sky\" loading=\"lazy\"/>\n        <div>\n          <h3>You Can't Drink Data</h3>\n          <p>A thousand people on Granville Street, and the AI guy standing in the middle of them.</p>\n        </div>\n      </a>\n    </article>\n    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/2026/05/04/punk-rock-ai/\">",
+      "anchors": [
+        {
+          "row": 7,
+          "text": "You Can't Drink Data",
+          "href": "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+          "presence": "card_title",
+          "blurb": "A thousand people on Granville Street, and the AI guy standing in the middle of them."
+        }
+      ],
+      "preserve_existing_cards": true,
+      "preserve_source_trail": true
+    },
+    {
+      "id": 12030,
+      "kind": "posts",
+      "slug": "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+      "url": "https://kriskrug.co/2026/06/26/canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one/",
+      "modified_gmt_at_reconfirm": "2026-08-01T19:57:26",
+      "find": "We lack consent architecture.</p>",
+      "replace": "We lack consent architecture. I already wrote <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">what the water math looks like from street level</a>.</p>",
+      "anchors": [
+        {
+          "row": 8,
+          "text": "what the water math looks like from street level",
+          "href": "https://kriskrug.co/2026/05/23/you-cant-drink-data/"
+        }
+      ],
+      "preserve_closing": true,
+      "forbid_about": true
+    },
+    {
+      "id": 6144,
+      "kind": "posts",
+      "slug": "ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence",
+      "url": "https://kriskrug.co/2024/06/29/ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:33:43",
+      "find": "Peace out! ???</p>",
+      "replace": "Peace out! ??? And <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">two years later I went to the protest and wrote down what the signs said</a>.</p>",
+      "anchors": [
+        {
+          "row": 9,
+          "text": "two years later I went to the protest and wrote down what the signs said",
+          "href": "https://kriskrug.co/2026/05/23/you-cant-drink-data/"
+        }
+      ],
+      "preserve_footer": true
+    },
+    {
+      "id": 11882,
+      "kind": "posts",
+      "slug": "we-trained-ai-on-stolen-work",
+      "url": "https://kriskrug.co/2026/05/19/we-trained-ai-on-stolen-work/",
+      "modified_gmt_at_reconfirm": "2026-06-24T18:20:09",
+      "find": "training material without consent.</p>",
+      "replace": "training material without consent. I also saw <a href=\"https://kriskrug.co/2026/05/23/you-cant-drink-data/\">the march where the illustrators showed up as a guild</a>.</p>",
+      "anchors": [
+        {
+          "row": 10,
+          "text": "the march where the illustrators showed up as a guild",
+          "href": "https://kriskrug.co/2026/05/23/you-cant-drink-data/"
+        }
+      ],
+      "preserve_existing_11936_links": true
+    }
+  ]
+}

--- a/scripts/apply_issue_829_ai_ethics_hub.py
+++ b/scripts/apply_issue_829_ai_ethics_hub.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Issue #829: add You Can't Drink Data to the /ai-ethics/ hub.
+
+Dry-run by default. Writes are gated on ID->slug match, exact text-match
+insertion, child-1 (#826) category proof, and a fresh context=edit snapshot.
+
+    python3 scripts/apply_issue_829_ai_ethics_hub.py --from-files
+    make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py'
+    make varlock-run CMD='python3 scripts/apply_issue_829_ai_ethics_hub.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-829"
+TARGETS_PATH = PACK / "targets.json"
+BEFORE_DIR = PACK / "before"
+AFTER_DIR = PACK / "after"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-829-ai-ethics-hub"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+PUNK_CARD = "Punk Rock AI"
+EXISTING_11936_NEEDLES = (
+    "environmental cost</a>",
+    "notes from my first AI protest",
+)
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-829"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def inline_link(row: dict) -> str:
+    return f'<a href="{row["href"]}">{row["text"]}</a>'
+
+
+def anchor_present(body: str, row: dict) -> bool:
+    if row.get("presence") == "card_title":
+        blurb = row.get("blurb") or ""
+        return row["href"] in body and row["text"] in body and blurb in body
+    return inline_link(row) in body
+
+
+def already_applied(body: str, spec: dict) -> bool:
+    return all(anchor_present(body, row) for row in spec["anchors"])
+
+
+def inserted_fragment(spec: dict) -> str:
+    find = spec["find"]
+    replace = spec["replace"]
+    prefix = os.path.commonprefix([find, replace])
+    find_rest = find[len(prefix) :]
+    replace_rest = replace[len(prefix) :]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def assert_anchors(body: str, spec: dict) -> None:
+    for row in spec["anchors"]:
+        if row.get("presence") == "card_title":
+            if body.count(row["href"]) != 1:
+                raise ValueError(f"{spec['id']}: expected one {row['href']!r}")
+            if row["text"] not in body:
+                raise ValueError(f"{spec['id']}: missing card title {row['text']!r}")
+            blurb = row.get("blurb") or ""
+            if blurb and blurb not in body:
+                raise ValueError(f"{spec['id']}: missing card blurb")
+            title_at = body.find(row["text"])
+            punk_at = body.find(PUNK_CARD)
+            if title_at < 0 or punk_at < 0 or title_at > punk_at:
+                raise ValueError(f"{spec['id']}: card is not ahead of Punk Rock AI")
+            continue
+        needle = inline_link(row)
+        if body.count(needle) != 1:
+            raise ValueError(f"{spec['id']}: expected one {needle!r}")
+
+
+def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
+    if already_applied(body, spec):
+        return None
+    find = spec["find"]
+    replace = spec["replace"]
+    count = body.count(find)
+    if count != 1:
+        raise ValueError(
+            f"{spec['id']}: find needle occurs {count} times; expected 1. "
+            "Insert by text match, not a stale block index."
+        )
+    added = inserted_fragment(spec)
+    if "\u2014" in added or "\u2013" in added:
+        raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
+    if any(ord(char) > 127 for char in added):
+        raise ValueError(f"{spec['id']}: inserted copy is not ASCII; use NCR")
+    rewritten = body.replace(find, replace, 1)
+    if spec.get("preserve_source_trail"):
+        if "Source trail" not in rewritten:
+            raise ValueError(f"{spec['id']}: Source trail kicker missing")
+    if spec.get("preserve_existing_cards"):
+        for href in targets["existing_source_trail_hrefs"]:
+            if body.count(href) != rewritten.count(href):
+                raise ValueError(f"{spec['id']}: existing card href {href} count changed")
+        if PUNK_CARD not in rewritten:
+            raise ValueError(f"{spec['id']}: Punk Rock AI card missing")
+    if spec.get("preserve_footer"):
+        if body.count(FOOTER_SENTINEL) != rewritten.count(FOOTER_SENTINEL):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+        hub_at = rewritten.find(spec["anchors"][0]["text"])
+        footer_at = rewritten.find(FOOTER_SENTINEL)
+        if hub_at < 0 or footer_at < 0 or hub_at > footer_at:
+            raise ValueError(f"{spec['id']}: insert is not before the collection footer")
+    if spec.get("preserve_closing"):
+        for needle in targets["preserved_closing_needles"]:
+            if body.count(needle) != rewritten.count(needle):
+                raise ValueError(f"{spec['id']}: closing paragraph drifted")
+    if spec.get("forbid_about") or spec.get("preserve_closing"):
+        if rewritten.count("/about/") != body.count("/about/"):
+            raise ValueError(f"{spec['id']}: /about/ href count changed")
+    if spec.get("preserve_existing_11936_links"):
+        for needle in EXISTING_11936_NEEDLES:
+            if needle not in rewritten:
+                raise ValueError(f"{spec['id']}: existing 11936 link {needle!r} missing")
+    for forbidden in targets["forbidden_href_substrings"]:
+        if forbidden in rewritten and forbidden not in body:
+            raise ValueError(f"{spec['id']}: forbidden href {forbidden} was added")
+    assert_anchors(rewritten, spec)
+    return rewritten
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    if live.get("id") != spec["id"]:
+        sys.exit(f"[ABORT] {spec['id']}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: slug is {live.get('slug')!r}, "
+            f"expected {spec['slug']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def child1_is_live(header: str, targets: dict) -> tuple[bool, list[str]]:
+    notes: list[str] = []
+    ready = True
+    for row in targets["child1_gate"]:
+        live = request(
+            f"{BASE_URL}/wp-json/wp/v2/posts/{row['id']}?_fields=id,slug,categories",
+            header,
+        )
+        if live.get("slug") != row["slug"]:
+            ready = False
+            notes.append(f"{row['id']} slug {live.get('slug')!r}")
+            continue
+        cats = list(live.get("categories") or [])
+        if row["to_category"] not in cats or row["from_category"] in cats:
+            ready = False
+            notes.append(f"{row['id']} categories {cats}")
+        else:
+            notes.append(f"{row['id']} ok {cats}")
+    return ready, notes
+
+
+def plan_item(spec: dict, body: str, targets: dict) -> dict | None:
+    try:
+        rewritten = rewrite_body(body, spec, targets)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: exact href+anchor already present.")
+        return None
+    return {"spec": spec, "before": body, "after": rewritten}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for row in spec["anchors"]:
+        print(f"        row {row['row']}: {row['text']!r} -> {row['href']}")
+
+
+def write_after_files(planned: list[dict]) -> None:
+    AFTER_DIR.mkdir(parents=True, exist_ok=True)
+    for item in planned:
+        spec = item["spec"]
+        path = AFTER_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+        path.write_text(item["after"], encoding="utf-8")
+        print(f"[AFTER] {path}")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    print_plan(item)
+    if not do_apply:
+        return
+    spec = item["spec"]
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_item(spec, raw_body(live), load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    allowed = {row["id"] for row in load_targets()["items"]}
+    post_id = snapshot.get("id")
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #829 set.")
+    spec = next(row for row in load_targets()["items"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(live, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def load_before_body(spec: dict) -> str:
+    stem = f"{spec['kind'][:-1]}-{spec['id']}"
+    raw_path = BEFORE_DIR / f"{stem}-content.raw.html"
+    rendered_path = BEFORE_DIR / f"{stem}-content.rendered.html"
+    if raw_path.is_file():
+        return raw_path.read_text(encoding="utf-8")
+    if rendered_path.is_file():
+        return rendered_path.read_text(encoding="utf-8")
+    sys.exit(f"[ABORT] missing before-file {raw_path} or {rendered_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #829 AI ethics hub links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-files", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    parser.add_argument(
+        "--allow-before-826",
+        action="store_true",
+        help="Unsafe. Bypass the child-1 category gate. Do not use on production.",
+    )
+    args = parser.parse_args()
+    targets = load_targets()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, auth_header(), args.apply)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id:
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+
+    if args.from_files:
+        planned = []
+        for spec in rows:
+            try:
+                item = plan_item(spec, load_before_body(spec), targets)
+            except ValueError as exc:
+                sys.exit(f"[ABORT] {exc}")
+            if item is not None:
+                planned.append(item)
+                print_plan(item)
+        if not planned:
+            print("[OK] nothing pending.")
+            return 0
+        write_after_files(planned)
+        print("[FROM-FILES] wrote after/ payloads. No WordPress writes.")
+        return 0
+
+    header = auth_header()
+    if args.apply and not args.allow_before_826:
+        ready, notes = child1_is_live(header, targets)
+        for note in notes:
+            print(f"[826] {note}")
+        if not ready:
+            sys.exit(
+                "[ABORT] #826 category fixes are not live. "
+                "Do not PATCH 12318/12030/6144/11882 yet."
+            )
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_item(spec, raw_body(live), targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            item["live"] = live
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Pass --apply after #826 is live and KK approves."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_829_ai_ethics_hub.py
+++ b/scripts/tests/test_apply_issue_829_ai_ethics_hub.py
@@ -1,0 +1,316 @@
+"""Offline safety tests for the issue #829 AI ethics hub helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_829_ai_ethics_hub.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_829_ai_ethics_hub", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def before_body(item_id: int) -> str:
+    spec = spec_by_id(item_id)
+    stem = f"{spec['kind'][:-1]}-{item_id}"
+    raw = MODULE.BEFORE_DIR / f"{stem}-content.raw.html"
+    rendered = MODULE.BEFORE_DIR / f"{stem}-content.rendered.html"
+    if raw.is_file():
+        return raw.read_text(encoding="utf-8")
+    return rendered.read_text(encoding="utf-8")
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    return {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else before_body(spec["id"])},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_829_ai_ethics_hub.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue829AiEthicsHubTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+        self.gate = {
+            row["id"]: {
+                "id": row["id"],
+                "slug": row["slug"],
+                "categories": [row["from_category"]],
+            }
+            for row in TARGETS["child1_gate"]
+        }
+
+    def _patch_request(self, calls, *, gate_ready=False):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/posts/" in url and "context=edit" not in url:
+                post_id = int(url.split("/posts/")[1].split("?")[0])
+                live = json.loads(json.dumps(self.gate[post_id]))
+                if gate_ready:
+                    spec = next(
+                        row for row in TARGETS["child1_gate"] if row["id"] == post_id
+                    )
+                    live["categories"] = [spec["to_category"]]
+                return live
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_rows_7_through_10(self):
+        ids = [row["id"] for row in TARGETS["items"]]
+        self.assertEqual(ids, [12318, 12030, 6144, 11882])
+        self.assertEqual(spec_by_id(12318)["slug"], "ai-ethics")
+        self.assertEqual(
+            spec_by_id(12030)["slug"],
+            "canada-doesnt-need-a-bigger-ai-machine-it-needs-a-better-one",
+        )
+        self.assertEqual(
+            spec_by_id(6144)["slug"],
+            "ai-is-not-your-friend-why-we-need-to-rethink-our-relationship-with-artificial-intelligence",
+        )
+        self.assertEqual(spec_by_id(11882)["slug"], "we-trained-ai-on-stolen-work")
+        anchors = [
+            (row["row"], row["text"], row["href"])
+            for spec in TARGETS["items"]
+            for row in spec["anchors"]
+        ]
+        self.assertEqual(
+            anchors,
+            [
+                (
+                    7,
+                    "You Can't Drink Data",
+                    "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+                ),
+                (
+                    8,
+                    "what the water math looks like from street level",
+                    "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+                ),
+                (
+                    9,
+                    "two years later I went to the protest and wrote down what the signs said",
+                    "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+                ),
+                (
+                    10,
+                    "the march where the illustrators showed up as a guild",
+                    "https://kriskrug.co/2026/05/23/you-cant-drink-data/",
+                ),
+            ],
+        )
+        self.assertNotIn(11936, ids)
+        self.assertNotIn(11929, ids)
+
+    def test_rewrite_12318_inserts_first_card_and_keeps_existing_cards(self):
+        spec = spec_by_id(12318)
+        before = before_body(12318)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn("You Can't Drink Data", after)
+        self.assertIn(TARGETS["card_blurb"], after)
+        self.assertLess(after.find("You Can't Drink Data"), after.find("Punk Rock AI"))
+        self.assertIn("Responsible AI Professional", after)
+        self.assertIn("AI ethics archive", after)
+        for href in TARGETS["existing_source_trail_hrefs"]:
+            self.assertEqual(before.count(href), after.count(href))
+        self.assertEqual(after.count("you-cant-drink-data"), 1)
+        self.assertEqual(after.count("aurora-media-card"), 4)
+        self.assertNotIn("\u2014", MODULE.inserted_fragment(spec))
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_12030_uses_first_compute_paragraph_and_skips_closing(self):
+        spec = spec_by_id(12030)
+        before = before_body(12030)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn("what the water math looks like from street level", after)
+        water = after.find("what the water math looks like from street level")
+        closing = after.find("just a faster leak")
+        self.assertGreater(closing, water)
+        self.assertEqual(
+            before.count("just a faster leak"), after.count("just a faster leak")
+        )
+        self.assertEqual(before.count("/about/"), after.count("/about/"))
+        self.assertNotIn("/about/", after)
+        self.assertIn("We lack consent architecture.", after)
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_6144_inserts_before_footer_and_does_not_duplicate_it(self):
+        spec = spec_by_id(6144)
+        before = before_body(6144)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        self.assertLess(
+            after.find("two years later I went to the protest and wrote down what the signs said"),
+            after.find("kk-collection-footer"),
+        )
+        self.assertIn("Peace out! ???", after)
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_11882_adds_guild_anchor_and_keeps_older_11936_links(self):
+        spec = spec_by_id(11882)
+        before = before_body(11882)
+        self.assertEqual(before.count("you-cant-drink-data"), 2)
+        self.assertNotIn("the march where the illustrators showed up as a guild", before)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertEqual(after.count("you-cant-drink-data"), 3)
+        self.assertIn("environmental cost</a>", after)
+        self.assertIn("notes from my first AI protest", after)
+        self.assertIn(
+            'href="https://kriskrug.co/2026/05/23/you-cant-drink-data/">the march where the illustrators showed up as a guild</a>',
+            after,
+        )
+        self.assertIn("training material without consent.", after)
+
+    def test_stale_block_index_is_ignored_text_match_wins(self):
+        spec = spec_by_id(12318)
+        before = before_body(12318)
+        self.assertIn("Source trail", before)
+        self.assertIn(spec["find"], before)
+        self.assertEqual(before.count(spec["find"]), 1)
+        self.assertIn("We lack consent architecture.</p>", before_body(12030))
+        self.assertEqual(
+            before_body(12030).count("We lack consent architecture.</p>"), 1
+        )
+
+    def test_missing_needle_aborts(self):
+        spec = spec_by_id(12030)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>no compute paragraph</p>", spec, TARGETS)
+
+    def test_from_files_writes_after_payloads_and_does_not_call_wordpress(self):
+        calls = []
+        after_dir = self.tmp_path / "after"
+        with (
+            mock.patch.object(MODULE, "AFTER_DIR", after_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--from-files"))
+        self.assertEqual(calls, [])
+        self.assertTrue((after_dir / "page-12318-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-12030-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-6144-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-11882-content.raw.html").is_file())
+
+    def test_live_dry_run_performs_no_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12318]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--allow-before-826", "--item-id", "12318")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_refuses_when_826_is_not_live(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "12318")
+        self.assertIn("#826", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE,
+                "request",
+                side_effect=self._patch_request(calls, gate_ready=True),
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "12030"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn(
+            "what the water math looks like from street level", writes[0]["content"]
+        )
+        self.assertIn("just a faster leak", writes[0]["content"])
+        self.assertNotIn("/about/", writes[0]["content"])
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("#826", apply_md)
+        self.assertIn("ai-ethics", apply_md)
+        self.assertIn("just a faster leak", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #829", apply_md)
+        self.assertNotIn("Fixes #402", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply-ready pack for [#829](https://github.com/WalksWithASwagger/kriskrug-wp/issues/829): insert a You Can't Drink Data card first on `/ai-ethics/` and add three inbound spokes. **Prepared, not applied.**

**Do not apply until #826 is live and KK says go.** `--apply` aborts until those five category fixes are live.

## Related Issue

Refs #829

Leaves #829 and #402 open (payload prepared, not applied).

## Changes

- `content/drafts/2026-08-02-seo-authority-hubs/fix-829/` — APPLY.md, targets.json, before/after snapshots
- `scripts/apply_issue_829_ai_ethics_hub.py` — dry-run default, `--from-files`, slug/ID checks, `--restore`
- `scripts/tests/test_apply_issue_829_ai_ethics_hub.py` — 13 offline tests

## Type of Change

- [x] Content update (payload only)
- [x] Documentation update

## Testing

- [x] `python3 -m unittest scripts.tests.test_apply_issue_829_ai_ethics_hub` (13 tests, OK)
- Live public GET 2026-08-19: 12318 has no drink-data card; 12030 / 6144 / 11882 lack the new anchors

## Deployment Notes

- [x] No special deployment steps required
- Do **not** run `--apply` from this PR. Gate 1 live apply is still #826 first.

## Additional Notes

`WP_USER` / `WP_APP_PASSWORD` were unset, so 6144 and 11882 before-files are public `content.rendered` only. Live `--apply` still GETs real `content.raw` and still requires slug/ID checks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c4f-22a9-7df9-9466-dea6653bf59e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c4f-22a9-7df9-9466-dea6653bf59e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


