### PR TITLE
content(#832): apply-ready meetup recap /events/ links, not applied

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/APPLY.md
@@ -1,0 +1,154 @@
+# #832 APPLY: route Vancouver AI meetup recaps to /events/
+
+**Prepared, not applied. Do not PATCH until #826 is live and KK says go.**
+Script is dry-run by default. `--apply` is the only write switch, and it refuses unless the five #826 category fixes are already live.
+
+Parent: #402. This is child 7 of 9. It **adds** `/events/` links. It does not swap existing `/vancouver-ai/` destinations.
+
+Do not close #832 or #402 when this runbook merges.
+
+**Do not write page 2250.** #635 owns `/events/`. The apply script hard-refuses ID 2250 on `--item-id`, `--restore`, `targets.items`, and any POST URL that contains `/pages/2250`.
+
+## Live reconfirm (logged-out public REST GET, 2026-08-19T23:22:56Z)
+
+No REST POST / PATCH / DELETE in this session. WP_USER / WP_APP_PASSWORD were unset, so there is no authenticated `context=edit` `content.raw` for the seven recaps or page 2250. Public REST confirmed slug/ID pairs and `content.rendered`. Page 12315 `modified_gmt` still matches the 2026-07-01 backup, so that backup's `content.raw` is the before-file for 12315.
+
+| ID | Kind | Slug | URL | HTTP | `kriskrug.co/events/` | `/vancouver-ai/` | Notes |
+|---|---|---|---|---:|---|---|---|
+| 4495 | post | `inside-the-innaugural-vancouver-ai-community-meetup` | `/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/` | 200 | **no** | yes (3) | Baked footer present. |
+| 9197 | post | `vancouver-ai-meetup-16-where-tech-creativity-and-community-collide` | `/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/` | 200 | **no** | yes (1) | Baked footer present. |
+| 8418 | post | `vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap` | `/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/` | 200 | **no** | yes (1) | Baked footer present. Empty `<p>` then footer. |
+| 6815 | post | `august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics` | `/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics` | 200 | **no** | yes (1) | No `kk-collection-footer`. Ends on the Related hub line. One AWS `/events/` URL is unrelated. |
+| 6251 | post | `creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights` | `/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/` | 200 | **no** | yes (1) | `meetup.com/vancouver-ai-meetup/events/` is not the hub. Footer present. |
+| 5768 | post | `june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines` | `/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/` | 200 | **no** | yes (1) | No footer. Has `/ai-events/` plus a Northeastern `/events/` URL. |
+| 4348 | post | `2024-vancouver-ai-community-meetups` | `/2023/12/27/2024-vancouver-ai-community-meetups/` | 200 | **no** | **no** (only `lu.ma/vancouver-ai`) | 2023 directory. Footer names AI Ethics. Insert in the intro, ahead of the dated list. |
+| 12315 | page | `vancouver-ai` | `/vancouver-ai/` | 200 | **no** | n/a | Events and recaps card still has only "Browse AI events" -> `/ai-events/`. |
+| 2250 | page | `events` | `/events/` | 200 | fixture only | n/a | **Must not write.** Public rendered SHA-256 `4353740134b28aa577de881cd41aaf071e8304444540687cb3562206145beb43`. |
+
+`/events/`, `/vancouver-ai/`, `/ai-events/`, and the seven recap permalinks were HTTP 200.
+
+The live `/events/` card still talks about Luma and registration. Do not copy any date from that card into the new sentences. Matrix anchors already avoid dates.
+
+## Snapshot gaps
+
+- No `context=edit` `content.raw` for posts 4495, 9197, 8418, 6815, 6251, 5768, 4348. Those `before/*-content.raw.html` files are public `content.rendered` stand-ins so `--from-files` can run offline. The first authenticated dry-run must recut `find` if a live raw needle misses.
+- Page 2250 has public rendered only. That is enough to prove this pack never mutates it. There is no 2250 `content.raw` in the pack.
+- Page 12315 raw is the 2026-07-01 backup. Live `modified_gmt` is still `2026-07-01T20:27:36`, and the Browse AI events button text is unchanged.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+| ID | Required slug |
+|---:|---|
+| 4495 | `inside-the-innaugural-vancouver-ai-community-meetup` |
+| 9197 | `vancouver-ai-meetup-16-where-tech-creativity-and-community-collide` |
+| 8418 | `vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap` |
+| 6815 | `august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics` |
+| 6251 | `creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights` |
+| 5768 | `june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines` |
+| 4348 | `2024-vancouver-ai-community-meetups` |
+| 12315 | `vancouver-ai` |
+
+Page 2250 slug `events` is recorded only as the must-not-write fixture.
+
+## What the script writes
+
+Content only. Titles, slugs, dates, status, featured media, tags, categories, and SEO meta stay untouched.
+
+| ID | Find (exactly once) | Inserted copy |
+|---|---|---|
+| 4495 | toast line ending `community!</p>` | trailing sentence, exact anchor `we still do this every month, and the next one is on the calendar` (row 18) |
+| 9197 | `converge to shape our collective future.</p>` | trailing sentence, exact anchor `the next one` (row 19) |
+| 8418 | empty paragraph immediately before the baked footer | new paragraph, exact anchor `come to the next one` (row 20) |
+| 6815 | Related hub sentence (keeps the `/vancouver-ai/` link) | trailing sentence, exact anchor `the current calendar` (row 21) |
+| 6251 | Host sign-off line | new paragraph before the footer, exact anchor `where the next one lands` (row 22) |
+| 5768 | `continue to explore, create, and inspire together.</p>` | trailing sentence, exact anchor `still monthly, still free, still worth the trip` (row 23) |
+| 4348 | italic intro goal paragraph | new intro paragraph ahead of the 2023-era list, exact anchor `the live calendar, which is the version that stays current` (row 24) |
+| 12315 | `Browse AI events` button on the Events and recaps card | second link, exact anchor `the calendar` (row 25). `/ai-events/` stays. |
+
+Inserted copy is ASCII. No em dashes. No dates. Existing `/vancouver-ai/` hrefs stay.
+
+Skip a row if that exact `href` + anchor already exists.
+
+## Must not
+
+- PATCH, POST, or restore page 2250, its Luma embed, registration card, or event media (#635).
+- Replace `/vancouver-ai/` links with `/events/`.
+- Recategorize meetup posts (4348's AI Ethics footer is out of payload).
+- Hard-code a meetup date in the new sentences.
+- Duplicate `kk-collection-footer`.
+- Run bulk `inject_links.py`.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_832_events_routing
+
+# Offline dry-run: rewrite the snapshotted before-files into after/. No network.
+python3 scripts/apply_issue_832_events_routing.py --from-files
+
+# Live GET dry-run: authenticated context=edit + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py'
+
+# Apply only after #826 is live and KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py --apply'
+```
+
+`--item-id 4495` limits to one object. `--item-id 2250` aborts. Re-run after a successful apply prints `[SKIP]`.
+
+`--apply` GETs the five #826 posts and aborts unless 3814 is out of 1757 into 1678, 3330 is out of 1757 into 1676, and 1067 / 1063 / 1147 are out of their wrong buckets into 1756.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-832-events-routing/rest-<page|post>-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py --restore backup/issue-832-events-routing/rest-post-4495-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py --restore backup/issue-832-events-routing/rest-post-4495-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the eight owned IDs, a slug mismatch, or page 2250.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/events/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/vancouver-ai/
+
+# Re-read the live card (do not copy dates into new copy)
+curl -sL "https://kriskrug.co/events/?cb=$RANDOM" | grep -i -n 'luma\|register\|meetup' | head
+
+curl -sL "https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/?cb=$RANDOM" \
+  | grep -F 'we still do this every month, and the next one is on the calendar'
+curl -sL "https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/?cb=$RANDOM" \
+  | grep -F 'the next one'
+curl -sL "https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/?cb=$RANDOM" \
+  | grep -F 'come to the next one'
+curl -sL "https://kriskrug.co/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics/?cb=$RANDOM" \
+  | grep -F 'the current calendar'
+curl -sL "https://kriskrug.co/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/?cb=$RANDOM" \
+  | grep -F 'where the next one lands'
+curl -sL "https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/?cb=$RANDOM" \
+  | grep -F 'still monthly, still free, still worth the trip'
+curl -sL "https://kriskrug.co/2023/12/27/2024-vancouver-ai-community-meetups/?cb=$RANDOM" \
+  | grep -F 'the live calendar, which is the version that stays current'
+curl -sL "https://kriskrug.co/vancouver-ai/?cb=$RANDOM" | grep -F 'the calendar'
+curl -sL "https://kriskrug.co/vancouver-ai/?cb=$RANDOM" | grep -F 'Browse AI events'
+
+# Page 2250 must match the pre-session public rendered snapshot
+curl -s "https://kriskrug.co/wp-json/wp/v2/pages/2250?_fields=id,slug,modified_gmt,content" \
+  | python3 -c "import hashlib,json,sys; d=json.load(sys.stdin); print(d['id'], d['slug']); print(hashlib.sha256(d['content']['rendered'].encode()).hexdigest())"
+```
+
+Expect: each of the seven recaps gains exactly one new `https://kriskrug.co/events/` anchor. 12315 keeps `/ai-events/` and adds `the calendar`. Existing `/vancouver-ai/` hrefs stay. Page 2250 rendered SHA-256 stays `4353740134b28aa577de881cd41aaf071e8304444540687cb3562206145beb43` unless #635 has written it for its own reasons. Footer counts on 4495 / 9197 / 8418 / 6251 / 4348 stay the same.
+
+## Out of payload
+
+- Page 2250 / Luma / event heroes (#635)
+- Taxonomy repair (#826)
+- Replacing `/vancouver-ai/` with `/events/`
+- Recategorizing 4348
+- Schema Event markup (parent #402 schema lane)
+- `inject_links.py`

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/page-12315-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/page-12315-content.raw.html
@@ -1,0 +1,71 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-vancouver-ai -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Vancouver AI</p>
+  <h2 class="aurora-display-heading">A living map of the local AI scene.</h2>
+  <p class="aurora-page-lead">This hub collects Kris Krug's field notes from Vancouver and British Columbia's AI ecosystem: meetups, builders, artists, civic conversations, policy questions, and the strange community work of helping people learn in public.</p>
+  <p>Start here if you want to understand the people, rooms, experiments, and tensions shaping AI on the west coast.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Start here</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>BC + AI Ecosystem</h3>
+      <p>A community network for builders, creatives, educators, researchers, and public-interest people working on AI in British Columbia.</p>
+      <p><a class="aurora-button" href="https://bc-ai.ca/">Visit BC + AI</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Events and recaps</h3>
+      <p>Meetups, hackathons, Web Summit field notes, community gatherings, and what actually happened in the room.</p>
+      <p><a class="aurora-button" href="/ai-events/">Browse AI events</a> and <a href="https://kriskrug.co/events/">the calendar</a>.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Work in the ecosystem</h3>
+      <p>See the projects, talks, trainings, and community systems that connect Kris's AI work to local culture.</p>
+      <p><a class="aurora-button" href="/work/">See the work</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Field notes</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/bc-ai-header.png?resize=640,400&amp;ssl=1" alt="BC AI event graphic" loading="lazy"/>
+        <div>
+          <h3>BC AI is live</h3>
+          <p>A community-first note on building the future we actually want.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/06/01/long-road-to-futureproof/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/vanai21-kris-jonny-stage.png?resize=640,400&amp;ssl=1" alt="Kris Krug and Jonny on stage at a Vancouver AI event" loading="lazy"/>
+        <div>
+          <h3>The long road to Futureproof</h3>
+          <p>What local AI community-building looks like after the hype cycle starts to bite.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/vancouver-ai-ecosystem/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/bc-studies-ai-community.png?resize=640,400&amp;ssl=1" alt="Vancouver AI and BC community graphic" loading="lazy"/>
+        <div>
+          <h3>Vancouver AI archive</h3>
+          <p>More posts from the local ecosystem, from grassroots meetups to public-interest AI conversations.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring Kris into your AI room</h2>
+    <p>For ecosystem strategy, community events, talks, workshops, or a practical read on the local AI scene, start with the room you are trying to build.</p>
+    <p><a class="aurora-button" href="/contact/">Start a conversation</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-4348-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-4348-content.raw.html
@@ -1,0 +1,335 @@
+
+<h3 class="wp-block-heading"><a href="https://lu.ma/vancouver-ai">Vancouver AI</a> community meetups welcomes all members of the community interested in the future of AI &#8211; researchers, artists, geeks, enthusiasts, entrepreneurs, experts, students and more! </h3>
+
+
+
+<p class="wp-block-paragraph"><em>Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.</em></p>
+
+
+
+<p class="wp-block-paragraph">For dates that stay current, use <a href="https://kriskrug.co/events/">the live calendar, which is the version that stays current</a>.</p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="uBr3JMpbnN"><a href="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/">DIY AI in Vancouver: Building a Grassroots BC AI Industry Association</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;DIY AI in Vancouver: Building a Grassroots BC AI Industry Association&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/embed/#?secret=ZbFLZmwQXv#?secret=uBr3JMpbnN" data-secret="uBr3JMpbnN" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m excited to share something special we&#8217;ve been working on for the <a href="https://lu.ma/future-proof?tag=ai%20meetup" data-type="link" data-id="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a>. This year, we&#8217;re hosting a series of meetups designed to dive deep into the world of Artificial Intelligence. Our aim is simple yet ambitious: to create a space where people from all walks of the AI landscape can come together to share knowledge, challenge ideas, and explore the real-world applications and ethical implications of AI.</p>
+
+
+
+<p class="wp-block-paragraph">We&#8217;re looking forward to a year of meaningful discussions and hands-on learning, with each meetup focusing on a different facet of AI. From the impact of AI on visual storytelling and personal branding to exploring its role in emerging fields like VR and gaming, we&#8217;re covering a wide spectrum. These sessions are more than just talks; they&#8217;re collaborative platforms for both seasoned pros and curious newcomers to connect and grow.</p>
+
+
+
+<p class="wp-block-paragraph">Our goal with these meetups is to foster a community that&#8217;s as diverse as the AI field itself. Whether you&#8217;re a developer, a researcher, an artist, or just someone fascinated by AI, we want you to be part of this journey. We believe in a straightforward, no-hype approach where the focus is on real value, deep technical insights, and honest discussions. Join us and be part of a conversation that&#8217;s shaping the future of AI, right here in Vancouver.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to seeing you there and diving into these compelling AI topics together.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="hobkydTjd0"><a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/embed/#?secret=DPASbG5aT2#?secret=hobkydTjd0" data-secret="hobkydTjd0" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h2>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.vancouverbiennale.com/" target="_blank" rel="noreferrer noopener"><strong>Vancouver Biennale</strong></a><strong>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://creativemornings.com/cities/van"><strong>Creative Mornings Vancouver</strong></a> &#8211; free monthly breakfast lectures for creatives</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://holistichybrid.com/"><strong>Holistic Hybrid</strong></a><strong>:</strong> A digital strategy powerhouse.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.linkedin.com/in/lindsay-bailey-600a46b/"><strong>Lindsay Bailey Law</strong></a><strong>:</strong> Legal expertise with a creative twist.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.augxlabs.com/"><strong>AugXLabs</strong></a><strong>:</strong> At the forefront of text-to-video AI.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://cmpfyr.co/"><strong>CMPFYR</strong></a><strong>:</strong> The digital arena&#8217;s rising star.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://fatalefestival.com/"><strong>The FATALE Festival</strong></a><strong>:</strong> The FATALE Festival is a beacon for forward-thinking art and technology enthusiasts.</li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>January</strong>: <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></li>
+
+
+
+<li><strong>February</strong>: <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></li>
+
+
+
+<li><strong>March</strong>: <a href="https://lu.ma/communications">https://lu.ma/communications</a></li>
+
+
+
+<li><strong>April</strong>: <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></li>
+
+
+
+<li><strong>May</strong>: <a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></li>
+
+
+
+<li><strong>June</strong>: <a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></li>
+
+
+
+<li><strong>July</strong>: <a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></li>
+
+
+
+<li><strong>August</strong>: <a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></li>
+
+
+
+<li><strong>September</strong>: <a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></li>
+
+
+
+<li><strong>October</strong>: <a href="https://lu.ma/esg">https://lu.ma/esg</a></li>
+
+
+
+<li><strong>November</strong>: <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></li>
+
+
+
+<li><strong>December</strong>: <a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35859da&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35859da" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="640" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=1024%2C640&#038;ssl=1" alt="Vancouver AI Meetup 2024 Event Calendar" class="wp-image-4350" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=768%2C480&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Meetup 2024 Event Calendar</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-trends">AI Trends &amp; Tools: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, January 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss emerging AI technologies and how they’re being applied in various industries and creative fields. Share experiences and get advice from the local AI community.<br /><strong>Target Audience:</strong> Anyone interested in AI and its applications<br /><strong>Key Takeaways:</strong> Learn about new trends in AI development from local experts and practitioners. Make valuable connections.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-storytelling">Visual Storytelling with AI: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, February 22, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> This meetup explores how visual storytellers like filmmakers are utilizing AI tools in their work and envisioning future possibilities.<br /><strong>Target Audience:</strong> Filmmakers, photographers, visual artists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Discussions on tools like DALL-E and Stable Diffusion and their applications; ethical challenges around AI and visual media.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/communications">AI Communications Circle: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, March 28, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss effective strategies for communicating AI concepts to different stakeholders and the role of language in human-AI relations.<br /><strong>Target Audience:</strong> Writers, communicators, product managers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Perspectives on explaining AI to the public and building trust around emerging technologies.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/communications">https://lu.ma/communications</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/hacking">AI Coding Symposium: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, April 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Tech talks and panels on the latest approaches to coding and developing intelligent applications.<br /><strong>Target Audience:</strong> Developers, engineers, data scientists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Insights on AI frameworks, best practices and upcoming trends in AI programming.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/socialmedia">AI Social Media &amp; Personal Branding: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, May 30, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss leveraging social platforms and content to establish authority in the AI space. Share challenges and solutions.<br /><strong>Target Audience:</strong> Consultants, entrepreneurs, freelancers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Tips on creating an online identity and engaging communities through prudent use of AI.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-music">AI Audio Alchemy: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, June 27, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discuss AI tools and techniques for audio/music and implications for creators in these fields.<br /><strong>Target Audience</strong>: Producers, composers, podcasters, voice professionals, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Learn how others are crafting AI into audio/aesthetic workflows imaginatively and responsibility.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link: </strong><a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-artists">AI Artistic Evolution: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 25th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An evening exploring how AI is shaping the future of art and creativity. Discuss tools, techniques and implications for artists.<br /><strong>Target Audience:</strong> Artists, designers, illustrators, photographers, film makers, creative professionals, marketing professionals, community managers. <br /><strong>Key Takeaways:</strong> Learn about emerging AI tools and techniques influencing different creative fields.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/growth-hacking">Growth Hacking: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 27th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> A deep dive into innovative AI strategies for hyper-growth and catapulting businesses to the next level.<br /><strong>Target Audience:</strong> Entrepreneurs, marketers, business professionals<br /><strong>Key Takeaways:</strong> Discover innovative AI-driven growth strategies and case studies. Gain insights on applying AI to marketing, customer acquisition and retention. Learn how startups are leveraging AI to scale rapidly.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/AI-meetup">AI Business Impact: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> September 26th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An enlightening evening exploring the burgeoning impact of Generative AI on business landscapes.<br /><strong>Target Audience:</strong> Business leaders, executives, innovators<br /><strong>Key Takeaways:</strong> Explore the transformational role of generative AI across various industries. Understand implications and applications for product development, operations, marketing. Discuss best practices for responsible and <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> integration.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/esg">Sustainability &amp; AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> Thursday, October 24, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discussions on integrating environmental, social and governance priorities into AI strategies.<br /><strong>Target Audience:</strong> Sustainability professionals, social impact practitioners<br /><strong>Key Takeaways:</strong> Learn how ESG priorities can inform AI strategies and development. Discuss partnering with AI for positive social and environmental impact. Identify opportunities for AI to address sustainability challenges.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/esg">https://lu.ma/esg</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-games">AI in VR &amp; Gaming: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> November 21st, 224<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Insights into cutting-edge AI applications and the future of gaming/VR experiences.<br /><strong>Target Audience:</strong> Gamers, developers, technologists<br /><strong>Key Takeaways:</strong> Demos of cutting-edge AI applications in gaming and immersive experiences. Discuss design considerations and future trends. Explore ethical issues around AI, addiction, realism in digital worlds.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/multimodal">Multimodal AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> December 19th, 2024<br /><strong>Location</strong>: 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An exploration of integrating text, image and sound recognition with AI.<br /><strong>Target Audience:</strong> Data scientists, UX designers, engineers<br /><strong>Key Takeaways: </strong>Understand approaches to integrating text, visual and audio AI systems. Learn challenges and opportunities of multimodal AI. Gain exposure to tools and techniques across industries.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h3>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit. Their support empowers us to blend art with technology innovatively. <a href="https://www.vancouverbiennale.com/">Learn more</a></li>
+
+
+
+<li><strong><a href="https://www.augxlabs.com/">AugXLabs</a>:</strong> At the forefront of augmented reality, AugXLabs brings cutting-edge tech to our events, enhancing the immersive experience. <a href="https://www.augxlabs.com/">Discover AugXLabs</a></li>
+
+
+
+<li><strong><a href="https://holistichybrid.com/">Holistic Hybrid</a>:</strong> A digital strategy powerhouse, Holistic Hybrid&#8217;s expertise in blending creativity with digital know-how elevates our platforms. <a href="https://holistichybrid.com/">Explore Holistic Hybrid</a></li>
+
+
+
+<li><strong><a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Lindsay Bailey Law</a>:</strong> Legal expertise with a creative twist. Lindsay Bailey provides invaluable legal guidance, ensuring our events and initiatives are on solid ground. <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Connect with Lindsay Bailey</a></li>
+
+
+
+<li><strong><a href="https://fatalefestival.com/">The FATALE Festival</a>:</strong> A partner in creativity and innovation, the FATALE Festival is a beacon for forward-thinking art and technology enthusiasts. <a href="https://fatalefestival.com/">Visit FATALE Festival</a></li>
+
+
+
+<li><strong><a href="https://cmpfyr.co/">CMPFYR</a>:</strong> The digital arena&#8217;s rising star, CMPFYR, brings fresh, tech-driven solutions to our digital strategy, pushing the boundaries of what&#8217;s possible. <a href="https://cmpfyr.co/">About CMPFYR</a></li>
+
+
+
+<li><a href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers, Internet Masterminds brings together a community of innovators and disruptors. <a href="https://internetmasterminds.org/">Discover Internet Masterminds</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Partnership Invitation</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Join forces with Future Proof Creatives to expand your reach and engage with a thriving community of innovators and creators. Our partnerships are tailored to amplify your brand&#8217;s presence among an audience passionate about art, technology, and sustainability. Past collaborations have included:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Innovative Workshops and Seminars:</strong> Co-create unique learning experiences in digital art, technology integration, and sustainable practices.</li>
+
+
+
+<li><strong>Exclusive Event Sponsorships:</strong> Be part of our compelling events like art-tech exhibitions, online forums, and creative meetups.</li>
+
+
+
+<li><strong>Product Showcases and Launches:</strong> Introduce your cutting-edge products to a community eager for innovation.</li>
+
+
+
+<li><strong>Customized Community Engagements:</strong> From think-tank sessions to creative challenges, we offer diverse platforms for meaningful interactions.</li>
+</ul>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re keen on partnering with Future Proof Creatives to connect with leading creators, innovators, and thought leaders, <a href="https://kriskrug.co/contact/" data-type="link" data-id="https://kriskrug.co/contact/">reach out to us</a>&#8230; Let&#8217;s create something extraordinary together!</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-ethics/">AI Ethics and Philosophy</a> collection. See also: <a href="https://kriskrug.co/2023/10/13/the-art-of-augmented-creativity-balancing-ai-community-and-self/">The Art of Augmented Creativity: Balancing AI, Community, and Self</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-4495-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-4495-content.raw.html
@@ -1,0 +1,467 @@
+
+<h2 class="wp-block-heading">Curiosity, Community, Creativity &amp; Code Converge</h2>
+
+
+
+<p class="wp-block-paragraph">The inaugural <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community Meetup</a>, convened at the heart of Vancouver&#8217;s creative nexus, <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media headquarters</a>, within the inspiring <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a> art warehouse, was a landmark event, signaling a vibrant kickoff for a series of gatherings dedicated to the exploration of artificial intelligence in creative realms.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/gln3RCVGZN4?si=CBmllOcq_juDUvke" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">This sold-out event attracted a wide array of participants, from curious enthusiasts to seasoned professionals, all drawn together by a shared passion for the potential of AI to transform storytelling, art, and technology. </p>
+
+
+
+<p class="wp-block-paragraph">Through a series of engaging discussions, interactive installations, and hands-on demonstrations, the meetup fostered a rich environment for collaboration, learning, and inspiration. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3265d42&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3265d42" class="wp-block-image size-full is-style-default wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="2226" height="1913" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2226%2C1913&#038;ssl=1" alt="" class="wp-image-4518" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?w=2226&amp;ssl=1 2226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=300%2C258&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1024%2C880&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=768%2C660&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1536%2C1320&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2048%2C1760&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Welcoming Vancouver AI Community to my new studio at Vancouver Biennale HQ.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The evening underscored the ethos of the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI community">Vancouver AI Community</a> Meetup: to build an inclusive, engaged group focused on the real-world applications and ethical considerations of AI, setting a dynamic precedent for future gatherings and cementing its role as a cornerstone for AI exploration in Vancouver.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326650a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326650a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="355" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI.jpg?resize=1024%2C355&#038;ssl=1" alt="" class="wp-image-4517" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1024%2C355&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=300%2C104&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=768%2C267&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1536%2C533&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=2048%2C711&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetups bring together a wide cross section of people working with AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>A Rallying Cry for Inclusivity and Exploration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3266d4d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3266d4d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1.jpg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-4508" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1536%2C861&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=2048%2C1148&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=528%2C297&amp;ssl=1 528w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Charlene Joseph: S?wx?wú7mesh Nation Language and Cultural teacher? ?opens with a song.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Community Meetup is founded on a principle of inclusivity. Our ethos is simple yet profound: to welcome everyone intrigued by AI&#8217;s potential. From seasoned researchers to budding artists, from tech enthusiasts to curious students, our aim is to forge a vibrant tapestry of individuals united by their passion for exploring the frontiers of artificial intelligence.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326760c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326760c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18.jpg?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-4520" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1536%2C864&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=2048%2C1152&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Philippe Pasquier is a professor at&nbsp;SFU&#8217;s School of Interactive Arts and&nbsp;Technology, where he directs the Metacreation Lab for Creative AI</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we plan meetups for the last week of every month throughout the year, our vision is to build an engaged, dynamic group. This community isn&#8217;t just about sharing knowledge; it&#8217;s about challenging each other, collaborating on real-world applications, and navigating the ethical labyrinth that AI presents.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Reflecting on Our First Gathering</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3267f37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3267f37" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-4511" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=2048%2C1151&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><em>Steve DiPaola</em>, active as an artist and a scientist, is a professor/researcher at Simon Fraser University, Steve directs the I-Viz Lab</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night of our first meetup was electric. <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media&#8217;s</a> headquarters, within the eclectic <a href="https://www.vancouverbiennale.com/">Vancouver Biennale Art Warehouse</a>, became a crucible of creativity and innovation. The event was a kaleidoscope of insights, demonstrations, and hands-on sessions, each designed to demystify AI and showcase its transformative power in creative endeavors.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Gratitude for Our Speakers</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32687c8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32687c8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="573" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15.jpg?resize=1024%2C573&#038;ssl=1" alt="" class="wp-image-4509" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1024%2C573&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Justine Gauthier is the Director of Corporate &amp; Legal Affairs at&nbsp;<a href="https://theorg.com/org/mila-quebec-artificial-intelligence-institute">Mila &#8211; Quebec Artificial Intelligence Institute</a>.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The success of our inaugural meetup owes much to the incredible speakers who shared their insights and visions with us. <a href="https://vancouver.ca/your-government/mike-klassen.aspx">Mike Klassen</a>, <a href="https://katearmstrong.com">Kate Armstrong</a>, <a href="http://stevebroback.com/about/">Steve Broback</a>, <a href="https://mila.quebec/en/person/justine-gauthier/">Justine Gauthier</a>, <a href="https://www.linkedin.com/in/steve-lowry-vancouver?originalSubdomain=ca">Steve Lowry</a>, and <a href="http://ispace.iat.sfu.ca/person/mirjana-prpa/">Mirjana Prpa</a> — each brought a unique perspective to the table, enriching our discussions and expanding our understanding of AI&#8217;s impact on society and creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3269001&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3269001" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="771" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2.jpg?resize=771%2C1024&#038;ssl=1" alt="" class="wp-image-4516" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=771%2C1024&amp;ssl=1 771w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=226%2C300&amp;ssl=1 226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=768%2C1020&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1157%2C1536&amp;ssl=1 1157w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1542%2C2048&amp;ssl=1 1542w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?w=1928&amp;ssl=1 1928w" sizes="auto, (max-width: 771px) 100vw, 771px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kate Armstrong: Director of&nbsp;<em>Living Labs</em>&nbsp;at Emily Carr University of Art + Design. Co-director of AI Futures for Art + Design</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their expertise helped to set a dynamic and insightful tone for the event, fostering a fertile ground for innovation and exchange.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Celebrating Our Artists</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326984d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326984d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="907" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6.jpg?resize=1024%2C907&#038;ssl=1" alt="" class="wp-image-4502" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1024%2C907&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=300%2C266&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=768%2C680&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1536%2C1361&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=2048%2C1815&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">An invocation to the Holy Mother of the Void is made; the void from which all things are born. As the future becomes the present and we forge into an age of AI art, how can we know what is human movement and what is not?</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our event was further illuminated by the contributions of pioneering AI artists who showcased interactive art installations at the forefront of avant-garde creativity. <a href="https://www.sfu.ca/siat/people/research-faculty/steve-dipaola.html">Steve DiPaola</a>, <a href="https://www.linkedin.com/in/meehae-song/">Meehae Song</a>, <a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier</a>, <a href="https://www.arshsobhan.com/">Arshia Sobhan</a>, <a href="https://www.facebook.com/orbitprincess/">Marina Tsougrianis (AKA Orbit Princess)</a>, and <a href="https://www.linkedin.com/in/vickymittal">Vicky Mittal</a> — these individuals are not just artists but trailblazers, merging technology with human expression in ways that challenge our perceptions and open new dialogues. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a09b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a09b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="570" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12.jpg?resize=1024%2C570&#038;ssl=1" alt="" class="wp-image-4512" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1024%2C570&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=768%2C427&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1536%2C854&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=2048%2C1139&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Portrait Jordan Bent: Special thanks for making photos and videos at the event Peter Holst.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their installations provided a tangible glimpse into the creative potential of AI, captivating attendees with a vivid display of the intersection between art and technology.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Fostering Growth and Collaboration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a8de&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a8de" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="863" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3.jpg?resize=863%2C1024&#038;ssl=1" alt="" class="wp-image-4501" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=863%2C1024&amp;ssl=1 863w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=253%2C300&amp;ssl=1 253w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=768%2C911&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1295%2C1536&amp;ssl=1 1295w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1727%2C2048&amp;ssl=1 1727w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 863px) 100vw, 863px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Old buddy Mike Klassen is a public affairs professional serving in executive leadership roles, media pundit and organizational spokesperson.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">What makes the Vancouver AI Community Meetup unique is its commitment to cultivating a supportive ecosystem for experimentation and growth. As its curator, I am dedicated to building a platform where individuals from various backgrounds can share their ideas, challenge each other, and collaborate on projects that push the envelope of what&#8217;s technologically and creatively possible.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b0bd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b0bd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="560" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10.jpg?resize=1024%2C560&#038;ssl=1" alt="" class="wp-image-4513" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1024%2C560&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=300%2C164&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=768%2C420&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1536%2C840&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=2048%2C1120&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Steve Lowry, the Founding Executive Director of AInBC</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our initiative goes beyond networking. We are creating a community where the exchange of knowledge and experiences leads to real-world applications and thoughtful consideration of AI&#8217;s impact on society. Through training sessions and workshops, we aim to equip creatives with the tools they need to harness the power of AI in their work, ensuring that our community remains at the forefront of this exciting field.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>The Road Ahead</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b928&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b928" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="552" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16.jpg?resize=1024%2C552&#038;ssl=1" alt="" class="wp-image-4514" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1024%2C552&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=300%2C162&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=768%2C414&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1536%2C827&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=2048%2C1103&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mark Busse: Strategy + Creativity + Design + Conversation = Ideas &amp; Engagement &amp; Community &amp; Impact. Add good food = magic.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look to the future, the Vancouver AI Community Meetup is poised at the edge of a new dawn. Our collective journey is only beginning, with each meetup strengthening our resolve and enriching our discourse. We stand on the threshold of a new era where technology and human ingenuity converge, creating a tapestry of unimaginable beauty and complexity.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-EzZHFIbxGIJvSUh" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">I extend an open invitation to you, regardless of your familiarity with AI, to join this adventure. Together, we can explore the vast expanse of artificial intelligence, learning, growing, and shaping a future where technology amplifies our creative potential.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c17a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c17a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="974" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9.jpg?resize=1024%2C974&#038;ssl=1" alt="" class="wp-image-4515" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1024%2C974&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=300%2C285&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=768%2C730&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1536%2C1461&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=2048%2C1948&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mirjana Prpa. Assistant Professor,&nbsp;Northeastern&nbsp; University</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For those eager to dive into this renaissance of technology and art, the Vancouver AI Community Meetup awaits. Join us as we navigate the uncharted waters of AI, forging paths where none existed, in pursuit of a future bright with promise and imbued with creativity.</p>
+
+
+
+<p class="wp-block-paragraph">Together, let&#8217;s make Vancouver a lighthouse of AI innovation and artistic exploration. Join our next meetup and become part of a community dedicated to shaping the future of artificial intelligence and beyond.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c99a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c99a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="993" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4.jpg?resize=993%2C1024&#038;ssl=1" alt="" class="wp-image-4499" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=993%2C1024&amp;ssl=1 993w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=291%2C300&amp;ssl=1 291w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=768%2C792&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1490%2C1536&amp;ssl=1 1490w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1987%2C2048&amp;ssl=1 1987w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 993px) 100vw, 993px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bantering about IP, copyright and the shifting legal framework in the face of technological disruption brought on by AI and ML.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For more details on our upcoming events and how you can be a part of this exciting journey, visit our website or follow us on our social channels. Let&#8217;s embark on this path together, exploring the endless possibilities that AI and creativity hold for our world.</p>
+
+
+
+<p class="wp-block-paragraph">As we reflect on the journey of the Vancouver AI Community Meetup and look forward to the paths yet to tread, it is essential to recognize the individuals and organizations whose contributions have been the bedrock of our burgeoning community.</p>
+
+
+
+<p class="wp-block-paragraph">A special round of applause to <a href="https://robertmichaelmurray.com/">Robert Michael Murray</a> and <a href="https://www.linkedin.com/in/d-yaschenko/">Daria Yashenko</a>. Behind the scenes, your efforts were the glue that held everything together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="572" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13.jpg?resize=1024%2C572&#038;ssl=1" alt="" class="wp-image-4510" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1024%2C572&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Our gratitude also extends to <a href="https://www.linkedin.com/in/wayneracine?originalSubdomain=ca">Wayne Shadow</a>, <a href="https://www.kempedmonds.com/">Kemp Edmonds</a>, Ukrainian Sofia, <a href="https://www.linkedin.com/in/shanegibson?originalSubdomain=ca">Shane Gibson</a>, <a href="https://www.linkedin.com/in/valerie-smaller-0270697/?originalSubdomain=ca">Valerie Smaller</a>, <a href="https://www.instagram.com/streetarteagle/">Vince Damoulin</a>, <a href="https://overviewinstitute.org/dt_team/kevin-kelley/">Kevin W. Kelley</a> and <a href="https://www.linkedin.com/in/nina-kim-4b24b338/?originalSubdomain=ca">Nina Kim</a>, <a href="https://internetmasterminds.org/">Matt Astifan</a>, <a href="https://www.peterholstphotography.com/">Peter Holst</a>. Each of you contributed uniquely and significantly, enriching our experience. Thanks <a href="https://www.linkedin.com/in/barriemowatt?originalSubdomain=ca">Barrie Mowatt</a> for believing in me.</p>
+
+
+
+<p class="wp-block-paragraph">Lastly, I must express my deepest appreciation to my advisors &#8211; <a href="https://www.linkedin.com/in/iamkhayyam">Khayyam Wakil</a>, <a href="https://www.emmabroback.com/">Emma Broback</a>, <a href="http://space.dentthefuture.com/speakers/jason-preston/">Jason Preston</a>, <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b?originalSubdomain=ca">Lindsay Bailey</a>, <a href="https://holistichybrid.com/">Robert Scales</a>, and Jessica Liang. Your guidance and wisdom and support is invaluable.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward, we&#8217;re excited to announce <a href="https://lu.ma/ai-storytelling">our next meetup scheduled for <strong>February 22nd</strong></a>. Expect more stimulating discussions, networking opportunities, and AI-powered creativity! Save your spot now: <a href="https://lu.ma/ai-images">Next Meetup Sign-up</a>.</p>
+
+
+
+<p class="wp-block-paragraph">Additionally, for those in Vancouver, don&#8217;t miss out on our <strong><a href="http://lu.ma/ai-storytelling">AI Storytelling Training</a></strong> happening in February. It&#8217;s a unique opportunity to dive deeper into the world of AI and enhance your storytelling skills. Secure your place here: <a href="https://lu.ma/ai-storytelling">AI Storytelling Training</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-1Mix9FfrRtWVLL2" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our journey together is just beginning. Let&#8217;s continue to build, learn, and innovate as a community. Your participation is what makes these events a success, and we can&#8217;t wait to see you again next month!</p>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re inspired by our work and wish to support future endeavours, please don&#8217;t hesitate to get in touch. <a href="https://kriskrug.notion.site/Sponsor-Vancouver-AI-Community-8ce6deaf7ebf4b5992d5d97e8205691a?pvs=4">We&#8217;re always looking for collaborators who share our vision.</a></p>
+
+
+
+<p class="wp-block-paragraph">Here’s to many more gatherings where AI meets creativity, technology, and community! And <a href="https://kriskrug.co/events/">we still do this every month, and the next one is on the calendar</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326daea&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326daea" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-4500" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326e3e6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326e3e6" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="563" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=750%2C563&#038;ssl=1" alt="" class="wp-image-4522" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=300%2C225&amp;ssl=1 300w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">&#8220;I&#8217;m watching a fucking bloodbath as generative AI eats one creative industry after another&#8230;.&#8221; by Vince Damoulin @streetarteagle</figcaption></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/">Vancouver AI Meetup #16: Where Tech, Creativity, and Community Collide</a> and <a href="https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/">Vancouver AI: The Community Building BC&#8217;s AI Future &#8211; February Meetup Recap</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-5768-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-5768-content.raw.html
@@ -1,0 +1,882 @@
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/wL2kGWDms2U?si=m5GjIium14MAYtFQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">In a world increasingly captivated by the potential of artificial intelligence, the <a href="https://lu.ma/vancouver-AI-meetup">Vancouver AI Meetup</a> stands as a testament to the vibrant community at the intersection of technology, creativity, and community. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350b473&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350b473" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5778" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetup at Future Proof Creatives Studio | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">With over 135 attendees, this gathering was a microcosm of the broader dialogue shaping the future of AI. I couldn’t be prouder of the buzzing atmosphere we created together on May 30th.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350bb9b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350bb9b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5801" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of this meetup was a palpable sense of community. It’s easy to imagine technology events as gatherings of individuals glued to their devices, but here, the reality was strikingly different. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350c542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350c542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5802" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">RULE 1: Can&#8217;t have a meetup without donuts! | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Conversations flowed freely, ideas were exchanged with enthusiasm, and a shared passion for AI’s potential united everyone in the room. </p>
+
+
+
+<figure class="wp-block-video"><video height="1920" style="aspect-ratio: 1080 / 1920;" width="1080" controls loop src="https://kriskrug.co/wp-content/uploads/2024/06/Reels6.mp4"></video></figure>
+
+
+
+<p class="wp-block-paragraph">Our meetups aren’t just a meeting of minds; they are a celebration of what those minds can achieve together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d055&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d055" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5804" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bright eyes and big smiles the friendly faces of the Vancouver AI Community | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The diversity of speakers underscored the multifaceted nature of AI. From academia to industry, the range of perspectives offered a holistic view of AI’s place in our world.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d790&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d790" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5776" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dennis Chenard, Northeastern University at AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://vancouver.northeastern.edu/events/ainbc-northeastern-university-vancouver-aaai-networking-night/">Dennis Chenard from Northeastern University</a> bridges the gap between theoretical knowledge and practical application, while <a href="https://vanstartupweek.ca/">Bill McGraw</a> highlighted AI’s transformative role in Impact and CSR. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350de2c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350de2c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5777" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bill McGraw Invites People to Vancouver Startup Week AI Events  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Yet, it was perhaps the inclusion of indigenous perspectives by <a href="https://mila.quebec/en/">Michael and Caroline Running Wolf</a> that most vividly illustrated the depth and breadth of the discussions taking place. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350e97e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350e97e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5786" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Running Wolf introduces himself and his work at the Vancouver AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their insights into <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and sovereignty challenged attendees to think beyond code and algorithms, to consider the societal implications of the technology we create.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f065&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f065" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5779" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Caroline Running Wolf introduces herself and her work at the Vancouver AI Community Meetup on May 30th  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Art and technology often seem like disparate realms, yet at this meetup, they converged in spectacular fashion. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f7f7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f7f7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5775" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void dancing with <a href="https://www.holonic.systems/">Holonic Systems Generative Music Sensors</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The performance by <a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic and <a href="https://www.instagram.com/orbitprincess/">Marina, the Holy Mother of the Void</a>, merging generative music with interpretive dance, was a powerful demonstration of emerging tech’s potential to transcend traditional boundaries and redefine creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350fee7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350fee7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5772" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic Systems answers questions about his generative music sensors project  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Similarly, <a href="https://www.sfu.ca/meta-creation/">Arshia Sobhan and Philippe Pasquier’s AutoLoom project</a> from Metacreation Lab for <a href="https://kriskrug.co/ai-for-creatives/" title="AI for Creatives">Creative AI</a> at SFU showcased how AI can be harnessed for artistic expression, further blurring the lines between creator and creation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351059f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351059f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5774" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/arshsobhan/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">Arshia Sobhan</a> shares the work of <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier&#8217;s</a> <a href="https://www.metacreation.net/">Metacreation Lab for Creative Artificial Intelligence</a> at the <a href="https://www.sfu.ca/siat.html">School of Interactive Art and Technology</a> at <a href="https://www.sfu.ca/">SFU</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://eml.ubc.ca/">Dr. Pennefather’s improvisation</a> with AI at UBC’s <a href="https://eml.ubc.ca/">Emerging Media Lab</a> challenged the linear relationship between human and machine. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3510c38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3510c38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5780" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://patrickpennefather.com/">Dr Patrick Pennefather</a> of UBC <a href="https://eml.ubc.ca/">Emerging Media Lab</a> rocking the mic at the Vancouver AI Community Meetup May 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://mvai.org/">Donald Jukes</a> introduced us to a cool new event I’m stoked about, “<a href="https://www.mvdemos.com/">Minimal Viable Demos,</a>” being organized by friends in the <a href="https://lu.ma/novus">Novus</a> and <a href="https://lu.ma/atelier.ubc">Atelier</a> communities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35112e9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35112e9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5770" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://emojipedia.org/camera">?</a> <a href="https://www.peterholstphotography.com/">Peter Holst</a> </figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://sianflanagan.com/">Sian Flanagan</a>’s poetic voice empowered the multi-passionate, while <a href="https://cofounderhub.org/">Gabriela Arno</a> facilitated entrepreneurial connections at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a> and <a href="https://lu.ma/calendar/cal-pXBoizODcGZmfYX">Meet Your Cofounder event series</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3511971&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3511971" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5783" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://thebusinessofyou.com/about-sian/">Sian Flanagan</a> shares poetry from <a href="https://www.amazon.ca/dp/1998754596">Silk On Ice: The Process of Growing into Grace</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But what truly set this event apart was its emphasis on inclusivity and community engagement. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512013&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512013" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5773" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> is helping startup founders connect with one another at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Roman the Intern shared with us his AI-generated videos and All You Need to Know YouTube Channel… </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512cc1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512cc1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5794" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">CEO of All You Need to Know Generative Video Production Services&#8230;. Roman the Intern.  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">he’s building a robot army and media empire with generative tools and popped the trunk and showed us his approach and process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351371d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351371d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5793" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sam Huo invites people to apply to speak at upcoming Google Developer Group Build with AI Event  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Sam Huo invited everybody to the Google Developer Groups Build with <a href="https://kriskrug.co/ai-events/" title="AI events">AI event</a>. I went to the last one and am volunteering at the upcoming one and think it’s a great technical event with low barriers and a sweet community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3513eaa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3513eaa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5805" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Artist and musician Ed Kennedy of Run Diffusion talks about creative generative AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed Kennedy from Run Diffusion talked about the cool creative opportunities they support: RunDiffusion provides AI workflows with private GPU hosting.</p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://circlesofai.org/">Circles of AI project</a>, spearheaded by <a href="https://www.linkedin.com/in/rochellegrayson">James Rowe and Rochelle Grayson</a>, aims to create a space where everyone could contribute to and benefit from AI’s advancements. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351450d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351450d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="641" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&#038;ssl=1" alt="" class="wp-image-5781" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=768%2C481&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?w=1365&amp;ssl=1 1365w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James Rowe launches Circles of AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">These initiatives, along with the active participation of volunteers and the support from diverse sponsors, highlighted a crucial truth: advancing AI is not just about technological breakthroughs; it’s about building a community that reflects the diversity and complexity of the world it seeks to serve.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3514ba0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3514ba0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5806" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sian Flanagan at the Vancouver AI Community Meetup March 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As attendees mingled, shared insights, and discussed future projects, one thing became clear: these meetups are just the beginning. The call to action for continued sharing and collaboration was not just about maintaining momentum; it was about recognizing that the journey of AI is one we undertake together. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5807" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">By fostering a culture of openness, curiosity, and mutual respect, events like this lay the groundwork for a future where AI can truly be a force for good. In reflecting on the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Meetup, it’s evident that the power of such gatherings lies not just in the knowledge shared but in the connections formed.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515bb6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515bb6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5808" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Bridging academia and industry, integrating art with technology, and embracing diverse perspectives are not just strategies for innovation; they are pillars for building an AI future that is inclusive, ethical, and profoundly human.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351623b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351623b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5811" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look forward to more meetups and more opportunities for interdisciplinary collaboration, let us remember that at the core of every technological advancement is a community of people committed to making a difference. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351693c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351693c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5812" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Meetup</a> is an awesome example of what happens when that community comes together: a confluence of minds and machines that promises to shape our world in ways we are only beginning to imagine.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351700c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351700c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5809" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Highlighting Key Demos</strong></p>
+
+
+
+<p class="wp-block-paragraph">The demos were the heart of the event, showcasing the cutting-edge applications of AI:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Lionel Ringenbach’s CompoVision AI Demo</strong></p>
+
+
+
+<p class="wp-block-paragraph">Lionel used three computer vision cameras, <a href="https://github.com/comfyanonymous/ComfyUI">ComfyUI</a>, <a href="https://llama.meta.com/llama3/">Llama3</a> and <a href="https://derivative.ca/">TouchDesigner</a> to create real-time visuals. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517833&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517833" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5787" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demo involved placing objects in front of the cameras, which were then meshed into prompts to generate stunning visuals on the wall. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517eb5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517eb5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5785" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Attendees got to tinker and prompt AIs with a variety of props.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351854c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351854c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5784" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Prajwal’s Jarvis Demo</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3518c1f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3518c1f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5790" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s Vision Apple Pro cap, equipped with a speaker, Wi-Fi, Bluetooth, Raspberry Pi, and a vision sensor, demonstrated the innovative potential of wearable AI. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351929e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351929e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5789" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Despite initial technical hiccups, the audience’s supportive cheers helped him showcase its capabilities, including poetry generation and real-time interactions.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351996f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351996f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5788" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">Stigmergic Action for Global Empowerment</a> &#8211; Jerrica Clelland</strong></p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">SAGE project</a> leverages video games for mental health support, highlighting the collaboration between technology and well-being. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5792" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of SAGE is an unwavering belief in the transformative power of storytelling, world-building, and gameplay as conduits for positive change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5791" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Acknowledgments</strong></p>
+
+
+
+<p class="wp-block-paragraph">A huge thank you to <a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> for coordinating the team of volunteers and organizing partners and sponsors. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351ae6d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351ae6d" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5795" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> at <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a> May 2024 Meetup at <a href="https://futureproofcreatives.com/">Future Proof Creatives Photo</a>: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to Jeff Clark, Alexandra the Bartender, Roz McNulty, Roman the Intern, James McKenzie, and Brittney Smaila for their invaluable contributions. Valerie and Daria, your logistical support was crucial to the event’s success.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Visual Recap</strong></p>
+
+
+
+<p class="wp-block-paragraph">Relive the event through a selection of the best photos and videos:</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351b59c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351b59c" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5798" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Video production by <a href="https://www.instagram.com/serbin_photography">Viktor Serbin</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://peterholst.pixieset.com/futureproofcreative-30may2024/">Peter Holst Photo Album</a><br />• <a href="https://diamondsedgephotography.pixieset.com/vancouveraicommunity/">Michelle Diamond Photo Album</a><br />• <a href="https://www.youtube.com/shorts/7u7dpxIV7vE">YouTube Highlights</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Thank You Note</strong></p>
+
+
+
+<p class="wp-block-paragraph">A heartfelt thank you to all the speakers, demo presenters, volunteers, and attendees who made this event a resounding success. Special gratitude to our sponsors and partners:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://augxlabs.com/">AugXLabs</a><br />• <a href="https://aifutures.org/">AI Futures for Art + Design</a><br />• <a href="https://www.sfu.ca/meta-creation/">Metacreation Lab at SFU</a><br />• <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351bcc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351bcc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5796" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Cocktails by <a href="https://www.sonsofvancouver.ca/">Sons of Vancouver</a> thank you <a href="https://www.linkedin.com/in/sovjames/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">James Lester</a> | <a href="https://www.peterholstphotography.com/"></a>Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://sonsofvancouver.ca/">Sons of Vancouver</a><br />• <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a><br />• <a href="https://holistichybrid.com/">Holistic Hybrid</a><br />• <a href="https://cmpfyr.com/">CMPFYR</a><br />• <a href="https://internetmasterminds.org/">Internet Masterminds</a><br />• <a href="https://thefatalefestival.com/">The FATALE Festival</a><br />• <a href="https://vlacc.ca/">VLACC (Vancouver Latin American Cultural Centre)</a><br />• <a href="https://taylightbrewing.com/">Taylight Brewing</a></p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-5797" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption class="wp-element-caption">Thanks for the support and the beers <a href="https://taylightbrewing.com/">Taylight Brewing</a>!!  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Looking Ahead</strong></p>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more innovative sessions at our future meetups. Don’t miss the next event and grab your Earlyworm Tickets now:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://lu.ma/june-AI-meetup">June Vancouver AI Community Meetup at Future Proof Creatives Studio</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Call to Action</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>We invite attendees and readers to share their experiences and photos from the event. Your suggestions and ideas are crucial for shaping future meetups, fostering a collaborative and innovative AI community.</strong></p>
+
+
+
+<p class="wp-block-paragraph">In the ever-evolving world of AI, community engagement and innovation are our guiding stars. Let’s continue to explore, create, and inspire together. It is <a href="https://kriskrug.co/events/">still monthly, still free, still worth the trip</a>.</p>
+
+
+
+<figure class="wp-block-image size-large is-resized"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5799" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://lu.ma/june-AI-meetup">Next event is June 27th and tickets are on sale. See ya there! 🙂 </a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3lnpZXM2iPH0wMh/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-6251-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-6251-content.raw.html
@@ -1,0 +1,770 @@
+
+<p class="wp-block-paragraph">Hey there, AI innovators and future-shapers, Kris Krüg here, reflecting on our last gathering and looking ahead to our next adventure in the <a href="https://lu.ma/YVR-AI">Vancouver AI Community Meetup series</a>. We&#8217;re building something special here, and I&#8217;m excited to share the journey with you all.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EqmixfIT_II?si=Fw7IReyh2M-0y6wu" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">June 27th: The Intersection of AI, Art, and Human Creativity</h2>
+
+
+
+<p class="wp-block-paragraph">Our June meetup at <a href="https://www.futureproofcreatives.com/">Future Proof Creatives</a> studio was a testament to the power of interdisciplinary collaboration. Here&#8217;s what we explored:</p>
+
+
+
+<h3 class="wp-block-heading">Event Highlights</h3>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Interactive Sound Walks with <a href="http://linkedin.com/in/holmium/">Ove Holmqvist</a></strong> Ove Holmqvist, the maestro of sound and tech, transported us into a sonic landscape where geospatial interactions met physical computing.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34885e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34885e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="578" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup.jpg?resize=1024%2C578&#038;ssl=1" alt="" class="wp-image-6271" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1024%2C578&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=768%2C433&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1536%2C867&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=2048%2C1156&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">His app turned our movements into music, crafting an auditory tapestry that was both ethereal and profoundly grounding. With <a href="https://www.movesense.com/">Movesense sensors</a>, the line between the physical and the digital blurred, creating a space where each step became a note in a grand, real-time composition.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3488d3c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3488d3c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="538" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&#038;ssl=1" alt="" class="wp-image-6270" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=300%2C158&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=768%2C404&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1536%2C807&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>2. <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">Autolume: Post-Photographic Cyborg Art</a></strong> I took the community on a journey through time and tech with Autolume, an AI-powered, post-photographic experiment. Imagine teaching a baby AI brain with 20 years of film portraits and watching it bloom into a digital entity capable of creating new art forms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489481&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489481" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-6278" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This project, in collaboration with <a href="https://www.metacreation.net/">Metacreation Lab for Creative AI at SFU</a>, showcased the beautiful chaos at the intersection of analog nostalgia and AI futurism. By feeding the AI with a vast archive of analog film portraits, <a href="https://www.metacreation.net/autolume">Autolume</a> learns to interpret and recreate human faces in entirely new artistic expressions, merging the past’s tactile essence with the future’s digital innovation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489cab&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489cab" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6273" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demonstration illustrated not just the technical prowess of AI but also its potential to redefine artistic boundaries, creating a unique symbiosis between human creativity and machine learning.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>3. <a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Lionel Ringenbach’s CompoVision</a></strong> <a href="https://ucodia.space/">Lionel Ringenbach </a>introduced us to CompoVision, an installation that doesn’t just see but interprets.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348a64a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348a64a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6269" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Real-time visual data transformed into interactive art, making us participants in a living, breathing digital organism. This piece not only caught the eye but also sparked a collaboration with a major tech firm, proving that in the digital age, art and opportunity are just a pixel apart.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6256" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>4. Networking and Community Building</strong> The evening was a hotbed of intellectual synergy, with researchers, investors, artists, coders, entrepreneurs, and students mingling over gourmet bites and artisanal brews. The conversations flowed as freely as the ideas, each interaction a potential seed for the next big thing in AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Spotlight on Cool Peeps and Projects</strong>: Our community is a network of networks, and many inspiring individuals and projects took the mic that night:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA _shyang</a></strong> kicked off the event with some fresh beatboxing and announced his upcoming talk at Sean Flanagan&#8217;s Playshop.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b9db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b9db" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6254" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://folioyvr.com/2024/06/ritchie-po-cybersecurity-data-privacy-lawyer/">Richie from Open Rep AI</a></strong> spoke about <a href="https://lu.ma/AIMastery">Anthony Green&#8217;s AI mastery series</a>, followed by <a href="https://www.linkedin.com/in/anthonygreen00/?originalSubdomain=ca">Anthony</a> sharing his insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348c1b9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348c1b9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6255" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Soham</strong>, a <a href="https://www.socratica.info/">Socratica</a> guy and <a href="https://www.atelier.ac/">Vancouver Atelier</a> founder, invited attendees to join the Atelier community.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348cb1e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348cb1e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6257" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://alexandrasamuel.com/">Alexandra Samuel</a></strong>, a famous writer and business thought leader, entertained us with funny and embarrassing stories of our friendship.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d1f2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d1f2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6258" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> from <a href="https://thecofoundershub.com/">Co-Founders Hub</a></strong> introduced her event, &#8216;<a href="https://lu.ma/meetyourcofoundervancouver">Meet Your Co-Founder</a>,&#8217; and discussed the upcoming sticker swap at the July AI meetup.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d9c5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d9c5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6259" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="http://kushalgoenka.com/">Kushal Goenka</a></strong>, an open-source AI advocate and engineer, shared his latest projects and insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e1f6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e1f6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6260" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.linkedin.com/in/kenny-macintyre-6872973/"><strong>Kenny Mack Truck</strong> </a>from the <a href="https://www.thebandits.ca/">Vancouver Bandits basketball team</a>, discussed his experience in the CEO AI workshop and creative work he&#8217;s doing in marketing.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e9dc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e9dc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6261" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/yangos/">Yangos Hadjiyannis</a></strong>, a big deal at <a href="https://www.siggraph.org/">SIGGRAPH</a>, talked about his AR/VR spatial video lab.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348f197&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348f197" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6262" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/prajwal-prashanth?miniProfileUrn=urn%3Ali%3Afs_miniProfile%3AACoAAEFdpdgBPffN7ej93MUm1IxgjQd72MT7peE">Prajwal Prashanth</a></strong> gave a talk about his <a href="https://www.youtube.com/watch?v=gBFboapI-Ew">Jarvis AI assistant</a> and about <a href="https://www.tks.world/">The Knowledge Society (TKS)</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348fa2d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348fa2d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6263" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kevinjosethomas/">Kevin Thomas</a></strong> Kevin featuring AI sign language interpreter he&#8217;s gonna demo in July.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3490175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3490175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6264" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://aydenlum.com/"><strong>Ayden</strong> <strong>Lum</strong></a>, an Atelier co-op participant, introduced himself and shared the workshops and <a href="https://insightful-future.beehiiv.com/">newsletters</a> he&#8217;s been involved with at Future Proof Creatives.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349085f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349085f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6265" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew Schwartzman</a></strong>, a high schooler, shared about his <a href="https://teen2life.podbean.com/">teen-focused podcast interviewing non-traditional successful entrepreneurs</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349101a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349101a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6266" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/donaldjewkes/">Donald Jukes</a></strong> discussed the <a href="https://kriskrug.co/2024/07/01/a-love-letter-to-vancouver-minimal-viable-demos/">Minimal Viable Demos event</a> and its blend of art, technology, science, and humanity.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6267" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kennedy-ed/">Ed Kennedy</a> from <a href="https://rundiffusion.com/">Run Diffusion</a></strong> explained cloud AI tools and their applications for creative professionals.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491e3f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491e3f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="618" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&#038;ssl=1" alt="" class="wp-image-6272" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=300%2C181&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=768%2C463&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1536%2C926&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://patrickpennefather.com/">Dr. Patrick Parra Pennefather</a></strong> engaged the crowd with intros and improv and general hilarious commentary.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492568&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492568" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-6277" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Screenshot</figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://thebusinessofyou.com/">Sian Flanagan</a></strong> shared insights from her book, performed a couple amazing original songs and announced her <a href="https://lu.ma/user/usr-1zfxAodTD8gqbh6">multi-passionate entrepreneur play shop</a>.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6274" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Jay David Milroy</strong>: &#8220;Love the mix of art and engineering. Love how you lift up others. I hope to try and find a way to participate and contribute.&#8221; Jay, your observation reflects the essence of what we&#8217;re trying to achieve &#8211; a blend of technical innovation and creative expression.</li>
+
+
+
+<li><strong>Darren Nicholls</strong>: &#8220;This is one of my favorite networking events.&#8221; Darren, it&#8217;s connections like these that drive innovation forward.</li>
+
+
+
+<li><strong>Yangos </strong><strong>Hadjiyannis</strong>: &#8220;Beautiful, authentic and meaningful event. Thank you Kris!&#8221; Authenticity and meaning are at the core of what we do, Yangos. Glad it resonated.</li>
+
+
+
+<li><strong>Wanda Halpert</strong>: &#8220;This was an excellent meetup that had people of all ages and background in AI discussing their progress and uses of this emerging tech.&#8221; Wanda, you&#8217;ve highlighted the strength of our diverse community. It&#8217;s this variety of perspectives that enriches our understanding of AI&#8217;s potential.</li>
+
+
+
+<li><strong>Ed Kennedy</strong>: &#8220;Fantastic event! Half lab/half party! Great speakers, great experiments, great networking. Always a pleasure!&#8221; Ed, you&#8217;ve nailed our approach &#8211; serious work in a fun, collaborative atmosphere.</li>
+
+
+
+<li><strong>Joe Leano</strong>: &#8220;My first event.. what an amazing experience. Everyone there had such amazing ideas. Amplified my creativity and looking to come back to next event.&#8221; Joe, welcome to the community. Your fresh perspective is invaluable as we continue to grow and evolve.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492d93&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492d93" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6275" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Huge thanks to <a href="https://www.peterholst.com/">Peter Holst</a> and <a href="https://www.viktorserbin.com/">Viktor Serbin</a> for documenting the event. Revisit the evening here: <a href="https://www.flickr.com/photos/kk/albums/72177720309491900">Photo Gallery</a> <a href="https://vimeo.com/showcase/vancouverai">Recap Video</a></p>
+
+
+
+<p class="wp-block-paragraph">And a heartfelt thank you to our sponsors and partners who make this possible: <a href="https://www.holistichybrid.com/">Holistic Hybrid</a>, <a href="https://www.augxlabs.com/">AugXLabs</a>, <a href="https://metacreation.net/">Metacreation Lab at SFU</a>, <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>, <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a>, <a href="https://internetmasterminds.com/">Internet Masterminds</a>, <a href="https://www.fatalfest.com/">The FATALE Festival</a>, <a href="https://www.sonsofvancouver.com/">Sons of Vancouver</a>, <a href="https://vlacc.ca/">VLACC</a>, and <a href="https://www.taylightbrewing.com/">Taylight Brewing</a>.</p>
+
+
+
+<h2 class="wp-block-heading">July 25th: Exploring Local-First AI in a Global Context (Now with Sticker Swap!)</h2>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3vbh2iIkl8jAl9O/simple" width="600" height="700" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our next meetup aligns with <a href="https://lu.ma/LOCALHOST_vancouver">LOCALHOST week</a> and <a href="https://www.ietf.org/how/meetings/120/">IETF 120</a>, offering a unique opportunity to explore AI through the lens of decentralized technologies. Here&#8217;s what we&#8217;re diving into:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Decentralized AI</strong>: We&#8217;ll examine how open-source, decentralized web technologies are reshaping AI development and deployment.</li>
+
+
+
+<li><strong>Applied AI</strong>: Through live demos, we&#8217;ll showcase real-world applications of AI across various industries.</li>
+
+
+
+<li><strong>Ethical Considerations</strong>: We&#8217;ll continue our ongoing discussion about the ethical implications of AI as it becomes more integrated into our daily lives.</li>
+
+
+
+<li><strong>Local Innovation</strong>: As part of our &#8216;Localhost&#8217; theme, we&#8217;re spotlighting Vancouver&#8217;s contributions to the global AI landscape.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="292" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&#038;ssl=1" alt="" class="wp-image-6276" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=300%2C86&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=768%2C219&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1536%2C439&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=2048%2C585&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<h3 class="wp-block-heading">NEW: AI Sticker Swap!</h3>
+
+
+
+<p class="wp-block-paragraph">Get ready for a fun addition to our meetup &#8211; a sticker swap! We&#8217;re inviting all attendees to create and bring stickers to share and trade. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493666&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493666" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6281" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">These don&#8217;t have to be AI-themed; they can represent your personal brand, a project you&#8217;re working on, your company, or any idea you&#8217;d like to share. It&#8217;s a great way to network, showcase your interests, and add some personality to your gear.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493cb9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493cb9" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="452" height="434" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=452%2C434&#038;ssl=1" alt="" class="wp-image-6282" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?w=452&amp;ssl=1 452w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=300%2C288&amp;ssl=1 300w" sizes="auto, (max-width: 452px) 100vw, 452px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;ll be bringing a variety of tech and AI stickers to kick things off, but we want to see what you&#8217;ve got too! Whether you&#8217;re designing new stickers or bringing your existing collection, come prepared to swap. It&#8217;s a casual, fun way to break the ice and learn about what others in our community are passionate about. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3494312&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3494312" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6284" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">So get creative, bring what you have, and let&#8217;s see what kind of unique sticker collections we can create together!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34948f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34948f5" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="382" height="452" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=382%2C452&#038;ssl=1" alt="" class="wp-image-6283" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?w=382&amp;ssl=1 382w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=254%2C300&amp;ssl=1 254w" sizes="auto, (max-width: 382px) 100vw, 382px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Key elements of the evening:</h3>
+
+
+
+<ol class="wp-block-list">
+<li>Presentations on AI and decentralized web synergies</li>
+
+
+
+<li>Interactive sessions exploring industry-specific AI applications</li>
+
+
+
+<li>Networking opportunities with local tech leaders and innovators</li>
+
+
+
+<li>Sticker Swap: A fun, informal way to share our AI passions</li>
+
+
+
+<li>Local AI Showcase: Celebrating Vancouver&#8217;s homegrown AI innovations</li>
+</ol>
+
+
+
+<p class="wp-block-paragraph">This event is part of LOCALHOST week, culminating in the <a href="https://ournetworks.ca/">Our Networks conference</a> on July 27th. We&#8217;re exploring how local-first tech can empower communities and reshape our digital interactions.</p>
+
+
+
+<p class="wp-block-paragraph">To our IETF 120 participants: We extend a warm invitation to join us and experience Vancouver&#8217;s vibrant AI community firsthand.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Our goal remains constant: <em>to foster a community that drives innovation, shares knowledge, and thoughtfully considers the real-world applications and ethical implications of AI. Whether you&#8217;re deep in the trenches of research, driving business innovation, exploring artistic applications, or simply curious about AI&#8217;s potential, you have a place here.</em></p>
+
+
+
+<p class="wp-block-paragraph">Join us on July 25th as we continue to explore and shape the future of AI, rooted in our local community but with a global perspective.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.meetup.com/vancouver-ai-meetup/events/">Register Now</a></p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to another evening of insight, innovation, and meaningful connections.</p>
+
+
+
+<p class="wp-block-paragraph">Stay curious and keep pushing boundaries,</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/">Kris Krüg</a><br />CEO, <a href="https://futureproofcreatives.com/">Future Proof Creatives</a><br />Host, <a href="https://lu.ma/future-proof">Vancouver AI Community Meetups</a></p>
+
+
+
+<p class="wp-block-paragraph">The live dates live <a href="https://kriskrug.co/events/">where the next one lands</a>.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">Vancouver AI Community Meetup Recap: June 2024 at Future Proof Creatives Studio</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-6815-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-6815-content.raw.html
@@ -1,0 +1,954 @@
+
+<p class="wp-block-paragraph">On August 29th, the <a href="https://futureproofcreatives.com/">Future Proof Creatives</a> studio at the <a href="https://www.vancouverbiennale.com/about-us/the-organization/">Vancouver Biennale Community Art Space</a> transformed into a crucible of ideas where technology, art, and community collided to create something truly special. </p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">Before we dive in, check out our gallery of nearly 500 high-resolution images from the Vancouver AI Community Meetup—ready for you to download and enjoy <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">right here</a>: <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">https://diamondsedgephotography.pixieset.com/aimeet-upaugust/</a></p>
+</blockquote>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="571" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&#038;ssl=1" alt="" class="wp-image-6857" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=768%2C428&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1536%2C857&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=2048%2C1142&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph">The atmosphere at 290 W 3rd Ave, Vancouver, was electric, with a diverse crowd of innovators, creators, and dreamers all eager to push the boundaries of what’s possible with AI. </p>
+
+
+
+<figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
+<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:500px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a></div></blockquote><script async src="//platform.instagram.com/en_US/embeds.js"></script>
+</div><figcaption class="wp-element-caption">Video by Viktor Serbin.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This gathering wasn’t your typical meetup; it was an assembly of minds ready to disrupt, create, and collaborate. The next <a href="https://lu.ma/AI-meetup">Vancovuer AI Community Meetup</a> is September 26th and <a href="https://lu.ma/AI-meetup">earlyworm tickets</a> are now available. 🙂</p>
+
+
+
+<p class="has-text-align-center wp-block-paragraph"><a href="https://lu.ma/event/evt-6VeJQM5kfFnNUmn" class="luma-checkout--button" data-luma-action="checkout" data-luma-event-id="evt-6VeJQM5kfFnNUmn">
+  Register for Event
+</a>
+
+<script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34095f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34095f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="579" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&#038;ssl=1" alt="" class="wp-image-6816" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=300%2C170&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=768%2C434&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?w=1220&amp;ssl=1 1220w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancovuer AI Meetup &#8211; photo by Juliana Loh</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="http://stevebroback.com/about/">Steve Broback</a> wrote of the Vancouver AI Community Meetups “one of the best events I’ve attended in the last 12 months… I met many creative, smart, and positive humans with a passion for AI there.” That’s exactly the energy we aim to cultivate—bringing together brilliant minds to share, inspire, and push the boundaries of what’s possible.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>The Power of Community: We’re Just Getting Started</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.joshuamichie.com/">Joshua Michie</a> said it perfect when he said, “We&#8217;re building something special with Vancouver AI meetups… What strikes me most is that everyone that attends is looking to make something cool in the city and are actively looking for co-collaborators.”</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3409ed5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3409ed5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6817" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Little Woo &amp; Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">That’s what this meetup was all about—bringing together a diverse mix of people from business, design, art, politics, activism, and beyond. Each person brought their unique energy, creating an environment centered on making meaningful connections and building something bigger than ourselves.</p>
+
+
+
+<p class="wp-block-paragraph">This eclectic mix of attendees, from seasoned professionals to curious newcomers, generated an atmosphere charged with deep, thoughtful conversations about AI’s potential and applications. Every interaction sparked new ideas and possibilities for collaboration, setting the stage for future innovations.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340a67b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340a67b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6818" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Prajwal Prashanth, A Visionary in the Making</strong></h3>
+
+
+
+<p class="wp-block-paragraph">One of the night’s highlights was undoubtedly the presentation by <a href="https://prajwal.is-a.dev/">Prajwal Prashanth, </a>a soon-to-be high school senior who stunned the audience with his groundbreaking innovation. Prajwal took the stage with an <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">AI-powered personal assistant complete with hearing and vision</a> embedded in his palm—technology with the potential to change lives, particularly for the visually impaired.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340ada5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340ada5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6819" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Showing Jarvis2 at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As he demonstrated how the device could “see” and interpret the world around it, translating visual inputs into words, the audience was captivated. “There is a crowd of people standing in front of me and a woman sitting on a chair,” the AI announced, and the room erupted in applause. This young innovator’s work illustrates the power of AI when harnessed with creativity and a clear purpose.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340b554&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340b554" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6820" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?w=1706&amp;ssl=1 1706w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s vision is to further develop this technology as a medical aid for the visually impaired, transforming it into an intuitive, wearable AI companion that can narrate the world in real-time. His technical prowess and forward-thinking approach serve as a reminder that the future of AI lies in the hands of bright young innovators ready to make a difference.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ed Kennedy’s Radical Exploration: Circuit Bending and Beyond</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/edwerk/">Ed Kennedy</a> brought a different kind of energy to the evening with his talk on circuit bending—a practice involving the modification of old electronics, toys, and musical instruments to create chaotic, otherworldly sounds. By manipulating these devices, Ed bends the very fabric of reality, creating entirely new experiences from the discarded and overlooked.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340c85d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340c85d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy Circuit Bending at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“Experiment often and early,” Ed urged. “This is a brand new space where anyone can make a key breakthrough.” His insights into data bending, where mediums like image files or CDs are creatively altered in their interpretation, expanded our understanding of the endless possibilities available when creativity and non-linear thinking intersect.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340d791&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340d791" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Glitch Art by Ed Kennedy at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed’s work challenges conventional approaches to technology and creativity, pushing us all to rethink how we engage with the digital world. His explorations serve as a powerful reminder that embracing chaos can lead to groundbreaking discoveries. Reminds me of the work <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and I are doing with <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">AI Model Bending in Autolume</a> remixing GAN AI models trained on my photography with that of other artists resulting in wild glitchart via the <a href="https://www.metacreation.net/autolume">neural visual synthesizer</a> at <a href="https://www.metacreation.net/">Metacreation Lab</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e014&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e014" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy, Kris Krüg and Alexis Smith at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ashley Conery’s CubeCommons: Rethinking Digital Interaction</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Ashley Conery added a reflective, yet revolutionary element to the evening with her presentation on <a href="https://aconery.wixsite.com/cube">CubeCommons</a>—a project that explores the intersection of post-colonial principles and digital commons. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe src="https://cubecommons.ca/embedPlaylist/87eb0e60-f83e-4492-a31d-fd40a5cd6e76" style="width:100%; height:100%;" frameborder="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://cubecommons.ca/profile/FutureProof/">CubeCommons</a> is more than a tech initiative; it’s a call to rethink our digital interactions as we transition to a future where spatial computing will redefine our online experiences.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e933&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e933" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“I was really moved by how folks shared their art and their learnings,” Ashley said. Her project challenges us to consider the ethical implications of our digital footprints and the spaces we create online. CubeCommons is about using digital platforms to foster real, meaningful connections, guided by principles of equity and inclusion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f120&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f120" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we build the future, Ashley’s project reminds us of the importance of ensuring that the digital world reflects the values of the communities it serves. Her insights push us to think critically about how we can create online spaces that are innovative, just, and inclusive.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Dean Shev on AI in Healthcare: A Call for Innovation</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/deanshev/?originalSubdomain=ca">Dean Shev </a>of <a href="https://www.fraserhealth.ca/">Fraser Valley Health Authority</a> directed the conversation towards the healthcare sector, highlighting the critical need for innovation in this field. Canada is facing a potential healthcare crisis by 2045, and the urgency to find multi-dimensional solutions is clear. Dean’s mission is to ignite groundbreaking innovation in healthcare, using AI as a catalyst for transformative change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f9e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f9e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">During the meetup, Dean connected the story of our resident young innovator—Prajwal, whose work he sees as a beacon of hope for the future of medical devices. However, Dean also underscored the challenges that lie ahead. “Systemic barriers in healthcare—bureaucracy, risk-averse culture, and financial constraints—often stifle innovation,” he warned.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34101a8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34101a8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6828" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Dean called for systemic changes, emphasizing the need for leadership that champions experimentation and provides resources for pilot programs and innovation labs. His message was clear: the future of healthcare depends on our ability to innovate now, to dismantle the barriers holding us back, and to fully harness the potential of AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Visual Highlights: Reflecting the Soul of the Meetup</h3>
+
+
+
+<p class="wp-block-paragraph">This evening wasn’t just a series of talks and demos—it was a sensory dive into the intersection of art, technology, and raw human creativity. <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a>’s spoken word piece explored the tangled future of brains, communities, and relationships, leaving the room charged with a new kind of electricity. Her performance reminded us that the future of AI isn’t just about tech; it’s about the emotional layers we bring to it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3410a2f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3410a2f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6829" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night’s rhythm was set by <a href="https://kevinfriel.com/">Kevin Friel</a> aka <a href="https://www.youtube.com/channel/UCTMySf7JbGMGUPt5-YQim8Q">Mr. Pixel Wizard’s</a> AI DMX lighting kit, which transformed the space into something alive. <a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu</a> AKA <a href="https://www.instagram.com/_shyang/">Shyang</a>, the West Coast beatboxer, laid down rhythms that felt like they were bending reality. </p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/mother.ofthevoid/">Holy Mother of the Void</a> merged house performance art with lessons on embodiment, pushing us to rethink the boundaries between the physical and the digital. <a href="https://www.instagram.com/sachagabriel/">Sacha Gabriel</a> closed out the night, spinning tracks that kept the energy flowing and the conversations going. This wasn’t just a showcase—it was a lived experience where sound, light, and AI met and mingled.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34112a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34112a0" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6830" style="width:600px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kevin Friel aka Mr. Pixel Wizard at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Badass people photographer <a href="https://www.instagram.com/DiamondsEdgePhotography/">Michelle Diamond</a> was there, sharing the essence of it all through her lens, while Victor Serbin filmed the night, turning moments into a visual story we can revisit. These photos and videos&#8230;. they’re pieces of our shared experience. If you’ve got photos, videos, or audio from the night, we’d love for you to share them with us. Add them to the <a href="https://www.notion.so/Vancouver-AI-Community-Meetup-Recap-August-29th-A-Night-of-Innovation-Connection-and-Future-For-358ab278f1c94f9992ccea77aaf2da02?pvs=21">Google album link</a>. These are our community story and pls feel free to use them and share them. 🙂</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3411a1a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3411a1a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6831" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jackson Wu aka SHYANGDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more media to drop soon, and in the meantime, spread the word. Bring your stories, bring your friends. We’re building something real, together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412162&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412162" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6832" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">DJ Sacha Gabriel Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="https://www.linkedin.com/in/chrisgranthall/">Chris Hall</a> said, “Wonderful event hosted by Kris Krüg and the team at Vancouver AI. Introduced to some innovative AI artists and enjoyed some great conversations on the topic of AI and how it is changing everything with new acquaintances.” For those who missed it, we’ve put together a <a href="https://youtube.com/shorts/suWVtA964ts?feature=share">video recap that you can check out here</a>. It’s not just a highlight reel; it’s a glimpse into what happens when a community comes together to push the boundaries of AI.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412986&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412986" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6833" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Orbit Princess aka Holy Mother of the Void at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Looking Ahead: September 26th Meetup &#8211; Join the Revolution</strong></h3>
+
+
+
+<p class="wp-block-paragraph">If you thought August’s meetup was something special, <a href="https://lu.ma/AI-meetup">just wait until September 26th</a>. We’re gearing up for even more mind-bending demos, talks that will challenge your understanding of AI, and of course, the same incredible community vibe that makes these meetups so unique.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-6VeJQM5kfFnNUmn/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Grab your tickets now:</p>
+
+
+
+<ul class="wp-block-list">
+<li>Early Bird (CA$35): For the quick-draw innovators. Limited spots, so move fast.</li>
+
+
+
+<li>Standard (CA$50): Full access, full experience. Fuel for body and mind included.</li>
+
+
+
+<li>Pay-it-forward (CA$100): Supercharge the collective. Your contribution opens doors for others.</li>
+
+
+
+<li></li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3413799&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3413799" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6835" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Community VibesDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>AI Trainings for Creatives: Elevate Your Skills</strong></h3>
+
+
+
+<p class="wp-block-paragraph">For those of you looking to level up your AI game, we’ve got you covered. Our <a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">AI Upgrade for Creative Professionals</a> will take you from zero to hero, giving you the tools to thrive in this brave new world. </p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="797" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&#038;ssl=1" alt="" class="wp-image-6856" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=300%2C233&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=768%2C598&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">The AI Upgrade for Creative Pros by Kris Krüg &amp; Peter Bittner</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">We’re talking cutting-edge, hands-on learning that’ll have you speaking fluent AI in no time.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Wrapping Up with Gratitude</strong></h3>
+
+
+
+<p class="wp-block-paragraph">A huge shoutout to <strong><a href="https://www.instagram.com/jessicaliangx/?hl=en">Jessica Liang</a> </strong>from<strong> </strong><a href="https://www.ilovenook.co/"><strong>Nook</strong> Coworking</a> for sharing insights on community and coworking, and for inviting us to her upcoming party—looking forward to it!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34142a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34142a0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6836" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jessica Liang of Nook Coworking at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Big thanks to the <strong>volunteer <a href="https://www.linkedin.com/in/lawrence-okolo-a062a2146/">Lawerence</a> &amp;  from Northeastern University</strong> who helped keep everything on track.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3414bac&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3414bac" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6837" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/aminishere/">Amin Sharifi</a> and Anita from <a href="https://www.enyalearning.ca/">Enya Learning</a></strong>—it’s an honor to keynote at your <a href="https://lu.ma/ons70lj3?tk=w8tLDe">Creative Technology Night</a> at the <a href="https://www.sfu.ca/dialogue.html">Wosk Center for Dialogue</a> this week.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34154d3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34154d3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6838" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita and Amin of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Matt Jones</strong>, from the <a href="https://techcouver.com/2024/08/20/bitcoin-block-party-vancouver/">Bitcoin Block Party</a> brought the <a href="https://www.instagram.com/sexyboysandgirlsclub/">Sexy Boys and Girls Club</a> fashion line to add some style to our event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3415db6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3415db6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6839" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Matt of Sexy Boys &amp; Girls Club at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/kassandra-m-linklater/">Kassandra Linklater</a></strong> and her mom, along with her mom’s best friend, two tech-savvy women in their 80s, brought a wealth of experience and culture.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416676&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416676" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6840" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"> Vancouver AI Community &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Cheers to <strong><a href="https://www.salesacademy.ca/shane-gibson-sales-trainer/">Shane Gibson</a>, </strong>AI sales guru, and performance artist<strong> <a href="https://littlewoo.org/">Little Woo</a></strong> for their unique perspectives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416efd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416efd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6841" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AI Sales Leader Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/pka3300/">Prashant Agrawal (Mr. P)</a></strong>, thanks for introducing us to Be Pacific and opening up new opportunities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341762f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341762f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6842" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mr. P Prashant Agrawal at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="http://linkedin.com/in/colleen-kennedy-41430881">Colleen Kennedy</a></strong> represented <a href="https://cogsys.ubc.ca/">UBC Cognitive Sciences (COGS)</a> and excited to have more of ya join us…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3417eb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3417eb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6843" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Colleen Kenney of UBC COGS at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and <strong>Jul<a href="https://julianaloh.ca/">iana Loh</a></strong>, VR artist, your photos, videos, and knowledge were invaluable.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3418998&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3418998" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6844" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Juliana Loh at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://jjgmckenzie.ca/"><strong>James</strong> McKenzie</a>, your steadfast support from the beginning is much appreciated.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34190fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34190fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6845" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James &amp; KK  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/simon-haworth-uk-us-prc/">Simon Haworth</a></strong>, thanks for rallying the BC AI Life Sciences community with me.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34198c6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34198c6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6846" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Simon Haworth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.yangos.work/"><strong>Yangos Hadjiyannis</strong> </a>wrapped up SIGGRAPH with style at the VR lounge, and hilarious <a href="https://patrickpennefather.com/"><strong>Dr. Patrick Parra Pennefather</strong> </a> of <a href="https://eml.ubc.ca/">UBC Emerging Media Lab</a> brought critical insights from the <a href="https://www.nvidia.com/en-us/executive-insights/">NVIDIA AI ethics panel at SIGGRAPH 2024</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341a036&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341a036" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6847" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Yangos and Patrick Pennefather at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Kudos to <a href="https://kushalgoenka.com/"><strong>Kushal </strong>Goenka</a> for sharing your SIGGRAPH journey and open-source spirit and <a href="https://www.youtube.com/c/KushalGoenka">free AI Education Videos</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341aaa5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341aaa5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6848" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kushal Goenka at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/derrick-carter-338ba441/">Derek Carter</a> </strong>from<a href="https://www.thesawmill.ca/"> Sawmill Motion Capture Studio</a> welcomes us to come for a visit</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b1d5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b1d5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6853" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Derek Carter of Sawmill Studios  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://yagudaev.com/about/"><strong>Michael Yagudev</strong></a> is our very own <a href="https://levelsio.com/">Vancouver AI Pieter Levels</a> your <a href="http://AudioWaveAI.com">AudioWaveAI.com</a> tool is an entrepreneurial inspiration.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b911&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b911" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6850" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Yagudev of AudioWave AI at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to <strong><a href="https://www.linkedin.com/in/rozmcnulty/">Roz McNulty</a></strong> of <a href="https://www.fashionic.ca/roz">Fashion Innovation Centre</a> for managing the door, registration, and signs…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341c053&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341c053" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6851" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI volunteer Roz McNaulty at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and to <strong><a href="https://www.mattcarolan.com/">Matt Carolan</a></strong> from <a href="https://aws.amazon.com/events/community-day/?developer-center-activities-cards.sort-by=item.additionalFields.startDateTime&amp;developer-center-activities-cards.sort-order=asc">AWS Community Days</a>—your Aussie magic lit up the event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d093&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d093" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6852" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AWS Community Days Organizer Matt Carolan at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Also, gratitude to <strong><a href="https://www.linkedin.com/in/jeffreyrclark/">Jeff Clark</a></strong> of <a href="https://favoland.com/">Favoland</a> for guiding attendees and being the friendly face at the entrance.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d827&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d827" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6854" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Favoland CEO Jeff Clark at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks to everyone who contributed to making this meetup unforgettable. Until next time!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341df69&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341df69" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6855" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void and KK at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Related:</strong> More local ecosystem notes live in my <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI community</a> hub. Live dates sit on <a href="https://kriskrug.co/events/">the current calendar</a>.</p>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-8418-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-8418-content.raw.html
@@ -1,0 +1,894 @@
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">The planetarium projector died halfway through <a href="https://en.wikipedia.org/wiki/Judy_Illes">Judy Illes&#8217;</a> neuroscience presentation. Perfect metaphor for where we stand with AI – bleeding-edge tech colliding with the mundane reality of blown bulbs. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/0_Bz1Zk-MSk?si=PacgDplOctJaV_YO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">One minute we&#8217;re exploring brain-computer interfaces that might decode consciousness; the next, we&#8217;re fumbling in the dark. That&#8217;s the beautiful paradox of <a href="https://vancouver.bc-ai.net/" data-type="link" data-id="https://vancouver.bc-ai.net/">our Vancouver AI community</a> – simultaneously reaching for the stars while keeping our feet planted in what makes us human.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Dr. Illes, trailblazing neuroethicist, is Professor of Neurology at the University of British Columbia (UBC), Distinguished University Scholar, UBC Distinguished Scholar in Neuroethics, and Director of Neuroethics Canada: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Gathering of Tribes</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai14">Last week, our latest AI meetup</a> drew a kaleidoscope of minds to the <a href="https://www.spacecentre.ca/">H.R. MacMillan Space Centre</a>. The place once famous for Pink Floyd laser shows now hosts a different kind of mind expansion. We assembled beneath the dome – data scientists sharing oxygen with artists, academics rubbing elbows with entrepreneurs, indigenous knowledge-keepers conversing with tech founders.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33735f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33735f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8459" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This wasn&#8217;t just another tech meetup with sanitized pitches and <a href="https://www.linkedin.com/in/kriskrug/">LinkedIn QR code exchanges</a>. This was humans wrestling with what it means to be human at the threshold of exponential change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3373d43&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3373d43" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8458" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kris Krüg, Host of Vancouver AI &amp; CEO of <a href="https://theupgrade.ai/">TheUpgrade.ai</a>: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/ceowarren/">Catherine Warren</a>, whose ear is bent by government decision-makers worldwide, took the mic to share her work with Ray, crafting an ethical economy where content creators actually get paid when AI learns from their work. Revolutionary concept, I know – actually compensating people for their intellectual labor instead of just scraping it.</p>
+
+
+
+<p class="wp-block-paragraph">&#8220;We are creating an ethical economy where rights holders can, for the first time, be paid for content training AI systems,&#8221; she explained, cutting through the usual rhetoric about AI with the precision of someone who&#8217;s been navigating digital transformations for decades. Next week, she&#8217;s off to New Zealand to consult with their government on creative and innovation economies – taking our community&#8217;s vision global and hopefully connecting with <a href="https://kriskrug.co/2024/12/28/system-check-vancouver-ai-community-meetups-december/">Peter Lucas Jones who shared with us at the NeurIPS Meetup</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/_I7DZNRF7HI?si=sAPe1XDW6oQASPzL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Philosophers Among Us</h2>
+
+
+
+<p class="wp-block-paragraph">The night opened with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila&#8217;s</a> haunting poem exploring the teleportation paradox – if you&#8217;re atomized and recreated elsewhere, are you still you? What if the machine malfunctions and now there are two of you? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337453d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337453d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8437" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI teleportation &#8211;chaos 20 &#8211;ar 16:9 &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 95c56c6b-fc91-4bdd-9d0f-dec82103ff5c</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words echoed through the <a href="https://www.spacecentre.ca/">Space Centre</a>:</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I inhale, and so do I. Too soon, too late, a staggered echo, a misfire, a step forward, a step back, waiting for myself to follow.&#8221;</p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33755cc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33755cc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI two roads diverged &#8211;chaos 20 &#8211;ar 16:9 &#8211;profile 363tw3z &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 744e7345-e8c7-4732-90dd-9f88afa8701d</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s been riding the digital wave since the late &#8217;90s, this hit home. Are we just becoming copies of ourselves as we upload our consciousness to these new systems? When I use AI to help me write, is that me or some shadow version of myself?</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/zenmindhacker/">Cian Whalley</a>, equally comfortable in the worlds of tech and spiritual practice as <a href="https://www.cognitivetech.net/">CTO at Cognitive Technology</a> and a Zen Buddhist priest, showcased <a href="https://thoughtcoder.com/">Digital Buddha</a> – an AI spiritual mentor trained on Buddhism, Kabbalah, and Hermetics. &#8220;It has been trained not to try to solve your problem as quickly as possible,&#8221; he explained with the wry smile of someone who knows that&#8217;s not how wisdom works.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3375c37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3375c37" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="1000" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=750%2C1000&#038;ssl=1" alt="" class="wp-image-8441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=225%2C300&amp;ssl=1 225w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The program reflects something I&#8217;ve been exploring personally – using AI not just for task completion but for introspection, <a href="https://spektor.ai/">recording voice memos about my dreams and anxieties, then using AI to analyze patterns and provide new perspectives</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="267" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&#038;ssl=1" alt="" class="wp-image-8446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=768%2C200&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?w=1298&amp;ssl=1 1298w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Builders of New Realities</h2>
+
+
+
+<p class="wp-block-paragraph">The demos showcased the raw creativity bursting from our community. Sev Geraskin, always provocative in the best way, presented <a href="https://www.wiserbotics.com/">Wiserbotics – an emotional model aimed at &#8220;solving the problem of scarcity of empathy in the world.&#8221;</a> Some might dismiss this as techno-optimism, but I&#8217;ve seen enough dystopian scenarios to welcome someone trying to increase empathy rather than engagement metrics.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33764f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33764f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8442" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Another soldout fullhouse for February 2025 edition of Vancouver AI community meetups: <a href="http://contentco.ca/">Photography by Michelle Damond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://extndly.com/">Ed Kennedy, fresh from quitting his corporate job to focus on his startup</a>, explained control vectors for language models – a way to guide AI outputs without brute-force prompting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3376b6f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3376b6f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8460" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;It&#8217;s saying &#8216;no, only talk from this area,'&#8221; he explained, showing how fine-tuned control could make interactions with AI more nuanced and meaningful. His art project &#8220;Latent Sculptures&#8221; explores the infinite possibilities of open-source AI-generated art, transforming structured inputs into endless visual narratives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33771fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33771fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-8447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?w=864&amp;ssl=1 864w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.deanshev.com/">Dean Shev</a> and his healthcare team at <a href="https://vht.ai/">VHT.ai</a> showcased their work with <a href="https://lnkd.in/gJmwhV-i">Northeastern University</a>, developing an AI model built with ethics at its core, designed to help physicians better interpret clinical data and create personalized treatment journeys.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://pacific.film/">Michael Tippett of Pacific Film</a>, whom I&#8217;ve known for over two decades, presented his <a href="https://www.youtube.com/@MrCanadaToday">delightfully subversive &#8220;Mr. Canada&#8221; AI filmmaking project</a> – an absurdist character interacting with deepfaked politicians to explore Canadian identity. What struck me was his approach to <a href="https://kriskrug.co/2023/10/21/ai-art-changes-in-animation-special-effects-film-games-the-creative-industries/?utm_source=chatgpt.com">AI filmmaking as an iterative process</a>, much like agile software development, where you discover the story as you go.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/WKrRDT1D_rU?si=L9SU5AjG_sUufHUn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">&#8220;I don&#8217;t really know where I&#8217;m going when I start,&#8221; Michael admitted. &#8220;AI filmmaking is like software development – it&#8217;s iterative.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3377939&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3377939" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8468" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA Shyang showed up and <em>synced</em> with the room</a>. Beatboxing that controlled the lights, flipping raw sound into an interface. No FX, no backing track—just pure analog human signal bending digital systems to its will. Beyond that, he’s a public speaking coach, teaching people to wield their voice like a weapon. AI can generate words, but it can’t <em>command a room</em> like this.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Wisdom Keepers</h2>
+
+
+
+<p class="wp-block-paragraph">The night&#8217;s keynote came from J<a href="https://neuroethics.med.ubc.ca/">udy Illes, Distinguished Professor at UBC specializing in Neuroethics</a>. Despite our failing projector, she delivered a masterclass on responsibility and humility in the face of technological possibility.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3378103&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3378103" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="388" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&#038;ssl=1" alt="" class="wp-image-8452" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=300%2C114&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=768%2C291&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1536%2C582&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=2048%2C776&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes Neuroethics keynote at Vancouver AI February 2025 community meetup: Photography by Michelle Diamond</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;With possibility comes humility,&#8221; she reminded us, walking through the 4,000-year history of humans trying to understand the brain – from Sumerians noticing the effects of poppy plants to today&#8217;s AI-powered brain-computer interfaces.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8450" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Kevin Friel AKA Mr Pixel Wizard is a highly creative, highly technical, fun to work with AV Master: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words on humility struck a chord: &#8220;It&#8217;s thinking about and learning from lessons of the past, scrutinizing authentically and with passion your design, promising to the limits of promise and not over-sensationalizing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337891f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337891f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8449" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s witnessed multiple technological revolutions, I can testify to how rare and precious this kind of humility is. Technologies come and go, but wisdom accumulates if we&#8217;re paying attention.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8453" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">After Judy, Jackson Wu (aka SHYANG) broke the intellectual tension with mind-blowing beatboxing, controlling the room&#8217;s light show with his vocal percussion – a perfect illustration of the analog human interfacing with digital systems. Beyond his performance art, he&#8217;s also a public speaking coach helping others find their voice.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379864&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379864" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8451" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Future We&#8217;re Building</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379fdd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379fdd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="529" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&#038;ssl=1" alt="" class="wp-image-8457" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=300%2C155&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=768%2C397&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1536%2C794&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=2048%2C1058&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.exponentialstudio.io/">Sissi Wang&#8217;s</a> passionate talk on conscious, exponential organizations framed our collective challenge: &#8220;We stand at extraordinary times with two mega trends – the rising of exponential technology and consciousness awakening.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337a80e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337a80e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sissi Wang Founder of Exponential Studios at Vancouver AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The former corporate rebel who led teams across 120 countries with IBM and Novartis walked us through how traditional organizational hierarchies are giving way to more fluid, network-based structures, and how AI can shift humans from &#8220;capacity units&#8221; to empowered creators: &#8220;What if AI could take away the 20-30% of your job you hate, what would you do with that elevated capacity?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b104&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b104" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8461" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This strikes at the heart of what I believe – that technology should free us to be more human, not less. I&#8217;ve been evangelizing this since my early days in the social media revolution, when I traveled the world showing creatives how to break free from traditional gatekeepers.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b988&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b988" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila launching the new Vancouver AI Datastorytelling Hackathon: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night culminated with the announcement of our <a href="https://hackathon.bc-ai.net/">$10,000 Vancouver AI Data Storytelling Hackathon</a>, funded by <a href="https://www.rivaltech.com/">Rival Technologies</a>. Four cycles, $2,500 prizes each, challenging our community to reinvent how we interpret and visualize data. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337d696&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337d696" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8428" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Step up and show off your AL/ML hacker ingenuity, creative coding chops, and data storytelling prowess in a no-holds-barred challenge that’s all about community, open-source maker culture, and real, tangible innovation.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The first challenge topic? Whether hot dogs are sandwiches. Because why not inject a little absurdist humor into our serious revolution? For anyone inspired to join, all the details live at <a href="https://www.rivaltech.com/">hackathon.bc-ai.net</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337deff&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337deff" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Using a custom dataset gathered with Rival Technologies’ market research tech, your mission is to transform raw numbers into an experience that’s interactive, visual, or narrative-driven. You decide how to make the data speak—whether that’s through a dynamic visualization, an engaging presentation, or even an unconventional performance powered by AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Ecosystem Emerges</h2>
+
+
+
+<p class="wp-block-paragraph">What I&#8217;m witnessing is an ecosystem forming in real-time. <a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew</a> and <a href="https://ryvconsulting.ca/About/">Ryv</a> announced they&#8217;re spinning off a <a href="https://lu.ma/sjjlwda1">Surrey AI Community Meetup</a> based on our model. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337e7db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337e7db" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8455" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">?Join Matthew Schwartzman &amp; Ryv at the Legion #8 Building on March 11th (6 PM – 9 PM) for an evening of thought-provoking AI discussions and net</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/anthonygreen00/">Anthony Green</a> (<a href="https://www.openrep.ai/">Co-Founder of OpenRep</a>, who appeared via video) and I are mapping Vancouver&#8217;s AI landscape, advocating for a BC AI Center that could secure government funding and infrastructure.</p>
+
+
+
+<figure class="wp-block-video"><video height="480" style="aspect-ratio: 848 / 480;" width="848" controls src="https://kriskrug.co/wp-content/uploads/2025/03/bb8b264b-8a7b-449e-a3ab-4967cec715d8.mp4"></video><figcaption class="wp-element-caption">Anthony Green, Founder of Openrep AI on Vancouver AI ecosystem.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m not naive about the challenges. As Anthony pointed out, we face a high cost of living driving talent south, gaps in venture funding (especially at pre-seed and late stages), and <a href="https://bc-ai.net/">no flagship AI institute despite our concentration of talent</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337f489&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337f489" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8423" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But I&#8217;ve been here before – at the dawn of web building in the late &#8217;90s, at the beginning of the social media revolution in 2004. I got lucky then; my timing and interests aligned as those technologies emerged. Now I feel the same buzz in the <a href="https://bc-ai.net/">emerging BC + Ai Ecosystem.</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.hornbyspark.com/">Quanna Parker</a> made the trek from Hornby Island—<strong>three ferries away</strong>—to be here, and his story is one of true grassroots AI exploration. Before most people had even heard of ChatGPT, Quanna was already building his own AI rig. Back in <em>summer 2022</em>, he was the first guy in my orbit to get GPUs up and running, training his own models <em>off-grid</em>, thinking about compute sovereignty before it was a buzzword.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337fe38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337fe38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8466" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But Quanna isn’t just another engineer—he’s a critical thinker, someone who <em>questions</em> the whole structure AI is being built on. He’s written a book, <strong>Thinking Critically in the Age of Artificial Intelligence</strong>, co-authored (with AI, of course), as an early exploration of what these tools mean for thought, authorship, and human creativity.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="338" height="522" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=338%2C522&#038;ssl=1" alt="" class="wp-image-8467" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?w=338&amp;ssl=1 338w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=194%2C300&amp;ssl=1 194w" sizes="auto, (max-width: 338px) 100vw, 338px" /></figure>
+
+
+
+<p class="wp-block-paragraph">Now? He’s working deep in the world of <strong>large language models and chat interfaces for one of the FANG companies</strong>, but still keeps his independent streak. He’s a reminder that you don’t need to be in San Francisco or New York to be ahead of the curve. You just need <strong>curiosity, a DIY spirit, and the willingness to experiment</strong>.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3380987&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3380987" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1021" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&#038;ssl=1" alt="" class="wp-image-8444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&amp;ssl=1 1021w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=768%2C770&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?w=1149&amp;ssl=1 1149w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">What makes this time different is that we&#8217;re not just creating new technologies – we&#8217;re creating new ways of being human. When <a href="https://www.linkedin.com/in/irwinoostindie/">Irwin Oostendie</a> of <a href="http://www.voor.ca/">Voor Urban Labs</a> talked about decolonizing public policy through technology and <a href="https://www.linkedin.com/in/deanshev/">Dean Shev</a> discussed <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> in healthcare they were talking about reshaping fundamental human relationships. </p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="qe1QwyfVGO"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson&#8217;s AI Sales Dojo</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Shane Gibson&#8217;s AI Sales Dojo&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/embed/#?secret=ZE1Ucq6CpH#?secret=qe1QwyfVGO" data-secret="qe1QwyfVGO" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson from The Professional Sales Academy</a> showed how AI tools can transform sales processes while still maintaining the human connection that makes sales work.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-8412" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=860%2C484&amp;ssl=1 860w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s why I&#8217;m here. That&#8217;s why we&#8217;re all here. Not just to ride the wave of the next tech boom, but to ensure that as these technologies reshape us, they do so in ways that amplify our humanity rather than diminish it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381467&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381467" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As the night ended and we cut the wedding cake for <a href="https://www.linkedin.com/in/jjgmckenzie/">James McKenzie</a>, I looked around the room at this community we&#8217;ve built – technologists and poets, scientists and mystics, all wrestling together with what comes next.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381cb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381cb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8422" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">None of this happens without our partners who fuel the revolution – <a href="https://segevllp.com/">SEGEV LLP</a> bringing legal expertise to the tech frontier, <a href="https://www.linkedin.com/in/dimitri-schwartzman-0ab8061/">Dimitri Schwartzman connecting real estate to community building</a>, <a href="https://www.youtube.com/@sonsofvancouver">Sons of Vancouver with their spirit of independent creativity</a>, and <a href="https://goodnessdistributors.com/">Goodness Distributors</a> spreading support through our ecosystem.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382453&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382453" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8462" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">From that Midjourney moment in November 2022 when AI first reached its tendrils into my brain, to now, hosting these gatherings of brilliant minds at the H.R. MacMillan Space Centre (once famous for Pink Floyd laser shows, now hosting a different kind of mind expansion), I&#8217;ve never felt more energized about our collective possibility. <a href="https://www.bc-ai.net/">The future isn&#8217;t something happening to us; it&#8217;s something we&#8217;re creating together, one community at a time</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382cc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382cc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8463" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">And yes, even when the projector dies mid-presentation, we keep going – because that&#8217;s what humans do. <a href="https://vancouver.bc-ai.net/">We adapt, we connect, we create meaning in the darkness</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai15">We&#8217;ll see you at the next one on March 26th</a>. <strong>The edge of tomorrow awaits, and it looks a lot like us.</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383523&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383523" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?w=1500&amp;ssl=1 1500w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383e07&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383e07" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8465" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">What are people saying?</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3384685&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3384685" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="710" height="176" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=710%2C176&#038;ssl=1" alt="" class="wp-image-8445" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?w=710&amp;ssl=1 710w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=300%2C74&amp;ssl=1 300w" sizes="auto, (max-width: 710px) 100vw, 710px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Great event, speakers were great, video documentation has been huge, love that I can catch up and share good talks. I miss the late nights of the old venue but it&#8217;s actually nice since it&#8217;s on a weekday that it ends a bit earlier. I&#8217;d like to see some rotation of the long time speakers, maybe bring on some new &#8220;residencies&#8221; of regular speakers and make a set time frame like 3-4 events for &#8220;regular&#8221; speakers/acts? Addition of non alcoholic drinks greatly appreciated. Another thing I miss from the events at the old loft is the feeling that anyone could show up with a laptop and show off their stuff, I notice that vibe is missing from the new venue because of all the organization with tables / signs. It would be neat if we had some more tables maybe in the food room or tables area that was designated as open tables for anyone to demo. Something that may help is a stronger web presence on it&#8217;s own domain with a more comprehensive website. vancouverai.buzz , vanai.community, vanai.club etc. Past video archives, descriptions of each event / speakers / luma links, Contest details, and big SPEAK AT OUR EVENT, DISPLAY YOUR WORK, SPONSOR US links, donations, etc. Seems to be missing, one place to go to for everything van AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Great networking and learning. My fourth event and every time the diversity of folks attending, the creativity the thought leadership shared by some amazing humans has blown me away.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hi Kris, Thanks for organizing such a valuable meetup tonight. I really appreciated Judy and Sissi&#8217;s presentations; I walked away with a lot of new knowledge. Your efforts in putting this event together were evident, and I&#8217;m excited for the next one.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hey Kris, great session tonight! Judy was awesome! I&#8217;d love to find an opportunity to collaborate. As you know, my focus is on AI as a productivity tool for small and medium sized businesses. Something I really value is that your community showcases topics outside of this focus. At the same time, that makes it hard to figure out opportunities to connect our work. You mentioned John Bondoc tonight and maybe he&#8217;s a link for both of us. Let&#8217;s grab a coffee in the next week or two and see what we can come up with. I&#8217;ll send you an email to find a time that works for us all.&nbsp;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385057&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385057" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="528" height="982" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=528%2C982&#038;ssl=1" alt="" class="wp-image-8430" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?w=528&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=161%2C300&amp;ssl=1 161w" sizes="auto, (max-width: 528px) 100vw, 528px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385726&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385726" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8464" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">If you are nearby, <a href="https://kriskrug.co/events/">come to the next one</a>.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-9197-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/after/post-9197-content.raw.html
@@ -1,0 +1,777 @@
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/VAI16">Vancouver AI Community Meetup #16</a> vibrated with creative energy, blending indigenous wisdom with bleeding-edge tech, grassroots community-building with critical thought. As I declared at the opening: &#8220;You are the <a href="https://bc-ai.ca/" title="BC + AI Ecosystem">BC + AI ecosystem</a>.&#8221; and what followed was a vivid demonstration of that ecosystem&#8217;s diversity and momentum.</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;Friends, we live at a time where new forms of expression are emerging right under our very eyes&#8230; whole new forms of expression.&#8221; —<a href="https://kriskrug.co/">Kris Krüg</a></p>
+</blockquote>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=4nv8YQSh4pPnU64r" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Cultural Grounding &amp; Community Foundations</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://twnation.ca/health-and-wellness/%C9%ACew%C9%99t%C9%99l-project/">Gabriel George Sr</a>. of the <a href="https://twnation.ca/">Tsleil-Waututh Nation</a> brought the room into sync—with land, lineage, and each other. He shared stories of his great-grandmother who lived right here, on this very patch of earth, back when it was still shoreline. </p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mVVmf0_zfEc?si=f-3KzodFwE1L9H7B" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Then he dropped a <em>new</em> song—one we’d never heard before—that bounced around the round room like it had always belonged there. No mic. Just presence. Just power. Just Gabriel doing what he does: weaving the ancient into the now.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f375b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f375b" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9207" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">British Columbia Artificial Intelligence Community of Practice</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://patrickpennefather.com/">Patrick Pennefather</a> followed with exciting news about published academic research in <a href="https://ojs.library.ubc.ca/index.php/bcstudies/index">BC Studies Journal</a> on the community itself. &#8220;<a href="https://ojs.library.ubc.ca/index.php/bcstudies/article/view/199875">Building a grassroots AI community of practice, a Vancouver centric use case</a>&#8221; documents how this thriving ecosystem has formed organically.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=9fPXdmNPkLS5e6TD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph"> Pennefather emphasized that as we explore this technology &#8220;with all the known unknowns and unknown unknowns of where it&#8217;s gonna go, we need to actually be centered in our own values.&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We are a community and as we start to build this technology, we are not individual lone wolves. And if you are, cool, and talk with people because it&#8217;s always better to belong to a pack.&#8221; — <a href="https://theatrefilm.ubc.ca/profile/patrick-pennefather/">Professor Patrick Parra Pennefather</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f4052&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f4052" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9201" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Emerging Sub-Communities &amp; Initiatives</h2>
+
+
+
+<p class="wp-block-paragraph">The ecosystem continues to spawn new offshoots. <a href="https://www.linkedin.com/in/ryvvaliquette/">Ryv Valiquette</a> shared updates on the <a href="https://surrey.bc-ai.net/">Surrey AI Meetup</a>, now in its second event with interactive games comparing real vs. AI content. The smaller setting offers a unique benefit: &#8220;The best part is circle time. Yes, it&#8217;s smaller. So we actually get to have a circle and go around, talk about stuff and share and it&#8217;s pretty awesome.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/kXsheUv7YC4?si=x8IHNOJSAESt4aEx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Other emerging groups include <a href="https://mac.bc-ai.net/">Mind, AI &amp; Consciousness Reading Group</a>, Womxn AI, Squamish AI, and the emerging AI.edu group exploring AI usage in learning and classrooms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300587&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300587" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="265" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537-1024x265.png?resize=1024%2C265&#038;ssl=1" alt="Surrey AI Community Meetup" class="wp-image-9202" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1024%2C265&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=768%2C198&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1536%2C397&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?w=1842&amp;ssl=1 1842w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Surrey AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/vijaya-kattumuri-pmp/">Vijaya</a> and <a href="https://www.linkedin.com/in/madhavee-inamdar-0220b9a/">Madhavee</a> announced their upcoming <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and governance conference (October 24th), emphasizing the need for values alignment and human-centric approaches. &#8220;AI is a huge thing,&#8221; they noted. &#8220;It can be a great monster, it can be a good monster, bad monster. So how do we really do that value alignment and the ethics part of it, the governance part of it?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300c54&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300c54" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9214" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.maap.ca/bio-carla-ritchie">Carla Ritchie</a> from <a href="https://www.vivomediaarts.com/people">Vivo Media Arts</a>, one of Canada&#8217;s oldest artist-run centers (founded 1973), shared her dream of building &#8220;a media hub where we&#8217;ll have the machines so that any person can get access to this technology and to be able to train it for themselves.&#8221; </p>
+
+
+
+<p class="wp-block-paragraph">She credited the community with connecting her to <a href="https://kriskrug.notion.site/BC-AI-Funding-Directory-133c6f799a33801bbeaae7de1fcb5395?pvs=4">AI funding resources</a>: &#8220;Being part of this community gave me access to other resources of funding. So I&#8217;ve already applied or sent letters of interest to four funders to build this dream.&#8221;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Creative Explorations &amp; Performances</h2>
+
+
+
+<p class="wp-block-paragraph">The meetup spotlighted several innovative projects. <a href="https://www.linkedin.com/in/lionelringenbach/">Lionel Ringenbach</a> (aka <a href="https://ucodia.space/">UCODIA</a>), an experimental software artist, demonstrated his transition from a 15-year software engineering career to creating 3D models of mushrooms through photogrammetry. </p>
+
+
+
+<p class="wp-block-paragraph">He explained how coding transformed his relationship with creativity: &#8220;I didn&#8217;t feel I could use my hands to make art, but all of a sudden code became like a paint brush.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/4RB_YT26dOM?si=I4h4HHQpvdwbn-89" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">His application &#8220;<a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Compovision</a>&#8221; allows users to generate images with AI &#8220;without using a single word, but instead using your hands and objects that are around you. And it&#8217;s able to create what you can imagine without any words.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EtXP1nt_5_o?si=bKePncYHpjifL4ez" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and his team from <a href="https://www.metacreation.net/">SFU&#8217;s METACREATION Lab for Creative AI</a> previewed their performance for <a href="https://forum.mutek.org/en/shows/2024/workshop-small-data-and-model-crafting-a-new-breed-of-ethical-creative-ai-tools-for-non-coders">Montreal&#8217;s Mutek Festival</a>, featuring musical AI agents &#8220;maam&#8221; and &#8220;Spire.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330167b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330167b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9309" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Their work focuses on small data and model crafting: &#8220;We&#8217;ve been developing a bunch of tools based on this idea of small data and model crafting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3301d35&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3301d35" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9307" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">We notice that artists don&#8217;t really want to use big models, trained on everyone else&#8217;s data&#8230; For-profit AI is all about uploading the data and using big models. And if you look elsewhere, there&#8217;s pretty much nothing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330238d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330238d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9308" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We notice that artists don&#8217;t really want to use big models, trained on everyone else data. They don&#8217;t really want to upload their data online. They don&#8217;t really want to learn how to program in Python to make some art with AI in California.&#8221; —<a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier, METACREATION Lab</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">Lionel later revealed another project <a href="https://www.youtube.com/watch?v=fnKD7IAVkeU">measuring AI energy consumption</a>—an &#8220;AI energy counter&#8221; not designed to blame users but to &#8220;help people guide to more ecological product maybe.&#8221; <a href="https://forum.mutek.org/en/cohort-of-ai-ecologies-lab-projects">At MUTEK’s <strong>AI Ecologies Lab</strong>, he’s prototyping new ways to <strong>track and surface the energy footprint of AI systems</strong></a>—not to shame, but to <em>illuminate</em>. </p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">This isn’t about optimization; it’s about <strong>awareness as agency</strong>. His lab project is a sensorium for seeing the carbon ghosts in the machine. Lionel’s work blends punk engineering with planetary mindfulness.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/fnKD7IAVkeU?si=AiI3RKcB5MMGMCZz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The <a href="https://hackathon.bc-ai.net/">Data Storytelling Hackathon</a></h2>
+
+
+
+<p class="wp-block-paragraph">The centerpiece of the evening was the data storytelling hackathon sponsored by <a href="https://www.rivaltech.com/">RIVAL Technologies</a>. <a href="https://bc500.biv.com/leaders/andrew-reid/">Andrew Reid</a> approached me with a problem: market research data typically ends up in boring PowerPoint slides. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3302ba3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3302ba3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9310" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">As I explained, &#8220;We do this amazing work for these biggest brands in the world. They spend huge amounts of money asking tens of thousands of people questions about all sorts of stuff. And then we get all this rich data back and the whole industry puts into PowerPoint presentations and bar charts and graphs and like it&#8217;s the AI age. We must be able to do something more.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/aUYZ6Il3kco?si=b0ZNXYzPlBQKP5re" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">The judging team included <a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale Evernden</a> and <a href="https://www.linkedin.com/in/mortonjulia/">Julia Morton</a> from <a href="https://www.rivaltech.com/">RIVAL</a>, along with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a> who built the judging rubric. Twelve teams submitted creative interpretations of survey data on the quirky prompt: &#8220;Is a hot dog a sandwich?&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I&#8217;ll just encourage everybody, if you can take a look at the submissions. We had 12 submissions. Five of them really stood out, and I was blown away by the kind of care and attention that went into the ideation process and the conceptualization of those thoughts into a deliverable.&#8221; —<a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33032df&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33032df" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9311" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/past5/">Sev Geraskin</a> of <a href="https://www.past5.com/">Past5</a> took home the $2,500 prize with his comprehensive Orchstr platform that classified respondents as &#8220;sandwich traditionalists&#8221; or &#8220;sandwich expansionists&#8221; and developed a &#8220;controversy score.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33039ef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33039ef" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9217" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The judging was unanimous, as Dale explained: &#8220;We put our top three on there and there was one that was on the first place of all of the lists, plus Andrews, the five judges all had this one on top, so it was easy.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330406c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330406c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9312" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">In the true spirit of community, Sev&#8217;s victory speech focused not on his own accomplishment but on highlighting another community member&#8217;s work: &#8220;I wanna talk more about the kind of talent we have here. And as I&#8217;m working on this exercise and I&#8217;m meeting more and more people, I&#8217;m impressed with just the quality of builders that we have in the city.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33046fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33046fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9313" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Swathi&#8217;s runner-up project <a href="https://github.com/raikwarswati/the-sandwich-trial">transformed the data into a comic book</a> courtroom drama where a hot dog stood trial for its sandwich status. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3304dd8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3304dd8" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9218" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">She built an impressive pipeline using only open-source models: &#8220;I built a pipeline where like after all the data insights are derived, there is a CSV&#8230; and you just hit play button and what you get output is&#8230; a comic novel.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330543a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330543a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9314" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Brittney closed the hackathon segment by announcing the next round&#8217;s theme: Canadian identity. Using data from <a href="https://angusreid.org/">Angus Reid</a> polling, participants will explore &#8220;What does it mean to be Canadian?&#8221; with winners announced just before Canada Day.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3305ab1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3305ab1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9315" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Beyond Chat: The Future of Interfaces</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://allenpike.com/">Allen Pike</a> of <a href="https://forestwalk.ai/">Forestwalk Labs</a> delivered a captivating keynote on the future of AI interfaces beyond chat. He traced the evolution from text terminals to GUIs to chat interfaces, and now to what he calls &#8220;post-chat interfaces.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mRqBjKFyfLc?si=ndBrOnwp71K8uGZ9" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We&#8217;re at the beginning of a really incredible generation of software and products and experiences that when we think of AI, we might often think of this chat experience, which isn&#8217;t going away, but there is so much more to come.&#8221; —<a href="https://www.linkedin.com/in/allenpike">Allen Pike</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">These emerging patterns include contextual right-click menus, natural language search fields, and AI that anticipates the &#8220;next obvious thing&#8221; a user might want to do. &#8220;The way that you can just start making a change and it&#8217;s immediately &#8216;oh, obviously you&#8217;re doing this, just press tab&#8217;&#8230; It&#8217;s so powerful,&#8221; Pike explained. &#8220;It makes all your rest of your software feel broken.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306269&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306269" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9302" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1536%2C1025&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Perhaps most provocatively, he described a future where interfaces might be completely generated on-the-fly for each user&#8217;s exact needs: &#8220;We can now generate a completely custom UI exactly for you that is unique to you in the moment right now&#8230; This is either the complete future of user interfaces and that all the stuff I just talked about, the computers will just generate it for us&#8230; Or this is completely deranged and will confuse everyone and be impossible to actually get working.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306907&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306907" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9303" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Community Spirit</h2>
+
+
+
+<p class="wp-block-paragraph">The event closed with a surprising twist: the community&#8217;s resident critic, <a href="https://kushalgoenka.com/">Kushal</a>, who traditionally closes with a rant, found himself with nothing to complain about. &#8220;I have been in the last while, like a month plus and so on completely detoxing, if you will, of all closed source proprietary shit completely&#8230; I honestly think nothing is pissing me off.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306ff6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306ff6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9304" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Instead, he celebrated the open-source movement and the educational impact of the hackathon: &#8220;You got everyone to start playing with these technologies on their computers&#8230; I saw some of the people that won&#8230; doing stuff with models, some of them open source, and it just builds education. If you know about it now, you now know how to talk about it.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307650&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307650" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9305" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Throughout the night, Krüg highlighted the community&#8217;s growing influence, from academic validation to government recognition. With sponsors including Dmitri Schwartzman, <a href="https://segevllp.com/">SEGEV LLP</a>, <a href="https://www.metacreation.net/">METACREATION Lab</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a>, and <a href="https://creativemornings.com/cities/van/">Creative Mornings Vancouver</a>, the ecosystem continues to blossom, proving that AI development doesn&#8217;t require selling our souls—just passion, creativity, and human connection.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9199" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?w=1200&amp;ssl=1 1200w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;When I walk into the JEDI&#8217;s office or InnovateBC, and I say that we have grown from 0 paying annual members to 50 in one moth, and that we have more than 200 people show up monthy&#8230; they really start paying attention.&#8221; —Kris Krüg</p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">As the group looked ahead to the <a href="https://lu.ma/websummit-vancouver">next meetup during Web Summit Vancouver on May 28th</a> (featuring 10 community startups), and the June 25th gathering after that, one thing was clear: this is no ordinary tech meetup, but rather a living laboratory where art, technology, ethics, and community converge to shape our collective future. If you want <a href="https://kriskrug.co/events/">the next one</a>, it is on the calendar.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="800" height="800" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=800%2C800&#038;ssl=1" alt="" class="wp-image-9198" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?w=800&amp;ssl=1 800w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 800px) 100vw, 800px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307e77&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307e77" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=1024%2C1024&#038;ssl=1" alt="Critical Voices Welcome" class="wp-image-9208" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308500&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308500" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9209" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308bb7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308bb7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9210" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309278&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309278" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9211" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309923&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309923" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9212" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309faa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309faa" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9213" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330a639&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330a639" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9215" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330ad02&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330ad02" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9216" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-content.raw.html
@@ -1,0 +1,71 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-vancouver-ai -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Vancouver AI</p>
+  <h2 class="aurora-display-heading">A living map of the local AI scene.</h2>
+  <p class="aurora-page-lead">This hub collects Kris Krug's field notes from Vancouver and British Columbia's AI ecosystem: meetups, builders, artists, civic conversations, policy questions, and the strange community work of helping people learn in public.</p>
+  <p>Start here if you want to understand the people, rooms, experiments, and tensions shaping AI on the west coast.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Start here</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>BC + AI Ecosystem</h3>
+      <p>A community network for builders, creatives, educators, researchers, and public-interest people working on AI in British Columbia.</p>
+      <p><a class="aurora-button" href="https://bc-ai.ca/">Visit BC + AI</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Events and recaps</h3>
+      <p>Meetups, hackathons, Web Summit field notes, community gatherings, and what actually happened in the room.</p>
+      <p><a class="aurora-button" href="/ai-events/">Browse AI events</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Work in the ecosystem</h3>
+      <p>See the projects, talks, trainings, and community systems that connect Kris's AI work to local culture.</p>
+      <p><a class="aurora-button" href="/work/">See the work</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Field notes</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/bc-ai-header.png?resize=640,400&amp;ssl=1" alt="BC AI event graphic" loading="lazy"/>
+        <div>
+          <h3>BC AI is live</h3>
+          <p>A community-first note on building the future we actually want.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/06/01/long-road-to-futureproof/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/vanai21-kris-jonny-stage.png?resize=640,400&amp;ssl=1" alt="Kris Krug and Jonny on stage at a Vancouver AI event" loading="lazy"/>
+        <div>
+          <h3>The long road to Futureproof</h3>
+          <p>What local AI community-building looks like after the hype cycle starts to bite.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/vancouver-ai-ecosystem/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/bc-studies-ai-community.png?resize=640,400&amp;ssl=1" alt="Vancouver AI and BC community graphic" loading="lazy"/>
+        <div>
+          <h3>Vancouver AI archive</h3>
+          <p>More posts from the local ecosystem, from grassroots meetups to public-interest AI conversations.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring Kris into your AI room</h2>
+    <p>For ecosystem strategy, community events, talks, workshops, or a practical read on the local AI scene, start with the room you are trying to build.</p>
+    <p><a class="aurora-button" href="/contact/">Start a conversation</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-content.rendered.html
@@ -1,0 +1,71 @@
+
+<!-- content-architecture-2026:topic-vancouver-ai -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Vancouver AI</p>
+  <h2 class="aurora-display-heading">A living map of the local AI scene.</h2>
+  <p class="aurora-page-lead">This hub collects Kris Krug&#8217;s field notes from Vancouver and British Columbia&#8217;s AI ecosystem: meetups, builders, artists, civic conversations, policy questions, and the strange community work of helping people learn in public.</p>
+  <p>Start here if you want to understand the people, rooms, experiments, and tensions shaping AI on the west coast.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Start here</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>BC + AI Ecosystem</h3>
+      <p>A community network for builders, creatives, educators, researchers, and public-interest people working on AI in British Columbia.</p>
+      <p><a class="aurora-button" href="https://bc-ai.ca/">Visit BC + AI</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Events and recaps</h3>
+      <p>Meetups, hackathons, Web Summit field notes, community gatherings, and what actually happened in the room.</p>
+      <p><a class="aurora-button" href="/ai-events/">Browse AI events</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Work in the ecosystem</h3>
+      <p>See the projects, talks, trainings, and community systems that connect Kris&#8217;s AI work to local culture.</p>
+      <p><a class="aurora-button" href="/work/">See the work</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Field notes</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/05/18/bc-ai-is-live-and-were-building-the-future-we-actually-want/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/bc-ai-header.png?resize=640,400&amp;ssl=1" alt="BC AI event graphic" loading="lazy"/>
+        <div>
+          <h3>BC AI is live</h3>
+          <p>A community-first note on building the future we actually want.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/06/01/long-road-to-futureproof/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/vanai21-kris-jonny-stage.png?resize=640,400&amp;ssl=1" alt="Kris Krug and Jonny on stage at a Vancouver AI event" loading="lazy"/>
+        <div>
+          <h3>The long road to Futureproof</h3>
+          <p>What local AI community-building looks like after the hype cycle starts to bite.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/vancouver-ai-ecosystem/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/04/bc-studies-ai-community.png?resize=640,400&amp;ssl=1" alt="Vancouver AI and BC community graphic" loading="lazy"/>
+        <div>
+          <h3>Vancouver AI archive</h3>
+          <p>More posts from the local ecosystem, from grassroots meetups to public-interest AI conversations.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring Kris into your AI room</h2>
+    <p>For ecosystem strategy, community events, talks, workshops, or a practical read on the local AI scene, start with the room you are trying to build.</p>
+    <p><a class="aurora-button" href="/contact/">Start a conversation</a></p>
+  </div>
+</section>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-12315-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 12315,
+  "slug": "vancouver-ai",
+  "status": "publish",
+  "link": "https://kriskrug.co/vancouver-ai/",
+  "modified": "2026-07-01T12:27:36",
+  "modified_gmt": "2026-07-01T20:27:36",
+  "type": "page",
+  "content_raw_bytes": 3676,
+  "content_rendered_bytes": 3712,
+  "content_raw_has_footer": false,
+  "snapshot_source": "repo_backup_20260701_content.raw + public_rest_rendered_20260819",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 0,
+  "title_rendered": "Vancouver AI Ecosystem"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-2250-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-2250-content.rendered.html
@@ -1,0 +1,899 @@
+
+<div class="aurora-events-page">
+  <section class="aurora-speaking-hero" aria-labelledby="aurora-events-title">
+    <div class="aurora-speaking-hero-copy">
+      <p class="aurora-kicker">Events I build, host &amp; speak at</p>
+      <h2 id="aurora-events-title">I don&#8217;t just attend the AI conversation. I host the room.</h2>
+      <p>From a monthly Vancouver meetup to film-club screenings, weekly office hours, and keynote stages from São Paulo to Whistler. These are the rooms where BC&#8217;s AI community actually shows up, argues, makes things, and leaves braver. Most run on Luma; come find the next one.</p>
+      <div class="aurora-action-row">
+        <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">Follow on Luma</a>
+        <a class="aurora-button aurora-button-secondary" href="/speaking/">Book Kris to speak</a>
+      </div>
+    </div>
+  </section>
+
+
+<!-- EVENTS_DYNAMIC_START -->
+
+<style>
+  /* Dated event cards on /events/: rich Upcoming + dense Past archive */
+  .aurora-events-page .aurora-proof-media--portrait img {
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    object-position: center top;
+  }
+  .aurora-events-page [data-events-bucket][data-events-empty="true"] {
+    display: none;
+  }
+  .aurora-events-page .aurora-event-cta-past {
+    display: none;
+  }
+  .aurora-events-page [data-events-grid="past"] .aurora-event-cta-upcoming {
+    display: none;
+  }
+  .aurora-events-page [data-events-grid="past"] .aurora-event-cta-past {
+    display: flex;
+  }
+  .aurora-events-page .aurora-event-status-note {
+    font-size: 0.9em;
+    opacity: 0.8;
+  }
+
+  /* Past archive: dense 3 / 2 / 1 grid */
+  .aurora-events-page [data-events-grid="past"] {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem 1rem;
+  }
+  @media (max-width: 900px) {
+    .aurora-events-page [data-events-grid="past"] {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  @media (max-width: 560px) {
+    .aurora-events-page [data-events-grid="past"] {
+      grid-template-columns: 1fr;
+    }
+  }
+  .aurora-events-page .aurora-event-card--compact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin: 0;
+  }
+  .aurora-events-page .aurora-event-compact-media {
+    margin: 0;
+    overflow: hidden;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.04);
+  }
+  .aurora-events-page .aurora-event-compact-media img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    object-fit: cover;
+    object-position: center;
+  }
+  .aurora-events-page .aurora-event-compact-media--empty {
+    aspect-ratio: 16 / 10;
+    background: linear-gradient(135deg, rgba(0,0,0,0.06), rgba(0,0,0,0.02));
+  }
+  .aurora-events-page .aurora-event-compact-body h3 {
+    font-size: 1.05rem;
+    margin: 0.15rem 0 0.35rem;
+    line-height: 1.25;
+  }
+  .aurora-events-page .aurora-event-compact-link {
+    font-size: 0.9rem;
+  }
+
+  /* Upcoming stays on the existing proof-grid / rich module rhythm */
+  .aurora-events-page [data-events-grid="upcoming"] .aurora-event-card--rich {
+    /* inherits .aurora-proof-module */
+  }
+</style>
+
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-upcoming" data-events-bucket="upcoming" data-events-empty="false">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Upcoming</p>
+      <h2 id="aurora-events-upcoming">On the calendar.</h2>
+      <p>Stages, festivals, and the next rooms. Register and come say hi.</p>
+    </div>
+    <div class="aurora-proof-grid" data-events-grid="upcoming">
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-08-13T11:00:00-07:00" data-event-id="iida-thermador-coffee-conversations-2026">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Thursday, Aug 13 · 9–11am · Thermador Experience &amp; Design Centre</p>
+          <h3>Coffee Conversations #1: The Impact of AI</h3>
+          <p>Invited guest at the first Coffee Conversations breakfast: an intimate small-room conversation about AI&#8217;s impact on the evolution of design, with IIDA Northern Pacific&#8217;s Vancouver community and Thermador.</p>
+          <div class="aurora-proof-tags"><span>Invited guest</span><span>AI + Design</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://www.iida-northernpacific.org/vancouverbc">IIDA Vancouver</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://www.iida-northernpacific.org/vancouverbc">IIDA Vancouver</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-09-08T21:00:00-07:00" data-event-id="how-can-we-help-pitch-night-2026">
+        <figure class="aurora-proof-media aurora-proof-media--portrait">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/2026-09-08-how-can-we-help-pitch-night-social-promo.jpg?ssl=1" alt="Panelist social graphic for Brands for Better Foundation How Can We Help? Pitch Night featuring Kris Krüg, Tuesday September 8 at BCIT Tech Collider" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Tuesday, Sept 8 · 6–9pm · BCIT Tech Collider</p>
+          <h3>How Can We Help? Pitch Night</h3>
+          <p>Panelist for Brands for Better Foundation: connecting nonprofits with skilled professionals for skills-based volunteering. Bringing a BC + AI Ecosystem perspective on practical knowledge-sharing and responsible tech in service of community.</p>
+          <div class="aurora-proof-tags"><span>Panelist</span><span>Vancouver</span><span>Nonprofits</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://www.eventbrite.ca/e/how-can-we-help-pitch-night-use-your-skills-to-support-nonprofits-tickets-1992057314051">Register on Eventbrite</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://www.eventbrite.ca/e/how-can-we-help-pitch-night-use-your-skills-to-support-nonprofits-tickets-1992057314051">Event details</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-09-30T22:00:00-07:00" data-event-id="vancouver-ai-meetup-2026-09-30">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Wed, Sept 30 · Space Centre</p>
+          <h3>Vancouver AI Community Meetup</h3>
+          <p>Next Vancouver AI Community Meetup on Wednesday, September 30. Hosted monthly at the H.R. MacMillan Space Centre.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Monthly</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://luma.com/sept-ai">Register on Luma</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://luma.com/sept-ai">Event details</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-event-card aurora-event-card--rich" data-event-end="2026-10-30T22:00:00-07:00" data-event-id="futureproof-festival-2026">
+        <figure class="aurora-proof-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/futureproof-salmon-starfield-share-20260527.jpg?ssl=1" alt="Futureproof Festival salmon-starfield share graphic" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Oct 28–30 · H.R. MacMillan Space Centre</p>
+          <h3>Futureproof Festival</h3>
+          <p>Inaugural Futureproof Festival at the H.R. MacMillan Space Centre, Oct 28–30, 2026. The rooms, screenings, and conversations BC + AI has been building toward.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Festival</span><span>Vancouver</span></div>
+          <div class="aurora-proof-actions aurora-event-cta-upcoming">
+            <a class="aurora-button aurora-button-primary" href="https://futureproof.website/">Save the date</a>
+          </div>
+          <div class="aurora-proof-actions aurora-event-cta-past">
+            <a class="aurora-button aurora-button-secondary" href="https://futureproof.website/">Festival site</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-past" data-events-bucket="past" data-events-empty="false">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Archive</p>
+      <h2 id="aurora-events-past">Past rooms.</h2>
+      <p>Every Vancouver AI meetup edition plus dated stages that have rolled off Upcoming.</p>
+    </div>
+    <div class="aurora-proof-grid" data-events-grid="past">
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-29T22:00:00-07:00" data-event-id="van-ai-meetup-31">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/09-veggie-skewers-michelle-diamond.jpg?ssl=1" alt="Vancouver AI Meetup #31 (photo: Michelle Diamond / Diamond's Edge Photography)" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #31 · Jul 2026</p>
+          <h3>Vancouver AI Meetup #31</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/july-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-09T22:00:00-07:00" data-event-id="2026-07-09-bc-ai-film-club-july-idea-lab">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · Multimodal Media Lab · Host</p>
+          <h3>BC + AI Film Club July: Idea Lab</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/summertime">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-09T21:00:00-07:00" data-event-id="2026-07-09-sfu-ai-panel">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · SFU · Panelist</p>
+          <h3>SFU AI panel</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-07-08T21:00:00-07:00" data-event-id="2026-07-08-ai-ethical-futures-lab-morten">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2026 · Vancouver · Host</p>
+          <h3>AI Ethical Futures Lab w/ Morten Rand-Hendriksen</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-06-24T22:00:00-07:00" data-event-id="van-ai-meetup-30">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/13-meetup-30-full-lineup-hero.png?ssl=1" alt="Vancouver AI Meetup #30" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #30 · Jun 2026</p>
+          <h3>Vancouver AI Meetup #30</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/june-vanai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-05-27T22:00:00-07:00" data-event-id="van-ai-meetup-29">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #29 · May 2026</p>
+          <h3>Vancouver AI Meetup #29</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vanai-may">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-05-01T12:00:00-07:00" data-event-id="creativemornings-perils-parallels-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/punk-rock-ai-creative-mornings.jpg?ssl=1" alt="Kris Krüg speaking at CreativeMornings Vancouver in front of a Stop Saying Bias slide" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 1, 2026 · Vancouver</p>
+          <h3>CreativeMornings: Perils &amp; Parallels</h3>
+          <a class="aurora-event-compact-link" href="https://creativemornings.com/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-29T22:00:00-07:00" data-event-id="van-ai-meetup-28">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/9-6bf27e0d-957a-4c79-b2bf-90349fecbf45.jpg?ssl=1" alt="Vancouver AI Meetup #28" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #28 · Apr 2026</p>
+          <h3>Vancouver AI Meetup #28</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vanai-april">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-12T19:30:00-07:00" data-event-id="2026-04-12-yvr-ai-welcome-salon-ted2026">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2026 · Alibi Room, Gastown · Host</p>
+          <h3>YVR AI Welcome Salon (TED2026 week)</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-04-01T11:50:00-07:00" data-event-id="2026-04-01-global-ai-summit-vancouver-panel">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2026 · UBC Robson Square · Moderator</p>
+          <h3>Global AI Summit Vancouver panel</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-03-31T11:50:00-07:00" data-event-id="2026-03-31-sea-to-sky-gondola-ai-ethics-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">March 2026 · Squamish · Workshop lead</p>
+          <h3>Sea to Sky Gondola AI-ethics workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-03-25T22:00:00-07:00" data-event-id="van-ai-meetup-27">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #27 · Mar 2026</p>
+          <h3>Vancouver AI Meetup #27</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-26T21:00:00-03:00" data-event-id="waiff-sao-paulo-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/press-2026-02-09-tela-viva-context-v2-1.jpg?ssl=1" alt="Tela Viva press coverage of WAIFF 2026, the World AI Film Festival in Brazil" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2026 · São Paulo · Keynote</p>
+          <h3>World AI Film Festival Brasil</h3>
+          <a class="aurora-event-compact-link" href="/speaking/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-25T22:00:00-07:00" data-event-id="van-ai-meetup-26">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #26 · Feb 2026</p>
+          <h3>Vancouver AI Meetup #26</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/deepdive">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-02-01T21:00:00-08:00" data-event-id="2026-02-01-vibe-working-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2026 · Vancouver · Workshop lead</p>
+          <h3>Vibe Working Workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-31T21:00:00-08:00" data-event-id="2026-01-31-first-tech-challenge-think-award">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2026 · Port Moody · Judge</p>
+          <h3>FIRST Tech Challenge: Think Award</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-28T22:00:00-07:00" data-event-id="van-ai-meetup-25">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #25 · Jan 2026</p>
+          <h3>Vancouver AI Meetup #25</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/liftoff">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2026-01-14T20:00:00-07:00" data-event-id="lasalle-college-keynote-2026">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/lasalle-college-graduation.jpg?ssl=1" alt="Kris Krüg on stage at LaSalle College Vancouver asking what you would never give up to AI" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2026 · Vancouver · Keynote</p>
+          <h3>LaSalle College Vancouver</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=-c7mgY2aSgM">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-12-18T22:00:00-07:00" data-event-id="van-ai-meetup-24">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #24 · Dec 2025</p>
+          <h3>Vancouver AI Meetup #24</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/awards">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-11-26T22:00:00-07:00" data-event-id="van-ai-meetup-23">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #23 · Nov 2025</p>
+          <h3>Vancouver AI Meetup #23</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai23">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-29T22:00:00-07:00" data-event-id="van-ai-meetup-22">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #22 · Oct 2025</p>
+          <h3>Vancouver AI Meetup #22 (First Annual BC + AI Film Festival)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai22">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-24T21:00:00-07:00" data-event-id="2025-10-24-munda-mennuie-residency">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Oct 2025 · Vancouver · Host</p>
+          <h3>Munda M&#8217;ennuie Residency</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/arthurkuhn">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-10-22T21:00:00-07:00" data-event-id="2025-10-22-dama-day-ai-for-nonprofits-keynote">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Oct 2025 · Deloitte Summit · Keynote</p>
+          <h3>DAMA Day Vancouver: AI for Non-Profits</h3>
+          <a class="aurora-event-compact-link" href="https://damavancouverbcchapter.wildapricot.org/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-24T22:00:00-07:00" data-event-id="van-ai-meetup-21">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #21 · Sep 2025</p>
+          <h3>Vancouver AI Meetup #21</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai21">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-02T21:00:00-07:00" data-event-id="2025-09-02-amd-media-copilot-workshop">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2025 · Virtual · Workshop</p>
+          <h3>AMD Media CoPilot AI Workshop</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-09-01T21:00:00-07:00" data-event-id="2025-09-01-ea-creative-innovation-keynote">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2025 · EA HQ Burnaby · Keynote</p>
+          <h3>Electronic Arts Creative Innovation Keynote</h3>
+          
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-08-27T22:00:00-07:00" data-event-id="van-ai-meetup-20">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #20 · Aug 2025</p>
+          <h3>Vancouver AI Meetup #20</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/vai20">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-08-10T21:00:00-07:00" data-event-id="2025-08-10-calm-before-storm-siggraph">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Aug 2025 · Alibi Room · Host</p>
+          <h3>Calm Before the Storm #SIGGRAPH</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/siggraph2025">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-07-30T22:00:00-07:00" data-event-id="van-ai-meetup-19">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #19 · Jul 2025</p>
+          <h3>Vancouver AI Meetup #19</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/julio">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-07-11T21:00:00-07:00" data-event-id="2025-07-11-bass-coast-brain-stage">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/2025-07-11-bass-coast-brain-stage-youtube.jpg?ssl=1" alt="Kris Krug speaking on the Bass Coast Brain Stage, Synthetic Consciousness / Dear AI talk thumbnail" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">July 2025 · Bass Coast, Merritt · Workshop</p>
+          <h3>Bass Coast Brain Stage: Dear AI</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=owtSPcpRinI">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-06-25T22:00:00-07:00" data-event-id="van-ai-meetup-18">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/surrey-ai-meetup-june-2025-080.jpg?ssl=1" alt="Vancouver AI Meetup #18" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #18 · Jun 2025</p>
+          <h3>Vancouver AI Meetup #18</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI18">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-06-03T18:00:00-07:00" data-event-id="channelnext-2025">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/channel-next.jpg?ssl=1" alt="ChannelNext keynote video thumbnail: Krüg on AI and who owns the future" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">June 2025 · Conference · Keynote</p>
+          <h3>ChannelNext</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=1OcC-0X6Nb8">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-28T22:00:00-07:00" data-event-id="van-ai-meetup-17">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/surrey-ai-meetup-may-2025-027.jpg?ssl=1" alt="Vancouver AI Meetup #17 (#WebSummit special edition)" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #17 · May 2025</p>
+          <h3>Vancouver AI Meetup #17 (#WebSummit special edition)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/websummit-vancouver">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-27T21:00:00-07:00" data-event-id="2025-05-27-web-summit-indigenomics-ai">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Web Summit Vancouver · Panelist</p>
+          <h3>Web Summit: Indigenomics AI</h3>
+          <a class="aurora-event-compact-link" href="https://vancouver.websummit.com/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-25T21:00:00-07:00" data-event-id="2025-05-25-calm-before-storm-websummit">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Alibi Room · Host</p>
+          <h3>Calm Before the Storm: Web Summit</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/LocalsOnly">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-05-06T21:00:00-07:00" data-event-id="2025-05-06-bc-ai-ecosystem-launch">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2025 · Zoom · Host</p>
+          <h3>BC + AI Ecosystem Launch Session</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/BCai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-04-30T22:00:00-07:00" data-event-id="van-ai-meetup-16">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #16 · Apr 2025</p>
+          <h3>Vancouver AI Meetup #16</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI16">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-04-09T20:00:00-07:00" data-event-id="2025-04-09-ted2025-community-meetup">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Apr 2025 · Vancouver · Host</p>
+          <h3>TED2025 Community Meetup</h3>
+          <a class="aurora-event-compact-link" href="https://web.archive.org/web/20250324140102/https://lu.ma/TED-Vancouver">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-03-26T22:00:00-07:00" data-event-id="van-ai-meetup-15">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #15 · Mar 2025</p>
+          <h3>Vancouver AI Meetup #15</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI15">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-03-20T21:00:00-07:00" data-event-id="2025-03-20-data-storytelling-hackathon">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Mar 2025 · Vancouver · Host</p>
+          <h3>Data Storytelling Hackathon</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2025/03/20/is-a-hotdog-a-sandwich-vancouver-aidata-storytelling-hackathon-w-andrew-reid/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-02-26T22:00:00-07:00" data-event-id="van-ai-meetup-14">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-feb-2025-072-scaled.jpg?ssl=1" alt="Vancouver AI Meetup #14" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #14 · Feb 2025</p>
+          <h3>Vancouver AI Meetup #14</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI14">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-02-05T21:00:00-08:00" data-event-id="2025-02-05-thinking-game-premiere">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Feb 2025 · Vancouver · Host</p>
+          <h3>The Thinking Game Premiere</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/thinking">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-01-29T22:00:00-07:00" data-event-id="van-ai-meetup-13">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #13 · Jan 2025</p>
+          <h3>Vancouver AI Meetup #13</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VAI13">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2025-01-23T20:00:00-07:00" data-event-id="whistler-institute-2025">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/whistler-institute.jpg?ssl=1" alt="Whistler Institute talk video thumbnail: Building the Creative Technology Future" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Jan 2025 · Whistler</p>
+          <h3>Whistler Institute Global Speaker Series</h3>
+          <a class="aurora-event-compact-link" href="https://www.youtube.com/watch?v=-XEsqsEbpoo">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-12-15T22:00:00-07:00" data-event-id="van-ai-meetup-12">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #12 · Dec 2024</p>
+          <h3>Vancouver AI Meetup #12 (#NeurIPS special edition)</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/NeurIPS2024">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-12-04T21:00:00-08:00" data-event-id="dot-summit-autoloom-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Dec 2024 (day approx) · Wosk Centre, Vancouver · Host</p>
+          <h3>Dialogue on Technology (DoT) Summit</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.beehiiv.com/p/vancouver-ai-revolution">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-11-27T22:00:00-07:00" data-event-id="van-ai-meetup-11">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-november-2024-162-scaled.jpg?ssl=1" alt="Vancouver AI Meetup #11" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #11 · Nov 2024</p>
+          <h3>Vancouver AI Meetup #11</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/VanAI-11">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-11-22T21:00:00-08:00" data-event-id="adplist-fireside-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Nov 22, 2024 · Vancouver · Fireside</p>
+          <h3>ADPList Vancouver Fireside</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/ai-chat">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-10-30T22:00:00-07:00" data-event-id="van-ai-meetup-10">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #10 · Oct 2024</p>
+          <h3>Vancouver AI Meetup #10</h3>
+          <a class="aurora-event-compact-link" href="https://luma.com/letsgo">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-09-25T22:00:00-07:00" data-event-id="van-ai-meetup-09">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #9 · Sep 2024</p>
+          <h3>Vancouver AI Meetup #9</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-09-11T21:00:00-07:00" data-event-id="enya-liftoff-keynote-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Sept 2024 (day approx) · Wosk Centre, Vancouver · Keynote</p>
+          <h3>ENYA Liftoff</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/09/11/the-human-algorithm-enya-learning-keynote/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-08-28T22:00:00-07:00" data-event-id="van-ai-meetup-08">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #8 · Aug 2024</p>
+          <h3>Vancouver AI Meetup #8</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-07-31T22:00:00-07:00" data-event-id="van-ai-meetup-07">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #7 · Jul 2024</p>
+          <h3>Vancouver AI Meetup #7</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-06-26T22:00:00-07:00" data-event-id="van-ai-meetup-06">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #6 · Jun 2024</p>
+          <h3>Vancouver AI Meetup #6</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-29T22:00:00-07:00" data-event-id="van-ai-meetup-05">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #5 · May 2024</p>
+          <h3>Vancouver AI Meetup #5</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-27T21:00:00-07:00" data-event-id="bcama-vision-conference-panel-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 2024 (day approx) · Vancouver · Moderator</p>
+          <h3>BCAMA Vision Conference</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/05/27/unpacking-ai-ethics-at-american-marketing-associationvisionconf2024/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-05-24T14:45:00-06:00" data-event-id="yorkton-film-festival-panel-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">May 24, 2024 · Yorkton, SK · Panel</p>
+          <h3>Yorkton Film Festival</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/05/25/ai-in-filmmaking-at-the-yorkton-film-festival/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-04-24T22:00:00-07:00" data-event-id="van-ai-meetup-04">
+        <figure class="aurora-event-compact-media">
+          <img data-recalc-dims="1" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/08/vancouver-ai-meetup-april-2024-112.jpg?ssl=1" alt="Vancouver AI Meetup #4" loading="lazy" decoding="async" />
+        </figure>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #4 · Apr 2024</p>
+          <h3>Vancouver AI Meetup #4</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-04-20T21:00:00-07:00" data-event-id="innovate-west-keynote-2024">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">April 2024 (day approx) · Vancouver · Keynote</p>
+          <h3>Innovate West</h3>
+          <a class="aurora-event-compact-link" href="https://kriskrug.co/2024/04/20/ai-mindset-keynote-at-innovate-west-2024-in-vancouver/">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-03-27T22:00:00-07:00" data-event-id="van-ai-meetup-03">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #3 · Mar 2024</p>
+          <h3>Vancouver AI Meetup #3</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-02-28T22:00:00-07:00" data-event-id="van-ai-meetup-02">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #2 · Feb 2024</p>
+          <h3>Vancouver AI Meetup #2</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+      <article class="aurora-event-card aurora-event-card--compact" data-event-end="2024-01-31T22:00:00-07:00" data-event-id="van-ai-meetup-01">
+<div class="aurora-event-compact-media aurora-event-compact-media--empty" aria-hidden="true"></div>
+        <div class="aurora-event-compact-body">
+          <p class="aurora-card-label">Meetup #1 · Jan 2024</p>
+          <h3>Vancouver AI Meetup #1</h3>
+          <a class="aurora-event-compact-link" href="https://lu.ma/vancouver-ai">Recap / details</a>
+        </div>
+      </article>
+    </div>
+  </section>
+
+<script>
+(function () {
+  var page = document.querySelector('.aurora-events-page');
+  if (!page) return;
+
+  function parseEnd(iso) {
+    var t = Date.parse(iso);
+    return Number.isFinite(t) ? t : NaN;
+  }
+
+  function syncBuckets() {
+    var now = Date.now();
+    var upcomingGrid = page.querySelector('[data-events-grid="upcoming"]');
+    var pastGrid = page.querySelector('[data-events-grid="past"]');
+    var upcomingBucket = page.querySelector('[data-events-bucket="upcoming"]');
+    var pastBucket = page.querySelector('[data-events-bucket="past"]');
+    if (!upcomingGrid || !pastGrid || !upcomingBucket || !pastBucket) return;
+
+    var cards = Array.prototype.slice.call(page.querySelectorAll('[data-event-end]'));
+    cards.sort(function (a, b) {
+      return parseEnd(b.getAttribute('data-event-end')) - parseEnd(a.getAttribute('data-event-end'));
+    });
+
+    cards.forEach(function (card) {
+      var end = parseEnd(card.getAttribute('data-event-end'));
+      if (!Number.isFinite(end)) return;
+      var target = end <= now ? pastGrid : upcomingGrid;
+      if (card.parentElement !== target) target.appendChild(card);
+    });
+
+    upcomingBucket.setAttribute('data-events-empty', upcomingGrid.children.length ? 'false' : 'true');
+    pastBucket.setAttribute('data-events-empty', pastGrid.children.length ? 'false' : 'true');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncBuckets);
+  } else {
+    syncBuckets();
+  }
+})();
+</script>
+
+<!-- EVENTS_DYNAMIC_END -->
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-host">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Series I produce &amp; host</p>
+      <h2 id="aurora-events-host">The rooms I build and keep building.</h2>
+      <p>Not one-off panels. Recurring rituals with their own crowds, collaborators, and momentum.</p>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Monthly · Vancouver</p>
+          <h3>Vancouver AI Community Meetup</h3>
+          <p>The flagship night I host and curate: builders, artists, founders, and the curious in one room every month. Demos, talks, arguments, and the occasional Squatchie Award. The heartbeat of the local scene.</p>
+          <div class="aurora-proof-tags"><span>Host &amp; curator</span><span>Monthly</span><span>Community</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">See upcoming meetups</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Weekly · Online</p>
+          <h3>BC + AI Office Hours</h3>
+          <p>Every Friday, an open working session for the BC + AI ecosystem: questions, show-and-tell, and practical help moving real AI work forward. The connective tissue between the big monthly rooms.</p>
+          <div class="aurora-proof-tags"><span>Host</span><span>Weekly</span><span>Members</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/bcai">Join BC + AI on Luma</a>
+            <a class="aurora-button aurora-button-secondary" href="https://bc-ai.ca/">About BC + AI</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Monthly · Multimodal Media Lab</p>
+          <h3>AI Film Club</h3>
+          <p>Co-led with <strong>Kevin Friel</strong> and <strong>Luke Minaker</strong>: monthly screenings and hands-on accelerators for filmmakers staying human while the tools get good at everything. Building toward the 2nd Annual BC + AI Film Festival in October 2026.</p>
+          <div class="aurora-proof-tags"><span>Co-host</span><span>Screenings</span><span>Accelerators</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://lu.ma/film">See film events</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Ongoing · BC + AI</p>
+          <h3>The special-interest groups</h3>
+          <p>The deeper-end rooms inside the ecosystem: Mind, AI &amp; Consciousness (MAC) deepdives, the AI + Education SIG, and the AI Ethical Futures Lab, plus regional chapters spinning up beyond Vancouver.</p>
+          <div class="aurora-proof-tags"><span>MAC deepdives</span><span>AI + Education</span><span>Ethical Futures</span></div>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="https://bc-ai.ca/">Explore BC + AI</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-stages">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Stages I speak on</p>
+      <h2 id="aurora-events-stages">Keynotes, festivals, and the rooms that travel.</h2>
+      <p>A few recent ones, several with the full talk on tape.</p>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">São Paulo · Keynote</p>
+          <h3>World AI Film Festival Brasil</h3>
+          <p>Opening keynote: "How to keep our souls intact when the machines get really good at making everything." The Both Hands Full framework for filmmakers, students, and creative technologists.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="/speaking/">See speaking topics</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Vancouver · Keynote</p>
+          <h3>LaSalle College</h3>
+          <p>"Both Hands Full: what creatives actually need to know about AI." A graduation-season keynote on staying human, useful, and employable as the tools accelerate.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=-c7mgY2aSgM">Watch the keynote</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Whistler · Speaker series</p>
+          <h3>Whistler Institute Global Speaker Series</h3>
+          <p>"Inside Vancouver's AI Boom": the local scene as a case study in building AI culture that's practical, ethical, and alive instead of hype-driven.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=-XEsqsEbpoo">Watch the talk</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Conference · Keynote</p>
+          <h3>ChannelNext</h3>
+          <p>"The future of humanity: chaos &amp; creativity", a keynote that ends in a live, on-stage AI synthesis of the whole conference. The kind of risk that only works live.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-primary" href="https://www.youtube.com/watch?v=1OcC-0X6Nb8">Watch the keynote</a>
+          </div>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <p class="aurora-card-label">Web Summit Vancouver</p>
+          <h3>Calm Before the Storm</h3>
+          <p>The community night I host on the eve of the big conferences (Web Summit, SIGGRAPH), so the locals own the room before the circus arrives.</p>
+          <div class="aurora-proof-actions">
+            <a class="aurora-button aurora-button-secondary" href="https://lu.ma/websummit-vancouver">See the next one</a>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-proof-section" aria-labelledby="aurora-events-signature">
+    <div class="aurora-section-heading">
+      <p class="aurora-kicker">Signature moments</p>
+      <h2 id="aurora-events-signature">The nights people still talk about.</h2>
+    </div>
+    <div class="aurora-proof-grid">
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>The Thinking Game premiere</h3>
+          <p>A documentary night at the Space Centre theatre with the AI Salon: big screen, bigger conversation.</p>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>The Squatchie Awards</h3>
+          <p>The community's tongue-in-cheek year-end recognition: Vancouver AI's answer to an awards show.</p>
+        </div>
+      </article>
+      <article class="aurora-proof-module aurora-proof-module-text">
+        <div class="aurora-proof-body">
+          <h3>Holiday Social / BC + AI Festivus</h3>
+          <p>The end-of-year gathering where the whole ecosystem (and a birthday or two) collides.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="aurora-final-cta" aria-labelledby="aurora-events-cta">
+    <p class="aurora-kicker">Bring me to your stage, or your city</p>
+    <h2 id="aurora-events-cta">Come to a room, or let's build one.</h2>
+    <p>Follow along on Luma for what's next, or bring a keynote, workshop, or community build to your event.</p>
+    <div class="aurora-action-row">
+      <a class="aurora-button aurora-button-primary" href="https://lu.ma/vancouver-ai">Follow on Luma</a>
+      <a class="aurora-button aurora-button-secondary" href="/speaking/">Book Kris to speak</a>
+    </div>
+  </section>
+</div>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-2250-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/page-2250-identity.json
@@ -1,0 +1,15 @@
+{
+  "id": 2250,
+  "slug": "events",
+  "status": "publish",
+  "link": "https://kriskrug.co/events/",
+  "modified": "2026-08-10T10:38:46",
+  "modified_gmt": "2026-08-10T18:38:46",
+  "type": "page",
+  "content_rendered_bytes": 56795,
+  "content_rendered_sha256": "4353740134b28aa577de881cd41aaf071e8304444540687cb3562206145beb43",
+  "snapshot_source": "public_rest_rendered_20260819_must_not_write_fixture",
+  "must_not_write": true,
+  "owned_by": 635,
+  "title_rendered": "Events"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-content.raw.html
@@ -1,0 +1,331 @@
+
+<h3 class="wp-block-heading"><a href="https://lu.ma/vancouver-ai">Vancouver AI</a> community meetups welcomes all members of the community interested in the future of AI &#8211; researchers, artists, geeks, enthusiasts, entrepreneurs, experts, students and more! </h3>
+
+
+
+<p class="wp-block-paragraph"><em>Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.</em></p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="uBr3JMpbnN"><a href="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/">DIY AI in Vancouver: Building a Grassroots BC AI Industry Association</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;DIY AI in Vancouver: Building a Grassroots BC AI Industry Association&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/embed/#?secret=ZbFLZmwQXv#?secret=uBr3JMpbnN" data-secret="uBr3JMpbnN" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m excited to share something special we&#8217;ve been working on for the <a href="https://lu.ma/future-proof?tag=ai%20meetup" data-type="link" data-id="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a>. This year, we&#8217;re hosting a series of meetups designed to dive deep into the world of Artificial Intelligence. Our aim is simple yet ambitious: to create a space where people from all walks of the AI landscape can come together to share knowledge, challenge ideas, and explore the real-world applications and ethical implications of AI.</p>
+
+
+
+<p class="wp-block-paragraph">We&#8217;re looking forward to a year of meaningful discussions and hands-on learning, with each meetup focusing on a different facet of AI. From the impact of AI on visual storytelling and personal branding to exploring its role in emerging fields like VR and gaming, we&#8217;re covering a wide spectrum. These sessions are more than just talks; they&#8217;re collaborative platforms for both seasoned pros and curious newcomers to connect and grow.</p>
+
+
+
+<p class="wp-block-paragraph">Our goal with these meetups is to foster a community that&#8217;s as diverse as the AI field itself. Whether you&#8217;re a developer, a researcher, an artist, or just someone fascinated by AI, we want you to be part of this journey. We believe in a straightforward, no-hype approach where the focus is on real value, deep technical insights, and honest discussions. Join us and be part of a conversation that&#8217;s shaping the future of AI, right here in Vancouver.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to seeing you there and diving into these compelling AI topics together.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="hobkydTjd0"><a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/embed/#?secret=DPASbG5aT2#?secret=hobkydTjd0" data-secret="hobkydTjd0" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h2>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.vancouverbiennale.com/" target="_blank" rel="noreferrer noopener"><strong>Vancouver Biennale</strong></a><strong>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://creativemornings.com/cities/van"><strong>Creative Mornings Vancouver</strong></a> &#8211; free monthly breakfast lectures for creatives</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://holistichybrid.com/"><strong>Holistic Hybrid</strong></a><strong>:</strong> A digital strategy powerhouse.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.linkedin.com/in/lindsay-bailey-600a46b/"><strong>Lindsay Bailey Law</strong></a><strong>:</strong> Legal expertise with a creative twist.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.augxlabs.com/"><strong>AugXLabs</strong></a><strong>:</strong> At the forefront of text-to-video AI.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://cmpfyr.co/"><strong>CMPFYR</strong></a><strong>:</strong> The digital arena&#8217;s rising star.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://fatalefestival.com/"><strong>The FATALE Festival</strong></a><strong>:</strong> The FATALE Festival is a beacon for forward-thinking art and technology enthusiasts.</li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>January</strong>: <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></li>
+
+
+
+<li><strong>February</strong>: <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></li>
+
+
+
+<li><strong>March</strong>: <a href="https://lu.ma/communications">https://lu.ma/communications</a></li>
+
+
+
+<li><strong>April</strong>: <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></li>
+
+
+
+<li><strong>May</strong>: <a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></li>
+
+
+
+<li><strong>June</strong>: <a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></li>
+
+
+
+<li><strong>July</strong>: <a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></li>
+
+
+
+<li><strong>August</strong>: <a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></li>
+
+
+
+<li><strong>September</strong>: <a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></li>
+
+
+
+<li><strong>October</strong>: <a href="https://lu.ma/esg">https://lu.ma/esg</a></li>
+
+
+
+<li><strong>November</strong>: <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></li>
+
+
+
+<li><strong>December</strong>: <a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35859da&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35859da" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="640" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=1024%2C640&#038;ssl=1" alt="Vancouver AI Meetup 2024 Event Calendar" class="wp-image-4350" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=768%2C480&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Meetup 2024 Event Calendar</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-trends">AI Trends &amp; Tools: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, January 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss emerging AI technologies and how they’re being applied in various industries and creative fields. Share experiences and get advice from the local AI community.<br /><strong>Target Audience:</strong> Anyone interested in AI and its applications<br /><strong>Key Takeaways:</strong> Learn about new trends in AI development from local experts and practitioners. Make valuable connections.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-storytelling">Visual Storytelling with AI: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, February 22, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> This meetup explores how visual storytellers like filmmakers are utilizing AI tools in their work and envisioning future possibilities.<br /><strong>Target Audience:</strong> Filmmakers, photographers, visual artists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Discussions on tools like DALL-E and Stable Diffusion and their applications; ethical challenges around AI and visual media.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/communications">AI Communications Circle: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, March 28, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss effective strategies for communicating AI concepts to different stakeholders and the role of language in human-AI relations.<br /><strong>Target Audience:</strong> Writers, communicators, product managers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Perspectives on explaining AI to the public and building trust around emerging technologies.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/communications">https://lu.ma/communications</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/hacking">AI Coding Symposium: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, April 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Tech talks and panels on the latest approaches to coding and developing intelligent applications.<br /><strong>Target Audience:</strong> Developers, engineers, data scientists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Insights on AI frameworks, best practices and upcoming trends in AI programming.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/socialmedia">AI Social Media &amp; Personal Branding: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, May 30, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss leveraging social platforms and content to establish authority in the AI space. Share challenges and solutions.<br /><strong>Target Audience:</strong> Consultants, entrepreneurs, freelancers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Tips on creating an online identity and engaging communities through prudent use of AI.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-music">AI Audio Alchemy: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, June 27, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discuss AI tools and techniques for audio/music and implications for creators in these fields.<br /><strong>Target Audience</strong>: Producers, composers, podcasters, voice professionals, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Learn how others are crafting AI into audio/aesthetic workflows imaginatively and responsibility.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link: </strong><a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-artists">AI Artistic Evolution: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 25th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An evening exploring how AI is shaping the future of art and creativity. Discuss tools, techniques and implications for artists.<br /><strong>Target Audience:</strong> Artists, designers, illustrators, photographers, film makers, creative professionals, marketing professionals, community managers. <br /><strong>Key Takeaways:</strong> Learn about emerging AI tools and techniques influencing different creative fields.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/growth-hacking">Growth Hacking: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 27th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> A deep dive into innovative AI strategies for hyper-growth and catapulting businesses to the next level.<br /><strong>Target Audience:</strong> Entrepreneurs, marketers, business professionals<br /><strong>Key Takeaways:</strong> Discover innovative AI-driven growth strategies and case studies. Gain insights on applying AI to marketing, customer acquisition and retention. Learn how startups are leveraging AI to scale rapidly.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/AI-meetup">AI Business Impact: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> September 26th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An enlightening evening exploring the burgeoning impact of Generative AI on business landscapes.<br /><strong>Target Audience:</strong> Business leaders, executives, innovators<br /><strong>Key Takeaways:</strong> Explore the transformational role of generative AI across various industries. Understand implications and applications for product development, operations, marketing. Discuss best practices for responsible and <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> integration.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/esg">Sustainability &amp; AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> Thursday, October 24, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discussions on integrating environmental, social and governance priorities into AI strategies.<br /><strong>Target Audience:</strong> Sustainability professionals, social impact practitioners<br /><strong>Key Takeaways:</strong> Learn how ESG priorities can inform AI strategies and development. Discuss partnering with AI for positive social and environmental impact. Identify opportunities for AI to address sustainability challenges.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/esg">https://lu.ma/esg</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-games">AI in VR &amp; Gaming: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> November 21st, 224<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Insights into cutting-edge AI applications and the future of gaming/VR experiences.<br /><strong>Target Audience:</strong> Gamers, developers, technologists<br /><strong>Key Takeaways:</strong> Demos of cutting-edge AI applications in gaming and immersive experiences. Discuss design considerations and future trends. Explore ethical issues around AI, addiction, realism in digital worlds.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/multimodal">Multimodal AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> December 19th, 2024<br /><strong>Location</strong>: 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An exploration of integrating text, image and sound recognition with AI.<br /><strong>Target Audience:</strong> Data scientists, UX designers, engineers<br /><strong>Key Takeaways: </strong>Understand approaches to integrating text, visual and audio AI systems. Learn challenges and opportunities of multimodal AI. Gain exposure to tools and techniques across industries.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h3>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit. Their support empowers us to blend art with technology innovatively. <a href="https://www.vancouverbiennale.com/">Learn more</a></li>
+
+
+
+<li><strong><a href="https://www.augxlabs.com/">AugXLabs</a>:</strong> At the forefront of augmented reality, AugXLabs brings cutting-edge tech to our events, enhancing the immersive experience. <a href="https://www.augxlabs.com/">Discover AugXLabs</a></li>
+
+
+
+<li><strong><a href="https://holistichybrid.com/">Holistic Hybrid</a>:</strong> A digital strategy powerhouse, Holistic Hybrid&#8217;s expertise in blending creativity with digital know-how elevates our platforms. <a href="https://holistichybrid.com/">Explore Holistic Hybrid</a></li>
+
+
+
+<li><strong><a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Lindsay Bailey Law</a>:</strong> Legal expertise with a creative twist. Lindsay Bailey provides invaluable legal guidance, ensuring our events and initiatives are on solid ground. <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Connect with Lindsay Bailey</a></li>
+
+
+
+<li><strong><a href="https://fatalefestival.com/">The FATALE Festival</a>:</strong> A partner in creativity and innovation, the FATALE Festival is a beacon for forward-thinking art and technology enthusiasts. <a href="https://fatalefestival.com/">Visit FATALE Festival</a></li>
+
+
+
+<li><strong><a href="https://cmpfyr.co/">CMPFYR</a>:</strong> The digital arena&#8217;s rising star, CMPFYR, brings fresh, tech-driven solutions to our digital strategy, pushing the boundaries of what&#8217;s possible. <a href="https://cmpfyr.co/">About CMPFYR</a></li>
+
+
+
+<li><a href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers, Internet Masterminds brings together a community of innovators and disruptors. <a href="https://internetmasterminds.org/">Discover Internet Masterminds</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Partnership Invitation</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Join forces with Future Proof Creatives to expand your reach and engage with a thriving community of innovators and creators. Our partnerships are tailored to amplify your brand&#8217;s presence among an audience passionate about art, technology, and sustainability. Past collaborations have included:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Innovative Workshops and Seminars:</strong> Co-create unique learning experiences in digital art, technology integration, and sustainable practices.</li>
+
+
+
+<li><strong>Exclusive Event Sponsorships:</strong> Be part of our compelling events like art-tech exhibitions, online forums, and creative meetups.</li>
+
+
+
+<li><strong>Product Showcases and Launches:</strong> Introduce your cutting-edge products to a community eager for innovation.</li>
+
+
+
+<li><strong>Customized Community Engagements:</strong> From think-tank sessions to creative challenges, we offer diverse platforms for meaningful interactions.</li>
+</ul>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re keen on partnering with Future Proof Creatives to connect with leading creators, innovators, and thought leaders, <a href="https://kriskrug.co/contact/" data-type="link" data-id="https://kriskrug.co/contact/">reach out to us</a>&#8230; Let&#8217;s create something extraordinary together!</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-ethics/">AI Ethics and Philosophy</a> collection. See also: <a href="https://kriskrug.co/2023/10/13/the-art-of-augmented-creativity-balancing-ai-community-and-self/">The Art of Augmented Creativity: Balancing AI, Community, and Self</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-content.rendered.html
@@ -1,0 +1,331 @@
+
+<h3 class="wp-block-heading"><a href="https://lu.ma/vancouver-ai">Vancouver AI</a> community meetups welcomes all members of the community interested in the future of AI &#8211; researchers, artists, geeks, enthusiasts, entrepreneurs, experts, students and more! </h3>
+
+
+
+<p class="wp-block-paragraph"><em>Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.</em></p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="uBr3JMpbnN"><a href="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/">DIY AI in Vancouver: Building a Grassroots BC AI Industry Association</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;DIY AI in Vancouver: Building a Grassroots BC AI Industry Association&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/04/19/vancouvers-ai-how-grassroots-innovation-is-reshaping-british-columbias-tech-future/embed/#?secret=ZbFLZmwQXv#?secret=uBr3JMpbnN" data-secret="uBr3JMpbnN" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m excited to share something special we&#8217;ve been working on for the <a href="https://lu.ma/future-proof?tag=ai%20meetup" data-type="link" data-id="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a>. This year, we&#8217;re hosting a series of meetups designed to dive deep into the world of Artificial Intelligence. Our aim is simple yet ambitious: to create a space where people from all walks of the AI landscape can come together to share knowledge, challenge ideas, and explore the real-world applications and ethical implications of AI.</p>
+
+
+
+<p class="wp-block-paragraph">We&#8217;re looking forward to a year of meaningful discussions and hands-on learning, with each meetup focusing on a different facet of AI. From the impact of AI on visual storytelling and personal branding to exploring its role in emerging fields like VR and gaming, we&#8217;re covering a wide spectrum. These sessions are more than just talks; they&#8217;re collaborative platforms for both seasoned pros and curious newcomers to connect and grow.</p>
+
+
+
+<p class="wp-block-paragraph">Our goal with these meetups is to foster a community that&#8217;s as diverse as the AI field itself. Whether you&#8217;re a developer, a researcher, an artist, or just someone fascinated by AI, we want you to be part of this journey. We believe in a straightforward, no-hype approach where the focus is on real value, deep technical insights, and honest discussions. Join us and be part of a conversation that&#8217;s shaping the future of AI, right here in Vancouver.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to seeing you there and diving into these compelling AI topics together.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="hobkydTjd0"><a href="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/">Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Future Proof: Inside Vancouver&#8217;s Thriving AI Ecosystem&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2024/10/10/future-proof-inside-vancouvers-thriving-ai-ecosystem/embed/#?secret=DPASbG5aT2#?secret=hobkydTjd0" data-secret="hobkydTjd0" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h2>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.vancouverbiennale.com/" target="_blank" rel="noreferrer noopener"><strong>Vancouver Biennale</strong></a><strong>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://creativemornings.com/cities/van"><strong>Creative Mornings Vancouver</strong></a> &#8211; free monthly breakfast lectures for creatives</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://holistichybrid.com/"><strong>Holistic Hybrid</strong></a><strong>:</strong> A digital strategy powerhouse.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.linkedin.com/in/lindsay-bailey-600a46b/"><strong>Lindsay Bailey Law</strong></a><strong>:</strong> Legal expertise with a creative twist.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://www.augxlabs.com/"><strong>AugXLabs</strong></a><strong>:</strong> At the forefront of text-to-video AI.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://cmpfyr.co/"><strong>CMPFYR</strong></a><strong>:</strong> The digital arena&#8217;s rising star.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers.</li>
+
+
+
+<li><a target="_blank" rel="noreferrer noopener" href="https://fatalefestival.com/"><strong>The FATALE Festival</strong></a><strong>:</strong> The FATALE Festival is a beacon for forward-thinking art and technology enthusiasts.</li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>January</strong>: <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></li>
+
+
+
+<li><strong>February</strong>: <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></li>
+
+
+
+<li><strong>March</strong>: <a href="https://lu.ma/communications">https://lu.ma/communications</a></li>
+
+
+
+<li><strong>April</strong>: <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></li>
+
+
+
+<li><strong>May</strong>: <a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></li>
+
+
+
+<li><strong>June</strong>: <a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></li>
+
+
+
+<li><strong>July</strong>: <a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></li>
+
+
+
+<li><strong>August</strong>: <a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></li>
+
+
+
+<li><strong>September</strong>: <a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></li>
+
+
+
+<li><strong>October</strong>: <a href="https://lu.ma/esg">https://lu.ma/esg</a></li>
+
+
+
+<li><strong>November</strong>: <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></li>
+
+
+
+<li><strong>December</strong>: <a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35859da&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35859da" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="640" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=1024%2C640&#038;ssl=1" alt="Vancouver AI Meetup 2024 Event Calendar" class="wp-image-4350" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/12/Untitled-design-1.png?resize=768%2C480&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Meetup 2024 Event Calendar</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-trends">AI Trends &amp; Tools: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, January 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss emerging AI technologies and how they’re being applied in various industries and creative fields. Share experiences and get advice from the local AI community.<br /><strong>Target Audience:</strong> Anyone interested in AI and its applications<br /><strong>Key Takeaways:</strong> Learn about new trends in AI development from local experts and practitioners. Make valuable connections.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-trends">https://lu.ma/ai-trends</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><br /><strong>Title:</strong> <a href="https://lu.ma/ai-storytelling">Visual Storytelling with AI: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, February 22, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> This meetup explores how visual storytellers like filmmakers are utilizing AI tools in their work and envisioning future possibilities.<br /><strong>Target Audience:</strong> Filmmakers, photographers, visual artists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Discussions on tools like DALL-E and Stable Diffusion and their applications; ethical challenges around AI and visual media.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-storytelling">https://lu.ma/ai-storytelling</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/communications">AI Communications Circle: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, March 28, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss effective strategies for communicating AI concepts to different stakeholders and the role of language in human-AI relations.<br /><strong>Target Audience:</strong> Writers, communicators, product managers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Perspectives on explaining AI to the public and building trust around emerging technologies.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/communications">https://lu.ma/communications</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/hacking">AI Coding Symposium: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, April 25, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Tech talks and panels on the latest approaches to coding and developing intelligent applications.<br /><strong>Target Audience:</strong> Developers, engineers, data scientists, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Insights on AI frameworks, best practices and upcoming trends in AI programming.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/hacking">https://lu.ma/hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title</strong>: <a href="https://lu.ma/socialmedia">AI Social Media &amp; Personal Branding: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, May 30, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Discuss leveraging social platforms and content to establish authority in the AI space. Share challenges and solutions.<br /><strong>Target Audience:</strong> Consultants, entrepreneurs, freelancers, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Tips on creating an online identity and engaging communities through prudent use of AI.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/socialmedia">https://lu.ma/socialmedia</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-music">AI Audio Alchemy: Vancouver AI Community Meetup</a><br /><strong>Date &amp; Time:</strong> Thursday, June 27, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discuss AI tools and techniques for audio/music and implications for creators in these fields.<br /><strong>Target Audience</strong>: Producers, composers, podcasters, voice professionals, AI professionals, enthusiasts and anyone interested in AI and its applications.<br /><strong>Key Takeaways:</strong> Learn how others are crafting AI into audio/aesthetic workflows imaginatively and responsibility.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link: </strong><a href="https://lu.ma/ai-music">https://lu.ma/ai-music</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-artists">AI Artistic Evolution: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 25th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An evening exploring how AI is shaping the future of art and creativity. Discuss tools, techniques and implications for artists.<br /><strong>Target Audience:</strong> Artists, designers, illustrators, photographers, film makers, creative professionals, marketing professionals, community managers. <br /><strong>Key Takeaways:</strong> Learn about emerging AI tools and techniques influencing different creative fields.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/ai-artists">https://lu.ma/ai-artists</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/growth-hacking">Growth Hacking: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> July 27th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> A deep dive into innovative AI strategies for hyper-growth and catapulting businesses to the next level.<br /><strong>Target Audience:</strong> Entrepreneurs, marketers, business professionals<br /><strong>Key Takeaways:</strong> Discover innovative AI-driven growth strategies and case studies. Gain insights on applying AI to marketing, customer acquisition and retention. Learn how startups are leveraging AI to scale rapidly.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/growth-hacking">https://lu.ma/growth-hacking</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/AI-meetup">AI Business Impact: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> September 26th<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An enlightening evening exploring the burgeoning impact of Generative AI on business landscapes.<br /><strong>Target Audience:</strong> Business leaders, executives, innovators<br /><strong>Key Takeaways:</strong> Explore the transformational role of generative AI across various industries. Understand implications and applications for product development, operations, marketing. Discuss best practices for responsible and <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> integration.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/AI-meetup">https://lu.ma/AI-meetup</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/esg">Sustainability &amp; AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> Thursday, October 24, 2024<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description</strong>: Discussions on integrating environmental, social and governance priorities into AI strategies.<br /><strong>Target Audience:</strong> Sustainability professionals, social impact practitioners<br /><strong>Key Takeaways:</strong> Learn how ESG priorities can inform AI strategies and development. Discuss partnering with AI for positive social and environmental impact. Identify opportunities for AI to address sustainability challenges.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/esg">https://lu.ma/esg</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/ai-games">AI in VR &amp; Gaming: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> November 21st, 224<br /><strong>Location:</strong> 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> Insights into cutting-edge AI applications and the future of gaming/VR experiences.<br /><strong>Target Audience:</strong> Gamers, developers, technologists<br /><strong>Key Takeaways:</strong> Demos of cutting-edge AI applications in gaming and immersive experiences. Discuss design considerations and future trends. Explore ethical issues around AI, addiction, realism in digital worlds.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong> <a href="https://lu.ma/ai-games">https://lu.ma/ai-games</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Title:</strong> <a href="https://lu.ma/multimodal">Multimodal AI: Vancouver AI Community Meetup</a><br /><strong>Date:</strong> December 19th, 2024<br /><strong>Location</strong>: 290 W 3rd Ave, Vancouver<br /><strong>Description:</strong> An exploration of integrating text, image and sound recognition with AI.<br /><strong>Target Audience:</strong> Data scientists, UX designers, engineers<br /><strong>Key Takeaways: </strong>Understand approaches to integrating text, visual and audio AI systems. Learn challenges and opportunities of multimodal AI. Gain exposure to tools and techniques across industries.<br /><strong>Host:</strong> Kris Krüg<br /><strong>Registration Link:</strong>&nbsp;<a href="https://lu.ma/multimodal">https://lu.ma/multimodal</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Big Love to Our Sponsors &amp; Partners</h3>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>:</strong> A trailblazer in public art, the Vancouver Biennale transforms the cityscape into an interactive art exhibit. Their support empowers us to blend art with technology innovatively. <a href="https://www.vancouverbiennale.com/">Learn more</a></li>
+
+
+
+<li><strong><a href="https://www.augxlabs.com/">AugXLabs</a>:</strong> At the forefront of augmented reality, AugXLabs brings cutting-edge tech to our events, enhancing the immersive experience. <a href="https://www.augxlabs.com/">Discover AugXLabs</a></li>
+
+
+
+<li><strong><a href="https://holistichybrid.com/">Holistic Hybrid</a>:</strong> A digital strategy powerhouse, Holistic Hybrid&#8217;s expertise in blending creativity with digital know-how elevates our platforms. <a href="https://holistichybrid.com/">Explore Holistic Hybrid</a></li>
+
+
+
+<li><strong><a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Lindsay Bailey Law</a>:</strong> Legal expertise with a creative twist. Lindsay Bailey provides invaluable legal guidance, ensuring our events and initiatives are on solid ground. <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b/">Connect with Lindsay Bailey</a></li>
+
+
+
+<li><strong><a href="https://fatalefestival.com/">The FATALE Festival</a>:</strong> A partner in creativity and innovation, the FATALE Festival is a beacon for forward-thinking art and technology enthusiasts. <a href="https://fatalefestival.com/">Visit FATALE Festival</a></li>
+
+
+
+<li><strong><a href="https://cmpfyr.co/">CMPFYR</a>:</strong> The digital arena&#8217;s rising star, CMPFYR, brings fresh, tech-driven solutions to our digital strategy, pushing the boundaries of what&#8217;s possible. <a href="https://cmpfyr.co/">About CMPFYR</a></li>
+
+
+
+<li><a href="https://internetmasterminds.org/"><strong>Internet Masterminds</strong></a>: A dynamic hub for digital entrepreneurs and online marketers, Internet Masterminds brings together a community of innovators and disruptors. <a href="https://internetmasterminds.org/">Discover Internet Masterminds</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Partnership Invitation</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Join forces with Future Proof Creatives to expand your reach and engage with a thriving community of innovators and creators. Our partnerships are tailored to amplify your brand&#8217;s presence among an audience passionate about art, technology, and sustainability. Past collaborations have included:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Innovative Workshops and Seminars:</strong> Co-create unique learning experiences in digital art, technology integration, and sustainable practices.</li>
+
+
+
+<li><strong>Exclusive Event Sponsorships:</strong> Be part of our compelling events like art-tech exhibitions, online forums, and creative meetups.</li>
+
+
+
+<li><strong>Product Showcases and Launches:</strong> Introduce your cutting-edge products to a community eager for innovation.</li>
+
+
+
+<li><strong>Customized Community Engagements:</strong> From think-tank sessions to creative challenges, we offer diverse platforms for meaningful interactions.</li>
+</ul>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re keen on partnering with Future Proof Creatives to connect with leading creators, innovators, and thought leaders, <a href="https://kriskrug.co/contact/" data-type="link" data-id="https://kriskrug.co/contact/">reach out to us</a>&#8230; Let&#8217;s create something extraordinary together!</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-ethics/">AI Ethics and Philosophy</a> collection. See also: <a href="https://kriskrug.co/2023/10/13/the-art-of-augmented-creativity-balancing-ai-community-and-self/">The Art of Augmented Creativity: Balancing AI, Community, and Self</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4348-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 4348,
+  "slug": "2024-vancouver-ai-community-meetups",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/12/27/2024-vancouver-ai-community-meetups/",
+  "modified": "2026-06-28T20:36:48",
+  "modified_gmt": "2026-06-29T04:36:48",
+  "type": "post",
+  "content_raw_bytes": 24883,
+  "content_rendered_bytes": 24883,
+  "content_raw_has_footer": true,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 0,
+  "title_rendered": "Vancouver AI Community Meetups &amp; BC + AI Ecosystem"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-content.raw.html
@@ -1,0 +1,467 @@
+
+<h2 class="wp-block-heading">Curiosity, Community, Creativity &amp; Code Converge</h2>
+
+
+
+<p class="wp-block-paragraph">The inaugural <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community Meetup</a>, convened at the heart of Vancouver&#8217;s creative nexus, <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media headquarters</a>, within the inspiring <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a> art warehouse, was a landmark event, signaling a vibrant kickoff for a series of gatherings dedicated to the exploration of artificial intelligence in creative realms.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/gln3RCVGZN4?si=CBmllOcq_juDUvke" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">This sold-out event attracted a wide array of participants, from curious enthusiasts to seasoned professionals, all drawn together by a shared passion for the potential of AI to transform storytelling, art, and technology. </p>
+
+
+
+<p class="wp-block-paragraph">Through a series of engaging discussions, interactive installations, and hands-on demonstrations, the meetup fostered a rich environment for collaboration, learning, and inspiration. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3265d42&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3265d42" class="wp-block-image size-full is-style-default wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="2226" height="1913" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2226%2C1913&#038;ssl=1" alt="" class="wp-image-4518" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?w=2226&amp;ssl=1 2226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=300%2C258&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1024%2C880&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=768%2C660&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1536%2C1320&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2048%2C1760&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Welcoming Vancouver AI Community to my new studio at Vancouver Biennale HQ.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The evening underscored the ethos of the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI community">Vancouver AI Community</a> Meetup: to build an inclusive, engaged group focused on the real-world applications and ethical considerations of AI, setting a dynamic precedent for future gatherings and cementing its role as a cornerstone for AI exploration in Vancouver.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326650a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326650a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="355" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI.jpg?resize=1024%2C355&#038;ssl=1" alt="" class="wp-image-4517" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1024%2C355&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=300%2C104&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=768%2C267&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1536%2C533&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=2048%2C711&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetups bring together a wide cross section of people working with AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>A Rallying Cry for Inclusivity and Exploration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3266d4d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3266d4d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1.jpg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-4508" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1536%2C861&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=2048%2C1148&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=528%2C297&amp;ssl=1 528w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Charlene Joseph: S?wx?wú7mesh Nation Language and Cultural teacher? ?opens with a song.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Community Meetup is founded on a principle of inclusivity. Our ethos is simple yet profound: to welcome everyone intrigued by AI&#8217;s potential. From seasoned researchers to budding artists, from tech enthusiasts to curious students, our aim is to forge a vibrant tapestry of individuals united by their passion for exploring the frontiers of artificial intelligence.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326760c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326760c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18.jpg?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-4520" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1536%2C864&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=2048%2C1152&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Philippe Pasquier is a professor at&nbsp;SFU&#8217;s School of Interactive Arts and&nbsp;Technology, where he directs the Metacreation Lab for Creative AI</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we plan meetups for the last week of every month throughout the year, our vision is to build an engaged, dynamic group. This community isn&#8217;t just about sharing knowledge; it&#8217;s about challenging each other, collaborating on real-world applications, and navigating the ethical labyrinth that AI presents.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Reflecting on Our First Gathering</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3267f37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3267f37" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-4511" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=2048%2C1151&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><em>Steve DiPaola</em>, active as an artist and a scientist, is a professor/researcher at Simon Fraser University, Steve directs the I-Viz Lab</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night of our first meetup was electric. <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media&#8217;s</a> headquarters, within the eclectic <a href="https://www.vancouverbiennale.com/">Vancouver Biennale Art Warehouse</a>, became a crucible of creativity and innovation. The event was a kaleidoscope of insights, demonstrations, and hands-on sessions, each designed to demystify AI and showcase its transformative power in creative endeavors.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Gratitude for Our Speakers</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32687c8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32687c8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="573" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15.jpg?resize=1024%2C573&#038;ssl=1" alt="" class="wp-image-4509" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1024%2C573&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Justine Gauthier is the Director of Corporate &amp; Legal Affairs at&nbsp;<a href="https://theorg.com/org/mila-quebec-artificial-intelligence-institute">Mila &#8211; Quebec Artificial Intelligence Institute</a>.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The success of our inaugural meetup owes much to the incredible speakers who shared their insights and visions with us. <a href="https://vancouver.ca/your-government/mike-klassen.aspx">Mike Klassen</a>, <a href="https://katearmstrong.com">Kate Armstrong</a>, <a href="http://stevebroback.com/about/">Steve Broback</a>, <a href="https://mila.quebec/en/person/justine-gauthier/">Justine Gauthier</a>, <a href="https://www.linkedin.com/in/steve-lowry-vancouver?originalSubdomain=ca">Steve Lowry</a>, and <a href="http://ispace.iat.sfu.ca/person/mirjana-prpa/">Mirjana Prpa</a> — each brought a unique perspective to the table, enriching our discussions and expanding our understanding of AI&#8217;s impact on society and creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3269001&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3269001" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="771" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2.jpg?resize=771%2C1024&#038;ssl=1" alt="" class="wp-image-4516" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=771%2C1024&amp;ssl=1 771w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=226%2C300&amp;ssl=1 226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=768%2C1020&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1157%2C1536&amp;ssl=1 1157w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1542%2C2048&amp;ssl=1 1542w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?w=1928&amp;ssl=1 1928w" sizes="auto, (max-width: 771px) 100vw, 771px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kate Armstrong: Director of&nbsp;<em>Living Labs</em>&nbsp;at Emily Carr University of Art + Design. Co-director of AI Futures for Art + Design</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their expertise helped to set a dynamic and insightful tone for the event, fostering a fertile ground for innovation and exchange.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Celebrating Our Artists</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326984d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326984d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="907" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6.jpg?resize=1024%2C907&#038;ssl=1" alt="" class="wp-image-4502" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1024%2C907&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=300%2C266&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=768%2C680&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1536%2C1361&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=2048%2C1815&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">An invocation to the Holy Mother of the Void is made; the void from which all things are born. As the future becomes the present and we forge into an age of AI art, how can we know what is human movement and what is not?</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our event was further illuminated by the contributions of pioneering AI artists who showcased interactive art installations at the forefront of avant-garde creativity. <a href="https://www.sfu.ca/siat/people/research-faculty/steve-dipaola.html">Steve DiPaola</a>, <a href="https://www.linkedin.com/in/meehae-song/">Meehae Song</a>, <a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier</a>, <a href="https://www.arshsobhan.com/">Arshia Sobhan</a>, <a href="https://www.facebook.com/orbitprincess/">Marina Tsougrianis (AKA Orbit Princess)</a>, and <a href="https://www.linkedin.com/in/vickymittal">Vicky Mittal</a> — these individuals are not just artists but trailblazers, merging technology with human expression in ways that challenge our perceptions and open new dialogues. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a09b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a09b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="570" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12.jpg?resize=1024%2C570&#038;ssl=1" alt="" class="wp-image-4512" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1024%2C570&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=768%2C427&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1536%2C854&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=2048%2C1139&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Portrait Jordan Bent: Special thanks for making photos and videos at the event Peter Holst.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their installations provided a tangible glimpse into the creative potential of AI, captivating attendees with a vivid display of the intersection between art and technology.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Fostering Growth and Collaboration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a8de&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a8de" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="863" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3.jpg?resize=863%2C1024&#038;ssl=1" alt="" class="wp-image-4501" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=863%2C1024&amp;ssl=1 863w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=253%2C300&amp;ssl=1 253w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=768%2C911&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1295%2C1536&amp;ssl=1 1295w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1727%2C2048&amp;ssl=1 1727w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 863px) 100vw, 863px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Old buddy Mike Klassen is a public affairs professional serving in executive leadership roles, media pundit and organizational spokesperson.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">What makes the Vancouver AI Community Meetup unique is its commitment to cultivating a supportive ecosystem for experimentation and growth. As its curator, I am dedicated to building a platform where individuals from various backgrounds can share their ideas, challenge each other, and collaborate on projects that push the envelope of what&#8217;s technologically and creatively possible.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b0bd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b0bd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="560" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10.jpg?resize=1024%2C560&#038;ssl=1" alt="" class="wp-image-4513" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1024%2C560&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=300%2C164&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=768%2C420&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1536%2C840&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=2048%2C1120&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Steve Lowry, the Founding Executive Director of AInBC</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our initiative goes beyond networking. We are creating a community where the exchange of knowledge and experiences leads to real-world applications and thoughtful consideration of AI&#8217;s impact on society. Through training sessions and workshops, we aim to equip creatives with the tools they need to harness the power of AI in their work, ensuring that our community remains at the forefront of this exciting field.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>The Road Ahead</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b928&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b928" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="552" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16.jpg?resize=1024%2C552&#038;ssl=1" alt="" class="wp-image-4514" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1024%2C552&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=300%2C162&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=768%2C414&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1536%2C827&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=2048%2C1103&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mark Busse: Strategy + Creativity + Design + Conversation = Ideas &amp; Engagement &amp; Community &amp; Impact. Add good food = magic.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look to the future, the Vancouver AI Community Meetup is poised at the edge of a new dawn. Our collective journey is only beginning, with each meetup strengthening our resolve and enriching our discourse. We stand on the threshold of a new era where technology and human ingenuity converge, creating a tapestry of unimaginable beauty and complexity.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-EzZHFIbxGIJvSUh" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">I extend an open invitation to you, regardless of your familiarity with AI, to join this adventure. Together, we can explore the vast expanse of artificial intelligence, learning, growing, and shaping a future where technology amplifies our creative potential.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c17a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c17a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="974" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9.jpg?resize=1024%2C974&#038;ssl=1" alt="" class="wp-image-4515" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1024%2C974&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=300%2C285&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=768%2C730&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1536%2C1461&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=2048%2C1948&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mirjana Prpa. Assistant Professor,&nbsp;Northeastern&nbsp; University</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For those eager to dive into this renaissance of technology and art, the Vancouver AI Community Meetup awaits. Join us as we navigate the uncharted waters of AI, forging paths where none existed, in pursuit of a future bright with promise and imbued with creativity.</p>
+
+
+
+<p class="wp-block-paragraph">Together, let&#8217;s make Vancouver a lighthouse of AI innovation and artistic exploration. Join our next meetup and become part of a community dedicated to shaping the future of artificial intelligence and beyond.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c99a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c99a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="993" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4.jpg?resize=993%2C1024&#038;ssl=1" alt="" class="wp-image-4499" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=993%2C1024&amp;ssl=1 993w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=291%2C300&amp;ssl=1 291w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=768%2C792&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1490%2C1536&amp;ssl=1 1490w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1987%2C2048&amp;ssl=1 1987w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 993px) 100vw, 993px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bantering about IP, copyright and the shifting legal framework in the face of technological disruption brought on by AI and ML.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For more details on our upcoming events and how you can be a part of this exciting journey, visit our website or follow us on our social channels. Let&#8217;s embark on this path together, exploring the endless possibilities that AI and creativity hold for our world.</p>
+
+
+
+<p class="wp-block-paragraph">As we reflect on the journey of the Vancouver AI Community Meetup and look forward to the paths yet to tread, it is essential to recognize the individuals and organizations whose contributions have been the bedrock of our burgeoning community.</p>
+
+
+
+<p class="wp-block-paragraph">A special round of applause to <a href="https://robertmichaelmurray.com/">Robert Michael Murray</a> and <a href="https://www.linkedin.com/in/d-yaschenko/">Daria Yashenko</a>. Behind the scenes, your efforts were the glue that held everything together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="572" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13.jpg?resize=1024%2C572&#038;ssl=1" alt="" class="wp-image-4510" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1024%2C572&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Our gratitude also extends to <a href="https://www.linkedin.com/in/wayneracine?originalSubdomain=ca">Wayne Shadow</a>, <a href="https://www.kempedmonds.com/">Kemp Edmonds</a>, Ukrainian Sofia, <a href="https://www.linkedin.com/in/shanegibson?originalSubdomain=ca">Shane Gibson</a>, <a href="https://www.linkedin.com/in/valerie-smaller-0270697/?originalSubdomain=ca">Valerie Smaller</a>, <a href="https://www.instagram.com/streetarteagle/">Vince Damoulin</a>, <a href="https://overviewinstitute.org/dt_team/kevin-kelley/">Kevin W. Kelley</a> and <a href="https://www.linkedin.com/in/nina-kim-4b24b338/?originalSubdomain=ca">Nina Kim</a>, <a href="https://internetmasterminds.org/">Matt Astifan</a>, <a href="https://www.peterholstphotography.com/">Peter Holst</a>. Each of you contributed uniquely and significantly, enriching our experience. Thanks <a href="https://www.linkedin.com/in/barriemowatt?originalSubdomain=ca">Barrie Mowatt</a> for believing in me.</p>
+
+
+
+<p class="wp-block-paragraph">Lastly, I must express my deepest appreciation to my advisors &#8211; <a href="https://www.linkedin.com/in/iamkhayyam">Khayyam Wakil</a>, <a href="https://www.emmabroback.com/">Emma Broback</a>, <a href="http://space.dentthefuture.com/speakers/jason-preston/">Jason Preston</a>, <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b?originalSubdomain=ca">Lindsay Bailey</a>, <a href="https://holistichybrid.com/">Robert Scales</a>, and Jessica Liang. Your guidance and wisdom and support is invaluable.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward, we&#8217;re excited to announce <a href="https://lu.ma/ai-storytelling">our next meetup scheduled for <strong>February 22nd</strong></a>. Expect more stimulating discussions, networking opportunities, and AI-powered creativity! Save your spot now: <a href="https://lu.ma/ai-images">Next Meetup Sign-up</a>.</p>
+
+
+
+<p class="wp-block-paragraph">Additionally, for those in Vancouver, don&#8217;t miss out on our <strong><a href="http://lu.ma/ai-storytelling">AI Storytelling Training</a></strong> happening in February. It&#8217;s a unique opportunity to dive deeper into the world of AI and enhance your storytelling skills. Secure your place here: <a href="https://lu.ma/ai-storytelling">AI Storytelling Training</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-1Mix9FfrRtWVLL2" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our journey together is just beginning. Let&#8217;s continue to build, learn, and innovate as a community. Your participation is what makes these events a success, and we can&#8217;t wait to see you again next month!</p>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re inspired by our work and wish to support future endeavours, please don&#8217;t hesitate to get in touch. <a href="https://kriskrug.notion.site/Sponsor-Vancouver-AI-Community-8ce6deaf7ebf4b5992d5d97e8205691a?pvs=4">We&#8217;re always looking for collaborators who share our vision.</a></p>
+
+
+
+<p class="wp-block-paragraph">Here’s to many more gatherings where AI meets creativity, technology, and community!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326daea&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326daea" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-4500" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326e3e6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326e3e6" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="563" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=750%2C563&#038;ssl=1" alt="" class="wp-image-4522" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=300%2C225&amp;ssl=1 300w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">&#8220;I&#8217;m watching a fucking bloodbath as generative AI eats one creative industry after another&#8230;.&#8221; by Vince Damoulin @streetarteagle</figcaption></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/">Vancouver AI Meetup #16: Where Tech, Creativity, and Community Collide</a> and <a href="https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/">Vancouver AI: The Community Building BC&#8217;s AI Future &#8211; February Meetup Recap</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-content.rendered.html
@@ -1,0 +1,467 @@
+
+<h2 class="wp-block-heading">Curiosity, Community, Creativity &amp; Code Converge</h2>
+
+
+
+<p class="wp-block-paragraph">The inaugural <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community Meetup</a>, convened at the heart of Vancouver&#8217;s creative nexus, <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media headquarters</a>, within the inspiring <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a> art warehouse, was a landmark event, signaling a vibrant kickoff for a series of gatherings dedicated to the exploration of artificial intelligence in creative realms.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/gln3RCVGZN4?si=CBmllOcq_juDUvke" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">This sold-out event attracted a wide array of participants, from curious enthusiasts to seasoned professionals, all drawn together by a shared passion for the potential of AI to transform storytelling, art, and technology. </p>
+
+
+
+<p class="wp-block-paragraph">Through a series of engaging discussions, interactive installations, and hands-on demonstrations, the meetup fostered a rich environment for collaboration, learning, and inspiration. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3265d42&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3265d42" class="wp-block-image size-full is-style-default wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="2226" height="1913" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2226%2C1913&#038;ssl=1" alt="" class="wp-image-4518" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?w=2226&amp;ssl=1 2226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=300%2C258&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1024%2C880&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=768%2C660&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=1536%2C1320&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/Kris-Krug-meetup.jpg?resize=2048%2C1760&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Welcoming Vancouver AI Community to my new studio at Vancouver Biennale HQ.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The evening underscored the ethos of the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI community">Vancouver AI Community</a> Meetup: to build an inclusive, engaged group focused on the real-world applications and ethical considerations of AI, setting a dynamic precedent for future gatherings and cementing its role as a cornerstone for AI exploration in Vancouver.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326650a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326650a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="355" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI.jpg?resize=1024%2C355&#038;ssl=1" alt="" class="wp-image-4517" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1024%2C355&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=300%2C104&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=768%2C267&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=1536%2C533&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/VanAI-scaled.jpg?resize=2048%2C711&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetups bring together a wide cross section of people working with AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>A Rallying Cry for Inclusivity and Exploration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3266d4d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3266d4d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1.jpg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-4508" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=1536%2C861&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=2048%2C1148&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-14-1-scaled.jpg?resize=528%2C297&amp;ssl=1 528w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Charlene Joseph: S?wx?wú7mesh Nation Language and Cultural teacher? ?opens with a song.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Community Meetup is founded on a principle of inclusivity. Our ethos is simple yet profound: to welcome everyone intrigued by AI&#8217;s potential. From seasoned researchers to budding artists, from tech enthusiasts to curious students, our aim is to forge a vibrant tapestry of individuals united by their passion for exploring the frontiers of artificial intelligence.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326760c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326760c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18.jpg?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-4520" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=1536%2C864&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=2048%2C1152&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-18-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Philippe Pasquier is a professor at&nbsp;SFU&#8217;s School of Interactive Arts and&nbsp;Technology, where he directs the Metacreation Lab for Creative AI</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we plan meetups for the last week of every month throughout the year, our vision is to build an engaged, dynamic group. This community isn&#8217;t just about sharing knowledge; it&#8217;s about challenging each other, collaborating on real-world applications, and navigating the ethical labyrinth that AI presents.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Reflecting on Our First Gathering</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3267f37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3267f37" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-4511" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=2048%2C1151&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-11-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><em>Steve DiPaola</em>, active as an artist and a scientist, is a professor/researcher at Simon Fraser University, Steve directs the I-Viz Lab</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night of our first meetup was electric. <a href="https://motleykrugmedia.com/">MØTLEYKRÜG Media&#8217;s</a> headquarters, within the eclectic <a href="https://www.vancouverbiennale.com/">Vancouver Biennale Art Warehouse</a>, became a crucible of creativity and innovation. The event was a kaleidoscope of insights, demonstrations, and hands-on sessions, each designed to demystify AI and showcase its transformative power in creative endeavors.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Gratitude for Our Speakers</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32687c8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32687c8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="573" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15.jpg?resize=1024%2C573&#038;ssl=1" alt="" class="wp-image-4509" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1024%2C573&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-15-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Justine Gauthier is the Director of Corporate &amp; Legal Affairs at&nbsp;<a href="https://theorg.com/org/mila-quebec-artificial-intelligence-institute">Mila &#8211; Quebec Artificial Intelligence Institute</a>.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The success of our inaugural meetup owes much to the incredible speakers who shared their insights and visions with us. <a href="https://vancouver.ca/your-government/mike-klassen.aspx">Mike Klassen</a>, <a href="https://katearmstrong.com">Kate Armstrong</a>, <a href="http://stevebroback.com/about/">Steve Broback</a>, <a href="https://mila.quebec/en/person/justine-gauthier/">Justine Gauthier</a>, <a href="https://www.linkedin.com/in/steve-lowry-vancouver?originalSubdomain=ca">Steve Lowry</a>, and <a href="http://ispace.iat.sfu.ca/person/mirjana-prpa/">Mirjana Prpa</a> — each brought a unique perspective to the table, enriching our discussions and expanding our understanding of AI&#8217;s impact on society and creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3269001&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3269001" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="771" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2.jpg?resize=771%2C1024&#038;ssl=1" alt="" class="wp-image-4516" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=771%2C1024&amp;ssl=1 771w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=226%2C300&amp;ssl=1 226w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=768%2C1020&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1157%2C1536&amp;ssl=1 1157w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?resize=1542%2C2048&amp;ssl=1 1542w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-2-scaled.jpg?w=1928&amp;ssl=1 1928w" sizes="auto, (max-width: 771px) 100vw, 771px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kate Armstrong: Director of&nbsp;<em>Living Labs</em>&nbsp;at Emily Carr University of Art + Design. Co-director of AI Futures for Art + Design</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their expertise helped to set a dynamic and insightful tone for the event, fostering a fertile ground for innovation and exchange.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Celebrating Our Artists</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326984d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326984d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="907" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6.jpg?resize=1024%2C907&#038;ssl=1" alt="" class="wp-image-4502" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1024%2C907&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=300%2C266&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=768%2C680&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=1536%2C1361&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-6-scaled.jpg?resize=2048%2C1815&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">An invocation to the Holy Mother of the Void is made; the void from which all things are born. As the future becomes the present and we forge into an age of AI art, how can we know what is human movement and what is not?</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our event was further illuminated by the contributions of pioneering AI artists who showcased interactive art installations at the forefront of avant-garde creativity. <a href="https://www.sfu.ca/siat/people/research-faculty/steve-dipaola.html">Steve DiPaola</a>, <a href="https://www.linkedin.com/in/meehae-song/">Meehae Song</a>, <a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier</a>, <a href="https://www.arshsobhan.com/">Arshia Sobhan</a>, <a href="https://www.facebook.com/orbitprincess/">Marina Tsougrianis (AKA Orbit Princess)</a>, and <a href="https://www.linkedin.com/in/vickymittal">Vicky Mittal</a> — these individuals are not just artists but trailblazers, merging technology with human expression in ways that challenge our perceptions and open new dialogues. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a09b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a09b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="570" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12.jpg?resize=1024%2C570&#038;ssl=1" alt="" class="wp-image-4512" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1024%2C570&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=768%2C427&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=1536%2C854&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-12-scaled.jpg?resize=2048%2C1139&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Portrait Jordan Bent: Special thanks for making photos and videos at the event Peter Holst.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their installations provided a tangible glimpse into the creative potential of AI, captivating attendees with a vivid display of the intersection between art and technology.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Fostering Growth and Collaboration</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326a8de&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326a8de" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="863" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3.jpg?resize=863%2C1024&#038;ssl=1" alt="" class="wp-image-4501" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=863%2C1024&amp;ssl=1 863w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=253%2C300&amp;ssl=1 253w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=768%2C911&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1295%2C1536&amp;ssl=1 1295w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?resize=1727%2C2048&amp;ssl=1 1727w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-3-scaled.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 863px) 100vw, 863px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Old buddy Mike Klassen is a public affairs professional serving in executive leadership roles, media pundit and organizational spokesperson.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">What makes the Vancouver AI Community Meetup unique is its commitment to cultivating a supportive ecosystem for experimentation and growth. As its curator, I am dedicated to building a platform where individuals from various backgrounds can share their ideas, challenge each other, and collaborate on projects that push the envelope of what&#8217;s technologically and creatively possible.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b0bd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b0bd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="560" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10.jpg?resize=1024%2C560&#038;ssl=1" alt="" class="wp-image-4513" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1024%2C560&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=300%2C164&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=768%2C420&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=1536%2C840&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-10-scaled.jpg?resize=2048%2C1120&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Steve Lowry, the Founding Executive Director of AInBC</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Our initiative goes beyond networking. We are creating a community where the exchange of knowledge and experiences leads to real-world applications and thoughtful consideration of AI&#8217;s impact on society. Through training sessions and workshops, we aim to equip creatives with the tools they need to harness the power of AI in their work, ensuring that our community remains at the forefront of this exciting field.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>The Road Ahead</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326b928&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326b928" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="552" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16.jpg?resize=1024%2C552&#038;ssl=1" alt="" class="wp-image-4514" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1024%2C552&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=300%2C162&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=768%2C414&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=1536%2C827&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-16-scaled.jpg?resize=2048%2C1103&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mark Busse: Strategy + Creativity + Design + Conversation = Ideas &amp; Engagement &amp; Community &amp; Impact. Add good food = magic.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look to the future, the Vancouver AI Community Meetup is poised at the edge of a new dawn. Our collective journey is only beginning, with each meetup strengthening our resolve and enriching our discourse. We stand on the threshold of a new era where technology and human ingenuity converge, creating a tapestry of unimaginable beauty and complexity.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-EzZHFIbxGIJvSUh" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">I extend an open invitation to you, regardless of your familiarity with AI, to join this adventure. Together, we can explore the vast expanse of artificial intelligence, learning, growing, and shaping a future where technology amplifies our creative potential.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c17a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c17a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="974" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9.jpg?resize=1024%2C974&#038;ssl=1" alt="" class="wp-image-4515" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1024%2C974&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=300%2C285&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=768%2C730&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=1536%2C1461&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-9-scaled.jpg?resize=2048%2C1948&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mirjana Prpa. Assistant Professor,&nbsp;Northeastern&nbsp; University</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For those eager to dive into this renaissance of technology and art, the Vancouver AI Community Meetup awaits. Join us as we navigate the uncharted waters of AI, forging paths where none existed, in pursuit of a future bright with promise and imbued with creativity.</p>
+
+
+
+<p class="wp-block-paragraph">Together, let&#8217;s make Vancouver a lighthouse of AI innovation and artistic exploration. Join our next meetup and become part of a community dedicated to shaping the future of artificial intelligence and beyond.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326c99a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326c99a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="993" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4.jpg?resize=993%2C1024&#038;ssl=1" alt="" class="wp-image-4499" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=993%2C1024&amp;ssl=1 993w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=291%2C300&amp;ssl=1 291w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=768%2C792&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1490%2C1536&amp;ssl=1 1490w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=1987%2C2048&amp;ssl=1 1987w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-4-scaled.jpg?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 993px) 100vw, 993px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bantering about IP, copyright and the shifting legal framework in the face of technological disruption brought on by AI and ML.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">For more details on our upcoming events and how you can be a part of this exciting journey, visit our website or follow us on our social channels. Let&#8217;s embark on this path together, exploring the endless possibilities that AI and creativity hold for our world.</p>
+
+
+
+<p class="wp-block-paragraph">As we reflect on the journey of the Vancouver AI Community Meetup and look forward to the paths yet to tread, it is essential to recognize the individuals and organizations whose contributions have been the bedrock of our burgeoning community.</p>
+
+
+
+<p class="wp-block-paragraph">A special round of applause to <a href="https://robertmichaelmurray.com/">Robert Michael Murray</a> and <a href="https://www.linkedin.com/in/d-yaschenko/">Daria Yashenko</a>. Behind the scenes, your efforts were the glue that held everything together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="572" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13.jpg?resize=1024%2C572&#038;ssl=1" alt="" class="wp-image-4510" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1024%2C572&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=768%2C429&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=1536%2C859&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=2048%2C1145&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/jim-dine-vancouver-biennale-kris-krug-december2024-13-scaled.jpg?resize=350%2C197&amp;ssl=1 350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Our gratitude also extends to <a href="https://www.linkedin.com/in/wayneracine?originalSubdomain=ca">Wayne Shadow</a>, <a href="https://www.kempedmonds.com/">Kemp Edmonds</a>, Ukrainian Sofia, <a href="https://www.linkedin.com/in/shanegibson?originalSubdomain=ca">Shane Gibson</a>, <a href="https://www.linkedin.com/in/valerie-smaller-0270697/?originalSubdomain=ca">Valerie Smaller</a>, <a href="https://www.instagram.com/streetarteagle/">Vince Damoulin</a>, <a href="https://overviewinstitute.org/dt_team/kevin-kelley/">Kevin W. Kelley</a> and <a href="https://www.linkedin.com/in/nina-kim-4b24b338/?originalSubdomain=ca">Nina Kim</a>, <a href="https://internetmasterminds.org/">Matt Astifan</a>, <a href="https://www.peterholstphotography.com/">Peter Holst</a>. Each of you contributed uniquely and significantly, enriching our experience. Thanks <a href="https://www.linkedin.com/in/barriemowatt?originalSubdomain=ca">Barrie Mowatt</a> for believing in me.</p>
+
+
+
+<p class="wp-block-paragraph">Lastly, I must express my deepest appreciation to my advisors &#8211; <a href="https://www.linkedin.com/in/iamkhayyam">Khayyam Wakil</a>, <a href="https://www.emmabroback.com/">Emma Broback</a>, <a href="http://space.dentthefuture.com/speakers/jason-preston/">Jason Preston</a>, <a href="https://www.linkedin.com/in/lindsay-bailey-600a46b?originalSubdomain=ca">Lindsay Bailey</a>, <a href="https://holistichybrid.com/">Robert Scales</a>, and Jessica Liang. Your guidance and wisdom and support is invaluable.</p>
+
+
+
+<p class="wp-block-paragraph">Looking forward, we&#8217;re excited to announce <a href="https://lu.ma/ai-storytelling">our next meetup scheduled for <strong>February 22nd</strong></a>. Expect more stimulating discussions, networking opportunities, and AI-powered creativity! Save your spot now: <a href="https://lu.ma/ai-images">Next Meetup Sign-up</a>.</p>
+
+
+
+<p class="wp-block-paragraph">Additionally, for those in Vancouver, don&#8217;t miss out on our <strong><a href="http://lu.ma/ai-storytelling">AI Storytelling Training</a></strong> happening in February. It&#8217;s a unique opportunity to dive deeper into the world of AI and enhance your storytelling skills. Secure your place here: <a href="https://lu.ma/ai-storytelling">AI Storytelling Training</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed-checkout/evt-1Mix9FfrRtWVLL2" width="600" height="650" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our journey together is just beginning. Let&#8217;s continue to build, learn, and innovate as a community. Your participation is what makes these events a success, and we can&#8217;t wait to see you again next month!</p>
+
+
+
+<p class="wp-block-paragraph">If you&#8217;re inspired by our work and wish to support future endeavours, please don&#8217;t hesitate to get in touch. <a href="https://kriskrug.notion.site/Sponsor-Vancouver-AI-Community-8ce6deaf7ebf4b5992d5d97e8205691a?pvs=4">We&#8217;re always looking for collaborators who share our vision.</a></p>
+
+
+
+<p class="wp-block-paragraph">Here’s to many more gatherings where AI meets creativity, technology, and community!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326daea&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326daea" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-4500" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/WhatsApp-Image-2024-01-26-at-12.47.24.jpeg?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a326e3e6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a326e3e6" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="563" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=750%2C563&#038;ssl=1" alt="" class="wp-image-4522" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/01/image.png?resize=300%2C225&amp;ssl=1 300w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">&#8220;I&#8217;m watching a fucking bloodbath as generative AI eats one creative industry after another&#8230;.&#8221; by Vince Damoulin @streetarteagle</figcaption></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/">Vancouver AI Meetup #16: Where Tech, Creativity, and Community Collide</a> and <a href="https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/">Vancouver AI: The Community Building BC&#8217;s AI Future &#8211; February Meetup Recap</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-4495-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 4495,
+  "slug": "inside-the-innaugural-vancouver-ai-community-meetup",
+  "status": "publish",
+  "link": "https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/",
+  "modified": "2026-06-28T20:36:32",
+  "modified_gmt": "2026-06-29T04:36:32",
+  "type": "post",
+  "content_raw_bytes": 57991,
+  "content_rendered_bytes": 57991,
+  "content_raw_has_footer": true,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 3,
+  "title_rendered": "Inside the Innaugural Vancouver AI Community Meetup"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-content.raw.html
@@ -1,0 +1,882 @@
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/wL2kGWDms2U?si=m5GjIium14MAYtFQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">In a world increasingly captivated by the potential of artificial intelligence, the <a href="https://lu.ma/vancouver-AI-meetup">Vancouver AI Meetup</a> stands as a testament to the vibrant community at the intersection of technology, creativity, and community. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350b473&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350b473" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5778" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetup at Future Proof Creatives Studio | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">With over 135 attendees, this gathering was a microcosm of the broader dialogue shaping the future of AI. I couldn’t be prouder of the buzzing atmosphere we created together on May 30th.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350bb9b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350bb9b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5801" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of this meetup was a palpable sense of community. It’s easy to imagine technology events as gatherings of individuals glued to their devices, but here, the reality was strikingly different. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350c542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350c542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5802" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">RULE 1: Can&#8217;t have a meetup without donuts! | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Conversations flowed freely, ideas were exchanged with enthusiasm, and a shared passion for AI’s potential united everyone in the room. </p>
+
+
+
+<figure class="wp-block-video"><video height="1920" style="aspect-ratio: 1080 / 1920;" width="1080" controls loop src="https://kriskrug.co/wp-content/uploads/2024/06/Reels6.mp4"></video></figure>
+
+
+
+<p class="wp-block-paragraph">Our meetups aren’t just a meeting of minds; they are a celebration of what those minds can achieve together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d055&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d055" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5804" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bright eyes and big smiles the friendly faces of the Vancouver AI Community | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The diversity of speakers underscored the multifaceted nature of AI. From academia to industry, the range of perspectives offered a holistic view of AI’s place in our world.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d790&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d790" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5776" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dennis Chenard, Northeastern University at AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://vancouver.northeastern.edu/events/ainbc-northeastern-university-vancouver-aaai-networking-night/">Dennis Chenard from Northeastern University</a> bridges the gap between theoretical knowledge and practical application, while <a href="https://vanstartupweek.ca/">Bill McGraw</a> highlighted AI’s transformative role in Impact and CSR. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350de2c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350de2c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5777" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bill McGraw Invites People to Vancouver Startup Week AI Events  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Yet, it was perhaps the inclusion of indigenous perspectives by <a href="https://mila.quebec/en/">Michael and Caroline Running Wolf</a> that most vividly illustrated the depth and breadth of the discussions taking place. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350e97e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350e97e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5786" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Running Wolf introduces himself and his work at the Vancouver AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their insights into <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and sovereignty challenged attendees to think beyond code and algorithms, to consider the societal implications of the technology we create.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f065&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f065" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5779" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Caroline Running Wolf introduces herself and her work at the Vancouver AI Community Meetup on May 30th  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Art and technology often seem like disparate realms, yet at this meetup, they converged in spectacular fashion. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f7f7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f7f7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5775" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void dancing with <a href="https://www.holonic.systems/">Holonic Systems Generative Music Sensors</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The performance by <a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic and <a href="https://www.instagram.com/orbitprincess/">Marina, the Holy Mother of the Void</a>, merging generative music with interpretive dance, was a powerful demonstration of emerging tech’s potential to transcend traditional boundaries and redefine creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350fee7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350fee7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5772" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic Systems answers questions about his generative music sensors project  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Similarly, <a href="https://www.sfu.ca/meta-creation/">Arshia Sobhan and Philippe Pasquier’s AutoLoom project</a> from Metacreation Lab for <a href="https://kriskrug.co/ai-for-creatives/" title="AI for Creatives">Creative AI</a> at SFU showcased how AI can be harnessed for artistic expression, further blurring the lines between creator and creation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351059f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351059f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5774" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/arshsobhan/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">Arshia Sobhan</a> shares the work of <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier&#8217;s</a> <a href="https://www.metacreation.net/">Metacreation Lab for Creative Artificial Intelligence</a> at the <a href="https://www.sfu.ca/siat.html">School of Interactive Art and Technology</a> at <a href="https://www.sfu.ca/">SFU</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://eml.ubc.ca/">Dr. Pennefather’s improvisation</a> with AI at UBC’s <a href="https://eml.ubc.ca/">Emerging Media Lab</a> challenged the linear relationship between human and machine. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3510c38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3510c38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5780" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://patrickpennefather.com/">Dr Patrick Pennefather</a> of UBC <a href="https://eml.ubc.ca/">Emerging Media Lab</a> rocking the mic at the Vancouver AI Community Meetup May 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://mvai.org/">Donald Jukes</a> introduced us to a cool new event I’m stoked about, “<a href="https://www.mvdemos.com/">Minimal Viable Demos,</a>” being organized by friends in the <a href="https://lu.ma/novus">Novus</a> and <a href="https://lu.ma/atelier.ubc">Atelier</a> communities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35112e9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35112e9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5770" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://emojipedia.org/camera">?</a> <a href="https://www.peterholstphotography.com/">Peter Holst</a> </figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://sianflanagan.com/">Sian Flanagan</a>’s poetic voice empowered the multi-passionate, while <a href="https://cofounderhub.org/">Gabriela Arno</a> facilitated entrepreneurial connections at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a> and <a href="https://lu.ma/calendar/cal-pXBoizODcGZmfYX">Meet Your Cofounder event series</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3511971&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3511971" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5783" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://thebusinessofyou.com/about-sian/">Sian Flanagan</a> shares poetry from <a href="https://www.amazon.ca/dp/1998754596">Silk On Ice: The Process of Growing into Grace</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But what truly set this event apart was its emphasis on inclusivity and community engagement. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512013&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512013" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5773" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> is helping startup founders connect with one another at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Roman the Intern shared with us his AI-generated videos and All You Need to Know YouTube Channel… </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512cc1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512cc1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5794" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">CEO of All You Need to Know Generative Video Production Services&#8230;. Roman the Intern.  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">he’s building a robot army and media empire with generative tools and popped the trunk and showed us his approach and process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351371d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351371d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5793" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sam Huo invites people to apply to speak at upcoming Google Developer Group Build with AI Event  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Sam Huo invited everybody to the Google Developer Groups Build with <a href="https://kriskrug.co/ai-events/" title="AI events">AI event</a>. I went to the last one and am volunteering at the upcoming one and think it’s a great technical event with low barriers and a sweet community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3513eaa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3513eaa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5805" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Artist and musician Ed Kennedy of Run Diffusion talks about creative generative AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed Kennedy from Run Diffusion talked about the cool creative opportunities they support: RunDiffusion provides AI workflows with private GPU hosting.</p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://circlesofai.org/">Circles of AI project</a>, spearheaded by <a href="https://www.linkedin.com/in/rochellegrayson">James Rowe and Rochelle Grayson</a>, aims to create a space where everyone could contribute to and benefit from AI’s advancements. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351450d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351450d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="641" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&#038;ssl=1" alt="" class="wp-image-5781" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=768%2C481&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?w=1365&amp;ssl=1 1365w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James Rowe launches Circles of AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">These initiatives, along with the active participation of volunteers and the support from diverse sponsors, highlighted a crucial truth: advancing AI is not just about technological breakthroughs; it’s about building a community that reflects the diversity and complexity of the world it seeks to serve.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3514ba0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3514ba0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5806" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sian Flanagan at the Vancouver AI Community Meetup March 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As attendees mingled, shared insights, and discussed future projects, one thing became clear: these meetups are just the beginning. The call to action for continued sharing and collaboration was not just about maintaining momentum; it was about recognizing that the journey of AI is one we undertake together. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5807" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">By fostering a culture of openness, curiosity, and mutual respect, events like this lay the groundwork for a future where AI can truly be a force for good. In reflecting on the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Meetup, it’s evident that the power of such gatherings lies not just in the knowledge shared but in the connections formed.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515bb6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515bb6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5808" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Bridging academia and industry, integrating art with technology, and embracing diverse perspectives are not just strategies for innovation; they are pillars for building an AI future that is inclusive, ethical, and profoundly human.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351623b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351623b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5811" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look forward to more meetups and more opportunities for interdisciplinary collaboration, let us remember that at the core of every technological advancement is a community of people committed to making a difference. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351693c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351693c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5812" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Meetup</a> is an awesome example of what happens when that community comes together: a confluence of minds and machines that promises to shape our world in ways we are only beginning to imagine.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351700c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351700c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5809" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Highlighting Key Demos</strong></p>
+
+
+
+<p class="wp-block-paragraph">The demos were the heart of the event, showcasing the cutting-edge applications of AI:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Lionel Ringenbach’s CompoVision AI Demo</strong></p>
+
+
+
+<p class="wp-block-paragraph">Lionel used three computer vision cameras, <a href="https://github.com/comfyanonymous/ComfyUI">ComfyUI</a>, <a href="https://llama.meta.com/llama3/">Llama3</a> and <a href="https://derivative.ca/">TouchDesigner</a> to create real-time visuals. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517833&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517833" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5787" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demo involved placing objects in front of the cameras, which were then meshed into prompts to generate stunning visuals on the wall. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517eb5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517eb5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5785" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Attendees got to tinker and prompt AIs with a variety of props.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351854c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351854c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5784" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Prajwal’s Jarvis Demo</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3518c1f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3518c1f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5790" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s Vision Apple Pro cap, equipped with a speaker, Wi-Fi, Bluetooth, Raspberry Pi, and a vision sensor, demonstrated the innovative potential of wearable AI. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351929e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351929e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5789" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Despite initial technical hiccups, the audience’s supportive cheers helped him showcase its capabilities, including poetry generation and real-time interactions.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351996f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351996f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5788" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">Stigmergic Action for Global Empowerment</a> &#8211; Jerrica Clelland</strong></p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">SAGE project</a> leverages video games for mental health support, highlighting the collaboration between technology and well-being. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5792" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of SAGE is an unwavering belief in the transformative power of storytelling, world-building, and gameplay as conduits for positive change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5791" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Acknowledgments</strong></p>
+
+
+
+<p class="wp-block-paragraph">A huge thank you to <a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> for coordinating the team of volunteers and organizing partners and sponsors. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351ae6d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351ae6d" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5795" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> at <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a> May 2024 Meetup at <a href="https://futureproofcreatives.com/">Future Proof Creatives Photo</a>: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to Jeff Clark, Alexandra the Bartender, Roz McNulty, Roman the Intern, James McKenzie, and Brittney Smaila for their invaluable contributions. Valerie and Daria, your logistical support was crucial to the event’s success.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Visual Recap</strong></p>
+
+
+
+<p class="wp-block-paragraph">Relive the event through a selection of the best photos and videos:</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351b59c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351b59c" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5798" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Video production by <a href="https://www.instagram.com/serbin_photography">Viktor Serbin</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://peterholst.pixieset.com/futureproofcreative-30may2024/">Peter Holst Photo Album</a><br />• <a href="https://diamondsedgephotography.pixieset.com/vancouveraicommunity/">Michelle Diamond Photo Album</a><br />• <a href="https://www.youtube.com/shorts/7u7dpxIV7vE">YouTube Highlights</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Thank You Note</strong></p>
+
+
+
+<p class="wp-block-paragraph">A heartfelt thank you to all the speakers, demo presenters, volunteers, and attendees who made this event a resounding success. Special gratitude to our sponsors and partners:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://augxlabs.com/">AugXLabs</a><br />• <a href="https://aifutures.org/">AI Futures for Art + Design</a><br />• <a href="https://www.sfu.ca/meta-creation/">Metacreation Lab at SFU</a><br />• <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351bcc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351bcc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5796" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Cocktails by <a href="https://www.sonsofvancouver.ca/">Sons of Vancouver</a> thank you <a href="https://www.linkedin.com/in/sovjames/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">James Lester</a> | <a href="https://www.peterholstphotography.com/"></a>Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://sonsofvancouver.ca/">Sons of Vancouver</a><br />• <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a><br />• <a href="https://holistichybrid.com/">Holistic Hybrid</a><br />• <a href="https://cmpfyr.com/">CMPFYR</a><br />• <a href="https://internetmasterminds.org/">Internet Masterminds</a><br />• <a href="https://thefatalefestival.com/">The FATALE Festival</a><br />• <a href="https://vlacc.ca/">VLACC (Vancouver Latin American Cultural Centre)</a><br />• <a href="https://taylightbrewing.com/">Taylight Brewing</a></p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-5797" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption class="wp-element-caption">Thanks for the support and the beers <a href="https://taylightbrewing.com/">Taylight Brewing</a>!!  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Looking Ahead</strong></p>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more innovative sessions at our future meetups. Don’t miss the next event and grab your Earlyworm Tickets now:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://lu.ma/june-AI-meetup">June Vancouver AI Community Meetup at Future Proof Creatives Studio</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Call to Action</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>We invite attendees and readers to share their experiences and photos from the event. Your suggestions and ideas are crucial for shaping future meetups, fostering a collaborative and innovative AI community.</strong></p>
+
+
+
+<p class="wp-block-paragraph">In the ever-evolving world of AI, community engagement and innovation are our guiding stars. Let’s continue to explore, create, and inspire together.</p>
+
+
+
+<figure class="wp-block-image size-large is-resized"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5799" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://lu.ma/june-AI-meetup">Next event is June 27th and tickets are on sale. See ya there! 🙂 </a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3lnpZXM2iPH0wMh/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-content.rendered.html
@@ -1,0 +1,882 @@
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/wL2kGWDms2U?si=m5GjIium14MAYtFQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">In a world increasingly captivated by the potential of artificial intelligence, the <a href="https://lu.ma/vancouver-AI-meetup">Vancouver AI Meetup</a> stands as a testament to the vibrant community at the intersection of technology, creativity, and community. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350b473&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350b473" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5778" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI Community Meetup at Future Proof Creatives Studio | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">With over 135 attendees, this gathering was a microcosm of the broader dialogue shaping the future of AI. I couldn’t be prouder of the buzzing atmosphere we created together on May 30th.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350bb9b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350bb9b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5801" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740543.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of this meetup was a palpable sense of community. It’s easy to imagine technology events as gatherings of individuals glued to their devices, but here, the reality was strikingly different. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350c542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350c542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5802" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740514.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">RULE 1: Can&#8217;t have a meetup without donuts! | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Conversations flowed freely, ideas were exchanged with enthusiasm, and a shared passion for AI’s potential united everyone in the room. </p>
+
+
+
+<figure class="wp-block-video"><video height="1920" style="aspect-ratio: 1080 / 1920;" width="1080" controls loop src="https://kriskrug.co/wp-content/uploads/2024/06/Reels6.mp4"></video></figure>
+
+
+
+<p class="wp-block-paragraph">Our meetups aren’t just a meeting of minds; they are a celebration of what those minds can achieve together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d055&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d055" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5804" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bright eyes and big smiles the friendly faces of the Vancouver AI Community | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The diversity of speakers underscored the multifaceted nature of AI. From academia to industry, the range of perspectives offered a holistic view of AI’s place in our world.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350d790&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350d790" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5776" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-82-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dennis Chenard, Northeastern University at AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://vancouver.northeastern.edu/events/ainbc-northeastern-university-vancouver-aaai-networking-night/">Dennis Chenard from Northeastern University</a> bridges the gap between theoretical knowledge and practical application, while <a href="https://vanstartupweek.ca/">Bill McGraw</a> highlighted AI’s transformative role in Impact and CSR. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350de2c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350de2c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5777" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-78-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Bill McGraw Invites People to Vancouver Startup Week AI Events  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Yet, it was perhaps the inclusion of indigenous perspectives by <a href="https://mila.quebec/en/">Michael and Caroline Running Wolf</a> that most vividly illustrated the depth and breadth of the discussions taking place. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350e97e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350e97e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5786" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-64-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Running Wolf introduces himself and his work at the Vancouver AI Community Meetup  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Their insights into <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and sovereignty challenged attendees to think beyond code and algorithms, to consider the societal implications of the technology we create.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f065&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f065" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5779" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749982.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Caroline Running Wolf introduces herself and her work at the Vancouver AI Community Meetup on May 30th  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Art and technology often seem like disparate realms, yet at this meetup, they converged in spectacular fashion. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350f7f7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350f7f7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5775" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-176-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void dancing with <a href="https://www.holonic.systems/">Holonic Systems Generative Music Sensors</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The performance by <a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic and <a href="https://www.instagram.com/orbitprincess/">Marina, the Holy Mother of the Void</a>, merging generative music with interpretive dance, was a powerful demonstration of emerging tech’s potential to transcend traditional boundaries and redefine creativity. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a350fee7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a350fee7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5772" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740297-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/holmium/?originalSubdomain=ca">Ove Holmqvest</a> of Holonic Systems answers questions about his generative music sensors project  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Similarly, <a href="https://www.sfu.ca/meta-creation/">Arshia Sobhan and Philippe Pasquier’s AutoLoom project</a> from Metacreation Lab for <a href="https://kriskrug.co/ai-for-creatives/" title="AI for Creatives">Creative AI</a> at SFU showcased how AI can be harnessed for artistic expression, further blurring the lines between creator and creation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351059f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351059f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5774" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-219-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/arshsobhan/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">Arshia Sobhan</a> shares the work of <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier&#8217;s</a> <a href="https://www.metacreation.net/">Metacreation Lab for Creative Artificial Intelligence</a> at the <a href="https://www.sfu.ca/siat.html">School of Interactive Art and Technology</a> at <a href="https://www.sfu.ca/">SFU</a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://eml.ubc.ca/">Dr. Pennefather’s improvisation</a> with AI at UBC’s <a href="https://eml.ubc.ca/">Emerging Media Lab</a> challenged the linear relationship between human and machine. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3510c38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3510c38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5780" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740627.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://patrickpennefather.com/">Dr Patrick Pennefather</a> of UBC <a href="https://eml.ubc.ca/">Emerging Media Lab</a> rocking the mic at the Vancouver AI Community Meetup May 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://mvai.org/">Donald Jukes</a> introduced us to a cool new event I’m stoked about, “<a href="https://www.mvdemos.com/">Minimal Viable Demos,</a>” being organized by friends in the <a href="https://lu.ma/novus">Novus</a> and <a href="https://lu.ma/atelier.ubc">Atelier</a> communities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a35112e9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a35112e9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5770" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740152.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://emojipedia.org/camera">?</a> <a href="https://www.peterholstphotography.com/">Peter Holst</a> </figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://sianflanagan.com/">Sian Flanagan</a>’s poetic voice empowered the multi-passionate, while <a href="https://cofounderhub.org/">Gabriela Arno</a> facilitated entrepreneurial connections at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a> and <a href="https://lu.ma/calendar/cal-pXBoizODcGZmfYX">Meet Your Cofounder event series</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3511971&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3511971" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5783" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740661-1.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://thebusinessofyou.com/about-sian/">Sian Flanagan</a> shares poetry from <a href="https://www.amazon.ca/dp/1998754596">Silk On Ice: The Process of Growing into Grace</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But what truly set this event apart was its emphasis on inclusivity and community engagement. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512013&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512013" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5773" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740161.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> is helping startup founders connect with one another at <a href="https://thecofoundershub.com/">The Cofounder&#8217;s Hub</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Roman the Intern shared with us his AI-generated videos and All You Need to Know YouTube Channel… </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3512cc1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3512cc1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5794" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-156-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">CEO of All You Need to Know Generative Video Production Services&#8230;. Roman the Intern.  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">he’s building a robot army and media empire with generative tools and popped the trunk and showed us his approach and process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351371d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351371d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5793" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-100-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sam Huo invites people to apply to speak at upcoming Google Developer Group Build with AI Event  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Sam Huo invited everybody to the Google Developer Groups Build with <a href="https://kriskrug.co/ai-events/" title="AI events">AI event</a>. I went to the last one and am volunteering at the upcoming one and think it’s a great technical event with low barriers and a sweet community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3513eaa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3513eaa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5805" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740035.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Artist and musician Ed Kennedy of Run Diffusion talks about creative generative AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed Kennedy from Run Diffusion talked about the cool creative opportunities they support: RunDiffusion provides AI workflows with private GPU hosting.</p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://circlesofai.org/">Circles of AI project</a>, spearheaded by <a href="https://www.linkedin.com/in/rochellegrayson">James Rowe and Rochelle Grayson</a>, aims to create a space where everyone could contribute to and benefit from AI’s advancements. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351450d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351450d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="641" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&#038;ssl=1" alt="" class="wp-image-5781" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=1024%2C641&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=300%2C188&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?resize=768%2C481&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740114-2.jpg?w=1365&amp;ssl=1 1365w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James Rowe launches Circles of AI  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">These initiatives, along with the active participation of volunteers and the support from diverse sponsors, highlighted a crucial truth: advancing AI is not just about technological breakthroughs; it’s about building a community that reflects the diversity and complexity of the world it seeks to serve.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3514ba0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3514ba0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5806" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740472.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sian Flanagan at the Vancouver AI Community Meetup March 2024  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As attendees mingled, shared insights, and discussed future projects, one thing became clear: these meetups are just the beginning. The call to action for continued sharing and collaboration was not just about maintaining momentum; it was about recognizing that the journey of AI is one we undertake together. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515542&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515542" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5807" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-5-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">By fostering a culture of openness, curiosity, and mutual respect, events like this lay the groundwork for a future where AI can truly be a force for good. In reflecting on the <a href="https://kriskrug.co/vancouver-ai/" title="Vancouver AI">Vancouver AI</a> Meetup, it’s evident that the power of such gatherings lies not just in the knowledge shared but in the connections formed.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3515bb6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3515bb6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5808" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-8-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Bridging academia and industry, integrating art with technology, and embracing diverse perspectives are not just strategies for innovation; they are pillars for building an AI future that is inclusive, ethical, and profoundly human.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351623b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351623b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5811" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749840.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we look forward to more meetups and more opportunities for interdisciplinary collaboration, let us remember that at the core of every technological advancement is a community of people committed to making a difference. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351693c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351693c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5812" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740590-2.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Meetup</a> is an awesome example of what happens when that community comes together: a confluence of minds and machines that promises to shape our world in ways we are only beginning to imagine.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351700c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351700c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5809" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-234-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Friendly faces of the Vancouver AI Community <a href="https://www.peterholstphotography.com/"></a> | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Highlighting Key Demos</strong></p>
+
+
+
+<p class="wp-block-paragraph">The demos were the heart of the event, showcasing the cutting-edge applications of AI:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Lionel Ringenbach’s CompoVision AI Demo</strong></p>
+
+
+
+<p class="wp-block-paragraph">Lionel used three computer vision cameras, <a href="https://github.com/comfyanonymous/ComfyUI">ComfyUI</a>, <a href="https://llama.meta.com/llama3/">Llama3</a> and <a href="https://derivative.ca/">TouchDesigner</a> to create real-time visuals. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517833&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517833" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5787" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-196-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demo involved placing objects in front of the cameras, which were then meshed into prompts to generate stunning visuals on the wall. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3517eb5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3517eb5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5785" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749850.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Attendees got to tinker and prompt AIs with a variety of props.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351854c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351854c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5784" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A749841.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Compovision AI by Lionel Ringenbach at Vancovuer AI Community Meetup |  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Prajwal’s Jarvis Demo</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3518c1f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3518c1f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5790" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-115-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s Vision Apple Pro cap, equipped with a speaker, Wi-Fi, Bluetooth, Raspberry Pi, and a vision sensor, demonstrated the innovative potential of wearable AI. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351929e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351929e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5789" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740573.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Despite initial technical hiccups, the audience’s supportive cheers helped him showcase its capabilities, including poetry generation and real-time interactions.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351996f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351996f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5788" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740446.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth demonstrates his homemade Apple Vision Pro at the May 2024 Vancouver AI Community Meetup  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">Stigmergic Action for Global Empowerment</a> &#8211; Jerrica Clelland</strong></p>
+
+
+
+<p class="wp-block-paragraph">The <a href="https://kriskrug.notion.site/SAGE-Community-fe936ea462e34ad8a4840462642f0eeb?pvs=4">SAGE project</a> leverages video games for mental health support, highlighting the collaboration between technology and well-being. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5792" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-52-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">At the heart of SAGE is an unwavering belief in the transformative power of storytelling, world-building, and gameplay as conduits for positive change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351a765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351a765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5791" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-244-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Acknowledgments</strong></p>
+
+
+
+<p class="wp-block-paragraph">A huge thank you to <a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> for coordinating the team of volunteers and organizing partners and sponsors. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351ae6d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351ae6d" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5795" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-51-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://www.linkedin.com/in/kempedmonds/?originalSubdomain=ca">Kemp Edmonds</a> at <a href="https://lu.ma/future-proof?tag=ai%20meetup">Vancouver AI Community</a> May 2024 Meetup at <a href="https://futureproofcreatives.com/">Future Proof Creatives Photo</a>: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to Jeff Clark, Alexandra the Bartender, Roz McNulty, Roman the Intern, James McKenzie, and Brittney Smaila for their invaluable contributions. Valerie and Daria, your logistical support was crucial to the event’s success.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Visual Recap</strong></p>
+
+
+
+<p class="wp-block-paragraph">Relive the event through a selection of the best photos and videos:</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351b59c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351b59c" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5798" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/FPCApr2024-_A740486.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Video production by <a href="https://www.instagram.com/serbin_photography">Viktor Serbin</a>  | Photo: <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://peterholst.pixieset.com/futureproofcreative-30may2024/">Peter Holst Photo Album</a><br />• <a href="https://diamondsedgephotography.pixieset.com/vancouveraicommunity/">Michelle Diamond Photo Album</a><br />• <a href="https://www.youtube.com/shorts/7u7dpxIV7vE">YouTube Highlights</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Thank You Note</strong></p>
+
+
+
+<p class="wp-block-paragraph">A heartfelt thank you to all the speakers, demo presenters, volunteers, and attendees who made this event a resounding success. Special gratitude to our sponsors and partners:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://augxlabs.com/">AugXLabs</a><br />• <a href="https://aifutures.org/">AI Futures for Art + Design</a><br />• <a href="https://www.sfu.ca/meta-creation/">Metacreation Lab at SFU</a><br />• <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a351bcc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a351bcc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5796" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-34-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Cocktails by <a href="https://www.sonsofvancouver.ca/">Sons of Vancouver</a> thank you <a href="https://www.linkedin.com/in/sovjames/?original_referer=https%3A%2F%2Fwww%2Egoogle%2Ecom%2F&amp;originalSubdomain=ca">James Lester</a> | <a href="https://www.peterholstphotography.com/"></a>Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://sonsofvancouver.ca/">Sons of Vancouver</a><br />• <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a><br />• <a href="https://holistichybrid.com/">Holistic Hybrid</a><br />• <a href="https://cmpfyr.com/">CMPFYR</a><br />• <a href="https://internetmasterminds.org/">Internet Masterminds</a><br />• <a href="https://thefatalefestival.com/">The FATALE Festival</a><br />• <a href="https://vlacc.ca/">VLACC (Vancouver Latin American Cultural Centre)</a><br />• <a href="https://taylightbrewing.com/">Taylight Brewing</a></p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-5797" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-54-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption class="wp-element-caption">Thanks for the support and the beers <a href="https://taylightbrewing.com/">Taylight Brewing</a>!!  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Looking Ahead</strong></p>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more innovative sessions at our future meetups. Don’t miss the next event and grab your Earlyworm Tickets now:</p>
+
+
+
+<p class="wp-block-paragraph">• <a href="https://lu.ma/june-AI-meetup">June Vancouver AI Community Meetup at Future Proof Creatives Studio</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Call to Action</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>We invite attendees and readers to share their experiences and photos from the event. Your suggestions and ideas are crucial for shaping future meetups, fostering a collaborative and innovative AI community.</strong></p>
+
+
+
+<p class="wp-block-paragraph">In the ever-evolving world of AI, community engagement and innovation are our guiding stars. Let’s continue to explore, create, and inspire together.</p>
+
+
+
+<figure class="wp-block-image size-large is-resized"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-5799" style="width:555px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/06/VanAICommunity_KK_MichelleDiamond-263-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://lu.ma/june-AI-meetup">Next event is June 27th and tickets are on sale. See ya there! 🙂 </a>  | Photo: <a href="https://www.diamondsedgephotography.com/">Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3lnpZXM2iPH0wMh/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-5768-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 5768,
+  "slug": "june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines",
+  "status": "publish",
+  "link": "https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/",
+  "modified": "2026-06-28T20:34:16",
+  "modified_gmt": "2026-06-29T04:34:16",
+  "type": "post",
+  "content_raw_bytes": 106718,
+  "content_rendered_bytes": 106718,
+  "content_raw_has_footer": false,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 1,
+  "title_rendered": "Vancouver AI Community Meetup Recap: June 2024 at Future Proof Creatives Studio"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-content.raw.html
@@ -1,0 +1,766 @@
+
+<p class="wp-block-paragraph">Hey there, AI innovators and future-shapers, Kris Krüg here, reflecting on our last gathering and looking ahead to our next adventure in the <a href="https://lu.ma/YVR-AI">Vancouver AI Community Meetup series</a>. We&#8217;re building something special here, and I&#8217;m excited to share the journey with you all.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EqmixfIT_II?si=Fw7IReyh2M-0y6wu" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">June 27th: The Intersection of AI, Art, and Human Creativity</h2>
+
+
+
+<p class="wp-block-paragraph">Our June meetup at <a href="https://www.futureproofcreatives.com/">Future Proof Creatives</a> studio was a testament to the power of interdisciplinary collaboration. Here&#8217;s what we explored:</p>
+
+
+
+<h3 class="wp-block-heading">Event Highlights</h3>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Interactive Sound Walks with <a href="http://linkedin.com/in/holmium/">Ove Holmqvist</a></strong> Ove Holmqvist, the maestro of sound and tech, transported us into a sonic landscape where geospatial interactions met physical computing.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34885e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34885e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="578" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup.jpg?resize=1024%2C578&#038;ssl=1" alt="" class="wp-image-6271" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1024%2C578&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=768%2C433&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1536%2C867&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=2048%2C1156&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">His app turned our movements into music, crafting an auditory tapestry that was both ethereal and profoundly grounding. With <a href="https://www.movesense.com/">Movesense sensors</a>, the line between the physical and the digital blurred, creating a space where each step became a note in a grand, real-time composition.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3488d3c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3488d3c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="538" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&#038;ssl=1" alt="" class="wp-image-6270" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=300%2C158&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=768%2C404&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1536%2C807&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>2. <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">Autolume: Post-Photographic Cyborg Art</a></strong> I took the community on a journey through time and tech with Autolume, an AI-powered, post-photographic experiment. Imagine teaching a baby AI brain with 20 years of film portraits and watching it bloom into a digital entity capable of creating new art forms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489481&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489481" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-6278" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This project, in collaboration with <a href="https://www.metacreation.net/">Metacreation Lab for Creative AI at SFU</a>, showcased the beautiful chaos at the intersection of analog nostalgia and AI futurism. By feeding the AI with a vast archive of analog film portraits, <a href="https://www.metacreation.net/autolume">Autolume</a> learns to interpret and recreate human faces in entirely new artistic expressions, merging the past’s tactile essence with the future’s digital innovation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489cab&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489cab" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6273" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demonstration illustrated not just the technical prowess of AI but also its potential to redefine artistic boundaries, creating a unique symbiosis between human creativity and machine learning.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>3. <a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Lionel Ringenbach’s CompoVision</a></strong> <a href="https://ucodia.space/">Lionel Ringenbach </a>introduced us to CompoVision, an installation that doesn’t just see but interprets.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348a64a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348a64a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6269" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Real-time visual data transformed into interactive art, making us participants in a living, breathing digital organism. This piece not only caught the eye but also sparked a collaboration with a major tech firm, proving that in the digital age, art and opportunity are just a pixel apart.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6256" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>4. Networking and Community Building</strong> The evening was a hotbed of intellectual synergy, with researchers, investors, artists, coders, entrepreneurs, and students mingling over gourmet bites and artisanal brews. The conversations flowed as freely as the ideas, each interaction a potential seed for the next big thing in AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Spotlight on Cool Peeps and Projects</strong>: Our community is a network of networks, and many inspiring individuals and projects took the mic that night:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA _shyang</a></strong> kicked off the event with some fresh beatboxing and announced his upcoming talk at Sean Flanagan&#8217;s Playshop.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b9db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b9db" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6254" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://folioyvr.com/2024/06/ritchie-po-cybersecurity-data-privacy-lawyer/">Richie from Open Rep AI</a></strong> spoke about <a href="https://lu.ma/AIMastery">Anthony Green&#8217;s AI mastery series</a>, followed by <a href="https://www.linkedin.com/in/anthonygreen00/?originalSubdomain=ca">Anthony</a> sharing his insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348c1b9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348c1b9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6255" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Soham</strong>, a <a href="https://www.socratica.info/">Socratica</a> guy and <a href="https://www.atelier.ac/">Vancouver Atelier</a> founder, invited attendees to join the Atelier community.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348cb1e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348cb1e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6257" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://alexandrasamuel.com/">Alexandra Samuel</a></strong>, a famous writer and business thought leader, entertained us with funny and embarrassing stories of our friendship.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d1f2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d1f2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6258" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> from <a href="https://thecofoundershub.com/">Co-Founders Hub</a></strong> introduced her event, &#8216;<a href="https://lu.ma/meetyourcofoundervancouver">Meet Your Co-Founder</a>,&#8217; and discussed the upcoming sticker swap at the July AI meetup.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d9c5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d9c5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6259" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="http://kushalgoenka.com/">Kushal Goenka</a></strong>, an open-source AI advocate and engineer, shared his latest projects and insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e1f6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e1f6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6260" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.linkedin.com/in/kenny-macintyre-6872973/"><strong>Kenny Mack Truck</strong> </a>from the <a href="https://www.thebandits.ca/">Vancouver Bandits basketball team</a>, discussed his experience in the CEO AI workshop and creative work he&#8217;s doing in marketing.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e9dc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e9dc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6261" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/yangos/">Yangos Hadjiyannis</a></strong>, a big deal at <a href="https://www.siggraph.org/">SIGGRAPH</a>, talked about his AR/VR spatial video lab.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348f197&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348f197" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6262" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/prajwal-prashanth?miniProfileUrn=urn%3Ali%3Afs_miniProfile%3AACoAAEFdpdgBPffN7ej93MUm1IxgjQd72MT7peE">Prajwal Prashanth</a></strong> gave a talk about his <a href="https://www.youtube.com/watch?v=gBFboapI-Ew">Jarvis AI assistant</a> and about <a href="https://www.tks.world/">The Knowledge Society (TKS)</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348fa2d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348fa2d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6263" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kevinjosethomas/">Kevin Thomas</a></strong> Kevin featuring AI sign language interpreter he&#8217;s gonna demo in July.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3490175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3490175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6264" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://aydenlum.com/"><strong>Ayden</strong> <strong>Lum</strong></a>, an Atelier co-op participant, introduced himself and shared the workshops and <a href="https://insightful-future.beehiiv.com/">newsletters</a> he&#8217;s been involved with at Future Proof Creatives.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349085f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349085f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6265" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew Schwartzman</a></strong>, a high schooler, shared about his <a href="https://teen2life.podbean.com/">teen-focused podcast interviewing non-traditional successful entrepreneurs</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349101a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349101a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6266" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/donaldjewkes/">Donald Jukes</a></strong> discussed the <a href="https://kriskrug.co/2024/07/01/a-love-letter-to-vancouver-minimal-viable-demos/">Minimal Viable Demos event</a> and its blend of art, technology, science, and humanity.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6267" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kennedy-ed/">Ed Kennedy</a> from <a href="https://rundiffusion.com/">Run Diffusion</a></strong> explained cloud AI tools and their applications for creative professionals.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491e3f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491e3f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="618" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&#038;ssl=1" alt="" class="wp-image-6272" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=300%2C181&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=768%2C463&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1536%2C926&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://patrickpennefather.com/">Dr. Patrick Parra Pennefather</a></strong> engaged the crowd with intros and improv and general hilarious commentary.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492568&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492568" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-6277" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Screenshot</figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://thebusinessofyou.com/">Sian Flanagan</a></strong> shared insights from her book, performed a couple amazing original songs and announced her <a href="https://lu.ma/user/usr-1zfxAodTD8gqbh6">multi-passionate entrepreneur play shop</a>.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6274" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Jay David Milroy</strong>: &#8220;Love the mix of art and engineering. Love how you lift up others. I hope to try and find a way to participate and contribute.&#8221; Jay, your observation reflects the essence of what we&#8217;re trying to achieve &#8211; a blend of technical innovation and creative expression.</li>
+
+
+
+<li><strong>Darren Nicholls</strong>: &#8220;This is one of my favorite networking events.&#8221; Darren, it&#8217;s connections like these that drive innovation forward.</li>
+
+
+
+<li><strong>Yangos </strong><strong>Hadjiyannis</strong>: &#8220;Beautiful, authentic and meaningful event. Thank you Kris!&#8221; Authenticity and meaning are at the core of what we do, Yangos. Glad it resonated.</li>
+
+
+
+<li><strong>Wanda Halpert</strong>: &#8220;This was an excellent meetup that had people of all ages and background in AI discussing their progress and uses of this emerging tech.&#8221; Wanda, you&#8217;ve highlighted the strength of our diverse community. It&#8217;s this variety of perspectives that enriches our understanding of AI&#8217;s potential.</li>
+
+
+
+<li><strong>Ed Kennedy</strong>: &#8220;Fantastic event! Half lab/half party! Great speakers, great experiments, great networking. Always a pleasure!&#8221; Ed, you&#8217;ve nailed our approach &#8211; serious work in a fun, collaborative atmosphere.</li>
+
+
+
+<li><strong>Joe Leano</strong>: &#8220;My first event.. what an amazing experience. Everyone there had such amazing ideas. Amplified my creativity and looking to come back to next event.&#8221; Joe, welcome to the community. Your fresh perspective is invaluable as we continue to grow and evolve.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492d93&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492d93" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6275" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Huge thanks to <a href="https://www.peterholst.com/">Peter Holst</a> and <a href="https://www.viktorserbin.com/">Viktor Serbin</a> for documenting the event. Revisit the evening here: <a href="https://www.flickr.com/photos/kk/albums/72177720309491900">Photo Gallery</a> <a href="https://vimeo.com/showcase/vancouverai">Recap Video</a></p>
+
+
+
+<p class="wp-block-paragraph">And a heartfelt thank you to our sponsors and partners who make this possible: <a href="https://www.holistichybrid.com/">Holistic Hybrid</a>, <a href="https://www.augxlabs.com/">AugXLabs</a>, <a href="https://metacreation.net/">Metacreation Lab at SFU</a>, <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>, <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a>, <a href="https://internetmasterminds.com/">Internet Masterminds</a>, <a href="https://www.fatalfest.com/">The FATALE Festival</a>, <a href="https://www.sonsofvancouver.com/">Sons of Vancouver</a>, <a href="https://vlacc.ca/">VLACC</a>, and <a href="https://www.taylightbrewing.com/">Taylight Brewing</a>.</p>
+
+
+
+<h2 class="wp-block-heading">July 25th: Exploring Local-First AI in a Global Context (Now with Sticker Swap!)</h2>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3vbh2iIkl8jAl9O/simple" width="600" height="700" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our next meetup aligns with <a href="https://lu.ma/LOCALHOST_vancouver">LOCALHOST week</a> and <a href="https://www.ietf.org/how/meetings/120/">IETF 120</a>, offering a unique opportunity to explore AI through the lens of decentralized technologies. Here&#8217;s what we&#8217;re diving into:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Decentralized AI</strong>: We&#8217;ll examine how open-source, decentralized web technologies are reshaping AI development and deployment.</li>
+
+
+
+<li><strong>Applied AI</strong>: Through live demos, we&#8217;ll showcase real-world applications of AI across various industries.</li>
+
+
+
+<li><strong>Ethical Considerations</strong>: We&#8217;ll continue our ongoing discussion about the ethical implications of AI as it becomes more integrated into our daily lives.</li>
+
+
+
+<li><strong>Local Innovation</strong>: As part of our &#8216;Localhost&#8217; theme, we&#8217;re spotlighting Vancouver&#8217;s contributions to the global AI landscape.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="292" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&#038;ssl=1" alt="" class="wp-image-6276" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=300%2C86&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=768%2C219&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1536%2C439&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=2048%2C585&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<h3 class="wp-block-heading">NEW: AI Sticker Swap!</h3>
+
+
+
+<p class="wp-block-paragraph">Get ready for a fun addition to our meetup &#8211; a sticker swap! We&#8217;re inviting all attendees to create and bring stickers to share and trade. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493666&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493666" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6281" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">These don&#8217;t have to be AI-themed; they can represent your personal brand, a project you&#8217;re working on, your company, or any idea you&#8217;d like to share. It&#8217;s a great way to network, showcase your interests, and add some personality to your gear.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493cb9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493cb9" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="452" height="434" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=452%2C434&#038;ssl=1" alt="" class="wp-image-6282" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?w=452&amp;ssl=1 452w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=300%2C288&amp;ssl=1 300w" sizes="auto, (max-width: 452px) 100vw, 452px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;ll be bringing a variety of tech and AI stickers to kick things off, but we want to see what you&#8217;ve got too! Whether you&#8217;re designing new stickers or bringing your existing collection, come prepared to swap. It&#8217;s a casual, fun way to break the ice and learn about what others in our community are passionate about. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3494312&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3494312" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6284" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">So get creative, bring what you have, and let&#8217;s see what kind of unique sticker collections we can create together!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34948f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34948f5" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="382" height="452" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=382%2C452&#038;ssl=1" alt="" class="wp-image-6283" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?w=382&amp;ssl=1 382w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=254%2C300&amp;ssl=1 254w" sizes="auto, (max-width: 382px) 100vw, 382px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Key elements of the evening:</h3>
+
+
+
+<ol class="wp-block-list">
+<li>Presentations on AI and decentralized web synergies</li>
+
+
+
+<li>Interactive sessions exploring industry-specific AI applications</li>
+
+
+
+<li>Networking opportunities with local tech leaders and innovators</li>
+
+
+
+<li>Sticker Swap: A fun, informal way to share our AI passions</li>
+
+
+
+<li>Local AI Showcase: Celebrating Vancouver&#8217;s homegrown AI innovations</li>
+</ol>
+
+
+
+<p class="wp-block-paragraph">This event is part of LOCALHOST week, culminating in the <a href="https://ournetworks.ca/">Our Networks conference</a> on July 27th. We&#8217;re exploring how local-first tech can empower communities and reshape our digital interactions.</p>
+
+
+
+<p class="wp-block-paragraph">To our IETF 120 participants: We extend a warm invitation to join us and experience Vancouver&#8217;s vibrant AI community firsthand.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Our goal remains constant: <em>to foster a community that drives innovation, shares knowledge, and thoughtfully considers the real-world applications and ethical implications of AI. Whether you&#8217;re deep in the trenches of research, driving business innovation, exploring artistic applications, or simply curious about AI&#8217;s potential, you have a place here.</em></p>
+
+
+
+<p class="wp-block-paragraph">Join us on July 25th as we continue to explore and shape the future of AI, rooted in our local community but with a global perspective.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.meetup.com/vancouver-ai-meetup/events/">Register Now</a></p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to another evening of insight, innovation, and meaningful connections.</p>
+
+
+
+<p class="wp-block-paragraph">Stay curious and keep pushing boundaries,</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/">Kris Krüg</a><br />CEO, <a href="https://futureproofcreatives.com/">Future Proof Creatives</a><br />Host, <a href="https://lu.ma/future-proof">Vancouver AI Community Meetups</a></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">Vancouver AI Community Meetup Recap: June 2024 at Future Proof Creatives Studio</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-content.rendered.html
@@ -1,0 +1,766 @@
+
+<p class="wp-block-paragraph">Hey there, AI innovators and future-shapers, Kris Krüg here, reflecting on our last gathering and looking ahead to our next adventure in the <a href="https://lu.ma/YVR-AI">Vancouver AI Community Meetup series</a>. We&#8217;re building something special here, and I&#8217;m excited to share the journey with you all.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EqmixfIT_II?si=Fw7IReyh2M-0y6wu" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">June 27th: The Intersection of AI, Art, and Human Creativity</h2>
+
+
+
+<p class="wp-block-paragraph">Our June meetup at <a href="https://www.futureproofcreatives.com/">Future Proof Creatives</a> studio was a testament to the power of interdisciplinary collaboration. Here&#8217;s what we explored:</p>
+
+
+
+<h3 class="wp-block-heading">Event Highlights</h3>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Interactive Sound Walks with <a href="http://linkedin.com/in/holmium/">Ove Holmqvist</a></strong> Ove Holmqvist, the maestro of sound and tech, transported us into a sonic landscape where geospatial interactions met physical computing.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34885e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34885e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="578" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup.jpg?resize=1024%2C578&#038;ssl=1" alt="" class="wp-image-6271" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1024%2C578&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=768%2C433&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=1536%2C867&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=2048%2C1156&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ove-holonic-meeup-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">His app turned our movements into music, crafting an auditory tapestry that was both ethereal and profoundly grounding. With <a href="https://www.movesense.com/">Movesense sensors</a>, the line between the physical and the digital blurred, creating a space where each step became a note in a grand, real-time composition.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3488d3c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3488d3c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="538" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&#038;ssl=1" alt="" class="wp-image-6270" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1024%2C538&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=300%2C158&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=768%2C404&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?resize=1536%2C807&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744227.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>2. <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">Autolume: Post-Photographic Cyborg Art</a></strong> I took the community on a journey through time and tech with Autolume, an AI-powered, post-photographic experiment. Imagine teaching a baby AI brain with 20 years of film portraits and watching it bloom into a digital entity capable of creating new art forms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489481&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489481" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-6278" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?resize=1152%2C1536&amp;ssl=1 1152w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-17.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This project, in collaboration with <a href="https://www.metacreation.net/">Metacreation Lab for Creative AI at SFU</a>, showcased the beautiful chaos at the intersection of analog nostalgia and AI futurism. By feeding the AI with a vast archive of analog film portraits, <a href="https://www.metacreation.net/autolume">Autolume</a> learns to interpret and recreate human faces in entirely new artistic expressions, merging the past’s tactile essence with the future’s digital innovation.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3489cab&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3489cab" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6273" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744256.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The demonstration illustrated not just the technical prowess of AI but also its potential to redefine artistic boundaries, creating a unique symbiosis between human creativity and machine learning.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>3. <a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Lionel Ringenbach’s CompoVision</a></strong> <a href="https://ucodia.space/">Lionel Ringenbach </a>introduced us to CompoVision, an installation that doesn’t just see but interprets.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348a64a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348a64a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6269" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744206.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Real-time visual data transformed into interactive art, making us participants in a living, breathing digital organism. This piece not only caught the eye but also sparked a collaboration with a major tech firm, proving that in the digital age, art and opportunity are just a pixel apart.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6256" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743960.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>4. Networking and Community Building</strong> The evening was a hotbed of intellectual synergy, with researchers, investors, artists, coders, entrepreneurs, and students mingling over gourmet bites and artisanal brews. The conversations flowed as freely as the ideas, each interaction a potential seed for the next big thing in AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><strong>Spotlight on Cool Peeps and Projects</strong>: Our community is a network of networks, and many inspiring individuals and projects took the mic that night:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA _shyang</a></strong> kicked off the event with some fresh beatboxing and announced his upcoming talk at Sean Flanagan&#8217;s Playshop.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348b9db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348b9db" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6254" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743976.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://folioyvr.com/2024/06/ritchie-po-cybersecurity-data-privacy-lawyer/">Richie from Open Rep AI</a></strong> spoke about <a href="https://lu.ma/AIMastery">Anthony Green&#8217;s AI mastery series</a>, followed by <a href="https://www.linkedin.com/in/anthonygreen00/?originalSubdomain=ca">Anthony</a> sharing his insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348c1b9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348c1b9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6255" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A743998.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Soham</strong>, a <a href="https://www.socratica.info/">Socratica</a> guy and <a href="https://www.atelier.ac/">Vancouver Atelier</a> founder, invited attendees to join the Atelier community.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348cb1e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348cb1e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6257" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744042.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://alexandrasamuel.com/">Alexandra Samuel</a></strong>, a famous writer and business thought leader, entertained us with funny and embarrassing stories of our friendship.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d1f2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d1f2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6258" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744069.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/gabriela-arno-a7b55b163/">Gabriela Arno</a> from <a href="https://thecofoundershub.com/">Co-Founders Hub</a></strong> introduced her event, &#8216;<a href="https://lu.ma/meetyourcofoundervancouver">Meet Your Co-Founder</a>,&#8217; and discussed the upcoming sticker swap at the July AI meetup.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348d9c5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348d9c5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6259" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744328.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="http://kushalgoenka.com/">Kushal Goenka</a></strong>, an open-source AI advocate and engineer, shared his latest projects and insights.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e1f6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e1f6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6260" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744109.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://www.linkedin.com/in/kenny-macintyre-6872973/"><strong>Kenny Mack Truck</strong> </a>from the <a href="https://www.thebandits.ca/">Vancouver Bandits basketball team</a>, discussed his experience in the CEO AI workshop and creative work he&#8217;s doing in marketing.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348e9dc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348e9dc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6261" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744129.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/yangos/">Yangos Hadjiyannis</a></strong>, a big deal at <a href="https://www.siggraph.org/">SIGGRAPH</a>, talked about his AR/VR spatial video lab.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348f197&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348f197" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6262" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744138.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/prajwal-prashanth?miniProfileUrn=urn%3Ali%3Afs_miniProfile%3AACoAAEFdpdgBPffN7ej93MUm1IxgjQd72MT7peE">Prajwal Prashanth</a></strong> gave a talk about his <a href="https://www.youtube.com/watch?v=gBFboapI-Ew">Jarvis AI assistant</a> and about <a href="https://www.tks.world/">The Knowledge Society (TKS)</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a348fa2d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a348fa2d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6263" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744147.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kevinjosethomas/">Kevin Thomas</a></strong> Kevin featuring AI sign language interpreter he&#8217;s gonna demo in July.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3490175&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3490175" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6264" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744159.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://aydenlum.com/"><strong>Ayden</strong> <strong>Lum</strong></a>, an Atelier co-op participant, introduced himself and shared the workshops and <a href="https://insightful-future.beehiiv.com/">newsletters</a> he&#8217;s been involved with at Future Proof Creatives.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349085f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349085f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6265" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744162.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew Schwartzman</a></strong>, a high schooler, shared about his <a href="https://teen2life.podbean.com/">teen-focused podcast interviewing non-traditional successful entrepreneurs</a>.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a349101a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a349101a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6266" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744170.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/donaldjewkes/">Donald Jukes</a></strong> discussed the <a href="https://kriskrug.co/2024/07/01/a-love-letter-to-vancouver-minimal-viable-demos/">Minimal Viable Demos event</a> and its blend of art, technology, science, and humanity.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491765&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491765" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6267" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744193.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.linkedin.com/in/kennedy-ed/">Ed Kennedy</a> from <a href="https://rundiffusion.com/">Run Diffusion</a></strong> explained cloud AI tools and their applications for creative professionals.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3491e3f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3491e3f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="618" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&#038;ssl=1" alt="" class="wp-image-6272" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1024%2C618&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=300%2C181&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=768%2C463&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?resize=1536%2C926&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744199.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://patrickpennefather.com/">Dr. Patrick Parra Pennefather</a></strong> engaged the crowd with intros and improv and general hilarious commentary.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492568&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492568" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-6277" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/ppp-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Screenshot</figcaption></figure>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://thebusinessofyou.com/">Sian Flanagan</a></strong> shared insights from her book, performed a couple amazing original songs and announced her <a href="https://lu.ma/user/usr-1zfxAodTD8gqbh6">multi-passionate entrepreneur play shop</a>.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6274" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744346.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Jay David Milroy</strong>: &#8220;Love the mix of art and engineering. Love how you lift up others. I hope to try and find a way to participate and contribute.&#8221; Jay, your observation reflects the essence of what we&#8217;re trying to achieve &#8211; a blend of technical innovation and creative expression.</li>
+
+
+
+<li><strong>Darren Nicholls</strong>: &#8220;This is one of my favorite networking events.&#8221; Darren, it&#8217;s connections like these that drive innovation forward.</li>
+
+
+
+<li><strong>Yangos </strong><strong>Hadjiyannis</strong>: &#8220;Beautiful, authentic and meaningful event. Thank you Kris!&#8221; Authenticity and meaning are at the core of what we do, Yangos. Glad it resonated.</li>
+
+
+
+<li><strong>Wanda Halpert</strong>: &#8220;This was an excellent meetup that had people of all ages and background in AI discussing their progress and uses of this emerging tech.&#8221; Wanda, you&#8217;ve highlighted the strength of our diverse community. It&#8217;s this variety of perspectives that enriches our understanding of AI&#8217;s potential.</li>
+
+
+
+<li><strong>Ed Kennedy</strong>: &#8220;Fantastic event! Half lab/half party! Great speakers, great experiments, great networking. Always a pleasure!&#8221; Ed, you&#8217;ve nailed our approach &#8211; serious work in a fun, collaborative atmosphere.</li>
+
+
+
+<li><strong>Joe Leano</strong>: &#8220;My first event.. what an amazing experience. Everyone there had such amazing ideas. Amplified my creativity and looking to come back to next event.&#8221; Joe, welcome to the community. Your fresh perspective is invaluable as we continue to grow and evolve.</li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3492d93&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3492d93" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6275" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/A744270.jpg?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photography by <a href="https://www.peterholstphotography.com/">Peter Holst</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Huge thanks to <a href="https://www.peterholst.com/">Peter Holst</a> and <a href="https://www.viktorserbin.com/">Viktor Serbin</a> for documenting the event. Revisit the evening here: <a href="https://www.flickr.com/photos/kk/albums/72177720309491900">Photo Gallery</a> <a href="https://vimeo.com/showcase/vancouverai">Recap Video</a></p>
+
+
+
+<p class="wp-block-paragraph">And a heartfelt thank you to our sponsors and partners who make this possible: <a href="https://www.holistichybrid.com/">Holistic Hybrid</a>, <a href="https://www.augxlabs.com/">AugXLabs</a>, <a href="https://metacreation.net/">Metacreation Lab at SFU</a>, <a href="https://www.vancouverbiennale.com/">Vancouver Biennale</a>, <a href="https://creativemornings.com/cities/van">Creative Mornings Vancouver</a>, <a href="https://internetmasterminds.com/">Internet Masterminds</a>, <a href="https://www.fatalfest.com/">The FATALE Festival</a>, <a href="https://www.sonsofvancouver.com/">Sons of Vancouver</a>, <a href="https://vlacc.ca/">VLACC</a>, and <a href="https://www.taylightbrewing.com/">Taylight Brewing</a>.</p>
+
+
+
+<h2 class="wp-block-heading">July 25th: Exploring Local-First AI in a Global Context (Now with Sticker Swap!)</h2>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-3vbh2iIkl8jAl9O/simple" width="600" height="700" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Our next meetup aligns with <a href="https://lu.ma/LOCALHOST_vancouver">LOCALHOST week</a> and <a href="https://www.ietf.org/how/meetings/120/">IETF 120</a>, offering a unique opportunity to explore AI through the lens of decentralized technologies. Here&#8217;s what we&#8217;re diving into:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Decentralized AI</strong>: We&#8217;ll examine how open-source, decentralized web technologies are reshaping AI development and deployment.</li>
+
+
+
+<li><strong>Applied AI</strong>: Through live demos, we&#8217;ll showcase real-world applications of AI across various industries.</li>
+
+
+
+<li><strong>Ethical Considerations</strong>: We&#8217;ll continue our ongoing discussion about the ethical implications of AI as it becomes more integrated into our daily lives.</li>
+
+
+
+<li><strong>Local Innovation</strong>: As part of our &#8216;Localhost&#8217; theme, we&#8217;re spotlighting Vancouver&#8217;s contributions to the global AI landscape.</li>
+</ul>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="292" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&#038;ssl=1" alt="" class="wp-image-6276" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1024%2C292&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=300%2C86&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=768%2C219&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=1536%2C439&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/image-16.png?resize=2048%2C585&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<h3 class="wp-block-heading">NEW: AI Sticker Swap!</h3>
+
+
+
+<p class="wp-block-paragraph">Get ready for a fun addition to our meetup &#8211; a sticker swap! We&#8217;re inviting all attendees to create and bring stickers to share and trade. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493666&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493666" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6281" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">These don&#8217;t have to be AI-themed; they can represent your personal brand, a project you&#8217;re working on, your company, or any idea you&#8217;d like to share. It&#8217;s a great way to network, showcase your interests, and add some personality to your gear.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3493cb9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3493cb9" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="452" height="434" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=452%2C434&#038;ssl=1" alt="" class="wp-image-6282" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?w=452&amp;ssl=1 452w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/15143694.png?resize=300%2C288&amp;ssl=1 300w" sizes="auto, (max-width: 452px) 100vw, 452px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;ll be bringing a variety of tech and AI stickers to kick things off, but we want to see what you&#8217;ve got too! Whether you&#8217;re designing new stickers or bringing your existing collection, come prepared to swap. It&#8217;s a casual, fun way to break the ice and learn about what others in our community are passionate about. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3494312&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3494312" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="596" height="596" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=596%2C596&#038;ssl=1" alt="" class="wp-image-6284" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?w=596&amp;ssl=1 596w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/master.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 596px) 100vw, 596px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">So get creative, bring what you have, and let&#8217;s see what kind of unique sticker collections we can create together!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34948f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34948f5" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="382" height="452" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=382%2C452&#038;ssl=1" alt="" class="wp-image-6283" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?w=382&amp;ssl=1 382w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/07/Untitled-1-1.png?resize=254%2C300&amp;ssl=1 254w" sizes="auto, (max-width: 382px) 100vw, 382px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Key elements of the evening:</h3>
+
+
+
+<ol class="wp-block-list">
+<li>Presentations on AI and decentralized web synergies</li>
+
+
+
+<li>Interactive sessions exploring industry-specific AI applications</li>
+
+
+
+<li>Networking opportunities with local tech leaders and innovators</li>
+
+
+
+<li>Sticker Swap: A fun, informal way to share our AI passions</li>
+
+
+
+<li>Local AI Showcase: Celebrating Vancouver&#8217;s homegrown AI innovations</li>
+</ol>
+
+
+
+<p class="wp-block-paragraph">This event is part of LOCALHOST week, culminating in the <a href="https://ournetworks.ca/">Our Networks conference</a> on July 27th. We&#8217;re exploring how local-first tech can empower communities and reshape our digital interactions.</p>
+
+
+
+<p class="wp-block-paragraph">To our IETF 120 participants: We extend a warm invitation to join us and experience Vancouver&#8217;s vibrant AI community firsthand.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Our goal remains constant: <em>to foster a community that drives innovation, shares knowledge, and thoughtfully considers the real-world applications and ethical implications of AI. Whether you&#8217;re deep in the trenches of research, driving business innovation, exploring artistic applications, or simply curious about AI&#8217;s potential, you have a place here.</em></p>
+
+
+
+<p class="wp-block-paragraph">Join us on July 25th as we continue to explore and shape the future of AI, rooted in our local community but with a global perspective.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.meetup.com/vancouver-ai-meetup/events/">Register Now</a></p>
+
+
+
+<p class="wp-block-paragraph">Looking forward to another evening of insight, innovation, and meaningful connections.</p>
+
+
+
+<p class="wp-block-paragraph">Stay curious and keep pushing boundaries,</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/">Kris Krüg</a><br />CEO, <a href="https://futureproofcreatives.com/">Future Proof Creatives</a><br />Host, <a href="https://lu.ma/future-proof">Vancouver AI Community Meetups</a></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection. See also: <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">Vancouver AI Community Meetup Recap: June 2024 at Future Proof Creatives Studio</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6251-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 6251,
+  "slug": "creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights",
+  "status": "publish",
+  "link": "https://kriskrug.co/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/",
+  "modified": "2026-06-28T20:33:29",
+  "modified_gmt": "2026-06-29T04:33:29",
+  "type": "post",
+  "content_raw_bytes": 76742,
+  "content_rendered_bytes": 76742,
+  "content_raw_has_footer": true,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 1,
+  "title_rendered": "Creativity in the Age of AI: Vancouver AI Community Meetup &#8211; June 2024 Highlights"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-content.raw.html
@@ -1,0 +1,954 @@
+
+<p class="wp-block-paragraph">On August 29th, the <a href="https://futureproofcreatives.com/">Future Proof Creatives</a> studio at the <a href="https://www.vancouverbiennale.com/about-us/the-organization/">Vancouver Biennale Community Art Space</a> transformed into a crucible of ideas where technology, art, and community collided to create something truly special. </p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">Before we dive in, check out our gallery of nearly 500 high-resolution images from the Vancouver AI Community Meetup—ready for you to download and enjoy <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">right here</a>: <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">https://diamondsedgephotography.pixieset.com/aimeet-upaugust/</a></p>
+</blockquote>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="571" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&#038;ssl=1" alt="" class="wp-image-6857" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=768%2C428&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1536%2C857&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=2048%2C1142&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph">The atmosphere at 290 W 3rd Ave, Vancouver, was electric, with a diverse crowd of innovators, creators, and dreamers all eager to push the boundaries of what’s possible with AI. </p>
+
+
+
+<figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
+<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:500px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a></div></blockquote><script async src="//platform.instagram.com/en_US/embeds.js"></script>
+</div><figcaption class="wp-element-caption">Video by Viktor Serbin.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This gathering wasn’t your typical meetup; it was an assembly of minds ready to disrupt, create, and collaborate. The next <a href="https://lu.ma/AI-meetup">Vancovuer AI Community Meetup</a> is September 26th and <a href="https://lu.ma/AI-meetup">earlyworm tickets</a> are now available. 🙂</p>
+
+
+
+<p class="has-text-align-center wp-block-paragraph"><a href="https://lu.ma/event/evt-6VeJQM5kfFnNUmn" class="luma-checkout--button" data-luma-action="checkout" data-luma-event-id="evt-6VeJQM5kfFnNUmn">
+  Register for Event
+</a>
+
+<script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34095f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34095f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="579" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&#038;ssl=1" alt="" class="wp-image-6816" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=300%2C170&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=768%2C434&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?w=1220&amp;ssl=1 1220w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancovuer AI Meetup &#8211; photo by Juliana Loh</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="http://stevebroback.com/about/">Steve Broback</a> wrote of the Vancouver AI Community Meetups “one of the best events I’ve attended in the last 12 months… I met many creative, smart, and positive humans with a passion for AI there.” That’s exactly the energy we aim to cultivate—bringing together brilliant minds to share, inspire, and push the boundaries of what’s possible.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>The Power of Community: We’re Just Getting Started</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.joshuamichie.com/">Joshua Michie</a> said it perfect when he said, “We&#8217;re building something special with Vancouver AI meetups… What strikes me most is that everyone that attends is looking to make something cool in the city and are actively looking for co-collaborators.”</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3409ed5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3409ed5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6817" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Little Woo &amp; Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">That’s what this meetup was all about—bringing together a diverse mix of people from business, design, art, politics, activism, and beyond. Each person brought their unique energy, creating an environment centered on making meaningful connections and building something bigger than ourselves.</p>
+
+
+
+<p class="wp-block-paragraph">This eclectic mix of attendees, from seasoned professionals to curious newcomers, generated an atmosphere charged with deep, thoughtful conversations about AI’s potential and applications. Every interaction sparked new ideas and possibilities for collaboration, setting the stage for future innovations.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340a67b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340a67b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6818" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Prajwal Prashanth, A Visionary in the Making</strong></h3>
+
+
+
+<p class="wp-block-paragraph">One of the night’s highlights was undoubtedly the presentation by <a href="https://prajwal.is-a.dev/">Prajwal Prashanth, </a>a soon-to-be high school senior who stunned the audience with his groundbreaking innovation. Prajwal took the stage with an <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">AI-powered personal assistant complete with hearing and vision</a> embedded in his palm—technology with the potential to change lives, particularly for the visually impaired.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340ada5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340ada5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6819" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Showing Jarvis2 at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As he demonstrated how the device could “see” and interpret the world around it, translating visual inputs into words, the audience was captivated. “There is a crowd of people standing in front of me and a woman sitting on a chair,” the AI announced, and the room erupted in applause. This young innovator’s work illustrates the power of AI when harnessed with creativity and a clear purpose.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340b554&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340b554" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6820" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?w=1706&amp;ssl=1 1706w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s vision is to further develop this technology as a medical aid for the visually impaired, transforming it into an intuitive, wearable AI companion that can narrate the world in real-time. His technical prowess and forward-thinking approach serve as a reminder that the future of AI lies in the hands of bright young innovators ready to make a difference.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ed Kennedy’s Radical Exploration: Circuit Bending and Beyond</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/edwerk/">Ed Kennedy</a> brought a different kind of energy to the evening with his talk on circuit bending—a practice involving the modification of old electronics, toys, and musical instruments to create chaotic, otherworldly sounds. By manipulating these devices, Ed bends the very fabric of reality, creating entirely new experiences from the discarded and overlooked.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340c85d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340c85d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy Circuit Bending at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“Experiment often and early,” Ed urged. “This is a brand new space where anyone can make a key breakthrough.” His insights into data bending, where mediums like image files or CDs are creatively altered in their interpretation, expanded our understanding of the endless possibilities available when creativity and non-linear thinking intersect.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340d791&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340d791" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Glitch Art by Ed Kennedy at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed’s work challenges conventional approaches to technology and creativity, pushing us all to rethink how we engage with the digital world. His explorations serve as a powerful reminder that embracing chaos can lead to groundbreaking discoveries. Reminds me of the work <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and I are doing with <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">AI Model Bending in Autolume</a> remixing GAN AI models trained on my photography with that of other artists resulting in wild glitchart via the <a href="https://www.metacreation.net/autolume">neural visual synthesizer</a> at <a href="https://www.metacreation.net/">Metacreation Lab</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e014&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e014" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy, Kris Krüg and Alexis Smith at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ashley Conery’s CubeCommons: Rethinking Digital Interaction</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Ashley Conery added a reflective, yet revolutionary element to the evening with her presentation on <a href="https://aconery.wixsite.com/cube">CubeCommons</a>—a project that explores the intersection of post-colonial principles and digital commons. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe src="https://cubecommons.ca/embedPlaylist/87eb0e60-f83e-4492-a31d-fd40a5cd6e76" style="width:100%; height:100%;" frameborder="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://cubecommons.ca/profile/FutureProof/">CubeCommons</a> is more than a tech initiative; it’s a call to rethink our digital interactions as we transition to a future where spatial computing will redefine our online experiences.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e933&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e933" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“I was really moved by how folks shared their art and their learnings,” Ashley said. Her project challenges us to consider the ethical implications of our digital footprints and the spaces we create online. CubeCommons is about using digital platforms to foster real, meaningful connections, guided by principles of equity and inclusion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f120&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f120" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we build the future, Ashley’s project reminds us of the importance of ensuring that the digital world reflects the values of the communities it serves. Her insights push us to think critically about how we can create online spaces that are innovative, just, and inclusive.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Dean Shev on AI in Healthcare: A Call for Innovation</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/deanshev/?originalSubdomain=ca">Dean Shev </a>of <a href="https://www.fraserhealth.ca/">Fraser Valley Health Authority</a> directed the conversation towards the healthcare sector, highlighting the critical need for innovation in this field. Canada is facing a potential healthcare crisis by 2045, and the urgency to find multi-dimensional solutions is clear. Dean’s mission is to ignite groundbreaking innovation in healthcare, using AI as a catalyst for transformative change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f9e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f9e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">During the meetup, Dean connected the story of our resident young innovator—Prajwal, whose work he sees as a beacon of hope for the future of medical devices. However, Dean also underscored the challenges that lie ahead. “Systemic barriers in healthcare—bureaucracy, risk-averse culture, and financial constraints—often stifle innovation,” he warned.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34101a8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34101a8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6828" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Dean called for systemic changes, emphasizing the need for leadership that champions experimentation and provides resources for pilot programs and innovation labs. His message was clear: the future of healthcare depends on our ability to innovate now, to dismantle the barriers holding us back, and to fully harness the potential of AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Visual Highlights: Reflecting the Soul of the Meetup</h3>
+
+
+
+<p class="wp-block-paragraph">This evening wasn’t just a series of talks and demos—it was a sensory dive into the intersection of art, technology, and raw human creativity. <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a>’s spoken word piece explored the tangled future of brains, communities, and relationships, leaving the room charged with a new kind of electricity. Her performance reminded us that the future of AI isn’t just about tech; it’s about the emotional layers we bring to it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3410a2f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3410a2f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6829" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night’s rhythm was set by <a href="https://kevinfriel.com/">Kevin Friel</a> aka <a href="https://www.youtube.com/channel/UCTMySf7JbGMGUPt5-YQim8Q">Mr. Pixel Wizard’s</a> AI DMX lighting kit, which transformed the space into something alive. <a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu</a> AKA <a href="https://www.instagram.com/_shyang/">Shyang</a>, the West Coast beatboxer, laid down rhythms that felt like they were bending reality. </p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/mother.ofthevoid/">Holy Mother of the Void</a> merged house performance art with lessons on embodiment, pushing us to rethink the boundaries between the physical and the digital. <a href="https://www.instagram.com/sachagabriel/">Sacha Gabriel</a> closed out the night, spinning tracks that kept the energy flowing and the conversations going. This wasn’t just a showcase—it was a lived experience where sound, light, and AI met and mingled.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34112a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34112a0" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6830" style="width:600px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kevin Friel aka Mr. Pixel Wizard at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Badass people photographer <a href="https://www.instagram.com/DiamondsEdgePhotography/">Michelle Diamond</a> was there, sharing the essence of it all through her lens, while Victor Serbin filmed the night, turning moments into a visual story we can revisit. These photos and videos&#8230;. they’re pieces of our shared experience. If you’ve got photos, videos, or audio from the night, we’d love for you to share them with us. Add them to the <a href="https://www.notion.so/Vancouver-AI-Community-Meetup-Recap-August-29th-A-Night-of-Innovation-Connection-and-Future-For-358ab278f1c94f9992ccea77aaf2da02?pvs=21">Google album link</a>. These are our community story and pls feel free to use them and share them. 🙂</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3411a1a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3411a1a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6831" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jackson Wu aka SHYANGDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more media to drop soon, and in the meantime, spread the word. Bring your stories, bring your friends. We’re building something real, together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412162&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412162" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6832" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">DJ Sacha Gabriel Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="https://www.linkedin.com/in/chrisgranthall/">Chris Hall</a> said, “Wonderful event hosted by Kris Krüg and the team at Vancouver AI. Introduced to some innovative AI artists and enjoyed some great conversations on the topic of AI and how it is changing everything with new acquaintances.” For those who missed it, we’ve put together a <a href="https://youtube.com/shorts/suWVtA964ts?feature=share">video recap that you can check out here</a>. It’s not just a highlight reel; it’s a glimpse into what happens when a community comes together to push the boundaries of AI.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412986&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412986" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6833" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Orbit Princess aka Holy Mother of the Void at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Looking Ahead: September 26th Meetup &#8211; Join the Revolution</strong></h3>
+
+
+
+<p class="wp-block-paragraph">If you thought August’s meetup was something special, <a href="https://lu.ma/AI-meetup">just wait until September 26th</a>. We’re gearing up for even more mind-bending demos, talks that will challenge your understanding of AI, and of course, the same incredible community vibe that makes these meetups so unique.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-6VeJQM5kfFnNUmn/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Grab your tickets now:</p>
+
+
+
+<ul class="wp-block-list">
+<li>Early Bird (CA$35): For the quick-draw innovators. Limited spots, so move fast.</li>
+
+
+
+<li>Standard (CA$50): Full access, full experience. Fuel for body and mind included.</li>
+
+
+
+<li>Pay-it-forward (CA$100): Supercharge the collective. Your contribution opens doors for others.</li>
+
+
+
+<li></li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3413799&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3413799" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6835" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Community VibesDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>AI Trainings for Creatives: Elevate Your Skills</strong></h3>
+
+
+
+<p class="wp-block-paragraph">For those of you looking to level up your AI game, we’ve got you covered. Our <a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">AI Upgrade for Creative Professionals</a> will take you from zero to hero, giving you the tools to thrive in this brave new world. </p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="797" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&#038;ssl=1" alt="" class="wp-image-6856" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=300%2C233&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=768%2C598&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">The AI Upgrade for Creative Pros by Kris Krüg &amp; Peter Bittner</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">We’re talking cutting-edge, hands-on learning that’ll have you speaking fluent AI in no time.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Wrapping Up with Gratitude</strong></h3>
+
+
+
+<p class="wp-block-paragraph">A huge shoutout to <strong><a href="https://www.instagram.com/jessicaliangx/?hl=en">Jessica Liang</a> </strong>from<strong> </strong><a href="https://www.ilovenook.co/"><strong>Nook</strong> Coworking</a> for sharing insights on community and coworking, and for inviting us to her upcoming party—looking forward to it!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34142a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34142a0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6836" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jessica Liang of Nook Coworking at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Big thanks to the <strong>volunteer <a href="https://www.linkedin.com/in/lawrence-okolo-a062a2146/">Lawerence</a> &amp;  from Northeastern University</strong> who helped keep everything on track.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3414bac&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3414bac" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6837" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/aminishere/">Amin Sharifi</a> and Anita from <a href="https://www.enyalearning.ca/">Enya Learning</a></strong>—it’s an honor to keynote at your <a href="https://lu.ma/ons70lj3?tk=w8tLDe">Creative Technology Night</a> at the <a href="https://www.sfu.ca/dialogue.html">Wosk Center for Dialogue</a> this week.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34154d3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34154d3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6838" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita and Amin of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Matt Jones</strong>, from the <a href="https://techcouver.com/2024/08/20/bitcoin-block-party-vancouver/">Bitcoin Block Party</a> brought the <a href="https://www.instagram.com/sexyboysandgirlsclub/">Sexy Boys and Girls Club</a> fashion line to add some style to our event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3415db6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3415db6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6839" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Matt of Sexy Boys &amp; Girls Club at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/kassandra-m-linklater/">Kassandra Linklater</a></strong> and her mom, along with her mom’s best friend, two tech-savvy women in their 80s, brought a wealth of experience and culture.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416676&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416676" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6840" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"> Vancouver AI Community &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Cheers to <strong><a href="https://www.salesacademy.ca/shane-gibson-sales-trainer/">Shane Gibson</a>, </strong>AI sales guru, and performance artist<strong> <a href="https://littlewoo.org/">Little Woo</a></strong> for their unique perspectives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416efd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416efd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6841" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AI Sales Leader Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/pka3300/">Prashant Agrawal (Mr. P)</a></strong>, thanks for introducing us to Be Pacific and opening up new opportunities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341762f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341762f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6842" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mr. P Prashant Agrawal at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="http://linkedin.com/in/colleen-kennedy-41430881">Colleen Kennedy</a></strong> represented <a href="https://cogsys.ubc.ca/">UBC Cognitive Sciences (COGS)</a> and excited to have more of ya join us…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3417eb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3417eb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6843" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Colleen Kenney of UBC COGS at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and <strong>Jul<a href="https://julianaloh.ca/">iana Loh</a></strong>, VR artist, your photos, videos, and knowledge were invaluable.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3418998&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3418998" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6844" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Juliana Loh at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://jjgmckenzie.ca/"><strong>James</strong> McKenzie</a>, your steadfast support from the beginning is much appreciated.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34190fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34190fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6845" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James &amp; KK  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/simon-haworth-uk-us-prc/">Simon Haworth</a></strong>, thanks for rallying the BC AI Life Sciences community with me.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34198c6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34198c6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6846" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Simon Haworth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.yangos.work/"><strong>Yangos Hadjiyannis</strong> </a>wrapped up SIGGRAPH with style at the VR lounge, and hilarious <a href="https://patrickpennefather.com/"><strong>Dr. Patrick Parra Pennefather</strong> </a> of <a href="https://eml.ubc.ca/">UBC Emerging Media Lab</a> brought critical insights from the <a href="https://www.nvidia.com/en-us/executive-insights/">NVIDIA AI ethics panel at SIGGRAPH 2024</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341a036&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341a036" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6847" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Yangos and Patrick Pennefather at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Kudos to <a href="https://kushalgoenka.com/"><strong>Kushal </strong>Goenka</a> for sharing your SIGGRAPH journey and open-source spirit and <a href="https://www.youtube.com/c/KushalGoenka">free AI Education Videos</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341aaa5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341aaa5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6848" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kushal Goenka at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/derrick-carter-338ba441/">Derek Carter</a> </strong>from<a href="https://www.thesawmill.ca/"> Sawmill Motion Capture Studio</a> welcomes us to come for a visit</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b1d5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b1d5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6853" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Derek Carter of Sawmill Studios  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://yagudaev.com/about/"><strong>Michael Yagudev</strong></a> is our very own <a href="https://levelsio.com/">Vancouver AI Pieter Levels</a> your <a href="http://AudioWaveAI.com">AudioWaveAI.com</a> tool is an entrepreneurial inspiration.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b911&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b911" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6850" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Yagudev of AudioWave AI at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to <strong><a href="https://www.linkedin.com/in/rozmcnulty/">Roz McNulty</a></strong> of <a href="https://www.fashionic.ca/roz">Fashion Innovation Centre</a> for managing the door, registration, and signs…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341c053&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341c053" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6851" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI volunteer Roz McNaulty at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and to <strong><a href="https://www.mattcarolan.com/">Matt Carolan</a></strong> from <a href="https://aws.amazon.com/events/community-day/?developer-center-activities-cards.sort-by=item.additionalFields.startDateTime&amp;developer-center-activities-cards.sort-order=asc">AWS Community Days</a>—your Aussie magic lit up the event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d093&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d093" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6852" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AWS Community Days Organizer Matt Carolan at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Also, gratitude to <strong><a href="https://www.linkedin.com/in/jeffreyrclark/">Jeff Clark</a></strong> of <a href="https://favoland.com/">Favoland</a> for guiding attendees and being the friendly face at the entrance.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d827&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d827" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6854" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Favoland CEO Jeff Clark at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks to everyone who contributed to making this meetup unforgettable. Until next time!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341df69&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341df69" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6855" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void and KK at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Related:</strong> More local ecosystem notes live in my <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI community</a> hub.</p>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-content.rendered.html
@@ -1,0 +1,954 @@
+
+<p class="wp-block-paragraph">On August 29th, the <a href="https://futureproofcreatives.com/">Future Proof Creatives</a> studio at the <a href="https://www.vancouverbiennale.com/about-us/the-organization/">Vancouver Biennale Community Art Space</a> transformed into a crucible of ideas where technology, art, and community collided to create something truly special. </p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">Before we dive in, check out our gallery of nearly 500 high-resolution images from the Vancouver AI Community Meetup—ready for you to download and enjoy <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">right here</a>: <a href="https://diamondsedgephotography.pixieset.com/aimeet-upaugust/">https://diamondsedgephotography.pixieset.com/aimeet-upaugust/</a></p>
+</blockquote>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="571" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&#038;ssl=1" alt="" class="wp-image-6857" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1024%2C571&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=300%2C167&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=768%2C428&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=1536%2C857&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image-1.png?resize=2048%2C1142&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph">The atmosphere at 290 W 3rd Ave, Vancouver, was electric, with a diverse crowd of innovators, creators, and dreamers all eager to push the boundaries of what’s possible with AI. </p>
+
+
+
+<figure class="wp-block-embed is-type-rich is-provider-instagram wp-block-embed-instagram"><div class="wp-block-embed__wrapper">
+<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:500px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/reel/C_YYozCvtHH/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;">View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a></div></blockquote><script async src="//platform.instagram.com/en_US/embeds.js"></script>
+</div><figcaption class="wp-element-caption">Video by Viktor Serbin.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This gathering wasn’t your typical meetup; it was an assembly of minds ready to disrupt, create, and collaborate. The next <a href="https://lu.ma/AI-meetup">Vancovuer AI Community Meetup</a> is September 26th and <a href="https://lu.ma/AI-meetup">earlyworm tickets</a> are now available. 🙂</p>
+
+
+
+<p class="has-text-align-center wp-block-paragraph"><a href="https://lu.ma/event/evt-6VeJQM5kfFnNUmn" class="luma-checkout--button" data-luma-action="checkout" data-luma-event-id="evt-6VeJQM5kfFnNUmn">
+  Register for Event
+</a>
+
+<script id="luma-checkout" src="https://embed.lu.ma/checkout-button.js"></script></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34095f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34095f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="579" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&#038;ssl=1" alt="" class="wp-image-6816" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=1024%2C579&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=300%2C170&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=768%2C434&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-vancouver-ai-meetup.png?w=1220&amp;ssl=1 1220w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancovuer AI Meetup &#8211; photo by Juliana Loh</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="http://stevebroback.com/about/">Steve Broback</a> wrote of the Vancouver AI Community Meetups “one of the best events I’ve attended in the last 12 months… I met many creative, smart, and positive humans with a passion for AI there.” That’s exactly the energy we aim to cultivate—bringing together brilliant minds to share, inspire, and push the boundaries of what’s possible.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>The Power of Community: We’re Just Getting Started</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.joshuamichie.com/">Joshua Michie</a> said it perfect when he said, “We&#8217;re building something special with Vancouver AI meetups… What strikes me most is that everyone that attends is looking to make something cool in the city and are actively looking for co-collaborators.”</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3409ed5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3409ed5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6817" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/little-woo-shane-gibson-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Little Woo &amp; Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">That’s what this meetup was all about—bringing together a diverse mix of people from business, design, art, politics, activism, and beyond. Each person brought their unique energy, creating an environment centered on making meaningful connections and building something bigger than ourselves.</p>
+
+
+
+<p class="wp-block-paragraph">This eclectic mix of attendees, from seasoned professionals to curious newcomers, generated an atmosphere charged with deep, thoughtful conversations about AI’s potential and applications. Every interaction sparked new ideas and possibilities for collaboration, setting the stage for future innovations.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340a67b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340a67b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6818" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/anita-enya-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Prajwal Prashanth, A Visionary in the Making</strong></h3>
+
+
+
+<p class="wp-block-paragraph">One of the night’s highlights was undoubtedly the presentation by <a href="https://prajwal.is-a.dev/">Prajwal Prashanth, </a>a soon-to-be high school senior who stunned the audience with his groundbreaking innovation. Prajwal took the stage with an <a href="https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/">AI-powered personal assistant complete with hearing and vision</a> embedded in his palm—technology with the potential to change lives, particularly for the visually impaired.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340ada5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340ada5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6819" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-vancouver-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Showing Jarvis2 at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As he demonstrated how the device could “see” and interpret the world around it, translating visual inputs into words, the audience was captivated. “There is a crowd of people standing in front of me and a woman sitting on a chair,” the AI announced, and the room erupted in applause. This young innovator’s work illustrates the power of AI when harnessed with creativity and a clear purpose.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340b554&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340b554" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6820" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/Prajwal-Prashanth-future-proof-creatives-scaled.jpg?w=1706&amp;ssl=1 1706w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Prajwal Prashanth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Prajwal’s vision is to further develop this technology as a medical aid for the visually impaired, transforming it into an intuitive, wearable AI companion that can narrate the world in real-time. His technical prowess and forward-thinking approach serve as a reminder that the future of AI lies in the hands of bright young innovators ready to make a difference.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ed Kennedy’s Radical Exploration: Circuit Bending and Beyond</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/edwerk/">Ed Kennedy</a> brought a different kind of energy to the evening with his talk on circuit bending—a practice involving the modification of old electronics, toys, and musical instruments to create chaotic, otherworldly sounds. By manipulating these devices, Ed bends the very fabric of reality, creating entirely new experiences from the discarded and overlooked.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340c85d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340c85d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-future-proof-creatives-vanAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy Circuit Bending at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“Experiment often and early,” Ed urged. “This is a brand new space where anyone can make a key breakthrough.” His insights into data bending, where mediums like image files or CDs are creatively altered in their interpretation, expanded our understanding of the endless possibilities available when creativity and non-linear thinking intersect.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340d791&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340d791" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/glitch-artist-ed-kennedy.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Glitch Art by Ed Kennedy at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Ed’s work challenges conventional approaches to technology and creativity, pushing us all to rethink how we engage with the digital world. His explorations serve as a powerful reminder that embracing chaos can lead to groundbreaking discoveries. Reminds me of the work <a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and I are doing with <a href="https://kriskrug.co/2024/06/18/the-cyborg-art-of-autolume-when-ai-meets-the-human-lens/">AI Model Bending in Autolume</a> remixing GAN AI models trained on my photography with that of other artists resulting in wild glitchart via the <a href="https://www.metacreation.net/autolume">neural visual synthesizer</a> at <a href="https://www.metacreation.net/">Metacreation Lab</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e014&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e014" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ed-kennedy-kriskrug-vanAI.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ed Kennedy, Kris Krüg and Alexis Smith at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Ashley Conery’s CubeCommons: Rethinking Digital Interaction</strong></h3>
+
+
+
+<p class="wp-block-paragraph">Ashley Conery added a reflective, yet revolutionary element to the evening with her presentation on <a href="https://aconery.wixsite.com/cube">CubeCommons</a>—a project that explores the intersection of post-colonial principles and digital commons. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe src="https://cubecommons.ca/embedPlaylist/87eb0e60-f83e-4492-a31d-fd40a5cd6e76" style="width:100%; height:100%;" frameborder="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://cubecommons.ca/profile/FutureProof/">CubeCommons</a> is more than a tech initiative; it’s a call to rethink our digital interactions as we transition to a future where spatial computing will redefine our online experiences.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340e933&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340e933" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ashley-con-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">“I was really moved by how folks shared their art and their learnings,” Ashley said. Her project challenges us to consider the ethical implications of our digital footprints and the spaces we create online. CubeCommons is about using digital platforms to foster real, meaningful connections, guided by principles of equity and inclusion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f120&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f120" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/cubecommons-vancouver-ai-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Ashley Conery Cube Commons at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As we build the future, Ashley’s project reminds us of the importance of ensuring that the digital world reflects the values of the communities it serves. Her insights push us to think critically about how we can create online spaces that are innovative, just, and inclusive.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Dean Shev on AI in Healthcare: A Call for Innovation</strong></h3>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/deanshev/?originalSubdomain=ca">Dean Shev </a>of <a href="https://www.fraserhealth.ca/">Fraser Valley Health Authority</a> directed the conversation towards the healthcare sector, highlighting the critical need for innovation in this field. Canada is facing a potential healthcare crisis by 2045, and the urgency to find multi-dimensional solutions is clear. Dean’s mission is to ignite groundbreaking innovation in healthcare, using AI as a catalyst for transformative change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a340f9e4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a340f9e4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-vancouverAI-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">During the meetup, Dean connected the story of our resident young innovator—Prajwal, whose work he sees as a beacon of hope for the future of medical devices. However, Dean also underscored the challenges that lie ahead. “Systemic barriers in healthcare—bureaucracy, risk-averse culture, and financial constraints—often stifle innovation,” he warned.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34101a8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34101a8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6828" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/dean-shev-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Dean called for systemic changes, emphasizing the need for leadership that champions experimentation and provides resources for pilot programs and innovation labs. His message was clear: the future of healthcare depends on our ability to innovate now, to dismantle the barriers holding us back, and to fully harness the potential of AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading">Visual Highlights: Reflecting the Soul of the Meetup</h3>
+
+
+
+<p class="wp-block-paragraph">This evening wasn’t just a series of talks and demos—it was a sensory dive into the intersection of art, technology, and raw human creativity. <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a>’s spoken word piece explored the tangled future of brains, communities, and relationships, leaving the room charged with a new kind of electricity. Her performance reminded us that the future of AI isn’t just about tech; it’s about the emotional layers we bring to it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3410a2f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3410a2f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6829" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/brittney-smaila-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night’s rhythm was set by <a href="https://kevinfriel.com/">Kevin Friel</a> aka <a href="https://www.youtube.com/channel/UCTMySf7JbGMGUPt5-YQim8Q">Mr. Pixel Wizard’s</a> AI DMX lighting kit, which transformed the space into something alive. <a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu</a> AKA <a href="https://www.instagram.com/_shyang/">Shyang</a>, the West Coast beatboxer, laid down rhythms that felt like they were bending reality. </p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.instagram.com/mother.ofthevoid/">Holy Mother of the Void</a> merged house performance art with lessons on embodiment, pushing us to rethink the boundaries between the physical and the digital. <a href="https://www.instagram.com/sachagabriel/">Sacha Gabriel</a> closed out the night, spinning tracks that kept the energy flowing and the conversations going. This wasn’t just a showcase—it was a lived experience where sound, light, and AI met and mingled.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34112a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34112a0" class="wp-block-image size-large is-resized wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6830" style="width:600px;height:auto" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/kevin-friel-future-proof-creatives.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kevin Friel aka Mr. Pixel Wizard at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Badass people photographer <a href="https://www.instagram.com/DiamondsEdgePhotography/">Michelle Diamond</a> was there, sharing the essence of it all through her lens, while Victor Serbin filmed the night, turning moments into a visual story we can revisit. These photos and videos&#8230;. they’re pieces of our shared experience. If you’ve got photos, videos, or audio from the night, we’d love for you to share them with us. Add them to the <a href="https://www.notion.so/Vancouver-AI-Community-Meetup-Recap-August-29th-A-Night-of-Innovation-Connection-and-Future-For-358ab278f1c94f9992ccea77aaf2da02?pvs=21">Google album link</a>. These are our community story and pls feel free to use them and share them. 🙂</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3411a1a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3411a1a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6831" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/shyang-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jackson Wu aka SHYANGDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Stay tuned for more media to drop soon, and in the meantime, spread the word. Bring your stories, bring your friends. We’re building something real, together.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412162&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412162" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6832" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/sasha-future-proof.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">DJ Sacha Gabriel Dean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As <a href="https://www.linkedin.com/in/chrisgranthall/">Chris Hall</a> said, “Wonderful event hosted by Kris Krüg and the team at Vancouver AI. Introduced to some innovative AI artists and enjoyed some great conversations on the topic of AI and how it is changing everything with new acquaintances.” For those who missed it, we’ve put together a <a href="https://youtube.com/shorts/suWVtA964ts?feature=share">video recap that you can check out here</a>. It’s not just a highlight reel; it’s a glimpse into what happens when a community comes together to push the boundaries of AI.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3412986&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3412986" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6833" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/holymother-future-proof-creatives-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Orbit Princess aka Holy Mother of the Void at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Looking Ahead: September 26th Meetup &#8211; Join the Revolution</strong></h3>
+
+
+
+<p class="wp-block-paragraph">If you thought August’s meetup was something special, <a href="https://lu.ma/AI-meetup">just wait until September 26th</a>. We’re gearing up for even more mind-bending demos, talks that will challenge your understanding of AI, and of course, the same incredible community vibe that makes these meetups so unique.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" src="https://lu.ma/embed/event/evt-6VeJQM5kfFnNUmn/simple" width="600" height="450" frameborder="0" style="border: 1px solid #bfcbda88; border-radius: 4px;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe></p>
+
+
+
+<p class="wp-block-paragraph">Grab your tickets now:</p>
+
+
+
+<ul class="wp-block-list">
+<li>Early Bird (CA$35): For the quick-draw innovators. Limited spots, so move fast.</li>
+
+
+
+<li>Standard (CA$50): Full access, full experience. Fuel for body and mind included.</li>
+
+
+
+<li>Pay-it-forward (CA$100): Supercharge the collective. Your contribution opens doors for others.</li>
+
+
+
+<li></li>
+</ul>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3413799&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3413799" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6835" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/crowd-shot-vancovuer-ai.jpeg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Community VibesDean Shev at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>AI Trainings for Creatives: Elevate Your Skills</strong></h3>
+
+
+
+<p class="wp-block-paragraph">For those of you looking to level up your AI game, we’ve got you covered. Our <a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">AI Upgrade for Creative Professionals</a> will take you from zero to hero, giving you the tools to thrive in this brave new world. </p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="797" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&#038;ssl=1" alt="" class="wp-image-6856" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=1024%2C797&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=300%2C233&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?resize=768%2C598&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/image.png?w=1536&amp;ssl=1 1536w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption"><a href="https://kriskrug.co/ai-upgrade-for-creative-professionals/">The AI Upgrade for Creative Pros by Kris Krüg &amp; Peter Bittner</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">We’re talking cutting-edge, hands-on learning that’ll have you speaking fluent AI in no time.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h3 class="wp-block-heading"><strong>Wrapping Up with Gratitude</strong></h3>
+
+
+
+<p class="wp-block-paragraph">A huge shoutout to <strong><a href="https://www.instagram.com/jessicaliangx/?hl=en">Jessica Liang</a> </strong>from<strong> </strong><a href="https://www.ilovenook.co/"><strong>Nook</strong> Coworking</a> for sharing insights on community and coworking, and for inviting us to her upcoming party—looking forward to it!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34142a0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34142a0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6836" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/jessica-nook-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Jessica Liang of Nook Coworking at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Big thanks to the <strong>volunteer <a href="https://www.linkedin.com/in/lawrence-okolo-a062a2146/">Lawerence</a> &amp;  from Northeastern University</strong> who helped keep everything on track.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3414bac&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3414bac" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6837" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/northeastern-studs-vancouverAI-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/aminishere/">Amin Sharifi</a> and Anita from <a href="https://www.enyalearning.ca/">Enya Learning</a></strong>—it’s an honor to keynote at your <a href="https://lu.ma/ons70lj3?tk=w8tLDe">Creative Technology Night</a> at the <a href="https://www.sfu.ca/dialogue.html">Wosk Center for Dialogue</a> this week.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34154d3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34154d3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6838" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/enya-vancouverAI-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Anita and Amin of ENYA at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Matt Jones</strong>, from the <a href="https://techcouver.com/2024/08/20/bitcoin-block-party-vancouver/">Bitcoin Block Party</a> brought the <a href="https://www.instagram.com/sexyboysandgirlsclub/">Sexy Boys and Girls Club</a> fashion line to add some style to our event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3415db6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3415db6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6839" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/00541686-410A-42F9-9559-1052841F7BE8-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Matt of Sexy Boys &amp; Girls Club at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/kassandra-m-linklater/">Kassandra Linklater</a></strong> and her mom, along with her mom’s best friend, two tech-savvy women in their 80s, brought a wealth of experience and culture.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416676&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416676" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6840" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/E505ED5D-33B7-403A-8749-6070144CD481-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"> Vancouver AI Community &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Cheers to <strong><a href="https://www.salesacademy.ca/shane-gibson-sales-trainer/">Shane Gibson</a>, </strong>AI sales guru, and performance artist<strong> <a href="https://littlewoo.org/">Little Woo</a></strong> for their unique perspectives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3416efd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3416efd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6841" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/8D1E9C3E-A3B0-4D8F-938C-6CCB57AEF60E-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AI Sales Leader Shane Gibson at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/pka3300/">Prashant Agrawal (Mr. P)</a></strong>, thanks for introducing us to Be Pacific and opening up new opportunities.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341762f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341762f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6842" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-72-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Mr. P Prashant Agrawal at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="http://linkedin.com/in/colleen-kennedy-41430881">Colleen Kennedy</a></strong> represented <a href="https://cogsys.ubc.ca/">UBC Cognitive Sciences (COGS)</a> and excited to have more of ya join us…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3417eb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3417eb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6843" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-76-1-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Colleen Kenney of UBC COGS at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and <strong>Jul<a href="https://julianaloh.ca/">iana Loh</a></strong>, VR artist, your photos, videos, and knowledge were invaluable.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3418998&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3418998" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6844" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-93-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Juliana Loh at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://jjgmckenzie.ca/"><strong>James</strong> McKenzie</a>, your steadfast support from the beginning is much appreciated.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34190fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34190fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6845" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/0BCC4E1C-FB6F-4113-B235-10F1DF0900C2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">James &amp; KK  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/simon-haworth-uk-us-prc/">Simon Haworth</a></strong>, thanks for rallying the BC AI Life Sciences community with me.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a34198c6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a34198c6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6846" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/9AE2CB5D-3114-48CA-9E2E-F7D2E020A3A2-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Simon Haworth at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.yangos.work/"><strong>Yangos Hadjiyannis</strong> </a>wrapped up SIGGRAPH with style at the VR lounge, and hilarious <a href="https://patrickpennefather.com/"><strong>Dr. Patrick Parra Pennefather</strong> </a> of <a href="https://eml.ubc.ca/">UBC Emerging Media Lab</a> brought critical insights from the <a href="https://www.nvidia.com/en-us/executive-insights/">NVIDIA AI ethics panel at SIGGRAPH 2024</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341a036&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341a036" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6847" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-195-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Yangos and Patrick Pennefather at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Kudos to <a href="https://kushalgoenka.com/"><strong>Kushal </strong>Goenka</a> for sharing your SIGGRAPH journey and open-source spirit and <a href="https://www.youtube.com/c/KushalGoenka">free AI Education Videos</a></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341aaa5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341aaa5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6848" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/2F1B9289-6709-4274-8504-491681CAB958-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kushal Goenka at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong><a href="https://www.linkedin.com/in/derrick-carter-338ba441/">Derek Carter</a> </strong>from<a href="https://www.thesawmill.ca/"> Sawmill Motion Capture Studio</a> welcomes us to come for a visit</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b1d5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b1d5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6853" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-254-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Derek Carter of Sawmill Studios  at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://yagudaev.com/about/"><strong>Michael Yagudev</strong></a> is our very own <a href="https://levelsio.com/">Vancouver AI Pieter Levels</a> your <a href="http://AudioWaveAI.com">AudioWaveAI.com</a> tool is an entrepreneurial inspiration.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341b911&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341b911" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6850" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-270-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Michael Yagudev of AudioWave AI at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Special thanks to <strong><a href="https://www.linkedin.com/in/rozmcnulty/">Roz McNulty</a></strong> of <a href="https://www.fashionic.ca/roz">Fashion Innovation Centre</a> for managing the door, registration, and signs…</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341c053&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341c053" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131.jpg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6851" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-131-scaled.jpg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI volunteer Roz McNaulty at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">and to <strong><a href="https://www.mattcarolan.com/">Matt Carolan</a></strong> from <a href="https://aws.amazon.com/events/community-day/?developer-center-activities-cards.sort-by=item.additionalFields.startDateTime&amp;developer-center-activities-cards.sort-order=asc">AWS Community Days</a>—your Aussie magic lit up the event.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d093&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d093" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6852" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-256-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">AWS Community Days Organizer Matt Carolan at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Also, gratitude to <strong><a href="https://www.linkedin.com/in/jeffreyrclark/">Jeff Clark</a></strong> of <a href="https://favoland.com/">Favoland</a> for guiding attendees and being the friendly face at the entrance.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341d827&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341d827" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-6854" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/AI_Meetup_August2024_MichelleDiamond-184-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Favoland CEO Jeff Clark at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks to everyone who contributed to making this meetup unforgettable. Until next time!</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a341df69&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a341df69" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D.jpeg?resize=683%2C1024&#038;ssl=1" alt="" class="wp-image-6855" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1024%2C1536&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?resize=1365%2C2048&amp;ssl=1 1365w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/09/ACBB5D76-4024-44D4-B08B-A286D46AC36D-scaled.jpeg?w=1707&amp;ssl=1 1707w" sizes="auto, (max-width: 683px) 100vw, 683px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Holy Mother of the Void and KK at Vancouver AI &#8211; <a href="https://www.diamondsedgephotography.com/">photo by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Related:</strong> More local ecosystem notes live in my <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI community</a> hub.</p>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-6815-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 6815,
+  "slug": "august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics",
+  "status": "publish",
+  "link": "https://kriskrug.co/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics/",
+  "modified": "2026-07-01T16:25:32",
+  "modified_gmt": "2026-07-02T00:25:32",
+  "type": "post",
+  "content_raw_bytes": 123029,
+  "content_rendered_bytes": 123029,
+  "content_raw_has_footer": false,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 1,
+  "title_rendered": "August Vancouver AI Community Meetup Recap &#8211; Hackers, Hustlers &amp; Heretics"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-content.raw.html
@@ -1,0 +1,894 @@
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">The planetarium projector died halfway through <a href="https://en.wikipedia.org/wiki/Judy_Illes">Judy Illes&#8217;</a> neuroscience presentation. Perfect metaphor for where we stand with AI – bleeding-edge tech colliding with the mundane reality of blown bulbs. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/0_Bz1Zk-MSk?si=PacgDplOctJaV_YO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">One minute we&#8217;re exploring brain-computer interfaces that might decode consciousness; the next, we&#8217;re fumbling in the dark. That&#8217;s the beautiful paradox of <a href="https://vancouver.bc-ai.net/" data-type="link" data-id="https://vancouver.bc-ai.net/">our Vancouver AI community</a> – simultaneously reaching for the stars while keeping our feet planted in what makes us human.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Dr. Illes, trailblazing neuroethicist, is Professor of Neurology at the University of British Columbia (UBC), Distinguished University Scholar, UBC Distinguished Scholar in Neuroethics, and Director of Neuroethics Canada: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Gathering of Tribes</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai14">Last week, our latest AI meetup</a> drew a kaleidoscope of minds to the <a href="https://www.spacecentre.ca/">H.R. MacMillan Space Centre</a>. The place once famous for Pink Floyd laser shows now hosts a different kind of mind expansion. We assembled beneath the dome – data scientists sharing oxygen with artists, academics rubbing elbows with entrepreneurs, indigenous knowledge-keepers conversing with tech founders.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33735f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33735f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8459" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This wasn&#8217;t just another tech meetup with sanitized pitches and <a href="https://www.linkedin.com/in/kriskrug/">LinkedIn QR code exchanges</a>. This was humans wrestling with what it means to be human at the threshold of exponential change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3373d43&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3373d43" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8458" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kris Krüg, Host of Vancouver AI &amp; CEO of <a href="https://theupgrade.ai/">TheUpgrade.ai</a>: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/ceowarren/">Catherine Warren</a>, whose ear is bent by government decision-makers worldwide, took the mic to share her work with Ray, crafting an ethical economy where content creators actually get paid when AI learns from their work. Revolutionary concept, I know – actually compensating people for their intellectual labor instead of just scraping it.</p>
+
+
+
+<p class="wp-block-paragraph">&#8220;We are creating an ethical economy where rights holders can, for the first time, be paid for content training AI systems,&#8221; she explained, cutting through the usual rhetoric about AI with the precision of someone who&#8217;s been navigating digital transformations for decades. Next week, she&#8217;s off to New Zealand to consult with their government on creative and innovation economies – taking our community&#8217;s vision global and hopefully connecting with <a href="https://kriskrug.co/2024/12/28/system-check-vancouver-ai-community-meetups-december/">Peter Lucas Jones who shared with us at the NeurIPS Meetup</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/_I7DZNRF7HI?si=sAPe1XDW6oQASPzL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Philosophers Among Us</h2>
+
+
+
+<p class="wp-block-paragraph">The night opened with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila&#8217;s</a> haunting poem exploring the teleportation paradox – if you&#8217;re atomized and recreated elsewhere, are you still you? What if the machine malfunctions and now there are two of you? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337453d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337453d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8437" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI teleportation &#8211;chaos 20 &#8211;ar 16:9 &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 95c56c6b-fc91-4bdd-9d0f-dec82103ff5c</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words echoed through the <a href="https://www.spacecentre.ca/">Space Centre</a>:</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I inhale, and so do I. Too soon, too late, a staggered echo, a misfire, a step forward, a step back, waiting for myself to follow.&#8221;</p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33755cc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33755cc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI two roads diverged &#8211;chaos 20 &#8211;ar 16:9 &#8211;profile 363tw3z &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 744e7345-e8c7-4732-90dd-9f88afa8701d</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s been riding the digital wave since the late &#8217;90s, this hit home. Are we just becoming copies of ourselves as we upload our consciousness to these new systems? When I use AI to help me write, is that me or some shadow version of myself?</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/zenmindhacker/">Cian Whalley</a>, equally comfortable in the worlds of tech and spiritual practice as <a href="https://www.cognitivetech.net/">CTO at Cognitive Technology</a> and a Zen Buddhist priest, showcased <a href="https://thoughtcoder.com/">Digital Buddha</a> – an AI spiritual mentor trained on Buddhism, Kabbalah, and Hermetics. &#8220;It has been trained not to try to solve your problem as quickly as possible,&#8221; he explained with the wry smile of someone who knows that&#8217;s not how wisdom works.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3375c37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3375c37" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="1000" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=750%2C1000&#038;ssl=1" alt="" class="wp-image-8441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=225%2C300&amp;ssl=1 225w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The program reflects something I&#8217;ve been exploring personally – using AI not just for task completion but for introspection, <a href="https://spektor.ai/">recording voice memos about my dreams and anxieties, then using AI to analyze patterns and provide new perspectives</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="267" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&#038;ssl=1" alt="" class="wp-image-8446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=768%2C200&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?w=1298&amp;ssl=1 1298w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Builders of New Realities</h2>
+
+
+
+<p class="wp-block-paragraph">The demos showcased the raw creativity bursting from our community. Sev Geraskin, always provocative in the best way, presented <a href="https://www.wiserbotics.com/">Wiserbotics – an emotional model aimed at &#8220;solving the problem of scarcity of empathy in the world.&#8221;</a> Some might dismiss this as techno-optimism, but I&#8217;ve seen enough dystopian scenarios to welcome someone trying to increase empathy rather than engagement metrics.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33764f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33764f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8442" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Another soldout fullhouse for February 2025 edition of Vancouver AI community meetups: <a href="http://contentco.ca/">Photography by Michelle Damond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://extndly.com/">Ed Kennedy, fresh from quitting his corporate job to focus on his startup</a>, explained control vectors for language models – a way to guide AI outputs without brute-force prompting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3376b6f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3376b6f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8460" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;It&#8217;s saying &#8216;no, only talk from this area,'&#8221; he explained, showing how fine-tuned control could make interactions with AI more nuanced and meaningful. His art project &#8220;Latent Sculptures&#8221; explores the infinite possibilities of open-source AI-generated art, transforming structured inputs into endless visual narratives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33771fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33771fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-8447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?w=864&amp;ssl=1 864w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.deanshev.com/">Dean Shev</a> and his healthcare team at <a href="https://vht.ai/">VHT.ai</a> showcased their work with <a href="https://lnkd.in/gJmwhV-i">Northeastern University</a>, developing an AI model built with ethics at its core, designed to help physicians better interpret clinical data and create personalized treatment journeys.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://pacific.film/">Michael Tippett of Pacific Film</a>, whom I&#8217;ve known for over two decades, presented his <a href="https://www.youtube.com/@MrCanadaToday">delightfully subversive &#8220;Mr. Canada&#8221; AI filmmaking project</a> – an absurdist character interacting with deepfaked politicians to explore Canadian identity. What struck me was his approach to <a href="https://kriskrug.co/2023/10/21/ai-art-changes-in-animation-special-effects-film-games-the-creative-industries/?utm_source=chatgpt.com">AI filmmaking as an iterative process</a>, much like agile software development, where you discover the story as you go.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/WKrRDT1D_rU?si=L9SU5AjG_sUufHUn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">&#8220;I don&#8217;t really know where I&#8217;m going when I start,&#8221; Michael admitted. &#8220;AI filmmaking is like software development – it&#8217;s iterative.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3377939&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3377939" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8468" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA Shyang showed up and <em>synced</em> with the room</a>. Beatboxing that controlled the lights, flipping raw sound into an interface. No FX, no backing track—just pure analog human signal bending digital systems to its will. Beyond that, he’s a public speaking coach, teaching people to wield their voice like a weapon. AI can generate words, but it can’t <em>command a room</em> like this.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Wisdom Keepers</h2>
+
+
+
+<p class="wp-block-paragraph">The night&#8217;s keynote came from J<a href="https://neuroethics.med.ubc.ca/">udy Illes, Distinguished Professor at UBC specializing in Neuroethics</a>. Despite our failing projector, she delivered a masterclass on responsibility and humility in the face of technological possibility.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3378103&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3378103" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="388" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&#038;ssl=1" alt="" class="wp-image-8452" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=300%2C114&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=768%2C291&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1536%2C582&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=2048%2C776&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes Neuroethics keynote at Vancouver AI February 2025 community meetup: Photography by Michelle Diamond</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;With possibility comes humility,&#8221; she reminded us, walking through the 4,000-year history of humans trying to understand the brain – from Sumerians noticing the effects of poppy plants to today&#8217;s AI-powered brain-computer interfaces.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8450" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Kevin Friel AKA Mr Pixel Wizard is a highly creative, highly technical, fun to work with AV Master: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words on humility struck a chord: &#8220;It&#8217;s thinking about and learning from lessons of the past, scrutinizing authentically and with passion your design, promising to the limits of promise and not over-sensationalizing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337891f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337891f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8449" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s witnessed multiple technological revolutions, I can testify to how rare and precious this kind of humility is. Technologies come and go, but wisdom accumulates if we&#8217;re paying attention.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8453" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">After Judy, Jackson Wu (aka SHYANG) broke the intellectual tension with mind-blowing beatboxing, controlling the room&#8217;s light show with his vocal percussion – a perfect illustration of the analog human interfacing with digital systems. Beyond his performance art, he&#8217;s also a public speaking coach helping others find their voice.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379864&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379864" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8451" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Future We&#8217;re Building</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379fdd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379fdd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="529" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&#038;ssl=1" alt="" class="wp-image-8457" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=300%2C155&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=768%2C397&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1536%2C794&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=2048%2C1058&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.exponentialstudio.io/">Sissi Wang&#8217;s</a> passionate talk on conscious, exponential organizations framed our collective challenge: &#8220;We stand at extraordinary times with two mega trends – the rising of exponential technology and consciousness awakening.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337a80e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337a80e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sissi Wang Founder of Exponential Studios at Vancouver AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The former corporate rebel who led teams across 120 countries with IBM and Novartis walked us through how traditional organizational hierarchies are giving way to more fluid, network-based structures, and how AI can shift humans from &#8220;capacity units&#8221; to empowered creators: &#8220;What if AI could take away the 20-30% of your job you hate, what would you do with that elevated capacity?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b104&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b104" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8461" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This strikes at the heart of what I believe – that technology should free us to be more human, not less. I&#8217;ve been evangelizing this since my early days in the social media revolution, when I traveled the world showing creatives how to break free from traditional gatekeepers.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b988&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b988" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila launching the new Vancouver AI Datastorytelling Hackathon: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night culminated with the announcement of our <a href="https://hackathon.bc-ai.net/">$10,000 Vancouver AI Data Storytelling Hackathon</a>, funded by <a href="https://www.rivaltech.com/">Rival Technologies</a>. Four cycles, $2,500 prizes each, challenging our community to reinvent how we interpret and visualize data. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337d696&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337d696" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8428" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Step up and show off your AL/ML hacker ingenuity, creative coding chops, and data storytelling prowess in a no-holds-barred challenge that’s all about community, open-source maker culture, and real, tangible innovation.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The first challenge topic? Whether hot dogs are sandwiches. Because why not inject a little absurdist humor into our serious revolution? For anyone inspired to join, all the details live at <a href="https://www.rivaltech.com/">hackathon.bc-ai.net</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337deff&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337deff" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Using a custom dataset gathered with Rival Technologies’ market research tech, your mission is to transform raw numbers into an experience that’s interactive, visual, or narrative-driven. You decide how to make the data speak—whether that’s through a dynamic visualization, an engaging presentation, or even an unconventional performance powered by AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Ecosystem Emerges</h2>
+
+
+
+<p class="wp-block-paragraph">What I&#8217;m witnessing is an ecosystem forming in real-time. <a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew</a> and <a href="https://ryvconsulting.ca/About/">Ryv</a> announced they&#8217;re spinning off a <a href="https://lu.ma/sjjlwda1">Surrey AI Community Meetup</a> based on our model. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337e7db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337e7db" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8455" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">?Join Matthew Schwartzman &amp; Ryv at the Legion #8 Building on March 11th (6 PM – 9 PM) for an evening of thought-provoking AI discussions and net</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/anthonygreen00/">Anthony Green</a> (<a href="https://www.openrep.ai/">Co-Founder of OpenRep</a>, who appeared via video) and I are mapping Vancouver&#8217;s AI landscape, advocating for a BC AI Center that could secure government funding and infrastructure.</p>
+
+
+
+<figure class="wp-block-video"><video height="480" style="aspect-ratio: 848 / 480;" width="848" controls src="https://kriskrug.co/wp-content/uploads/2025/03/bb8b264b-8a7b-449e-a3ab-4967cec715d8.mp4"></video><figcaption class="wp-element-caption">Anthony Green, Founder of Openrep AI on Vancouver AI ecosystem.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m not naive about the challenges. As Anthony pointed out, we face a high cost of living driving talent south, gaps in venture funding (especially at pre-seed and late stages), and <a href="https://bc-ai.net/">no flagship AI institute despite our concentration of talent</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337f489&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337f489" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8423" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But I&#8217;ve been here before – at the dawn of web building in the late &#8217;90s, at the beginning of the social media revolution in 2004. I got lucky then; my timing and interests aligned as those technologies emerged. Now I feel the same buzz in the <a href="https://bc-ai.net/">emerging BC + Ai Ecosystem.</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.hornbyspark.com/">Quanna Parker</a> made the trek from Hornby Island—<strong>three ferries away</strong>—to be here, and his story is one of true grassroots AI exploration. Before most people had even heard of ChatGPT, Quanna was already building his own AI rig. Back in <em>summer 2022</em>, he was the first guy in my orbit to get GPUs up and running, training his own models <em>off-grid</em>, thinking about compute sovereignty before it was a buzzword.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337fe38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337fe38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8466" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But Quanna isn’t just another engineer—he’s a critical thinker, someone who <em>questions</em> the whole structure AI is being built on. He’s written a book, <strong>Thinking Critically in the Age of Artificial Intelligence</strong>, co-authored (with AI, of course), as an early exploration of what these tools mean for thought, authorship, and human creativity.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="338" height="522" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=338%2C522&#038;ssl=1" alt="" class="wp-image-8467" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?w=338&amp;ssl=1 338w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=194%2C300&amp;ssl=1 194w" sizes="auto, (max-width: 338px) 100vw, 338px" /></figure>
+
+
+
+<p class="wp-block-paragraph">Now? He’s working deep in the world of <strong>large language models and chat interfaces for one of the FANG companies</strong>, but still keeps his independent streak. He’s a reminder that you don’t need to be in San Francisco or New York to be ahead of the curve. You just need <strong>curiosity, a DIY spirit, and the willingness to experiment</strong>.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3380987&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3380987" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1021" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&#038;ssl=1" alt="" class="wp-image-8444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&amp;ssl=1 1021w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=768%2C770&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?w=1149&amp;ssl=1 1149w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">What makes this time different is that we&#8217;re not just creating new technologies – we&#8217;re creating new ways of being human. When <a href="https://www.linkedin.com/in/irwinoostindie/">Irwin Oostendie</a> of <a href="http://www.voor.ca/">Voor Urban Labs</a> talked about decolonizing public policy through technology and <a href="https://www.linkedin.com/in/deanshev/">Dean Shev</a> discussed <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> in healthcare they were talking about reshaping fundamental human relationships. </p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="qe1QwyfVGO"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson&#8217;s AI Sales Dojo</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Shane Gibson&#8217;s AI Sales Dojo&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/embed/#?secret=ZE1Ucq6CpH#?secret=qe1QwyfVGO" data-secret="qe1QwyfVGO" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson from The Professional Sales Academy</a> showed how AI tools can transform sales processes while still maintaining the human connection that makes sales work.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-8412" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=860%2C484&amp;ssl=1 860w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s why I&#8217;m here. That&#8217;s why we&#8217;re all here. Not just to ride the wave of the next tech boom, but to ensure that as these technologies reshape us, they do so in ways that amplify our humanity rather than diminish it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381467&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381467" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As the night ended and we cut the wedding cake for <a href="https://www.linkedin.com/in/jjgmckenzie/">James McKenzie</a>, I looked around the room at this community we&#8217;ve built – technologists and poets, scientists and mystics, all wrestling together with what comes next.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381cb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381cb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8422" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">None of this happens without our partners who fuel the revolution – <a href="https://segevllp.com/">SEGEV LLP</a> bringing legal expertise to the tech frontier, <a href="https://www.linkedin.com/in/dimitri-schwartzman-0ab8061/">Dimitri Schwartzman connecting real estate to community building</a>, <a href="https://www.youtube.com/@sonsofvancouver">Sons of Vancouver with their spirit of independent creativity</a>, and <a href="https://goodnessdistributors.com/">Goodness Distributors</a> spreading support through our ecosystem.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382453&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382453" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8462" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">From that Midjourney moment in November 2022 when AI first reached its tendrils into my brain, to now, hosting these gatherings of brilliant minds at the H.R. MacMillan Space Centre (once famous for Pink Floyd laser shows, now hosting a different kind of mind expansion), I&#8217;ve never felt more energized about our collective possibility. <a href="https://www.bc-ai.net/">The future isn&#8217;t something happening to us; it&#8217;s something we&#8217;re creating together, one community at a time</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382cc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382cc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8463" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">And yes, even when the projector dies mid-presentation, we keep going – because that&#8217;s what humans do. <a href="https://vancouver.bc-ai.net/">We adapt, we connect, we create meaning in the darkness</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai15">We&#8217;ll see you at the next one on March 26th</a>. <strong>The edge of tomorrow awaits, and it looks a lot like us.</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383523&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383523" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?w=1500&amp;ssl=1 1500w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383e07&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383e07" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8465" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">What are people saying?</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3384685&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3384685" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="710" height="176" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=710%2C176&#038;ssl=1" alt="" class="wp-image-8445" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?w=710&amp;ssl=1 710w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=300%2C74&amp;ssl=1 300w" sizes="auto, (max-width: 710px) 100vw, 710px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Great event, speakers were great, video documentation has been huge, love that I can catch up and share good talks. I miss the late nights of the old venue but it&#8217;s actually nice since it&#8217;s on a weekday that it ends a bit earlier. I&#8217;d like to see some rotation of the long time speakers, maybe bring on some new &#8220;residencies&#8221; of regular speakers and make a set time frame like 3-4 events for &#8220;regular&#8221; speakers/acts? Addition of non alcoholic drinks greatly appreciated. Another thing I miss from the events at the old loft is the feeling that anyone could show up with a laptop and show off their stuff, I notice that vibe is missing from the new venue because of all the organization with tables / signs. It would be neat if we had some more tables maybe in the food room or tables area that was designated as open tables for anyone to demo. Something that may help is a stronger web presence on it&#8217;s own domain with a more comprehensive website. vancouverai.buzz , vanai.community, vanai.club etc. Past video archives, descriptions of each event / speakers / luma links, Contest details, and big SPEAK AT OUR EVENT, DISPLAY YOUR WORK, SPONSOR US links, donations, etc. Seems to be missing, one place to go to for everything van AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Great networking and learning. My fourth event and every time the diversity of folks attending, the creativity the thought leadership shared by some amazing humans has blown me away.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hi Kris, Thanks for organizing such a valuable meetup tonight. I really appreciated Judy and Sissi&#8217;s presentations; I walked away with a lot of new knowledge. Your efforts in putting this event together were evident, and I&#8217;m excited for the next one.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hey Kris, great session tonight! Judy was awesome! I&#8217;d love to find an opportunity to collaborate. As you know, my focus is on AI as a productivity tool for small and medium sized businesses. Something I really value is that your community showcases topics outside of this focus. At the same time, that makes it hard to figure out opportunities to connect our work. You mentioned John Bondoc tonight and maybe he&#8217;s a link for both of us. Let&#8217;s grab a coffee in the next week or two and see what we can come up with. I&#8217;ll send you an email to find a time that works for us all.&nbsp;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385057&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385057" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="528" height="982" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=528%2C982&#038;ssl=1" alt="" class="wp-image-8430" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?w=528&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=161%2C300&amp;ssl=1 161w" sizes="auto, (max-width: 528px) 100vw, 528px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385726&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385726" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8464" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-content.rendered.html
@@ -1,0 +1,894 @@
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">The planetarium projector died halfway through <a href="https://en.wikipedia.org/wiki/Judy_Illes">Judy Illes&#8217;</a> neuroscience presentation. Perfect metaphor for where we stand with AI – bleeding-edge tech colliding with the mundane reality of blown bulbs. </p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/0_Bz1Zk-MSk?si=PacgDplOctJaV_YO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">One minute we&#8217;re exploring brain-computer interfaces that might decode consciousness; the next, we&#8217;re fumbling in the dark. That&#8217;s the beautiful paradox of <a href="https://vancouver.bc-ai.net/" data-type="link" data-id="https://vancouver.bc-ai.net/">our Vancouver AI community</a> – simultaneously reaching for the stars while keeping our feet planted in what makes us human.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-13.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Dr. Illes, trailblazing neuroethicist, is Professor of Neurology at the University of British Columbia (UBC), Distinguished University Scholar, UBC Distinguished Scholar in Neuroethics, and Director of Neuroethics Canada: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Gathering of Tribes</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai14">Last week, our latest AI meetup</a> drew a kaleidoscope of minds to the <a href="https://www.spacecentre.ca/">H.R. MacMillan Space Centre</a>. The place once famous for Pink Floyd laser shows now hosts a different kind of mind expansion. We assembled beneath the dome – data scientists sharing oxygen with artists, academics rubbing elbows with entrepreneurs, indigenous knowledge-keepers conversing with tech founders.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33735f5&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33735f5" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8459" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-26.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This wasn&#8217;t just another tech meetup with sanitized pitches and <a href="https://www.linkedin.com/in/kriskrug/">LinkedIn QR code exchanges</a>. This was humans wrestling with what it means to be human at the threshold of exponential change.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3373d43&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3373d43" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8458" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-25.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Kris Krüg, Host of Vancouver AI &amp; CEO of <a href="https://theupgrade.ai/">TheUpgrade.ai</a>: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/ceowarren/">Catherine Warren</a>, whose ear is bent by government decision-makers worldwide, took the mic to share her work with Ray, crafting an ethical economy where content creators actually get paid when AI learns from their work. Revolutionary concept, I know – actually compensating people for their intellectual labor instead of just scraping it.</p>
+
+
+
+<p class="wp-block-paragraph">&#8220;We are creating an ethical economy where rights holders can, for the first time, be paid for content training AI systems,&#8221; she explained, cutting through the usual rhetoric about AI with the precision of someone who&#8217;s been navigating digital transformations for decades. Next week, she&#8217;s off to New Zealand to consult with their government on creative and innovation economies – taking our community&#8217;s vision global and hopefully connecting with <a href="https://kriskrug.co/2024/12/28/system-check-vancouver-ai-community-meetups-december/">Peter Lucas Jones who shared with us at the NeurIPS Meetup</a>.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/_I7DZNRF7HI?si=sAPe1XDW6oQASPzL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Philosophers Among Us</h2>
+
+
+
+<p class="wp-block-paragraph">The night opened with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila&#8217;s</a> haunting poem exploring the teleportation paradox – if you&#8217;re atomized and recreated elsewhere, are you still you? What if the machine malfunctions and now there are two of you? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337453d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337453d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8437" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_95c56c6b-fc91-4bdd-9d0f-dec82103ff5c_0.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI teleportation &#8211;chaos 20 &#8211;ar 16:9 &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 95c56c6b-fc91-4bdd-9d0f-dec82103ff5c</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words echoed through the <a href="https://www.spacecentre.ca/">Space Centre</a>:</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I inhale, and so do I. Too soon, too late, a staggered echo, a misfire, a step forward, a step back, waiting for myself to follow.&#8221;</p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33755cc&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33755cc" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="574" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&#038;ssl=1" alt="" class="wp-image-8439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=1024%2C574&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=768%2C430&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/u4659472789_httpss.mj_.rundnZ3ob5G-ew_httpss.mj_.runXH-Hr3lS50M_744e7345-e8c7-4732-90dd-9f88afa8701d_2.jpeg?w=1456&amp;ssl=1 1456w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">https://s.mj.run/dnZ3ob5G-ew https://s.mj.run/XH-Hr3lS50M https://s.mj.run/84oyt3PG-OM https://s.mj.run/Hq0c2hEm6YM https://s.mj.run/TSWECoelAVI two roads diverged &#8211;chaos 20 &#8211;ar 16:9 &#8211;profile 363tw3z &#8211;stylize 50 &#8211;weird 600 &#8211;v 6.1 Job ID: 744e7345-e8c7-4732-90dd-9f88afa8701d</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s been riding the digital wave since the late &#8217;90s, this hit home. Are we just becoming copies of ourselves as we upload our consciousness to these new systems? When I use AI to help me write, is that me or some shadow version of myself?</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/zenmindhacker/">Cian Whalley</a>, equally comfortable in the worlds of tech and spiritual practice as <a href="https://www.cognitivetech.net/">CTO at Cognitive Technology</a> and a Zen Buddhist priest, showcased <a href="https://thoughtcoder.com/">Digital Buddha</a> – an AI spiritual mentor trained on Buddhism, Kabbalah, and Hermetics. &#8220;It has been trained not to try to solve your problem as quickly as possible,&#8221; he explained with the wry smile of someone who knows that&#8217;s not how wisdom works.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3375c37&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3375c37" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="750" height="1000" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=750%2C1000&#038;ssl=1" alt="" class="wp-image-8441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?w=750&amp;ssl=1 750w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-11.png?resize=225%2C300&amp;ssl=1 225w" sizes="auto, (max-width: 750px) 100vw, 750px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The program reflects something I&#8217;ve been exploring personally – using AI not just for task completion but for introspection, <a href="https://spektor.ai/">recording voice memos about my dreams and anxieties, then using AI to analyze patterns and provide new perspectives</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="267" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&#038;ssl=1" alt="" class="wp-image-8446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=1024%2C267&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?resize=768%2C200&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.31.11.png?w=1298&amp;ssl=1 1298w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Builders of New Realities</h2>
+
+
+
+<p class="wp-block-paragraph">The demos showcased the raw creativity bursting from our community. Sev Geraskin, always provocative in the best way, presented <a href="https://www.wiserbotics.com/">Wiserbotics – an emotional model aimed at &#8220;solving the problem of scarcity of empathy in the world.&#8221;</a> Some might dismiss this as techno-optimism, but I&#8217;ve seen enough dystopian scenarios to welcome someone trying to increase empathy rather than engagement metrics.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33764f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33764f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8442" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-12.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Another soldout fullhouse for February 2025 edition of Vancouver AI community meetups: <a href="http://contentco.ca/">Photography by Michelle Damond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://extndly.com/">Ed Kennedy, fresh from quitting his corporate job to focus on his startup</a>, explained control vectors for language models – a way to guide AI outputs without brute-force prompting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3376b6f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3376b6f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8460" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-27.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;It&#8217;s saying &#8216;no, only talk from this area,'&#8221; he explained, showing how fine-tuned control could make interactions with AI more nuanced and meaningful. His art project &#8220;Latent Sculptures&#8221; explores the infinite possibilities of open-source AI-generated art, transforming structured inputs into endless visual narratives.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33771fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33771fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="768" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&#038;ssl=1" alt="" class="wp-image-8447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=768%2C1024&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?resize=225%2C300&amp;ssl=1 225w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-15.png?w=864&amp;ssl=1 864w" sizes="auto, (max-width: 768px) 100vw, 768px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.deanshev.com/">Dean Shev</a> and his healthcare team at <a href="https://vht.ai/">VHT.ai</a> showcased their work with <a href="https://lnkd.in/gJmwhV-i">Northeastern University</a>, developing an AI model built with ethics at its core, designed to help physicians better interpret clinical data and create personalized treatment journeys.</p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://pacific.film/">Michael Tippett of Pacific Film</a>, whom I&#8217;ve known for over two decades, presented his <a href="https://www.youtube.com/@MrCanadaToday">delightfully subversive &#8220;Mr. Canada&#8221; AI filmmaking project</a> – an absurdist character interacting with deepfaked politicians to explore Canadian identity. What struck me was his approach to <a href="https://kriskrug.co/2023/10/21/ai-art-changes-in-animation-special-effects-film-games-the-creative-industries/?utm_source=chatgpt.com">AI filmmaking as an iterative process</a>, much like agile software development, where you discover the story as you go.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/WKrRDT1D_rU?si=L9SU5AjG_sUufHUn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">&#8220;I don&#8217;t really know where I&#8217;m going when I start,&#8221; Michael admitted. &#8220;AI filmmaking is like software development – it&#8217;s iterative.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3377939&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3377939" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8468" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-35.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/jacksonspeaks/">Jackson Wu AKA Shyang showed up and <em>synced</em> with the room</a>. Beatboxing that controlled the lights, flipping raw sound into an interface. No FX, no backing track—just pure analog human signal bending digital systems to its will. Beyond that, he’s a public speaking coach, teaching people to wield their voice like a weapon. AI can generate words, but it can’t <em>command a room</em> like this.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Wisdom Keepers</h2>
+
+
+
+<p class="wp-block-paragraph">The night&#8217;s keynote came from J<a href="https://neuroethics.med.ubc.ca/">udy Illes, Distinguished Professor at UBC specializing in Neuroethics</a>. Despite our failing projector, she delivered a masterclass on responsibility and humility in the face of technological possibility.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3378103&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3378103" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="388" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&#038;ssl=1" alt="" class="wp-image-8452" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1024%2C388&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=300%2C114&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=768%2C291&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=1536%2C582&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-20.png?resize=2048%2C776&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes Neuroethics keynote at Vancouver AI February 2025 community meetup: Photography by Michelle Diamond</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">&#8220;With possibility comes humility,&#8221; she reminded us, walking through the 4,000-year history of humans trying to understand the brain – from Sumerians noticing the effects of poppy plants to today&#8217;s AI-powered brain-computer interfaces.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8450" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-18.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption class="wp-element-caption">Kevin Friel AKA Mr Pixel Wizard is a highly creative, highly technical, fun to work with AV Master: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Her words on humility struck a chord: &#8220;It&#8217;s thinking about and learning from lessons of the past, scrutinizing authentically and with passion your design, promising to the limits of promise and not over-sensationalizing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337891f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337891f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8449" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-17.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As someone who&#8217;s witnessed multiple technological revolutions, I can testify to how rare and precious this kind of humility is. Technologies come and go, but wisdom accumulates if we&#8217;re paying attention.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379082&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379082" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8453" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-21.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">After Judy, Jackson Wu (aka SHYANG) broke the intellectual tension with mind-blowing beatboxing, controlling the room&#8217;s light show with his vocal percussion – a perfect illustration of the analog human interfacing with digital systems. Beyond his performance art, he&#8217;s also a public speaking coach helping others find their voice.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379864&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379864" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8451" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-19.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Dr. Judy Illes, Keynote Speaker at Vancouver AI: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Future We&#8217;re Building</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3379fdd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3379fdd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="529" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&#038;ssl=1" alt="" class="wp-image-8457" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1024%2C529&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=300%2C155&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=768%2C397&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=1536%2C794&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-24.png?resize=2048%2C1058&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.exponentialstudio.io/">Sissi Wang&#8217;s</a> passionate talk on conscious, exponential organizations framed our collective challenge: &#8220;We stand at extraordinary times with two mega trends – the rising of exponential technology and consciousness awakening.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337a80e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337a80e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-22.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Sissi Wang Founder of Exponential Studios at Vancouver AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The former corporate rebel who led teams across 120 countries with IBM and Novartis walked us through how traditional organizational hierarchies are giving way to more fluid, network-based structures, and how AI can shift humans from &#8220;capacity units&#8221; to empowered creators: &#8220;What if AI could take away the 20-30% of your job you hate, what would you do with that elevated capacity?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b104&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b104" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8461" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-28.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">This strikes at the heart of what I believe – that technology should free us to be more human, not less. I&#8217;ve been evangelizing this since my early days in the social media revolution, when I traveled the world showing creatives how to break free from traditional gatekeepers.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337b988&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337b988" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-7.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Brittney Smaila launching the new Vancouver AI Datastorytelling Hackathon: <a href="http://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The night culminated with the announcement of our <a href="https://hackathon.bc-ai.net/">$10,000 Vancouver AI Data Storytelling Hackathon</a>, funded by <a href="https://www.rivaltech.com/">Rival Technologies</a>. Four cycles, $2,500 prizes each, challenging our community to reinvent how we interpret and visualize data. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337d696&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337d696" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8428" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/1-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Step up and show off your AL/ML hacker ingenuity, creative coding chops, and data storytelling prowess in a no-holds-barred challenge that’s all about community, open-source maker culture, and real, tangible innovation.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">The first challenge topic? Whether hot dogs are sandwiches. Because why not inject a little absurdist humor into our serious revolution? For anyone inspired to join, all the details live at <a href="https://www.rivaltech.com/">hackathon.bc-ai.net</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337deff&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337deff" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/2-1.png?w=1350&amp;ssl=1 1350w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Using a custom dataset gathered with Rival Technologies’ market research tech, your mission is to transform raw numbers into an experience that’s interactive, visual, or narrative-driven. You decide how to make the data speak—whether that’s through a dynamic visualization, an engaging presentation, or even an unconventional performance powered by AI.</figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The Ecosystem Emerges</h2>
+
+
+
+<p class="wp-block-paragraph">What I&#8217;m witnessing is an ecosystem forming in real-time. <a href="https://www.linkedin.com/in/matthew-schwartzman-9ba462261/">Matthew</a> and <a href="https://ryvconsulting.ca/About/">Ryv</a> announced they&#8217;re spinning off a <a href="https://lu.ma/sjjlwda1">Surrey AI Community Meetup</a> based on our model. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337e7db&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337e7db" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8455" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-23.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">?Join Matthew Schwartzman &amp; Ryv at the Legion #8 Building on March 11th (6 PM – 9 PM) for an evening of thought-provoking AI discussions and net</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/anthonygreen00/">Anthony Green</a> (<a href="https://www.openrep.ai/">Co-Founder of OpenRep</a>, who appeared via video) and I are mapping Vancouver&#8217;s AI landscape, advocating for a BC AI Center that could secure government funding and infrastructure.</p>
+
+
+
+<figure class="wp-block-video"><video height="480" style="aspect-ratio: 848 / 480;" width="848" controls src="https://kriskrug.co/wp-content/uploads/2025/03/bb8b264b-8a7b-449e-a3ab-4967cec715d8.mp4"></video><figcaption class="wp-element-caption">Anthony Green, Founder of Openrep AI on Vancouver AI ecosystem.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I&#8217;m not naive about the challenges. As Anthony pointed out, we face a high cost of living driving talent south, gaps in venture funding (especially at pre-seed and late stages), and <a href="https://bc-ai.net/">no flagship AI institute despite our concentration of talent</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337f489&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337f489" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8423" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-5.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But I&#8217;ve been here before – at the dawn of web building in the late &#8217;90s, at the beginning of the social media revolution in 2004. I got lucky then; my timing and interests aligned as those technologies emerged. Now I feel the same buzz in the <a href="https://bc-ai.net/">emerging BC + Ai Ecosystem.</a></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.hornbyspark.com/">Quanna Parker</a> made the trek from Hornby Island—<strong>three ferries away</strong>—to be here, and his story is one of true grassroots AI exploration. Before most people had even heard of ChatGPT, Quanna was already building his own AI rig. Back in <em>summer 2022</em>, he was the first guy in my orbit to get GPUs up and running, training his own models <em>off-grid</em>, thinking about compute sovereignty before it was a buzzword.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a337fe38&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a337fe38" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8466" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-33.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">But Quanna isn’t just another engineer—he’s a critical thinker, someone who <em>questions</em> the whole structure AI is being built on. He’s written a book, <strong>Thinking Critically in the Age of Artificial Intelligence</strong>, co-authored (with AI, of course), as an early exploration of what these tools mean for thought, authorship, and human creativity.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="338" height="522" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=338%2C522&#038;ssl=1" alt="" class="wp-image-8467" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?w=338&amp;ssl=1 338w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-34.png?resize=194%2C300&amp;ssl=1 194w" sizes="auto, (max-width: 338px) 100vw, 338px" /></figure>
+
+
+
+<p class="wp-block-paragraph">Now? He’s working deep in the world of <strong>large language models and chat interfaces for one of the FANG companies</strong>, but still keeps his independent streak. He’s a reminder that you don’t need to be in San Francisco or New York to be ahead of the curve. You just need <strong>curiosity, a DIY spirit, and the willingness to experiment</strong>.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3380987&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3380987" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1021" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&#038;ssl=1" alt="" class="wp-image-8444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=1021%2C1024&amp;ssl=1 1021w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=768%2C770&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-14.png?w=1149&amp;ssl=1 1149w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">What makes this time different is that we&#8217;re not just creating new technologies – we&#8217;re creating new ways of being human. When <a href="https://www.linkedin.com/in/irwinoostindie/">Irwin Oostendie</a> of <a href="http://www.voor.ca/">Voor Urban Labs</a> talked about decolonizing public policy through technology and <a href="https://www.linkedin.com/in/deanshev/">Dean Shev</a> discussed <a href="https://kriskrug.co/ai-ethics/" title="ethical AI">ethical AI</a> in healthcare they were talking about reshaping fundamental human relationships. </p>
+
+
+
+<figure class="wp-block-embed is-type-wp-embed is-provider-kris-kr-g-generative-ai-tools-amp-techniques wp-block-embed-kris-kr-g-generative-ai-tools-amp-techniques"><div class="wp-block-embed__wrapper">
+<blockquote class="wp-embedded-content" data-secret="qe1QwyfVGO"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson&#8217;s AI Sales Dojo</a></blockquote><iframe loading="lazy" class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;" title="&#8220;Shane Gibson&#8217;s AI Sales Dojo&#8221; &#8212; Kris Krüg | Generative AI Tools &amp; Techniques" src="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/embed/#?secret=ZE1Ucq6CpH#?secret=qe1QwyfVGO" data-secret="qe1QwyfVGO" width="500" height="282" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+</div></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">Shane Gibson from The Professional Sales Academy</a> showed how AI tools can transform sales processes while still maintaining the human connection that makes sales work.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="576" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&#038;ssl=1" alt="" class="wp-image-8412" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=1024%2C576&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=300%2C169&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=768%2C432&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?resize=860%2C484&amp;ssl=1 860w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-1.png?w=1280&amp;ssl=1 1280w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">That&#8217;s why I&#8217;m here. That&#8217;s why we&#8217;re all here. Not just to ride the wave of the next tech boom, but to ensure that as these technologies reshape us, they do so in ways that amplify our humanity rather than diminish it.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381467&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381467" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-9.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">As the night ended and we cut the wedding cake for <a href="https://www.linkedin.com/in/jjgmckenzie/">James McKenzie</a>, I looked around the room at this community we&#8217;ve built – technologists and poets, scientists and mystics, all wrestling together with what comes next.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3381cb4&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3381cb4" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8422" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-4.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">None of this happens without our partners who fuel the revolution – <a href="https://segevllp.com/">SEGEV LLP</a> bringing legal expertise to the tech frontier, <a href="https://www.linkedin.com/in/dimitri-schwartzman-0ab8061/">Dimitri Schwartzman connecting real estate to community building</a>, <a href="https://www.youtube.com/@sonsofvancouver">Sons of Vancouver with their spirit of independent creativity</a>, and <a href="https://goodnessdistributors.com/">Goodness Distributors</a> spreading support through our ecosystem.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382453&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382453" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8462" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-29.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">From that Midjourney moment in November 2022 when AI first reached its tendrils into my brain, to now, hosting these gatherings of brilliant minds at the H.R. MacMillan Space Centre (once famous for Pink Floyd laser shows, now hosting a different kind of mind expansion), I&#8217;ve never felt more energized about our collective possibility. <a href="https://www.bc-ai.net/">The future isn&#8217;t something happening to us; it&#8217;s something we&#8217;re creating together, one community at a time</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3382cc9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3382cc9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8463" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-30.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">And yes, even when the projector dies mid-presentation, we keep going – because that&#8217;s what humans do. <a href="https://vancouver.bc-ai.net/">We adapt, we connect, we create meaning in the darkness</a>.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=1536%2C1536&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-10.png?w=1600&amp;ssl=1 1600w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://lu.ma/vai15">We&#8217;ll see you at the next one on March 26th</a>. <strong>The edge of tomorrow awaits, and it looks a lot like us.</strong></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383523&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383523" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-8434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/vai15-feb-vancouverAI-2.png?w=1500&amp;ssl=1 1500w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3383e07&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3383e07" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8465" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-32.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption"><a href="https://contentco.ca/">Vancouver AI community meetup and BC + AI events: </a><a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">What are people saying?</h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3384685&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3384685" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="710" height="176" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=710%2C176&#038;ssl=1" alt="" class="wp-image-8445" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?w=710&amp;ssl=1 710w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/Screenshot-2025-03-02-at-09.22.36.png?resize=300%2C74&amp;ssl=1 300w" sizes="auto, (max-width: 710px) 100vw, 710px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Great event, speakers were great, video documentation has been huge, love that I can catch up and share good talks. I miss the late nights of the old venue but it&#8217;s actually nice since it&#8217;s on a weekday that it ends a bit earlier. I&#8217;d like to see some rotation of the long time speakers, maybe bring on some new &#8220;residencies&#8221; of regular speakers and make a set time frame like 3-4 events for &#8220;regular&#8221; speakers/acts? Addition of non alcoholic drinks greatly appreciated. Another thing I miss from the events at the old loft is the feeling that anyone could show up with a laptop and show off their stuff, I notice that vibe is missing from the new venue because of all the organization with tables / signs. It would be neat if we had some more tables maybe in the food room or tables area that was designated as open tables for anyone to demo. Something that may help is a stronger web presence on it&#8217;s own domain with a more comprehensive website. vancouverai.buzz , vanai.community, vanai.club etc. Past video archives, descriptions of each event / speakers / luma links, Contest details, and big SPEAK AT OUR EVENT, DISPLAY YOUR WORK, SPONSOR US links, donations, etc. Seems to be missing, one place to go to for everything van AI.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Great networking and learning. My fourth event and every time the diversity of folks attending, the creativity the thought leadership shared by some amazing humans has blown me away.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hi Kris, Thanks for organizing such a valuable meetup tonight. I really appreciated Judy and Sissi&#8217;s presentations; I walked away with a lot of new knowledge. Your efforts in putting this event together were evident, and I&#8217;m excited for the next one.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">Hey Kris, great session tonight! Judy was awesome! I&#8217;d love to find an opportunity to collaborate. As you know, my focus is on AI as a productivity tool for small and medium sized businesses. Something I really value is that your community showcases topics outside of this focus. At the same time, that makes it hard to figure out opportunities to connect our work. You mentioned John Bondoc tonight and maybe he&#8217;s a link for both of us. Let&#8217;s grab a coffee in the next week or two and see what we can come up with. I&#8217;ll send you an email to find a time that works for us all.&nbsp;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385057&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385057" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="528" height="982" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=528%2C982&#038;ssl=1" alt="" class="wp-image-8430" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?w=528&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-8.png?resize=161%2C300&amp;ssl=1 161w" sizes="auto, (max-width: 528px) 100vw, 528px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3385726&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3385726" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-8464" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/image-31.png?w=1728&amp;ssl=1 1728w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Vancouver AI community meetup and BC + AI events: <a href="https://contentco.ca/">Photography by Michelle Diamond</a></figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-8418-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 8418,
+  "slug": "vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap",
+  "status": "publish",
+  "link": "https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/",
+  "modified": "2026-06-28T20:30:15",
+  "modified_gmt": "2026-06-29T04:30:15",
+  "type": "post",
+  "content_raw_bytes": 104069,
+  "content_rendered_bytes": 104069,
+  "content_raw_has_footer": true,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 1,
+  "title_rendered": "Vancouver AI: The Community Building BC&#8217;s AI Future &#8211; February Meetup Recap"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-content.raw.html
@@ -1,0 +1,777 @@
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/VAI16">Vancouver AI Community Meetup #16</a> vibrated with creative energy, blending indigenous wisdom with bleeding-edge tech, grassroots community-building with critical thought. As I declared at the opening: &#8220;You are the <a href="https://bc-ai.ca/" title="BC + AI Ecosystem">BC + AI ecosystem</a>.&#8221; and what followed was a vivid demonstration of that ecosystem&#8217;s diversity and momentum.</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;Friends, we live at a time where new forms of expression are emerging right under our very eyes&#8230; whole new forms of expression.&#8221; —<a href="https://kriskrug.co/">Kris Krüg</a></p>
+</blockquote>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=4nv8YQSh4pPnU64r" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Cultural Grounding &amp; Community Foundations</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://twnation.ca/health-and-wellness/%C9%ACew%C9%99t%C9%99l-project/">Gabriel George Sr</a>. of the <a href="https://twnation.ca/">Tsleil-Waututh Nation</a> brought the room into sync—with land, lineage, and each other. He shared stories of his great-grandmother who lived right here, on this very patch of earth, back when it was still shoreline. </p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mVVmf0_zfEc?si=f-3KzodFwE1L9H7B" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Then he dropped a <em>new</em> song—one we’d never heard before—that bounced around the round room like it had always belonged there. No mic. Just presence. Just power. Just Gabriel doing what he does: weaving the ancient into the now.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f375b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f375b" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9207" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">British Columbia Artificial Intelligence Community of Practice</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://patrickpennefather.com/">Patrick Pennefather</a> followed with exciting news about published academic research in <a href="https://ojs.library.ubc.ca/index.php/bcstudies/index">BC Studies Journal</a> on the community itself. &#8220;<a href="https://ojs.library.ubc.ca/index.php/bcstudies/article/view/199875">Building a grassroots AI community of practice, a Vancouver centric use case</a>&#8221; documents how this thriving ecosystem has formed organically.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=9fPXdmNPkLS5e6TD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph"> Pennefather emphasized that as we explore this technology &#8220;with all the known unknowns and unknown unknowns of where it&#8217;s gonna go, we need to actually be centered in our own values.&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We are a community and as we start to build this technology, we are not individual lone wolves. And if you are, cool, and talk with people because it&#8217;s always better to belong to a pack.&#8221; — <a href="https://theatrefilm.ubc.ca/profile/patrick-pennefather/">Professor Patrick Parra Pennefather</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f4052&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f4052" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9201" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Emerging Sub-Communities &amp; Initiatives</h2>
+
+
+
+<p class="wp-block-paragraph">The ecosystem continues to spawn new offshoots. <a href="https://www.linkedin.com/in/ryvvaliquette/">Ryv Valiquette</a> shared updates on the <a href="https://surrey.bc-ai.net/">Surrey AI Meetup</a>, now in its second event with interactive games comparing real vs. AI content. The smaller setting offers a unique benefit: &#8220;The best part is circle time. Yes, it&#8217;s smaller. So we actually get to have a circle and go around, talk about stuff and share and it&#8217;s pretty awesome.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/kXsheUv7YC4?si=x8IHNOJSAESt4aEx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Other emerging groups include <a href="https://mac.bc-ai.net/">Mind, AI &amp; Consciousness Reading Group</a>, Womxn AI, Squamish AI, and the emerging AI.edu group exploring AI usage in learning and classrooms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300587&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300587" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="265" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537-1024x265.png?resize=1024%2C265&#038;ssl=1" alt="Surrey AI Community Meetup" class="wp-image-9202" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1024%2C265&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=768%2C198&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1536%2C397&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?w=1842&amp;ssl=1 1842w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Surrey AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/vijaya-kattumuri-pmp/">Vijaya</a> and <a href="https://www.linkedin.com/in/madhavee-inamdar-0220b9a/">Madhavee</a> announced their upcoming <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and governance conference (October 24th), emphasizing the need for values alignment and human-centric approaches. &#8220;AI is a huge thing,&#8221; they noted. &#8220;It can be a great monster, it can be a good monster, bad monster. So how do we really do that value alignment and the ethics part of it, the governance part of it?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300c54&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300c54" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9214" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.maap.ca/bio-carla-ritchie">Carla Ritchie</a> from <a href="https://www.vivomediaarts.com/people">Vivo Media Arts</a>, one of Canada&#8217;s oldest artist-run centers (founded 1973), shared her dream of building &#8220;a media hub where we&#8217;ll have the machines so that any person can get access to this technology and to be able to train it for themselves.&#8221; </p>
+
+
+
+<p class="wp-block-paragraph">She credited the community with connecting her to <a href="https://kriskrug.notion.site/BC-AI-Funding-Directory-133c6f799a33801bbeaae7de1fcb5395?pvs=4">AI funding resources</a>: &#8220;Being part of this community gave me access to other resources of funding. So I&#8217;ve already applied or sent letters of interest to four funders to build this dream.&#8221;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Creative Explorations &amp; Performances</h2>
+
+
+
+<p class="wp-block-paragraph">The meetup spotlighted several innovative projects. <a href="https://www.linkedin.com/in/lionelringenbach/">Lionel Ringenbach</a> (aka <a href="https://ucodia.space/">UCODIA</a>), an experimental software artist, demonstrated his transition from a 15-year software engineering career to creating 3D models of mushrooms through photogrammetry. </p>
+
+
+
+<p class="wp-block-paragraph">He explained how coding transformed his relationship with creativity: &#8220;I didn&#8217;t feel I could use my hands to make art, but all of a sudden code became like a paint brush.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/4RB_YT26dOM?si=I4h4HHQpvdwbn-89" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">His application &#8220;<a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Compovision</a>&#8221; allows users to generate images with AI &#8220;without using a single word, but instead using your hands and objects that are around you. And it&#8217;s able to create what you can imagine without any words.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EtXP1nt_5_o?si=bKePncYHpjifL4ez" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and his team from <a href="https://www.metacreation.net/">SFU&#8217;s METACREATION Lab for Creative AI</a> previewed their performance for <a href="https://forum.mutek.org/en/shows/2024/workshop-small-data-and-model-crafting-a-new-breed-of-ethical-creative-ai-tools-for-non-coders">Montreal&#8217;s Mutek Festival</a>, featuring musical AI agents &#8220;maam&#8221; and &#8220;Spire.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330167b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330167b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9309" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Their work focuses on small data and model crafting: &#8220;We&#8217;ve been developing a bunch of tools based on this idea of small data and model crafting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3301d35&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3301d35" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9307" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">We notice that artists don&#8217;t really want to use big models, trained on everyone else&#8217;s data&#8230; For-profit AI is all about uploading the data and using big models. And if you look elsewhere, there&#8217;s pretty much nothing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330238d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330238d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9308" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We notice that artists don&#8217;t really want to use big models, trained on everyone else data. They don&#8217;t really want to upload their data online. They don&#8217;t really want to learn how to program in Python to make some art with AI in California.&#8221; —<a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier, METACREATION Lab</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">Lionel later revealed another project <a href="https://www.youtube.com/watch?v=fnKD7IAVkeU">measuring AI energy consumption</a>—an &#8220;AI energy counter&#8221; not designed to blame users but to &#8220;help people guide to more ecological product maybe.&#8221; <a href="https://forum.mutek.org/en/cohort-of-ai-ecologies-lab-projects">At MUTEK’s <strong>AI Ecologies Lab</strong>, he’s prototyping new ways to <strong>track and surface the energy footprint of AI systems</strong></a>—not to shame, but to <em>illuminate</em>. </p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">This isn’t about optimization; it’s about <strong>awareness as agency</strong>. His lab project is a sensorium for seeing the carbon ghosts in the machine. Lionel’s work blends punk engineering with planetary mindfulness.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/fnKD7IAVkeU?si=AiI3RKcB5MMGMCZz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The <a href="https://hackathon.bc-ai.net/">Data Storytelling Hackathon</a></h2>
+
+
+
+<p class="wp-block-paragraph">The centerpiece of the evening was the data storytelling hackathon sponsored by <a href="https://www.rivaltech.com/">RIVAL Technologies</a>. <a href="https://bc500.biv.com/leaders/andrew-reid/">Andrew Reid</a> approached me with a problem: market research data typically ends up in boring PowerPoint slides. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3302ba3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3302ba3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9310" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">As I explained, &#8220;We do this amazing work for these biggest brands in the world. They spend huge amounts of money asking tens of thousands of people questions about all sorts of stuff. And then we get all this rich data back and the whole industry puts into PowerPoint presentations and bar charts and graphs and like it&#8217;s the AI age. We must be able to do something more.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/aUYZ6Il3kco?si=b0ZNXYzPlBQKP5re" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">The judging team included <a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale Evernden</a> and <a href="https://www.linkedin.com/in/mortonjulia/">Julia Morton</a> from <a href="https://www.rivaltech.com/">RIVAL</a>, along with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a> who built the judging rubric. Twelve teams submitted creative interpretations of survey data on the quirky prompt: &#8220;Is a hot dog a sandwich?&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I&#8217;ll just encourage everybody, if you can take a look at the submissions. We had 12 submissions. Five of them really stood out, and I was blown away by the kind of care and attention that went into the ideation process and the conceptualization of those thoughts into a deliverable.&#8221; —<a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33032df&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33032df" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9311" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/past5/">Sev Geraskin</a> of <a href="https://www.past5.com/">Past5</a> took home the $2,500 prize with his comprehensive Orchstr platform that classified respondents as &#8220;sandwich traditionalists&#8221; or &#8220;sandwich expansionists&#8221; and developed a &#8220;controversy score.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33039ef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33039ef" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9217" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The judging was unanimous, as Dale explained: &#8220;We put our top three on there and there was one that was on the first place of all of the lists, plus Andrews, the five judges all had this one on top, so it was easy.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330406c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330406c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9312" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">In the true spirit of community, Sev&#8217;s victory speech focused not on his own accomplishment but on highlighting another community member&#8217;s work: &#8220;I wanna talk more about the kind of talent we have here. And as I&#8217;m working on this exercise and I&#8217;m meeting more and more people, I&#8217;m impressed with just the quality of builders that we have in the city.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33046fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33046fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9313" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Swathi&#8217;s runner-up project <a href="https://github.com/raikwarswati/the-sandwich-trial">transformed the data into a comic book</a> courtroom drama where a hot dog stood trial for its sandwich status. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3304dd8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3304dd8" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9218" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">She built an impressive pipeline using only open-source models: &#8220;I built a pipeline where like after all the data insights are derived, there is a CSV&#8230; and you just hit play button and what you get output is&#8230; a comic novel.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330543a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330543a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9314" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Brittney closed the hackathon segment by announcing the next round&#8217;s theme: Canadian identity. Using data from <a href="https://angusreid.org/">Angus Reid</a> polling, participants will explore &#8220;What does it mean to be Canadian?&#8221; with winners announced just before Canada Day.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3305ab1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3305ab1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9315" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Beyond Chat: The Future of Interfaces</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://allenpike.com/">Allen Pike</a> of <a href="https://forestwalk.ai/">Forestwalk Labs</a> delivered a captivating keynote on the future of AI interfaces beyond chat. He traced the evolution from text terminals to GUIs to chat interfaces, and now to what he calls &#8220;post-chat interfaces.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mRqBjKFyfLc?si=ndBrOnwp71K8uGZ9" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We&#8217;re at the beginning of a really incredible generation of software and products and experiences that when we think of AI, we might often think of this chat experience, which isn&#8217;t going away, but there is so much more to come.&#8221; —<a href="https://www.linkedin.com/in/allenpike">Allen Pike</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">These emerging patterns include contextual right-click menus, natural language search fields, and AI that anticipates the &#8220;next obvious thing&#8221; a user might want to do. &#8220;The way that you can just start making a change and it&#8217;s immediately &#8216;oh, obviously you&#8217;re doing this, just press tab&#8217;&#8230; It&#8217;s so powerful,&#8221; Pike explained. &#8220;It makes all your rest of your software feel broken.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306269&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306269" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9302" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1536%2C1025&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Perhaps most provocatively, he described a future where interfaces might be completely generated on-the-fly for each user&#8217;s exact needs: &#8220;We can now generate a completely custom UI exactly for you that is unique to you in the moment right now&#8230; This is either the complete future of user interfaces and that all the stuff I just talked about, the computers will just generate it for us&#8230; Or this is completely deranged and will confuse everyone and be impossible to actually get working.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306907&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306907" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9303" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Community Spirit</h2>
+
+
+
+<p class="wp-block-paragraph">The event closed with a surprising twist: the community&#8217;s resident critic, <a href="https://kushalgoenka.com/">Kushal</a>, who traditionally closes with a rant, found himself with nothing to complain about. &#8220;I have been in the last while, like a month plus and so on completely detoxing, if you will, of all closed source proprietary shit completely&#8230; I honestly think nothing is pissing me off.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306ff6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306ff6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9304" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Instead, he celebrated the open-source movement and the educational impact of the hackathon: &#8220;You got everyone to start playing with these technologies on their computers&#8230; I saw some of the people that won&#8230; doing stuff with models, some of them open source, and it just builds education. If you know about it now, you now know how to talk about it.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307650&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307650" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9305" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Throughout the night, Krüg highlighted the community&#8217;s growing influence, from academic validation to government recognition. With sponsors including Dmitri Schwartzman, <a href="https://segevllp.com/">SEGEV LLP</a>, <a href="https://www.metacreation.net/">METACREATION Lab</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a>, and <a href="https://creativemornings.com/cities/van/">Creative Mornings Vancouver</a>, the ecosystem continues to blossom, proving that AI development doesn&#8217;t require selling our souls—just passion, creativity, and human connection.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9199" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?w=1200&amp;ssl=1 1200w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;When I walk into the JEDI&#8217;s office or InnovateBC, and I say that we have grown from 0 paying annual members to 50 in one moth, and that we have more than 200 people show up monthy&#8230; they really start paying attention.&#8221; —Kris Krüg</p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">As the group looked ahead to the <a href="https://lu.ma/websummit-vancouver">next meetup during Web Summit Vancouver on May 28th</a> (featuring 10 community startups), and the June 25th gathering after that, one thing was clear: this is no ordinary tech meetup, but rather a living laboratory where art, technology, ethics, and community converge to shape our collective future.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="800" height="800" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=800%2C800&#038;ssl=1" alt="" class="wp-image-9198" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?w=800&amp;ssl=1 800w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 800px) 100vw, 800px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307e77&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307e77" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=1024%2C1024&#038;ssl=1" alt="Critical Voices Welcome" class="wp-image-9208" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308500&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308500" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9209" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308bb7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308bb7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9210" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309278&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309278" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9211" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309923&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309923" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9212" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309faa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309faa" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9213" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330a639&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330a639" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9215" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330ad02&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330ad02" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9216" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-content.rendered.html
@@ -1,0 +1,777 @@
+
+<p class="wp-block-paragraph">The <a href="https://lu.ma/VAI16">Vancouver AI Community Meetup #16</a> vibrated with creative energy, blending indigenous wisdom with bleeding-edge tech, grassroots community-building with critical thought. As I declared at the opening: &#8220;You are the <a href="https://bc-ai.ca/" title="BC + AI Ecosystem">BC + AI ecosystem</a>.&#8221; and what followed was a vivid demonstration of that ecosystem&#8217;s diversity and momentum.</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;Friends, we live at a time where new forms of expression are emerging right under our very eyes&#8230; whole new forms of expression.&#8221; —<a href="https://kriskrug.co/">Kris Krüg</a></p>
+</blockquote>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=4nv8YQSh4pPnU64r" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Cultural Grounding &amp; Community Foundations</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://twnation.ca/health-and-wellness/%C9%ACew%C9%99t%C9%99l-project/">Gabriel George Sr</a>. of the <a href="https://twnation.ca/">Tsleil-Waututh Nation</a> brought the room into sync—with land, lineage, and each other. He shared stories of his great-grandmother who lived right here, on this very patch of earth, back when it was still shoreline. </p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mVVmf0_zfEc?si=f-3KzodFwE1L9H7B" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Then he dropped a <em>new</em> song—one we’d never heard before—that bounced around the round room like it had always belonged there. No mic. Just presence. Just power. Just Gabriel doing what he does: weaving the ancient into the now.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f375b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f375b" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9207" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-4.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">British Columbia Artificial Intelligence Community of Practice</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://patrickpennefather.com/">Patrick Pennefather</a> followed with exciting news about published academic research in <a href="https://ojs.library.ubc.ca/index.php/bcstudies/index">BC Studies Journal</a> on the community itself. &#8220;<a href="https://ojs.library.ubc.ca/index.php/bcstudies/article/view/199875">Building a grassroots AI community of practice, a Vancouver centric use case</a>&#8221; documents how this thriving ecosystem has formed organically.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/dE8HdDaVvAM?si=9fPXdmNPkLS5e6TD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph"> Pennefather emphasized that as we explore this technology &#8220;with all the known unknowns and unknown unknowns of where it&#8217;s gonna go, we need to actually be centered in our own values.&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We are a community and as we start to build this technology, we are not individual lone wolves. And if you are, cool, and talk with people because it&#8217;s always better to belong to a pack.&#8221; — <a href="https://theatrefilm.ubc.ca/profile/patrick-pennefather/">Professor Patrick Parra Pennefather</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a32f4052&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a32f4052" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9201" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/IMG_8069.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Emerging Sub-Communities &amp; Initiatives</h2>
+
+
+
+<p class="wp-block-paragraph">The ecosystem continues to spawn new offshoots. <a href="https://www.linkedin.com/in/ryvvaliquette/">Ryv Valiquette</a> shared updates on the <a href="https://surrey.bc-ai.net/">Surrey AI Meetup</a>, now in its second event with interactive games comparing real vs. AI content. The smaller setting offers a unique benefit: &#8220;The best part is circle time. Yes, it&#8217;s smaller. So we actually get to have a circle and go around, talk about stuff and share and it&#8217;s pretty awesome.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/kXsheUv7YC4?si=x8IHNOJSAESt4aEx" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">Other emerging groups include <a href="https://mac.bc-ai.net/">Mind, AI &amp; Consciousness Reading Group</a>, Womxn AI, Squamish AI, and the emerging AI.edu group exploring AI usage in learning and classrooms.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300587&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300587" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="265" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537-1024x265.png?resize=1024%2C265&#038;ssl=1" alt="Surrey AI Community Meetup" class="wp-image-9202" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1024%2C265&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=300%2C78&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=768%2C198&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?resize=1536%2C397&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-2-e1746215917537.png?w=1842&amp;ssl=1 1842w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Surrey AI Community Meetup</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/vijaya-kattumuri-pmp/">Vijaya</a> and <a href="https://www.linkedin.com/in/madhavee-inamdar-0220b9a/">Madhavee</a> announced their upcoming <a href="https://kriskrug.co/ai-ethics/" title="AI ethics">AI ethics</a> and governance conference (October 24th), emphasizing the need for values alignment and human-centric approaches. &#8220;AI is a huge thing,&#8221; they noted. &#8220;It can be a great monster, it can be a good monster, bad monster. So how do we really do that value alignment and the ethics part of it, the governance part of it?&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3300c54&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3300c54" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9214" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-11.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.maap.ca/bio-carla-ritchie">Carla Ritchie</a> from <a href="https://www.vivomediaarts.com/people">Vivo Media Arts</a>, one of Canada&#8217;s oldest artist-run centers (founded 1973), shared her dream of building &#8220;a media hub where we&#8217;ll have the machines so that any person can get access to this technology and to be able to train it for themselves.&#8221; </p>
+
+
+
+<p class="wp-block-paragraph">She credited the community with connecting her to <a href="https://kriskrug.notion.site/BC-AI-Funding-Directory-133c6f799a33801bbeaae7de1fcb5395?pvs=4">AI funding resources</a>: &#8220;Being part of this community gave me access to other resources of funding. So I&#8217;ve already applied or sent letters of interest to four funders to build this dream.&#8221;</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Creative Explorations &amp; Performances</h2>
+
+
+
+<p class="wp-block-paragraph">The meetup spotlighted several innovative projects. <a href="https://www.linkedin.com/in/lionelringenbach/">Lionel Ringenbach</a> (aka <a href="https://ucodia.space/">UCODIA</a>), an experimental software artist, demonstrated his transition from a 15-year software engineering career to creating 3D models of mushrooms through photogrammetry. </p>
+
+
+
+<p class="wp-block-paragraph">He explained how coding transformed his relationship with creativity: &#8220;I didn&#8217;t feel I could use my hands to make art, but all of a sudden code became like a paint brush.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/4RB_YT26dOM?si=I4h4HHQpvdwbn-89" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph">His application &#8220;<a href="https://ucodia.notion.site/Compovision-0f100df5c4df495580d33762444bf8f8">Compovision</a>&#8221; allows users to generate images with AI &#8220;without using a single word, but instead using your hands and objects that are around you. And it&#8217;s able to create what you can imagine without any words.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/EtXP1nt_5_o?si=bKePncYHpjifL4ez" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://kriskrug.co/2024/05/04/the-metacreative-code-philippe-pasquiers-remix-of-ai-and-creative-arts/">Philippe Pasquier</a> and his team from <a href="https://www.metacreation.net/">SFU&#8217;s METACREATION Lab for Creative AI</a> previewed their performance for <a href="https://forum.mutek.org/en/shows/2024/workshop-small-data-and-model-crafting-a-new-breed-of-ethical-creative-ai-tools-for-non-coders">Montreal&#8217;s Mutek Festival</a>, featuring musical AI agents &#8220;maam&#8221; and &#8220;Spire.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330167b&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330167b" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9309" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-22.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Their work focuses on small data and model crafting: &#8220;We&#8217;ve been developing a bunch of tools based on this idea of small data and model crafting. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3301d35&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3301d35" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9307" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-20.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">We notice that artists don&#8217;t really want to use big models, trained on everyone else&#8217;s data&#8230; For-profit AI is all about uploading the data and using big models. And if you look elsewhere, there&#8217;s pretty much nothing.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330238d&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330238d" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9308" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-21.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We notice that artists don&#8217;t really want to use big models, trained on everyone else data. They don&#8217;t really want to upload their data online. They don&#8217;t really want to learn how to program in Python to make some art with AI in California.&#8221; —<a href="https://www.sfu.ca/siat/people/research-faculty/philippe-pasquier.html">Philippe Pasquier, METACREATION Lab</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">Lionel later revealed another project <a href="https://www.youtube.com/watch?v=fnKD7IAVkeU">measuring AI energy consumption</a>—an &#8220;AI energy counter&#8221; not designed to blame users but to &#8220;help people guide to more ecological product maybe.&#8221; <a href="https://forum.mutek.org/en/cohort-of-ai-ecologies-lab-projects">At MUTEK’s <strong>AI Ecologies Lab</strong>, he’s prototyping new ways to <strong>track and surface the energy footprint of AI systems</strong></a>—not to shame, but to <em>illuminate</em>. </p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="wp-block-paragraph">This isn’t about optimization; it’s about <strong>awareness as agency</strong>. His lab project is a sensorium for seeing the carbon ghosts in the machine. Lionel’s work blends punk engineering with planetary mindfulness.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/fnKD7IAVkeU?si=AiI3RKcB5MMGMCZz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">The <a href="https://hackathon.bc-ai.net/">Data Storytelling Hackathon</a></h2>
+
+
+
+<p class="wp-block-paragraph">The centerpiece of the evening was the data storytelling hackathon sponsored by <a href="https://www.rivaltech.com/">RIVAL Technologies</a>. <a href="https://bc500.biv.com/leaders/andrew-reid/">Andrew Reid</a> approached me with a problem: market research data typically ends up in boring PowerPoint slides. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3302ba3&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3302ba3" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9310" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-23.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">As I explained, &#8220;We do this amazing work for these biggest brands in the world. They spend huge amounts of money asking tens of thousands of people questions about all sorts of stuff. And then we get all this rich data back and the whole industry puts into PowerPoint presentations and bar charts and graphs and like it&#8217;s the AI age. We must be able to do something more.&#8221;</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/aUYZ6Il3kco?si=b0ZNXYzPlBQKP5re" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+
+
+<p class="wp-block-paragraph">The judging team included <a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale Evernden</a> and <a href="https://www.linkedin.com/in/mortonjulia/">Julia Morton</a> from <a href="https://www.rivaltech.com/">RIVAL</a>, along with <a href="https://www.linkedin.com/in/brittneysmaila/">Brittney Smaila</a> who built the judging rubric. Twelve teams submitted creative interpretations of survey data on the quirky prompt: &#8220;Is a hot dog a sandwich?&#8221;</p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;I&#8217;ll just encourage everybody, if you can take a look at the submissions. We had 12 submissions. Five of them really stood out, and I was blown away by the kind of care and attention that went into the ideation process and the conceptualization of those thoughts into a deliverable.&#8221; —<a href="https://www.linkedin.com/in/dale-evernden-b8b07a4/">Dale</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a></p>
+</blockquote>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33032df&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33032df" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9311" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-24.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://www.linkedin.com/in/past5/">Sev Geraskin</a> of <a href="https://www.past5.com/">Past5</a> took home the $2,500 prize with his comprehensive Orchstr platform that classified respondents as &#8220;sandwich traditionalists&#8221; or &#8220;sandwich expansionists&#8221; and developed a &#8220;controversy score.&#8221; </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33039ef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33039ef" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9217" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-14.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">The judging was unanimous, as Dale explained: &#8220;We put our top three on there and there was one that was on the first place of all of the lists, plus Andrews, the five judges all had this one on top, so it was easy.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330406c&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330406c" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9312" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-25.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">In the true spirit of community, Sev&#8217;s victory speech focused not on his own accomplishment but on highlighting another community member&#8217;s work: &#8220;I wanna talk more about the kind of talent we have here. And as I&#8217;m working on this exercise and I&#8217;m meeting more and more people, I&#8217;m impressed with just the quality of builders that we have in the city.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a33046fa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a33046fa" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9313" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-26.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Swathi&#8217;s runner-up project <a href="https://github.com/raikwarswati/the-sandwich-trial">transformed the data into a comic book</a> courtroom drama where a hot dog stood trial for its sandwich status. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3304dd8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3304dd8" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9218" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-15.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">She built an impressive pipeline using only open-source models: &#8220;I built a pipeline where like after all the data insights are derived, there is a CSV&#8230; and you just hit play button and what you get output is&#8230; a comic novel.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330543a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330543a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9314" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-27.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Brittney closed the hackathon segment by announcing the next round&#8217;s theme: Canadian identity. Using data from <a href="https://angusreid.org/">Angus Reid</a> polling, participants will explore &#8220;What does it mean to be Canadian?&#8221; with winners announced just before Canada Day.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3305ab1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3305ab1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9315" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-28.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Beyond Chat: The Future of Interfaces</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://allenpike.com/">Allen Pike</a> of <a href="https://forestwalk.ai/">Forestwalk Labs</a> delivered a captivating keynote on the future of AI interfaces beyond chat. He traced the evolution from text terminals to GUIs to chat interfaces, and now to what he calls &#8220;post-chat interfaces.&#8221;</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/mRqBjKFyfLc?si=ndBrOnwp71K8uGZ9" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen=""></iframe></p>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;We&#8217;re at the beginning of a really incredible generation of software and products and experiences that when we think of AI, we might often think of this chat experience, which isn&#8217;t going away, but there is so much more to come.&#8221; —<a href="https://www.linkedin.com/in/allenpike">Allen Pike</a></p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">These emerging patterns include contextual right-click menus, natural language search fields, and AI that anticipates the &#8220;next obvious thing&#8221; a user might want to do. &#8220;The way that you can just start making a change and it&#8217;s immediately &#8216;oh, obviously you&#8217;re doing this, just press tab&#8217;&#8230; It&#8217;s so powerful,&#8221; Pike explained. &#8220;It makes all your rest of your software feel broken.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306269&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306269" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9302" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?resize=1536%2C1025&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-16.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Perhaps most provocatively, he described a future where interfaces might be completely generated on-the-fly for each user&#8217;s exact needs: &#8220;We can now generate a completely custom UI exactly for you that is unique to you in the moment right now&#8230; This is either the complete future of user interfaces and that all the stuff I just talked about, the computers will just generate it for us&#8230; Or this is completely deranged and will confuse everyone and be impossible to actually get working.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306907&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306907" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9303" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-17.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<h2 class="wp-block-heading">Community Spirit</h2>
+
+
+
+<p class="wp-block-paragraph">The event closed with a surprising twist: the community&#8217;s resident critic, <a href="https://kushalgoenka.com/">Kushal</a>, who traditionally closes with a rant, found himself with nothing to complain about. &#8220;I have been in the last while, like a month plus and so on completely detoxing, if you will, of all closed source proprietary shit completely&#8230; I honestly think nothing is pissing me off.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3306ff6&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3306ff6" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9304" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-18.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Instead, he celebrated the open-source movement and the educational impact of the hackathon: &#8220;You got everyone to start playing with these technologies on their computers&#8230; I saw some of the people that won&#8230; doing stuff with models, some of them open source, and it just builds education. If you know about it now, you now know how to talk about it.&#8221;</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307650&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307650" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-9305" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-19.png?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Throughout the night, Krüg highlighted the community&#8217;s growing influence, from academic validation to government recognition. With sponsors including Dmitri Schwartzman, <a href="https://segevllp.com/">SEGEV LLP</a>, <a href="https://www.metacreation.net/">METACREATION Lab</a>, <a href="https://www.rivaltech.com/">RIVAL Technologies</a>, and <a href="https://creativemornings.com/cities/van/">Creative Mornings Vancouver</a>, the ecosystem continues to blossom, proving that AI development doesn&#8217;t require selling our souls—just passion, creativity, and human connection.</p>
+
+
+
+<figure class="wp-block-image size-large"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9199" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=1024%2C1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?resize=40%2C40&amp;ssl=1 40w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-1.png?w=1200&amp;ssl=1 1200w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /></figure>
+
+
+
+<blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow">
+<p class="wp-block-paragraph">&#8220;When I walk into the JEDI&#8217;s office or InnovateBC, and I say that we have grown from 0 paying annual members to 50 in one moth, and that we have more than 200 people show up monthy&#8230; they really start paying attention.&#8221; —Kris Krüg</p>
+</blockquote>
+
+
+
+<p class="wp-block-paragraph">As the group looked ahead to the <a href="https://lu.ma/websummit-vancouver">next meetup during Web Summit Vancouver on May 28th</a> (featuring 10 community startups), and the June 25th gathering after that, one thing was clear: this is no ordinary tech meetup, but rather a living laboratory where art, technology, ethics, and community converge to shape our collective future.</p>
+
+
+
+<figure class="wp-block-image size-full"><img data-recalc-dims="1" loading="lazy" decoding="async" width="800" height="800" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=800%2C800&#038;ssl=1" alt="" class="wp-image-9198" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?w=800&amp;ssl=1 800w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 800px) 100vw, 800px" /></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3307e77&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3307e77" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=1024%2C1024&#038;ssl=1" alt="Critical Voices Welcome" class="wp-image-9208" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-5.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308500&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308500" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9209" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-6.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3308bb7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3308bb7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9210" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-7.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309278&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309278" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9211" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-8.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309923&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309923" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9212" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-9.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a3309faa&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a3309faa" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9213" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-10.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330a639&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330a639" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9215" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-12.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a330ad02&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a330ad02" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="1024" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=1024%2C1024&#038;ssl=1" alt="" class="wp-image-9216" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?w=1024&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=300%2C300&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=150%2C150&amp;ssl=1 150w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=768%2C768&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=200%2C200&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=100%2C100&amp;ssl=1 100w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/05/image-13.png?resize=40%2C40&amp;ssl=1 40w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/vancouver-ai/">Vancouver AI Ecosystem</a> collection.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/before/post-9197-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 9197,
+  "slug": "vancouver-ai-meetup-16-where-tech-creativity-and-community-collide",
+  "status": "publish",
+  "link": "https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/",
+  "modified": "2026-06-28T20:27:08",
+  "modified_gmt": "2026-06-29T04:27:08",
+  "type": "post",
+  "content_raw_bytes": 83434,
+  "content_rendered_bytes": 83434,
+  "content_raw_has_footer": true,
+  "snapshot_source": "public_rest_rendered_20260819_no_context_edit",
+  "kriskrug_events_hrefs": 0,
+  "vancouver_ai_hrefs": 1,
+  "title_rendered": "Vancouver AI Meetup #16: Where Tech, Creativity, and Community Collide"
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/targets.json
@@ -1,0 +1,203 @@
+{
+  "issue": 832,
+  "parent": 402,
+  "blocked_by": 826,
+  "must_not_write_ids": [
+    2250
+  ],
+  "must_not_write_slug": "events",
+  "page_2250_rendered_sha256": "4353740134b28aa577de881cd41aaf071e8304444540687cb3562206145beb43",
+  "live_reconfirm": "2026-08-19T23:22:56Z",
+  "status": "prepared_not_applied",
+  "snapshot_note": "WP creds were unset. Posts 4495/9197/8418/6815/6251/5768/4348 before/content.raw.html files are public REST content.rendered stand-ins. Page 12315 content.raw.html is the 2026-07-01 authenticated backup whose modified_gmt still matches live. Page 2250 is a public rendered fixture only.",
+  "forbidden_href_substrings": [],
+  "forbidden_inserted_substrings": [
+    "Sept",
+    "September",
+    "Oct",
+    "October",
+    "Nov",
+    "November",
+    "—",
+    "–"
+  ],
+  "ai_events_href": "/ai-events/",
+  "ai_events_anchor": "Browse AI events",
+  "vancouver_ai_href": "https://kriskrug.co/vancouver-ai/",
+  "child1_gate": [
+    {
+      "id": 3814,
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "from_category": 1757,
+      "to_category": 1678
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "from_category": 1757,
+      "to_category": 1676
+    },
+    {
+      "id": 1067,
+      "slug": "hardcore-superstar-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1063,
+      "slug": "made-in-vancouver-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1147,
+      "slug": "fashion-photoshoot-for-discollection",
+      "from_category": 1665,
+      "to_category": 1756
+    }
+  ],
+  "items": [
+    {
+      "id": 4495,
+      "kind": "posts",
+      "slug": "inside-the-innaugural-vancouver-ai-community-meetup",
+      "url": "https://kriskrug.co/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:36:32",
+      "find": "to many more gatherings where AI meets creativity, technology, and community!</p>",
+      "replace": "to many more gatherings where AI meets creativity, technology, and community! And <a href=\"https://kriskrug.co/events/\">we still do this every month, and the next one is on the calendar</a>.</p>",
+      "anchors": [
+        {
+          "row": 18,
+          "text": "we still do this every month, and the next one is on the calendar",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 9197,
+      "kind": "posts",
+      "slug": "vancouver-ai-meetup-16-where-tech-creativity-and-community-collide",
+      "url": "https://kriskrug.co/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:27:08",
+      "find": "converge to shape our collective future.</p>",
+      "replace": "converge to shape our collective future. If you want <a href=\"https://kriskrug.co/events/\">the next one</a>, it is on the calendar.</p>",
+      "anchors": [
+        {
+          "row": 19,
+          "text": "the next one",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 8418,
+      "kind": "posts",
+      "slug": "vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap",
+      "url": "https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:30:15",
+      "find": "<p class=\"wp-block-paragraph\"></p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>",
+      "replace": "<p class=\"wp-block-paragraph\">If you are nearby, <a href=\"https://kriskrug.co/events/\">come to the next one</a>.</p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>",
+      "anchors": [
+        {
+          "row": 20,
+          "text": "come to the next one",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 6815,
+      "kind": "posts",
+      "slug": "august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics",
+      "url": "https://kriskrug.co/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics/",
+      "modified_gmt_at_reconfirm": "2026-07-02T00:25:32",
+      "find": "More local ecosystem notes live in my <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI community</a> hub.</p>",
+      "replace": "More local ecosystem notes live in my <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI community</a> hub. Live dates sit on <a href=\"https://kriskrug.co/events/\">the current calendar</a>.</p>",
+      "anchors": [
+        {
+          "row": 21,
+          "text": "the current calendar",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 6251,
+      "kind": "posts",
+      "slug": "creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights",
+      "url": "https://kriskrug.co/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:33:29",
+      "find": "Host, <a href=\"https://lu.ma/future-proof\">Vancouver AI Community Meetups</a></p>",
+      "replace": "Host, <a href=\"https://lu.ma/future-proof\">Vancouver AI Community Meetups</a></p>\n\n\n\n<p class=\"wp-block-paragraph\">The live dates live <a href=\"https://kriskrug.co/events/\">where the next one lands</a>.</p>",
+      "anchors": [
+        {
+          "row": 22,
+          "text": "where the next one lands",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 5768,
+      "kind": "posts",
+      "slug": "june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines",
+      "url": "https://kriskrug.co/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:34:16",
+      "find": "continue to explore, create, and inspire together.</p>",
+      "replace": "continue to explore, create, and inspire together. It is <a href=\"https://kriskrug.co/events/\">still monthly, still free, still worth the trip</a>.</p>",
+      "anchors": [
+        {
+          "row": 23,
+          "text": "still monthly, still free, still worth the trip",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_vancouver_ai": true
+    },
+    {
+      "id": 4348,
+      "kind": "posts",
+      "slug": "2024-vancouver-ai-community-meetups",
+      "url": "https://kriskrug.co/2023/12/27/2024-vancouver-ai-community-meetups/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:36:48",
+      "find": "Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.</em></p>",
+      "replace": "Our goal is to build an engaged group through knowledge sharing, collaboration, and discussion of real-world applications and ethical implications of AI.</em></p>\n\n\n\n<p class=\"wp-block-paragraph\">For dates that stay current, use <a href=\"https://kriskrug.co/events/\">the live calendar, which is the version that stays current</a>.</p>",
+      "anchors": [
+        {
+          "row": 24,
+          "text": "the live calendar, which is the version that stays current",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_vancouver_ai": true,
+      "insert_in_intro": true
+    },
+    {
+      "id": 12315,
+      "kind": "pages",
+      "slug": "vancouver-ai",
+      "url": "https://kriskrug.co/vancouver-ai/",
+      "modified_gmt_at_reconfirm": "2026-07-01T20:27:36",
+      "find": "<p><a class=\"aurora-button\" href=\"/ai-events/\">Browse AI events</a></p>",
+      "replace": "<p><a class=\"aurora-button\" href=\"/ai-events/\">Browse AI events</a> and <a href=\"https://kriskrug.co/events/\">the calendar</a>.</p>",
+      "anchors": [
+        {
+          "row": 25,
+          "text": "the calendar",
+          "href": "https://kriskrug.co/events/"
+        }
+      ],
+      "preserve_ai_events": true
+    }
+  ]
+}

--- a/scripts/apply_issue_832_events_routing.py
+++ b/scripts/apply_issue_832_events_routing.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Issue #832: add /events/ links on meetup recaps and page 12315.
+
+Dry-run by default. Writes are gated on ID->slug match, exact text-match
+insertion, child-1 (#826) category proof, and a fresh context=edit snapshot.
+
+Page 2250 (/events/) is owned by #635. This script hard-refuses that ID.
+
+    python3 scripts/apply_issue_832_events_routing.py --from-files
+    make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py'
+    make varlock-run CMD='python3 scripts/apply_issue_832_events_routing.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-832"
+TARGETS_PATH = PACK / "targets.json"
+BEFORE_DIR = PACK / "before"
+AFTER_DIR = PACK / "after"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-832-events-routing"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+FORBIDDEN_WRITE_ID = 2250
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def write_ids(targets: dict | None = None) -> set[int]:
+    data = targets if targets is not None else load_targets()
+    return {row["id"] for row in data["items"]}
+
+
+def refuse_write_id(item_id: int, targets: dict | None = None) -> None:
+    data = targets if targets is not None else load_targets()
+    blocked = set(data.get("must_not_write_ids") or [FORBIDDEN_WRITE_ID])
+    blocked.add(FORBIDDEN_WRITE_ID)
+    if item_id in blocked:
+        sys.exit(
+            f"[ABORT] page {item_id} is owned by #635. This pack must not write it."
+        )
+    if item_id not in write_ids(data) and item_id == FORBIDDEN_WRITE_ID:
+        sys.exit(f"[ABORT] refusing write id {item_id}.")
+
+
+def assert_targets_safe(targets: dict) -> None:
+    blocked = set(targets.get("must_not_write_ids") or [FORBIDDEN_WRITE_ID])
+    blocked.add(FORBIDDEN_WRITE_ID)
+    owned = write_ids(targets)
+    overlap = owned & blocked
+    if overlap:
+        sys.exit(f"[ABORT] write set intersects must-not-write ids: {sorted(overlap)}")
+    if FORBIDDEN_WRITE_ID in owned:
+        sys.exit("[ABORT] page 2250 leaked into targets.items.")
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    if payload is not None:
+        if "/pages/2250" in url or "/pages/2250?" in url:
+            sys.exit("[ABORT] refusing a write URL for page 2250.")
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-832"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    if item.get("id") == FORBIDDEN_WRITE_ID:
+        sys.exit("[ABORT] refusing to snapshot-then-write page 2250.")
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def already_applied(body: str, spec: dict) -> bool:
+    return all(
+        f'<a href="{row["href"]}">{row["text"]}</a>' in body for row in spec["anchors"]
+    )
+
+
+def inserted_fragment(spec: dict) -> str:
+    find = spec["find"]
+    replace = spec["replace"]
+    prefix = os.path.commonprefix([find, replace])
+    find_rest = find[len(prefix) :]
+    replace_rest = replace[len(prefix) :]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def vancouver_ai_count(body: str) -> int:
+    return body.count("https://kriskrug.co/vancouver-ai/") + body.count(
+        'href="/vancouver-ai/"'
+    )
+
+
+def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
+    if spec["id"] == FORBIDDEN_WRITE_ID or spec["id"] in set(
+        targets.get("must_not_write_ids") or []
+    ):
+        raise ValueError(f"{spec['id']}: refused; page 2250 is not in the write set")
+    if already_applied(body, spec):
+        return None
+    find = spec["find"]
+    replace = spec["replace"]
+    count = body.count(find)
+    if count != 1:
+        raise ValueError(
+            f"{spec['id']}: find needle occurs {count} times; expected 1. "
+            "Insert by text match, not a stale block index."
+        )
+    added = inserted_fragment(spec)
+    if "\u2014" in added or "\u2013" in added:
+        raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
+    if any(ord(char) > 127 for char in added):
+        raise ValueError(f"{spec['id']}: inserted copy is not ASCII; use NCR")
+    for forbidden in targets.get("forbidden_inserted_substrings") or []:
+        if forbidden and forbidden in added:
+            raise ValueError(
+                f"{spec['id']}: inserted copy contains forbidden {forbidden!r}"
+            )
+    rewritten = body.replace(find, replace, 1)
+    if spec.get("preserve_footer"):
+        if body.count(FOOTER_SENTINEL) != rewritten.count(FOOTER_SENTINEL):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+    if spec.get("preserve_vancouver_ai"):
+        if vancouver_ai_count(rewritten) < vancouver_ai_count(body):
+            raise ValueError(f"{spec['id']}: /vancouver-ai/ href count dropped")
+        if targets["vancouver_ai_href"] in body and targets["vancouver_ai_href"] not in rewritten:
+            raise ValueError(f"{spec['id']}: existing /vancouver-ai/ href was removed")
+    if spec.get("preserve_ai_events"):
+        if targets["ai_events_href"] not in rewritten:
+            raise ValueError(f"{spec['id']}: /ai-events/ href missing")
+        if targets["ai_events_anchor"] not in rewritten:
+            raise ValueError(f"{spec['id']}: Browse AI events anchor missing")
+    if spec.get("insert_in_intro"):
+        anchor = spec["anchors"][0]["text"]
+        list_marker = "lu.ma/ai-trends"
+        if list_marker in rewritten and rewritten.find(anchor) > rewritten.find(list_marker):
+            raise ValueError(f"{spec['id']}: intro link landed after the 2023-era list")
+    for forbidden in targets.get("forbidden_href_substrings") or []:
+        if forbidden in rewritten and forbidden not in body:
+            raise ValueError(f"{spec['id']}: forbidden href {forbidden} was added")
+    for row in spec["anchors"]:
+        needle = f'<a href="{row["href"]}">{row["text"]}</a>'
+        if rewritten.count(needle) != 1:
+            raise ValueError(f"{spec['id']}: expected one {needle!r}")
+    return rewritten
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    if live.get("id") != spec["id"]:
+        sys.exit(f"[ABORT] {spec['id']}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: slug is {live.get('slug')!r}, "
+            f"expected {spec['slug']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    refuse_write_id(spec["id"])
+    return request(rest_url(spec), header)
+
+
+def child1_is_live(header: str, targets: dict) -> tuple[bool, list[str]]:
+    notes: list[str] = []
+    ready = True
+    for row in targets["child1_gate"]:
+        live = request(
+            f"{BASE_URL}/wp-json/wp/v2/posts/{row['id']}?_fields=id,slug,categories",
+            header,
+        )
+        if live.get("slug") != row["slug"]:
+            ready = False
+            notes.append(f"{row['id']} slug {live.get('slug')!r}")
+            continue
+        cats = list(live.get("categories") or [])
+        if row["to_category"] not in cats or row["from_category"] in cats:
+            ready = False
+            notes.append(f"{row['id']} categories {cats}")
+        else:
+            notes.append(f"{row['id']} ok {cats}")
+    return ready, notes
+
+
+def plan_item(spec: dict, body: str, targets: dict) -> dict | None:
+    refuse_write_id(spec["id"], targets)
+    try:
+        rewritten = rewrite_body(body, spec, targets)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: exact href+anchor already present.")
+        return None
+    return {"spec": spec, "before": body, "after": rewritten}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for row in spec["anchors"]:
+        print(f"        row {row['row']}: {row['text']!r} -> {row['href']}")
+
+
+def write_after_files(planned: list[dict]) -> None:
+    AFTER_DIR.mkdir(parents=True, exist_ok=True)
+    for item in planned:
+        spec = item["spec"]
+        path = AFTER_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+        path.write_text(item["after"], encoding="utf-8")
+        print(f"[AFTER] {path}")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    print_plan(item)
+    if not do_apply:
+        return
+    spec = item["spec"]
+    refuse_write_id(spec["id"])
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_item(spec, raw_body(live), load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    post_id = snapshot.get("id")
+    refuse_write_id(post_id)
+    allowed = write_ids()
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #832 write set.")
+    spec = next(row for row in load_targets()["items"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(live, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def load_before_body(spec: dict) -> str:
+    path = BEFORE_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+    if not path.is_file():
+        sys.exit(f"[ABORT] missing before-file {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #832 meetup recap /events/ links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-files", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    parser.add_argument(
+        "--allow-before-826",
+        action="store_true",
+        help="Unsafe. Bypass the child-1 category gate. Do not use on production.",
+    )
+    args = parser.parse_args()
+    targets = load_targets()
+    assert_targets_safe(targets)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.item_id == FORBIDDEN_WRITE_ID:
+        sys.exit("[ABORT] page 2250 is owned by #635. This pack must not write it.")
+
+    if args.restore:
+        restore_snapshot(args.restore, auth_header(), args.apply)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id:
+        refuse_write_id(args.item_id, targets)
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+
+    if args.from_files:
+        planned = []
+        for spec in rows:
+            try:
+                item = plan_item(spec, load_before_body(spec), targets)
+            except ValueError as exc:
+                sys.exit(f"[ABORT] {exc}")
+            if item is not None:
+                planned.append(item)
+                print_plan(item)
+        if not planned:
+            print("[OK] nothing pending.")
+            return 0
+        write_after_files(planned)
+        print("[FROM-FILES] wrote after/ payloads. No WordPress writes.")
+        return 0
+
+    header = auth_header()
+    if args.apply and not args.allow_before_826:
+        ready, notes = child1_is_live(header, targets)
+        for note in notes:
+            print(f"[826] {note}")
+        if not ready:
+            sys.exit(
+                "[ABORT] #826 category fixes are not live. Do not PATCH meetup recaps or 12315 yet."
+            )
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_item(spec, raw_body(live), targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            item["live"] = live
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Pass --apply after #826 is live and KK approves."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_832_events_routing.py
+++ b/scripts/tests/test_apply_issue_832_events_routing.py
@@ -1,0 +1,316 @@
+"""Offline safety tests for the issue #832 events routing helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_832_events_routing.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_832_events_routing", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def before_body(item_id: int) -> str:
+    spec = spec_by_id(item_id)
+    return (
+        MODULE.BEFORE_DIR / f"{spec['kind'][:-1]}-{item_id}-content.raw.html"
+    ).read_text(encoding="utf-8")
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    return {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else before_body(spec["id"])},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_832_events_routing.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue832EventsRoutingTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+        self.gate = {
+            row["id"]: {
+                "id": row["id"],
+                "slug": row["slug"],
+                "categories": [row["from_category"]],
+            }
+            for row in TARGETS["child1_gate"]
+        }
+
+    def _patch_request(self, calls, *, gate_ready=False):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/pages/2250" in url and body is not None:
+                raise AssertionError("page 2250 must never be in a write URL")
+            if "/posts/" in url and "context=edit" not in url:
+                post_id = int(url.split("/posts/")[1].split("?")[0])
+                live = json.loads(json.dumps(self.gate[post_id]))
+                if gate_ready:
+                    spec = next(
+                        row for row in TARGETS["child1_gate"] if row["id"] == post_id
+                    )
+                    live["categories"] = [spec["to_category"]]
+                return live
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            if item_id == 2250:
+                raise AssertionError("page 2250 is not in the write set")
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_rows_18_through_25(self):
+        ids = [row["id"] for row in TARGETS["items"]]
+        self.assertEqual(ids, [4495, 9197, 8418, 6815, 6251, 5768, 4348, 12315])
+        self.assertNotIn(2250, ids)
+        self.assertEqual(TARGETS["must_not_write_ids"], [2250])
+        slugs = {row["id"]: row["slug"] for row in TARGETS["items"]}
+        self.assertEqual(
+            slugs[4495], "inside-the-innaugural-vancouver-ai-community-meetup"
+        )
+        self.assertEqual(slugs[12315], "vancouver-ai")
+        anchors = [
+            (row["row"], row["text"], row["href"])
+            for spec in TARGETS["items"]
+            for row in spec["anchors"]
+        ]
+        self.assertEqual(
+            anchors,
+            [
+                (
+                    18,
+                    "we still do this every month, and the next one is on the calendar",
+                    "https://kriskrug.co/events/",
+                ),
+                (19, "the next one", "https://kriskrug.co/events/"),
+                (20, "come to the next one", "https://kriskrug.co/events/"),
+                (21, "the current calendar", "https://kriskrug.co/events/"),
+                (22, "where the next one lands", "https://kriskrug.co/events/"),
+                (
+                    23,
+                    "still monthly, still free, still worth the trip",
+                    "https://kriskrug.co/events/",
+                ),
+                (
+                    24,
+                    "the live calendar, which is the version that stays current",
+                    "https://kriskrug.co/events/",
+                ),
+                (25, "the calendar", "https://kriskrug.co/events/"),
+            ],
+        )
+
+    def test_write_set_never_includes_2250(self):
+        self.assertNotIn(2250, MODULE.write_ids(TARGETS))
+        MODULE.assert_targets_safe(TARGETS)
+        with self.assertRaises(SystemExit) as caught:
+            MODULE.refuse_write_id(2250, TARGETS)
+        self.assertIn("2250", str(caught.exception))
+        with self.assertRaises(SystemExit):
+            run_main("--item-id", "2250", "--from-files")
+
+    def test_rewrite_recaps_add_one_events_link_and_keep_vancouver_ai(self):
+        for item_id in (4495, 9197, 8418, 6815, 6251, 5768, 4348):
+            spec = spec_by_id(item_id)
+            before = before_body(item_id)
+            after = MODULE.rewrite_body(before, spec, TARGETS)
+            self.assertIsNotNone(after, msg=item_id)
+            self.assertEqual(
+                after.count('<a href="https://kriskrug.co/events/">'),
+                before.count('<a href="https://kriskrug.co/events/">') + 1,
+            )
+            self.assertGreaterEqual(
+                MODULE.vancouver_ai_count(after), MODULE.vancouver_ai_count(before)
+            )
+            if spec.get("preserve_footer"):
+                self.assertEqual(
+                    before.count("kk-collection-footer"),
+                    after.count("kk-collection-footer"),
+                )
+            if after.find("kk-collection-footer") >= 0:
+                self.assertLess(
+                    after.find(spec["anchors"][0]["text"]),
+                    after.find("kk-collection-footer"),
+                )
+            self.assertNotIn("\u2014", MODULE.inserted_fragment(spec))
+            self.assertNotIn("Sept", MODULE.inserted_fragment(spec))
+            self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_4348_sits_in_the_intro_ahead_of_the_2023_list(self):
+        spec = spec_by_id(4348)
+        after = MODULE.rewrite_body(before_body(4348), spec, TARGETS)
+        self.assertIsNotNone(after)
+        anchor = after.find("the live calendar, which is the version that stays current")
+        listed = after.find("lu.ma/ai-trends")
+        footer = after.find("kk-collection-footer")
+        self.assertGreater(listed, anchor)
+        self.assertGreater(footer, listed)
+
+    def test_rewrite_12315_adds_calendar_and_keeps_browse_ai_events(self):
+        spec = spec_by_id(12315)
+        before = before_body(12315)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn('href="/ai-events/"', after)
+        self.assertIn("Browse AI events", after)
+        self.assertIn('<a href="https://kriskrug.co/events/">the calendar</a>', after)
+        self.assertEqual(before.count("Browse AI events"), after.count("Browse AI events"))
+        self.assertNotIn("2250", after)
+
+    def test_missing_needle_aborts(self):
+        spec = spec_by_id(4495)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>no toast</p>", spec, TARGETS)
+
+    def test_from_files_writes_after_payloads_and_does_not_call_wordpress(self):
+        calls = []
+        after_dir = self.tmp_path / "after"
+        with (
+            mock.patch.object(MODULE, "AFTER_DIR", after_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--from-files"))
+        self.assertEqual(calls, [])
+        for item_id, kind in (
+            (4495, "post"),
+            (9197, "post"),
+            (8418, "post"),
+            (6815, "post"),
+            (6251, "post"),
+            (5768, "post"),
+            (4348, "post"),
+            (12315, "page"),
+        ):
+            self.assertTrue((after_dir / f"{kind}-{item_id}-content.raw.html").is_file())
+        self.assertFalse((after_dir / "page-2250-content.raw.html").exists())
+
+    def test_live_dry_run_performs_no_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertTrue(all("2250" not in url for url, _ in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12315]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--allow-before-826", "--item-id", "12315")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_refuses_when_826_is_not_live(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "4495")
+        self.assertIn("#826", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE,
+                "request",
+                side_effect=self._patch_request(calls, gate_ready=True),
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "6815"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn("the current calendar", writes[0]["content"])
+        self.assertIn("https://kriskrug.co/vancouver-ai/", writes[0]["content"])
+        self.assertTrue(all("2250" not in url for url, _ in calls))
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_restore_refuses_page_2250(self):
+        snapshot = self.tmp_path / "rest-page-2250-before.json"
+        snapshot.write_text(
+            json.dumps(
+                {
+                    "id": 2250,
+                    "slug": "events",
+                    "type": "page",
+                    "content": {"raw": "<p>no</p>"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(SystemExit) as caught:
+            run_main("--restore", str(snapshot))
+        self.assertIn("2250", str(caught.exception))
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("2250", apply_md)
+        self.assertIn("#635", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #832", apply_md)
+        self.assertNotIn("Fixes #402", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply-ready pack for [#832](https://github.com/WalksWithASwagger/kriskrug-wp/issues/832): add `/events/` links on seven Vancouver AI meetup recaps and a second `the calendar` link on `/vancouver-ai/`. **Prepared, not applied.**

**Do not apply until #826 is live and KK says go.** `--apply` aborts until those category fixes are live. Page 2250 (`/events/`) is snapshotted as a fixture only and is hard-refused by the script.

## Related Issue

Refs #832

Leaves #832 and #402 open (payload prepared, not applied).

## Changes

- `content/drafts/2026-08-02-seo-authority-hubs/fix-832/` — APPLY.md, targets.json, before/after snapshots (2250 fixture only)
- `scripts/apply_issue_832_events_routing.py` — dry-run default, `--from-files`, slug/ID checks, `--restore`, refuses 2250
- `scripts/tests/test_apply_issue_832_events_routing.py` — 13 offline tests

## Type of Change

- [x] Content update (payload only)
- [x] Documentation update

## Testing

- [x] `python3 -m unittest scripts.tests.test_apply_issue_832_events_routing` (13 tests, OK)
- Live public GET 2026-08-19: none of the seven recaps or page 12315 already link `kriskrug.co/events/`

## Deployment Notes

- [x] No special deployment steps required
- Do **not** run `--apply` from this PR. Gate 1 live apply is still #826 first.
- Do **not** write page 2250.

## Additional Notes

`WP_USER` / `WP_APP_PASSWORD` were unset, so recap before-files are public `content.rendered` stand-ins. Live `--apply` still GETs real `content.raw` and still requires slug/ID checks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c4f-22a9-7df9-9466-dea6653bf59e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c4f-22a9-7df9-9466-dea6653bf59e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


