### PR TITLE
content(#830): apply-ready Cyber Love Garden hub links, not applied

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/APPLY.md
@@ -1,0 +1,148 @@
+# #830 APPLY: Cyber Love Garden hub links
+
+**Prepared, not applied. Do not PATCH until KK says go.**
+Script is dry-run by default. `--apply` is the only write switch, and it refuses unless #826's post 2819 contact-href repair is already live (no `kriskrug.com/contact`).
+
+Parent: #402. This is child 5 of 9. Child 1 (#826) still owns the 2819 contact-href repair (row 30). This pack does not recategorize anything and does not retouch that href except to abort if the repair is missing.
+
+Do not close #830 or #402 when this runbook merges.
+
+## Live reconfirm (logged-out public REST, 2026-08-19T23:21:16Z)
+
+No REST POST / PATCH / DELETE in this session. WP creds were unset, so there is no authenticated `context=edit` `content.raw`. Public REST confirmed slug/ID pairs and snapshotted `content.rendered` into `before/`. Page 12316 `content.raw.html` is the 2026-07-01 topic-hub source pack, which still matches live rendered except WordPress adding `decoding="async"` on `<img>`.
+
+| ID | Kind | Slug | URL | HTTP | Internal body links | Notes |
+|---|---|---|---|---:|---:|---|
+| 12316 | page | `ai-for-creatives` | `/ai-for-creatives/` | 200 | 5 (Both Hands Full, Taste Is Your Moat, archive, services, speaking) | No Cyber Love Garden card. `modified_gmt` `2026-07-01T20:27:40`. |
+| 2819 | post | `exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out` | `/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/` | 200 | 3 (contact + footer) | No link to 2650. `https://kriskrug.co/contact/` is live. `kriskrug.com/contact` is absent. `modified_gmt` `2026-08-18T02:16:05`. |
+| 2661 | post | `headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona` | `/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/` | 200 | 2 (footer only) | No link to 2650. One baked `kk-collection-footer`. |
+| 3567 | post | `community-art-project-development-process-guide` | `/2023/10/15/community-art-project-development-process-guide/` | 200 | 2 (footer only) | No link to 2650. Intro is still the italic technology-brings-people-together paragraph. |
+| 2650 | post | `the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld` | `/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/` | 200 | footer into `/ai-for-creatives/` | Destination only. Do not PATCH this body. Featured media 2654. |
+
+Five target URLs were 200: `/ai-for-creatives/`, the three spoke posts, and post 2650. `/contact/` was also 200.
+
+### #826 row 30 on 2819 (today)
+
+Public rendered has `href="https://kriskrug.co/contact/"` and zero `kriskrug.com/contact`. That is the #826 repair this child must not redo and must not regress. `--apply` still GETs 2819 and aborts if the dead href is back or the repaired href is missing.
+
+### Block recount (today's HTML, not the 2026-08-02 index)
+
+Insertion is by **text match**, not a stale block index.
+
+- 12316: insert a Read next card after Taste Is Your Moat and before the AI creatives archive card. Both Hands Full and Taste cards stay byte-identical.
+- 2819: Discord-experiment paragraph that ends `glimpse into our journey.` Do not touch the contact paragraph.
+- 2661: closing body line `See you on the dance floor!` before the baked footer.
+- 3567: intro paragraph that ends `the communal experience can be the message.`
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+| ID | Required slug |
+|---:|---|
+| 12316 | `ai-for-creatives` |
+| 2819 | `exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out` |
+| 2661 | `headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona` |
+| 3567 | `community-art-project-development-process-guide` |
+| 2650 | `the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld` (read-only destination) |
+
+## What the script writes
+
+Content only. Titles, slugs, dates, status, featured media, tags, categories, and SEO meta stay untouched.
+
+| ID | Find (exactly once) | Inserted copy |
+|---|---|---|
+| 12316 | Taste card close, then the archive card open | new Read next card titled `The Cyber Love Garden` linking 2650. Blurb exactly: `Art, AI, and XR in a burn camp built for it.` (row 26) |
+| 2819 | Discord experiment paragraph ending `glimpse into our journey.` | trailing sentence: exact anchor `the garden where we ran this in person` (row 27) |
+| 2661 | `See you on the dance floor!</p>` | trailing sentence: exact anchor `what we built at Otherworld` (row 28) |
+| 3567 | intro ending `the communal experience can be the message.` | trailing sentence: exact anchor `a worked example of all of this` (row 29) |
+
+Inserted copy is ASCII. No em dashes. No NCR needed in the new sentences. Existing NCRs and unicode in 2819 / 2661 / 3567 stay as they are.
+
+Skip a row if that exact `href` + anchor already exists.
+
+## Snapshot gaps
+
+- No authenticated `content.raw` for 2819, 2661, or 3567. `before/post-*-content.raw.html` is the public `content.rendered` stand-in so `--from-files` can run offline. Live `--apply` must GET `context=edit` and will abort if the find needle is missing in raw.
+- Page 12316 raw is reconstructed from `content/source-packs/content-architecture-2026/wp-payloads/topic-hubs/ai-for-creatives.html`, not from `context=edit`.
+- Post 2650 body is not snapshotted as a write target.
+
+## Must not
+
+- Repair or rewrite the 2819 contact href (row 30 / #826). Abort if that repair is not live.
+- Touch post 2650 body.
+- Recategorize 1147 or any other post.
+- Remove or rewrite the Both Hands Full or Taste Is Your Moat cards on 12316.
+- Duplicate `kk-collection-footer`.
+- Run bulk `inject_links.py`.
+
+## Source-pack write-surface warning
+
+Page 12316 is also the topic-hub payload at `content/source-packs/content-architecture-2026/wp-payloads/topic-hubs/ai-for-creatives.html`. That file does **not** include this garden card. If that payload is applied after these links land, it will wipe the card unless it is re-cut.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_830_cyber_love_garden
+
+# Offline dry-run: rewrite the snapshotted before-files into after/. No network.
+python3 scripts/apply_issue_830_cyber_love_garden.py --from-files
+
+# Live GET dry-run: authenticated context=edit + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py'
+
+# Apply only after #826 2819 contact repair is live and KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py --apply'
+```
+
+`--item-id 12316` limits to one object. Re-run after a successful apply prints `[SKIP]`.
+
+`--apply` GETs post 2819 and aborts unless `kriskrug.com/contact` is absent and `https://kriskrug.co/contact/` is present.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-830-cyber-love-garden/rest-<page|post>-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py --restore backup/issue-830-cyber-love-garden/rest-page-12316-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py --restore backup/issue-830-cyber-love-garden/rest-page-12316-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the four write IDs or a slug mismatch. Rollback body is the snapshotted `content.raw`.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/ai-for-creatives/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/
+
+curl -sL "https://kriskrug.co/ai-for-creatives/?cb=$RANDOM" | grep -F 'The Cyber Love Garden'
+curl -sL "https://kriskrug.co/ai-for-creatives/?cb=$RANDOM" | grep -F 'Art, AI, and XR in a burn camp built for it.'
+curl -sL "https://kriskrug.co/ai-for-creatives/?cb=$RANDOM" | grep -c 'both-hands-full'
+curl -sL "https://kriskrug.co/ai-for-creatives/?cb=$RANDOM" | grep -c 'your-taste-is-your-moat'
+
+curl -sL "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/?cb=$RANDOM" \
+  | grep -F 'the garden where we ran this in person'
+curl -sL "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/?cb=$RANDOM" \
+  | grep -c 'kriskrug.com/contact'
+# last command must print 0
+
+curl -sL "https://kriskrug.co/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/?cb=$RANDOM" \
+  | grep -F 'what we built at Otherworld'
+curl -sL "https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/?cb=$RANDOM" \
+  | grep -F 'a worked example of all of this'
+```
+
+Expect: 12316 gains one new Read next card (2650) and still has Both Hands Full and Taste Is Your Moat. 2819 garden anchor present and `kriskrug.com/contact` absent. 2661 and 3567 footer counts unchanged.
+
+## Out of payload
+
+- Contact-link repair on 2819 (#826 row 30)
+- Taxonomy repair on 1067 / 1063 / 1147 / 3814 / 3330 (#826)
+- Post 2650 body
+- Hub cards on 12013 / 12318 / 12319
+- `inject_links.py`

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/page-12316-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/page-12316-content.raw.html
@@ -1,0 +1,80 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-for-creatives -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI for creatives</p>
+  <h2 class="aurora-display-heading">Use the tools without flattening your taste.</h2>
+  <p class="aurora-page-lead">This hub is for artists, designers, writers, filmmakers, musicians, educators, and creative teams trying to work with AI without becoming generic. The point is not more output. The point is sharper taste, better systems, and work that still sounds like a person made it.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Creative practice</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Taste before prompts</h3>
+      <p>Prompt craft matters, but judgment matters more. A creative AI practice starts with taste, constraints, and point of view.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Make culture, not content</h3>
+      <p>The useful work is building a voice, a ritual, and a body of work that can survive the feed.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Voice-first workflows</h3>
+      <p>Talking, recording, sketching, remixing, and editing can make AI feel more like a studio assistant than a slot machine.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Creative systems</h3>
+      <p>Build repeatable workflows for talks, essays, images, research, and publishing without outsourcing your point of view.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Read next</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/01/24/both-hands-full/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?resize=640,400&amp;ssl=1" alt="Both Hands Full creative AI artwork" loading="lazy">
+        <div>
+          <h3>Both Hands Full</h3>
+          <p>A creative thesis for staying human while the tools get faster.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/15/your-taste-is-your-moat/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?resize=640,400&amp;ssl=1" alt="AI for creatives visual artwork" loading="lazy">
+        <div>
+          <h3>Your taste is your moat</h3>
+          <p>Why creative judgment becomes more valuable as production gets easier.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/05/WalksWithASwagger_year_2055_film_still_farshot_20_happy_solarpu_c1c61961-c4e4-418e-b9fc-37b576b73d21-1.png?resize=640,400&amp;ssl=1" alt="The Cyber Love Garden at Otherworld" loading="lazy">
+        <div>
+          <h3>The Cyber Love Garden</h3>
+          <p>Art, AI, and XR in a burn camp built for it.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-creatives/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?resize=640,400&amp;ssl=1" alt="Taste before prompts graphic" loading="lazy">
+        <div>
+          <h3>AI creatives archive</h3>
+          <p>Field notes for artists, makers, and creative technologists working with generative systems.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring this into a studio, school, or team</h2>
+    <p>Kris builds talks, workshops, and strategy sessions for creative people who need practical AI fluency without surrendering taste.</p>
+    <p><a class="aurora-button" href="/generative-ai-services/">Explore AI services</a> <a class="aurora-button" href="/speaking/">Book a talk</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-2661-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-2661-content.raw.html
@@ -1,0 +1,95 @@
+
+<p class="wp-block-paragraph">Hello, fellow art enthusiasts! As a passionate participant in the pulsating realm of art and creativity, I&#8217;ve always championed the cause of self-expression. It&#8217;s a fundamental aspect of our being, irrespective of our origins or identities. With the festival season on the horizon and folks making plans to head out to <a href="https://burningman.org/">Burning Man</a>, <a href="https://www.shambhalamusicfestival.com/">Shambhala</a>, <a href="https://www.coachella.com/">Coachella</a>, <a href="https://basscoast.ca">Bass Coast</a> and a host of other cool events&#8230; I want to illuminate an empowering journey that welcomes all festival aficionados, transcending gender and body type boundaries.</p>
+
+
+
+<p class="wp-block-paragraph">Introducing <a href="https://daniellediamond.ca">Danielle Diamond</a>, an extraordinary costume designer and transformation facilitator. She&#8217;s redefining festival fashion with her groundbreaking <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a>. This service isn&#8217;t just for women; Danielle&#8217;s clientele often encompasses men who are eager to plunge into the festival spirit but might feel hesitant about their personal style.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a689aaf7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a689aaf7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="983" height="799" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=983%2C799&#038;ssl=1" alt="" class="wp-image-2663" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?w=983&amp;ssl=1 983w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=768%2C624&amp;ssl=1 768w" sizes="auto, (max-width: 983px) 100vw, 983px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Rave Mom and Camp Daddy at Otherworld 2023 with Cyber Love Garden</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Unleashing Your Festival Persona with Festival Style Activations</strong></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://daniellediamond.ca/bio-contact-2/">Danielle&#8217;s Festival Style Activations</a> are a vibrant blend of personal shopping, costume styling, and personal transformation. With her sharp aesthetic sense and comprehension of personal archetypes, Danielle ensures your festival attire mirrors your inner self.</p>
+
+
+
+<p class="wp-block-paragraph">Whether you&#8217;re a festival novice or a veteran, this service is an open invitation to shed your inhibitions and discover new dimensions of yourself in a nurturing, judgement-free space.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s a glimpse into the enchanting process:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Shopping Trip:</strong> Danielle navigates you through exclusive style sanctuaries, choosing from diverse collections that will mold your unique festival ensembles.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Costume Styling:</strong> Danielle curates your transformative outfits with a mindful approach, contemplating every element, from apparel to accessories, wigs, and makeup.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Transformation:</strong> The Festival Style Activations go beyond costume creation, offering a voyage of self-exploration and expression. You&#8217;ll delve into your inner archetypes and gain the liberty to personify your fantasies in a secure festival setting.</p>
+
+
+
+<p class="wp-block-paragraph">Intrigued to know more? Delve into the complete spectrum of <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a> in Danielle&#8217;s original blog post.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>A Universal Embrace of Festival Fashion</strong></p>
+
+
+
+<p class="wp-block-paragraph">The allure of Festival Style Activations is its universal appeal. Whether you identify as a man, woman, or non-binary; whether you&#8217;re petite, plus-size, or somewhere in between; Danielle&#8217;s services beckon everyone to explore and rejoice in their unique energy.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maximizing Your Festival Experience</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>Connect with the Community: </strong>Festivals are about the collective journey. Engage with your fellow festival-goers to weave a web of shared creativity and celebration.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Welcome the Unknown:</strong> Festival Style Activations inspire you to uncover new aspects of your persona. Embrace this chance with an open mind and heart.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Chronicle Your Journey:</strong> Don’t forget to document your transformative odyssey and share it on social media. </p>
+
+
+
+<p class="wp-block-paragraph">Here are a few pointers to optimize your Festival Style Activation:</p>
+
+
+
+<p class="wp-block-paragraph">Festivals are a canvas for self-expression, creativity, and community. Danielle&#8217;s Festival Style Activations provide everyone the chance to step into their power and radiate vibrantly.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s to an unforgettable summer of metamorphosis and jubilation. See you on the dance floor! Start with <a href="https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/">what we built at Otherworld</a>.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2024/05/26/jennifer-podemski-storytelling-masterclass-yorkton-film-festival/">Jennifer Podemski Storytelling Masterclass &#8211; Yorkton Film Festival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-2819-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-2819-content.raw.html
@@ -1,0 +1,196 @@
+
+<h4 class="wp-block-heading">I. Introduction</h4>
+
+
+
+<p class="wp-block-paragraph">Art and technology often dance at the edge of possibility. Recently, I joined a fascinating collaborative endeavor known as &#8220;<a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out</a>&#8220;.</p>
+
+
+
+<p class="wp-block-paragraph">This project, hosted on my Friends of Krüg (FøK) <a href="https://discord.com/">Discord</a> server, was not only an artistic experiment but a rich exploration of creativity, community, and technological innovation. Here&#8217;s a glimpse into our journey. This Discord round was the remote cousin of <a href="https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/">the garden where we ran this in person</a>.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/6eOl8gyFo4c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+
+
+<h4 class="wp-block-heading">II. The Creative Process</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Zoom Out Technique</strong>: The essence of this project lay in a deceptively simple idea: &#8220;Zoom Out.&#8221; Each participant took an image, zoomed out, and added their perspective, creating a cascading visual narrative.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Workflow</strong>: Our method involved selecting an image, upscaling it, and then using a &#8220;Custom Zoom&#8221; feature to adjust the prompt. This systematic approach allowed for individual creativity while maintaining cohesion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6835ff2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6835ff2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">III. Participant Contributions</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. My Contribution as KRÜG</strong>: Along with talented individuals like <a href="https://crisbeasley.medium.com/">Cris Beasley</a>, I had the pleasure of weaving in thematic elements like &#8220;cyber love garden&#8221; and &#8220;biopunk microcosm.&#8221; It was a playground for creativity, where each person&#8217;s touch added depth and intrigue.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Exploring Styles and Themes</strong>: From &#8220;arabesque geometric infusion&#8221; to abstract ideas, we ventured into various artistic landscapes. Each contribution was a unique voice in a chorus of creativity.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6836959&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6836959" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">IV. Role of Technology</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Midjourney Bot</strong>: An AI, <a href="https://www.midjourney.com/home/">Midjourney</a> Bot, became an unexpected companion, providing insights into image details and settings. It&#8217;s a testament to how technology can be an ally in artistic pursuits.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Discord as a Platform</strong>: Our entire adventure took place on Discord, highlighting the potential of digital spaces to foster collaboration and community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68370a9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68370a9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">V. Final Creation</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Creating the Video</strong>: Crosstopher&#8217;s skill in stitching the images into a cohesive video added a cinematic flair. The result was not just a series of pictures but a fluid visual story.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Observing the Details</strong>: The final piece had intriguing artifacts and alignment, reflecting the organic nature of our collaboration. It was polished, yet retained the raw energy of our creative process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a683783e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a683783e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VI. Conclusion</h4>
+
+
+
+<p class="wp-block-paragraph">&#8220;Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out&#8221; was more than an art experiment; it was a testament to what&#8217;s possible when creative minds converge. It was an exploration, a learning experience, and above all, a celebration of art, technology, and human connection.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6837f3a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6837f3a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VII. Credits and Acknowledgments</h4>
+
+
+
+<p class="wp-block-paragraph">A heartfelt acknowledgment to all who participated, especially <a href="https://www.instagram.com/crosstopher/">Crosstopher</a> and <a href="http://www.crisbeasley.com/">Cris Beasley</a>. Your energy, creativity, and spirit were the lifeblood of this project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68386b0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68386b0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">The final video and the entire creative journey speak volumes about the untapped potential of collaborative art. Feel free to explore the <a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">final video here</a> and share your thoughts.</p>
+
+
+
+<p class="wp-block-paragraph">As always, I&#8217;m here, exploring the edge of art and technology. If this resonates with you or if you&#8217;re curious to learn more, <a href="https://kriskrug.co/contact/">connect with me</a>. Let&#8217;s continue to create, question, and envision the future of art together.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-tools/">Generative AI Tools</a> collection. See also: <a href="https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/">How AI tools like Midjourney, DALL·E &#038; ChatGPT are reshaping the creative landscape</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-3567-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/after/post-3567-content.raw.html
@@ -1,0 +1,434 @@
+
+<h2 class="wp-block-heading">Building Community Through Art: A Guide to Navigating the Complexities of Community Art Projects</h2>
+
+
+
+<p class="wp-block-paragraph"><em>by Kris Krüg, Cyber Love Garden c0-organizer, Photographer, Creative Technologist, and Community Catalyst</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together.&#8221; This mantra doesn&#8217;t just apply to the digital world. It&#8217;s equally valid in the sphere of community art projects, where technology can be a medium and the communal experience can be the message.</em> The Cyber Love Garden is <a href="https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/">a worked example of all of this</a>.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691a7a7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691a7a7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3585" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Why Community Art Matters</h2>
+
+
+
+<p class="wp-block-paragraph">If a picture&#8217;s worth a thousand words, then a community art project is worth a thousand conversations. Not just any small talk, but those layered dialogues that happen when people come together to create something greater than themselves. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691af75&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691af75" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-3581" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">It&#8217;s not just art; it&#8217;s a shared journey, an ongoing narrative of who we are and what we aspire to become as a community. &#8220;Everything is interesting. Look closer.&#8221;.  In community art, this call to look closer becomes a collective endeavor.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691b867&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691b867" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3571" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photos by Kris Krüg</figcaption></figure>
+
+
+
+<h2 class="wp-block-heading">The Genesis: Idea and Consensus</h2>
+
+
+
+<p class="wp-block-paragraph">An art project starts as a spark—an idea. This spark is useless without oxygen, the community&#8217;s collective breath. Host gatherings, be they physical meetups or virtual hangouts, where people can contribute ideas freely. Once a sea of ideas is before you, how do you navigate? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691bff8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691bff8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3572" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Democracy is your compass. Use a voting system, but remember, it&#8217;s not just a popularity contest; the idea needs to be feasible and meaningful. Aim for consensus, not just majority rule.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691c935&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691c935" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="598" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&#038;ssl=1" alt="" class="wp-image-3582" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=300%2C175&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=768%2C448&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1536%2C897&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=2048%2C1195&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Nitty-Gritty: Planning and Fundraising</h2>
+
+
+
+<p class="wp-block-paragraph">Get the idea down on paper—sketch it, write it, code it, whatever your medium. Create a comprehensive plan covering the design, materials, labor, budget, and timeline. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3583" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Unless you’re tapping into the Bank of Love and Imagination, you&#8217;ll need funds. Grants, crowdfunding, local business sponsorships—there are as many ways to raise money as there are to spend it.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<h2 class="wp-block-heading">The Real Work: Building and Installing</h2>
+
+
+
+<p class="wp-block-paragraph">Crafting the project can be both the most challenging and the most fulfilling part. Don&#8217;t go it alone. Assemble a ragtag crew of volunteers, each with their unique skills and quirks. Keep in mind, you&#8217;re not just building an art project; you&#8217;re building a community. Document the journey, for every hammer hit and paint stroke is a page in your collective story.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691daef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691daef" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3573" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Final Frontier: Maintenance and Evolution</h2>
+
+
+
+<p class="wp-block-paragraph">Art, like a garden, requires tending. Assign caretakers or make a community schedule. Consider seasonal upgrades to keep the project fresh. If your art piece is a &#8220;portal entryway,&#8221; think of how you can change it to reflect different themes or community milestones.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691e37f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691e37f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3574" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Beyond the Art: Lifelong Community Engagement</h2>
+
+
+
+<p class="wp-block-paragraph">The art project may be &#8216;complete,&#8217; but its lifecycle is far from over. Keep the community engaged through events, social media, or good old-fashioned meetups. Make your art project a living entity that grows and evolves with the community it represents.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f172&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f172" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="548" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18.jpg?resize=1024%2C548&#038;ssl=1" alt="" class="wp-image-3575" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1024%2C548&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=300%2C161&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=768%2C411&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1536%2C822&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=2048%2C1096&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together,&#8221; but let&#8217;s not forget that the oldest form of technology is storytelling. Through community art, we are all storytellers, and the narrative we create together is our shared legacy.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>Keep looking closer. Keep building. Keep dreaming.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>—Kris Krüg</em></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f9f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f9f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3576" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Here&#8217;s a draft step-by-step guide to help you get started. Iterate and upgrade these steps and tell me what you learn!! 🙂 </h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a69201d7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a69201d7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3577" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Idea Generation</strong>: Host a community meeting or online forum where everyone can pitch ideas. The best community art projects resonate with the collective.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Consensus Building</strong>: Conduct surveys or use a voting mechanism to finalize the idea that resonates most. It&#8217;s not just about majority rule; consider the impact and feasibility too.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Planning</strong>: Draft a detailed plan, including the project&#8217;s scope, materials needed, estimated budget, and timeline. Work out who does what.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Fundraising</strong>: Identify potential sources of funding—grants, local businesses, crowdfunding—and launch your fundraising campaign.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Material Sourcing</strong>: Once the funds are secured, source the necessary materials and tools. Local partnerships can be gold here.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Team Assembly</strong>: Recruit community members based on skills and interests. The tech-savvy might handle documentation, while the artistically inclined work on design.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Building the Project</strong>: Start with a soft launch—a mini-version or a part of the full project—to test assumptions and make adjustments. Then scale to the full project.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Installation</strong>: Choose a highly visible and accessible location. Make sure you have the necessary permits and community buy-in.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Documentation</strong>: Document the process and the final outcome through photos, videos, and written stories. Share this across social media and local press.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Warehousing</strong>: If the art project is not permanent, have a plan for storing materials. Community centers or local businesses might offer space.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maintenance</strong>: Assign a team or create a schedule for community members to keep the project in good shape.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Upgrades</strong>: Plan for upgrades or extensions. The art project can evolve, just like the community it represents.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Community Engagement</strong>: Keep the community involved, not just as spectators but as active participants, for the life cycle of the art project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6920c49&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6920c49" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="632" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18.jpg?resize=1024%2C632&#038;ssl=1" alt="" class="wp-image-3578" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1024%2C632&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=300%2C185&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=768%2C474&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1536%2C948&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=2048%2C1264&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Appendix: Blind Spots &amp; Considerations</h3>
+
+
+
+<p class="wp-block-paragraph">In any community art project, there are bound to be overlooked elements that can make or break the endeavor. To ensure that our art not only touches souls but also builds a stronger, more inclusive community, we need to confront these blind spots head-on.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921469&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921469" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="624" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18.jpg?resize=1024%2C624&#038;ssl=1" alt="" class="wp-image-3579" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1024%2C624&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=300%2C183&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=768%2C468&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1536%2C936&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=2048%2C1248&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<ol class="wp-block-list">
+<li><strong>Inclusivity</strong> &#8211; Ensure your project is accessible to everyone in the community. Consider ramps, translations, and sensory-friendly environments to make your project inclusive.</li>
+
+
+
+<li><strong>Environmental Impact</strong> &#8211; Art shouldn’t cost the Earth. Make sustainability a cornerstone of your project, from material selection to disposal methods.</li>
+
+
+
+<li><strong>Legal Considerations</strong> &#8211; Navigating the sea of zoning laws, permits, and copyrights is critical. Consult with experts to ensure that your project complies with all local, state, and federal regulations.</li>
+
+
+
+<li><strong>Emotional Safety</strong> &#8211; Art provokes thought, but it shouldn&#8217;t provoke harm. Ensure your project doesn’t inadvertently marginalize or offend members of the community.</li>
+
+
+
+<li><strong>Disassembly Plan</strong> &#8211; If your project has an expiration date, have a responsible and environmentally friendly disassembly and disposal plan in place.</li>
+
+
+
+<li><strong>Historical Context</strong> &#8211; Does your project acknowledge or ignore the community&#8217;s cultural and historical nuances? Sensitivity to context enriches the project&#8217;s layers of meaning.</li>
+
+
+
+<li><strong>Conflict Resolution</strong> &#8211; Prepare for disagreements by having a clear conflict resolution or mediation strategy in place.</li>
+
+
+
+<li><strong>Digital Extensions</strong> &#8211; In our interconnected world, creating a digital component to your art project can widen its reach and deepen its impact.</li>
+
+
+
+<li><strong>Feedback Mechanism</strong> &#8211; How will the community&#8217;s voice be integrated throughout the life cycle of the project? Consider surveys, public meetings, and social media as feedback channels.</li>
+
+
+
+<li><strong>Spiritual Connection</strong> &#8211; Art often reaches places words cannot. Consider if there&#8217;s a spiritual dimension to your project that can touch people at an even deeper level.</li>
+</ol>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921d41&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921d41" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244.jpg?resize=1024%2C498&#038;ssl=1" alt="" class="wp-image-3580" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1536%2C747&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=2048%2C996&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-for-creatives/">AI for Creatives</a> collection. See also: <a href="https://kriskrug.co/2024/10/28/kicking-ass-in-2025-a-techartists-guide-to-creative-survival/">Kicking Ass in 2025: A Techartist&#8217;s Guide to Creative Survival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-content.raw.html
@@ -1,0 +1,71 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-for-creatives -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI for creatives</p>
+  <h2 class="aurora-display-heading">Use the tools without flattening your taste.</h2>
+  <p class="aurora-page-lead">This hub is for artists, designers, writers, filmmakers, musicians, educators, and creative teams trying to work with AI without becoming generic. The point is not more output. The point is sharper taste, better systems, and work that still sounds like a person made it.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Creative practice</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Taste before prompts</h3>
+      <p>Prompt craft matters, but judgment matters more. A creative AI practice starts with taste, constraints, and point of view.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Make culture, not content</h3>
+      <p>The useful work is building a voice, a ritual, and a body of work that can survive the feed.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Voice-first workflows</h3>
+      <p>Talking, recording, sketching, remixing, and editing can make AI feel more like a studio assistant than a slot machine.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Creative systems</h3>
+      <p>Build repeatable workflows for talks, essays, images, research, and publishing without outsourcing your point of view.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Read next</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/01/24/both-hands-full/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?resize=640,400&amp;ssl=1" alt="Both Hands Full creative AI artwork" loading="lazy">
+        <div>
+          <h3>Both Hands Full</h3>
+          <p>A creative thesis for staying human while the tools get faster.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/15/your-taste-is-your-moat/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?resize=640,400&amp;ssl=1" alt="AI for creatives visual artwork" loading="lazy">
+        <div>
+          <h3>Your taste is your moat</h3>
+          <p>Why creative judgment becomes more valuable as production gets easier.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-creatives/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?resize=640,400&amp;ssl=1" alt="Taste before prompts graphic" loading="lazy">
+        <div>
+          <h3>AI creatives archive</h3>
+          <p>Field notes for artists, makers, and creative technologists working with generative systems.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring this into a studio, school, or team</h2>
+    <p>Kris builds talks, workshops, and strategy sessions for creative people who need practical AI fluency without surrendering taste.</p>
+    <p><a class="aurora-button" href="/generative-ai-services/">Explore AI services</a> <a class="aurora-button" href="/speaking/">Book a talk</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-content.rendered.html
@@ -1,0 +1,71 @@
+
+<!-- content-architecture-2026:topic-ai-for-creatives -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI for creatives</p>
+  <h2 class="aurora-display-heading">Use the tools without flattening your taste.</h2>
+  <p class="aurora-page-lead">This hub is for artists, designers, writers, filmmakers, musicians, educators, and creative teams trying to work with AI without becoming generic. The point is not more output. The point is sharper taste, better systems, and work that still sounds like a person made it.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Creative practice</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Taste before prompts</h3>
+      <p>Prompt craft matters, but judgment matters more. A creative AI practice starts with taste, constraints, and point of view.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Make culture, not content</h3>
+      <p>The useful work is building a voice, a ritual, and a body of work that can survive the feed.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Voice-first workflows</h3>
+      <p>Talking, recording, sketching, remixing, and editing can make AI feel more like a studio assistant than a slot machine.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Creative systems</h3>
+      <p>Build repeatable workflows for talks, essays, images, research, and publishing without outsourcing your point of view.</p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Read next</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/01/24/both-hands-full/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/MASTER-Blog-header.png?resize=640,400&amp;ssl=1" alt="Both Hands Full creative AI artwork" loading="lazy"/>
+        <div>
+          <h3>Both Hands Full</h3>
+          <p>A creative thesis for staying human while the tools get faster.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2026/05/15/your-taste-is-your-moat/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/01/ai-creatives-krug.jpeg?resize=640,400&amp;ssl=1" alt="AI for creatives visual artwork" loading="lazy"/>
+        <div>
+          <h3>Your taste is your moat</h3>
+          <p>Why creative judgment becomes more valuable as production gets easier.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/ai-creatives/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2026/06/01-blog-hero-taste-before-prompts.png?resize=640,400&amp;ssl=1" alt="Taste before prompts graphic" loading="lazy"/>
+        <div>
+          <h3>AI creatives archive</h3>
+          <p>Field notes for artists, makers, and creative technologists working with generative systems.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Bring this into a studio, school, or team</h2>
+    <p>Kris builds talks, workshops, and strategy sessions for creative people who need practical AI fluency without surrendering taste.</p>
+    <p><a class="aurora-button" href="/generative-ai-services/">Explore AI services</a> <a class="aurora-button" href="/speaking/">Book a talk</a></p>
+  </div>
+</section>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/page-12316-identity.json
@@ -1,0 +1,22 @@
+{
+  "id": 12316,
+  "slug": "ai-for-creatives",
+  "status": "publish",
+  "link": "https://kriskrug.co/ai-for-creatives/",
+  "modified": "2026-07-01T12:27:40",
+  "modified_gmt": "2026-07-01T20:27:40",
+  "type": "page",
+  "featured_media": 0,
+  "categories": null,
+  "content_source": "source_pack_and_public_rest",
+  "content_raw_missing": false,
+  "content_rendered_bytes": 3620,
+  "content_raw_bytes": 3599,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": false,
+  "has_kriskrug_com_contact": false,
+  "has_kriskrug_co_contact": false,
+  "has_cyber_love_garden_href": false,
+  "content_raw_source": "content/source-packs/content-architecture-2026/wp-payloads/topic-hubs/ai-for-creatives.html",
+  "note": "Public REST has no content.raw. Raw stand-in is the 2026-07-01 topic-hub payload that still matches live rendered (WP adds decoding=async on img)."
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2650-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2650-identity.json
@@ -1,0 +1,16 @@
+{
+  "id": 2650,
+  "slug": "the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/",
+  "modified": "2026-06-28T20:39:55",
+  "modified_gmt": "2026-06-29T04:39:55",
+  "type": "post",
+  "featured_media": 2654,
+  "categories": [
+    1665
+  ],
+  "title_rendered": "The Cyber Love Garden: A Crossroads of Art and AI at Otherworld",
+  "write_target": false,
+  "note": "Destination only. Do not PATCH post 2650."
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-content.raw.html
@@ -1,0 +1,95 @@
+
+<p class="wp-block-paragraph">Hello, fellow art enthusiasts! As a passionate participant in the pulsating realm of art and creativity, I&#8217;ve always championed the cause of self-expression. It&#8217;s a fundamental aspect of our being, irrespective of our origins or identities. With the festival season on the horizon and folks making plans to head out to <a href="https://burningman.org/">Burning Man</a>, <a href="https://www.shambhalamusicfestival.com/">Shambhala</a>, <a href="https://www.coachella.com/">Coachella</a>, <a href="https://basscoast.ca">Bass Coast</a> and a host of other cool events&#8230; I want to illuminate an empowering journey that welcomes all festival aficionados, transcending gender and body type boundaries.</p>
+
+
+
+<p class="wp-block-paragraph">Introducing <a href="https://daniellediamond.ca">Danielle Diamond</a>, an extraordinary costume designer and transformation facilitator. She&#8217;s redefining festival fashion with her groundbreaking <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a>. This service isn&#8217;t just for women; Danielle&#8217;s clientele often encompasses men who are eager to plunge into the festival spirit but might feel hesitant about their personal style.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a689aaf7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a689aaf7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="983" height="799" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=983%2C799&#038;ssl=1" alt="" class="wp-image-2663" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?w=983&amp;ssl=1 983w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=768%2C624&amp;ssl=1 768w" sizes="auto, (max-width: 983px) 100vw, 983px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Rave Mom and Camp Daddy at Otherworld 2023 with Cyber Love Garden</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Unleashing Your Festival Persona with Festival Style Activations</strong></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://daniellediamond.ca/bio-contact-2/">Danielle&#8217;s Festival Style Activations</a> are a vibrant blend of personal shopping, costume styling, and personal transformation. With her sharp aesthetic sense and comprehension of personal archetypes, Danielle ensures your festival attire mirrors your inner self.</p>
+
+
+
+<p class="wp-block-paragraph">Whether you&#8217;re a festival novice or a veteran, this service is an open invitation to shed your inhibitions and discover new dimensions of yourself in a nurturing, judgement-free space.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s a glimpse into the enchanting process:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Shopping Trip:</strong> Danielle navigates you through exclusive style sanctuaries, choosing from diverse collections that will mold your unique festival ensembles.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Costume Styling:</strong> Danielle curates your transformative outfits with a mindful approach, contemplating every element, from apparel to accessories, wigs, and makeup.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Transformation:</strong> The Festival Style Activations go beyond costume creation, offering a voyage of self-exploration and expression. You&#8217;ll delve into your inner archetypes and gain the liberty to personify your fantasies in a secure festival setting.</p>
+
+
+
+<p class="wp-block-paragraph">Intrigued to know more? Delve into the complete spectrum of <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a> in Danielle&#8217;s original blog post.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>A Universal Embrace of Festival Fashion</strong></p>
+
+
+
+<p class="wp-block-paragraph">The allure of Festival Style Activations is its universal appeal. Whether you identify as a man, woman, or non-binary; whether you&#8217;re petite, plus-size, or somewhere in between; Danielle&#8217;s services beckon everyone to explore and rejoice in their unique energy.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maximizing Your Festival Experience</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>Connect with the Community: </strong>Festivals are about the collective journey. Engage with your fellow festival-goers to weave a web of shared creativity and celebration.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Welcome the Unknown:</strong> Festival Style Activations inspire you to uncover new aspects of your persona. Embrace this chance with an open mind and heart.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Chronicle Your Journey:</strong> Don’t forget to document your transformative odyssey and share it on social media. </p>
+
+
+
+<p class="wp-block-paragraph">Here are a few pointers to optimize your Festival Style Activation:</p>
+
+
+
+<p class="wp-block-paragraph">Festivals are a canvas for self-expression, creativity, and community. Danielle&#8217;s Festival Style Activations provide everyone the chance to step into their power and radiate vibrantly.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s to an unforgettable summer of metamorphosis and jubilation. See you on the dance floor!</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2024/05/26/jennifer-podemski-storytelling-masterclass-yorkton-film-festival/">Jennifer Podemski Storytelling Masterclass &#8211; Yorkton Film Festival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-content.rendered.html
@@ -1,0 +1,95 @@
+
+<p class="wp-block-paragraph">Hello, fellow art enthusiasts! As a passionate participant in the pulsating realm of art and creativity, I&#8217;ve always championed the cause of self-expression. It&#8217;s a fundamental aspect of our being, irrespective of our origins or identities. With the festival season on the horizon and folks making plans to head out to <a href="https://burningman.org/">Burning Man</a>, <a href="https://www.shambhalamusicfestival.com/">Shambhala</a>, <a href="https://www.coachella.com/">Coachella</a>, <a href="https://basscoast.ca">Bass Coast</a> and a host of other cool events&#8230; I want to illuminate an empowering journey that welcomes all festival aficionados, transcending gender and body type boundaries.</p>
+
+
+
+<p class="wp-block-paragraph">Introducing <a href="https://daniellediamond.ca">Danielle Diamond</a>, an extraordinary costume designer and transformation facilitator. She&#8217;s redefining festival fashion with her groundbreaking <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a>. This service isn&#8217;t just for women; Danielle&#8217;s clientele often encompasses men who are eager to plunge into the festival spirit but might feel hesitant about their personal style.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a689aaf7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a689aaf7" class="wp-block-image size-full wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="983" height="799" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=983%2C799&#038;ssl=1" alt="" class="wp-image-2663" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?w=983&amp;ssl=1 983w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/07/00DC7AB1-0040-401D-B251-78FCCE9CEB66_1_105_c.jpeg?resize=768%2C624&amp;ssl=1 768w" sizes="auto, (max-width: 983px) 100vw, 983px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">Rave Mom and Camp Daddy at Otherworld 2023 with Cyber Love Garden</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Unleashing Your Festival Persona with Festival Style Activations</strong></p>
+
+
+
+<p class="wp-block-paragraph"><a href="https://daniellediamond.ca/bio-contact-2/">Danielle&#8217;s Festival Style Activations</a> are a vibrant blend of personal shopping, costume styling, and personal transformation. With her sharp aesthetic sense and comprehension of personal archetypes, Danielle ensures your festival attire mirrors your inner self.</p>
+
+
+
+<p class="wp-block-paragraph">Whether you&#8217;re a festival novice or a veteran, this service is an open invitation to shed your inhibitions and discover new dimensions of yourself in a nurturing, judgement-free space.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s a glimpse into the enchanting process:</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Shopping Trip:</strong> Danielle navigates you through exclusive style sanctuaries, choosing from diverse collections that will mold your unique festival ensembles.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Costume Styling:</strong> Danielle curates your transformative outfits with a mindful approach, contemplating every element, from apparel to accessories, wigs, and makeup.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Personal Transformation:</strong> The Festival Style Activations go beyond costume creation, offering a voyage of self-exploration and expression. You&#8217;ll delve into your inner archetypes and gain the liberty to personify your fantasies in a secure festival setting.</p>
+
+
+
+<p class="wp-block-paragraph">Intrigued to know more? Delve into the complete spectrum of <a href="https://daniellediamond.ca/2023/07/02/festival-style-activation/">Festival Style Activations</a> in Danielle&#8217;s original blog post.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>A Universal Embrace of Festival Fashion</strong></p>
+
+
+
+<p class="wp-block-paragraph">The allure of Festival Style Activations is its universal appeal. Whether you identify as a man, woman, or non-binary; whether you&#8217;re petite, plus-size, or somewhere in between; Danielle&#8217;s services beckon everyone to explore and rejoice in their unique energy.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maximizing Your Festival Experience</strong></p>
+
+
+
+<p class="wp-block-paragraph"><strong>Connect with the Community: </strong>Festivals are about the collective journey. Engage with your fellow festival-goers to weave a web of shared creativity and celebration.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Welcome the Unknown:</strong> Festival Style Activations inspire you to uncover new aspects of your persona. Embrace this chance with an open mind and heart.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Chronicle Your Journey:</strong> Don’t forget to document your transformative odyssey and share it on social media. </p>
+
+
+
+<p class="wp-block-paragraph">Here are a few pointers to optimize your Festival Style Activation:</p>
+
+
+
+<p class="wp-block-paragraph">Festivals are a canvas for self-expression, creativity, and community. Danielle&#8217;s Festival Style Activations provide everyone the chance to step into their power and radiate vibrantly.</p>
+
+
+
+<p class="wp-block-paragraph">Here&#8217;s to an unforgettable summer of metamorphosis and jubilation. See you on the dance floor!</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2024/05/26/jennifer-podemski-storytelling-masterclass-yorkton-film-festival/">Jennifer Podemski Storytelling Masterclass &#8211; Yorkton Film Festival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2661-identity.json
@@ -1,0 +1,23 @@
+{
+  "id": 2661,
+  "slug": "headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/",
+  "modified": "2026-06-28T20:39:47",
+  "modified_gmt": "2026-06-29T04:39:47",
+  "type": "post",
+  "featured_media": 2662,
+  "categories": [
+    1676
+  ],
+  "content_source": "public_rest_rendered",
+  "content_raw_missing": true,
+  "content_rendered_bytes": 7134,
+  "content_raw_bytes": null,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true,
+  "has_kriskrug_com_contact": false,
+  "has_kriskrug_co_contact": false,
+  "has_cyber_love_garden_href": false,
+  "note": "WP creds missing. content.raw.html is the public content.rendered stand-in for --from-files. Live --apply must GET context=edit and slug-check before any PATCH."
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-content.raw.html
@@ -1,0 +1,196 @@
+
+<h4 class="wp-block-heading">I. Introduction</h4>
+
+
+
+<p class="wp-block-paragraph">Art and technology often dance at the edge of possibility. Recently, I joined a fascinating collaborative endeavor known as &#8220;<a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out</a>&#8220;.</p>
+
+
+
+<p class="wp-block-paragraph">This project, hosted on my Friends of Krüg (FøK) <a href="https://discord.com/">Discord</a> server, was not only an artistic experiment but a rich exploration of creativity, community, and technological innovation. Here&#8217;s a glimpse into our journey.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/6eOl8gyFo4c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+
+
+<h4 class="wp-block-heading">II. The Creative Process</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Zoom Out Technique</strong>: The essence of this project lay in a deceptively simple idea: &#8220;Zoom Out.&#8221; Each participant took an image, zoomed out, and added their perspective, creating a cascading visual narrative.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Workflow</strong>: Our method involved selecting an image, upscaling it, and then using a &#8220;Custom Zoom&#8221; feature to adjust the prompt. This systematic approach allowed for individual creativity while maintaining cohesion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6835ff2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6835ff2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">III. Participant Contributions</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. My Contribution as KRÜG</strong>: Along with talented individuals like <a href="https://crisbeasley.medium.com/">Cris Beasley</a>, I had the pleasure of weaving in thematic elements like &#8220;cyber love garden&#8221; and &#8220;biopunk microcosm.&#8221; It was a playground for creativity, where each person&#8217;s touch added depth and intrigue.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Exploring Styles and Themes</strong>: From &#8220;arabesque geometric infusion&#8221; to abstract ideas, we ventured into various artistic landscapes. Each contribution was a unique voice in a chorus of creativity.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6836959&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6836959" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">IV. Role of Technology</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Midjourney Bot</strong>: An AI, <a href="https://www.midjourney.com/home/">Midjourney</a> Bot, became an unexpected companion, providing insights into image details and settings. It&#8217;s a testament to how technology can be an ally in artistic pursuits.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Discord as a Platform</strong>: Our entire adventure took place on Discord, highlighting the potential of digital spaces to foster collaboration and community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68370a9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68370a9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">V. Final Creation</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Creating the Video</strong>: Crosstopher&#8217;s skill in stitching the images into a cohesive video added a cinematic flair. The result was not just a series of pictures but a fluid visual story.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Observing the Details</strong>: The final piece had intriguing artifacts and alignment, reflecting the organic nature of our collaboration. It was polished, yet retained the raw energy of our creative process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a683783e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a683783e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VI. Conclusion</h4>
+
+
+
+<p class="wp-block-paragraph">&#8220;Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out&#8221; was more than an art experiment; it was a testament to what&#8217;s possible when creative minds converge. It was an exploration, a learning experience, and above all, a celebration of art, technology, and human connection.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6837f3a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6837f3a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VII. Credits and Acknowledgments</h4>
+
+
+
+<p class="wp-block-paragraph">A heartfelt acknowledgment to all who participated, especially <a href="https://www.instagram.com/crosstopher/">Crosstopher</a> and <a href="http://www.crisbeasley.com/">Cris Beasley</a>. Your energy, creativity, and spirit were the lifeblood of this project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68386b0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68386b0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">The final video and the entire creative journey speak volumes about the untapped potential of collaborative art. Feel free to explore the <a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">final video here</a> and share your thoughts.</p>
+
+
+
+<p class="wp-block-paragraph">As always, I&#8217;m here, exploring the edge of art and technology. If this resonates with you or if you&#8217;re curious to learn more, <a href="https://kriskrug.co/contact/">connect with me</a>. Let&#8217;s continue to create, question, and envision the future of art together.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-tools/">Generative AI Tools</a> collection. See also: <a href="https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/">How AI tools like Midjourney, DALL·E &#038; ChatGPT are reshaping the creative landscape</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-content.rendered.html
@@ -1,0 +1,196 @@
+
+<h4 class="wp-block-heading">I. Introduction</h4>
+
+
+
+<p class="wp-block-paragraph">Art and technology often dance at the edge of possibility. Recently, I joined a fascinating collaborative endeavor known as &#8220;<a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out</a>&#8220;.</p>
+
+
+
+<p class="wp-block-paragraph">This project, hosted on my Friends of Krüg (FøK) <a href="https://discord.com/">Discord</a> server, was not only an artistic experiment but a rich exploration of creativity, community, and technological innovation. Here&#8217;s a glimpse into our journey.</p>
+
+
+
+<iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/6eOl8gyFo4c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+
+
+<h4 class="wp-block-heading">II. The Creative Process</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Zoom Out Technique</strong>: The essence of this project lay in a deceptively simple idea: &#8220;Zoom Out.&#8221; Each participant took an image, zoomed out, and added their perspective, creating a cascading visual narrative.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Workflow</strong>: Our method involved selecting an image, upscaling it, and then using a &#8220;Custom Zoom&#8221; feature to adjust the prompt. This systematic approach allowed for individual creativity while maintaining cohesion.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6835ff2&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6835ff2" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2824" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-7.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">III. Participant Contributions</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. My Contribution as KRÜG</strong>: Along with talented individuals like <a href="https://crisbeasley.medium.com/">Cris Beasley</a>, I had the pleasure of weaving in thematic elements like &#8220;cyber love garden&#8221; and &#8220;biopunk microcosm.&#8221; It was a playground for creativity, where each person&#8217;s touch added depth and intrigue.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Exploring Styles and Themes</strong>: From &#8220;arabesque geometric infusion&#8221; to abstract ideas, we ventured into various artistic landscapes. Each contribution was a unique voice in a chorus of creativity.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6836959&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6836959" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2822" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-4.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">IV. Role of Technology</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. The Midjourney Bot</strong>: An AI, <a href="https://www.midjourney.com/home/">Midjourney</a> Bot, became an unexpected companion, providing insights into image details and settings. It&#8217;s a testament to how technology can be an ally in artistic pursuits.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Discord as a Platform</strong>: Our entire adventure took place on Discord, highlighting the potential of digital spaces to foster collaboration and community.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68370a9&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68370a9" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2827" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">V. Final Creation</h4>
+
+
+
+<p class="wp-block-paragraph"><strong>1. Creating the Video</strong>: Crosstopher&#8217;s skill in stitching the images into a cohesive video added a cinematic flair. The result was not just a series of pictures but a fluid visual story.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>2. Observing the Details</strong>: The final piece had intriguing artifacts and alignment, reflecting the organic nature of our collaboration. It was polished, yet retained the raw energy of our creative process.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a683783e&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a683783e" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2826" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-2.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VI. Conclusion</h4>
+
+
+
+<p class="wp-block-paragraph">&#8220;Exquisite Corpse: Collaborative AI Art Experiment on Discord w/ Midjourney Zoom Out&#8221; was more than an art experiment; it was a testament to what&#8217;s possible when creative minds converge. It was an exploration, a learning experience, and above all, a celebration of art, technology, and human connection.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6837f3a&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6837f3a" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2823" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-5.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h4 class="wp-block-heading">VII. Credits and Acknowledgments</h4>
+
+
+
+<p class="wp-block-paragraph">A heartfelt acknowledgment to all who participated, especially <a href="https://www.instagram.com/crosstopher/">Crosstopher</a> and <a href="http://www.crisbeasley.com/">Cris Beasley</a>. Your energy, creativity, and spirit were the lifeblood of this project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a68386b0&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a68386b0" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="568" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&#038;ssl=1" alt="" class="wp-image-2825" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1024%2C568&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=300%2C166&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=768%2C426&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=1536%2C852&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/08/kk-corpse-6.jpg?resize=2048%2C1136&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
+
+
+
+<p class="wp-block-paragraph">The final video and the entire creative journey speak volumes about the untapped potential of collaborative art. Feel free to explore the <a href="https://www.youtube.com/watch?v=6eOl8gyFo4c">final video here</a> and share your thoughts.</p>
+
+
+
+<p class="wp-block-paragraph">As always, I&#8217;m here, exploring the edge of art and technology. If this resonates with you or if you&#8217;re curious to learn more, <a href="https://kriskrug.co/contact/">connect with me</a>. Let&#8217;s continue to create, question, and envision the future of art together.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-tools/">Generative AI Tools</a> collection. See also: <a href="https://kriskrug.co/2023/10/08/how-ai-tools-like-midjourney-dall%c2%b7e-chatgpt-are-reshaping-the-creative-landscape/">How AI tools like Midjourney, DALL·E &#038; ChatGPT are reshaping the creative landscape</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-2819-identity.json
@@ -1,0 +1,23 @@
+{
+  "id": 2819,
+  "slug": "exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/",
+  "modified": "2026-08-17T18:16:05",
+  "modified_gmt": "2026-08-18T02:16:05",
+  "type": "post",
+  "featured_media": 2820,
+  "categories": [
+    1680
+  ],
+  "content_source": "public_rest_rendered",
+  "content_raw_missing": true,
+  "content_rendered_bytes": 18117,
+  "content_raw_bytes": null,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true,
+  "has_kriskrug_com_contact": false,
+  "has_kriskrug_co_contact": true,
+  "has_cyber_love_garden_href": false,
+  "note": "WP creds missing. content.raw.html is the public content.rendered stand-in for --from-files. Live --apply must GET context=edit and slug-check before any PATCH."
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-content.raw.html
@@ -1,0 +1,434 @@
+
+<h2 class="wp-block-heading">Building Community Through Art: A Guide to Navigating the Complexities of Community Art Projects</h2>
+
+
+
+<p class="wp-block-paragraph"><em>by Kris Krüg, Cyber Love Garden c0-organizer, Photographer, Creative Technologist, and Community Catalyst</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together.&#8221; This mantra doesn&#8217;t just apply to the digital world. It&#8217;s equally valid in the sphere of community art projects, where technology can be a medium and the communal experience can be the message.</em></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691a7a7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691a7a7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3585" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Why Community Art Matters</h2>
+
+
+
+<p class="wp-block-paragraph">If a picture&#8217;s worth a thousand words, then a community art project is worth a thousand conversations. Not just any small talk, but those layered dialogues that happen when people come together to create something greater than themselves. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691af75&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691af75" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-3581" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">It&#8217;s not just art; it&#8217;s a shared journey, an ongoing narrative of who we are and what we aspire to become as a community. &#8220;Everything is interesting. Look closer.&#8221;.  In community art, this call to look closer becomes a collective endeavor.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691b867&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691b867" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3571" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photos by Kris Krüg</figcaption></figure>
+
+
+
+<h2 class="wp-block-heading">The Genesis: Idea and Consensus</h2>
+
+
+
+<p class="wp-block-paragraph">An art project starts as a spark—an idea. This spark is useless without oxygen, the community&#8217;s collective breath. Host gatherings, be they physical meetups or virtual hangouts, where people can contribute ideas freely. Once a sea of ideas is before you, how do you navigate? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691bff8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691bff8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3572" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Democracy is your compass. Use a voting system, but remember, it&#8217;s not just a popularity contest; the idea needs to be feasible and meaningful. Aim for consensus, not just majority rule.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691c935&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691c935" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="598" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&#038;ssl=1" alt="" class="wp-image-3582" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=300%2C175&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=768%2C448&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1536%2C897&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=2048%2C1195&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Nitty-Gritty: Planning and Fundraising</h2>
+
+
+
+<p class="wp-block-paragraph">Get the idea down on paper—sketch it, write it, code it, whatever your medium. Create a comprehensive plan covering the design, materials, labor, budget, and timeline. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3583" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Unless you’re tapping into the Bank of Love and Imagination, you&#8217;ll need funds. Grants, crowdfunding, local business sponsorships—there are as many ways to raise money as there are to spend it.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<h2 class="wp-block-heading">The Real Work: Building and Installing</h2>
+
+
+
+<p class="wp-block-paragraph">Crafting the project can be both the most challenging and the most fulfilling part. Don&#8217;t go it alone. Assemble a ragtag crew of volunteers, each with their unique skills and quirks. Keep in mind, you&#8217;re not just building an art project; you&#8217;re building a community. Document the journey, for every hammer hit and paint stroke is a page in your collective story.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691daef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691daef" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3573" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Final Frontier: Maintenance and Evolution</h2>
+
+
+
+<p class="wp-block-paragraph">Art, like a garden, requires tending. Assign caretakers or make a community schedule. Consider seasonal upgrades to keep the project fresh. If your art piece is a &#8220;portal entryway,&#8221; think of how you can change it to reflect different themes or community milestones.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691e37f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691e37f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3574" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Beyond the Art: Lifelong Community Engagement</h2>
+
+
+
+<p class="wp-block-paragraph">The art project may be &#8216;complete,&#8217; but its lifecycle is far from over. Keep the community engaged through events, social media, or good old-fashioned meetups. Make your art project a living entity that grows and evolves with the community it represents.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f172&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f172" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="548" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18.jpg?resize=1024%2C548&#038;ssl=1" alt="" class="wp-image-3575" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1024%2C548&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=300%2C161&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=768%2C411&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1536%2C822&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=2048%2C1096&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together,&#8221; but let&#8217;s not forget that the oldest form of technology is storytelling. Through community art, we are all storytellers, and the narrative we create together is our shared legacy.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>Keep looking closer. Keep building. Keep dreaming.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>—Kris Krüg</em></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f9f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f9f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3576" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Here&#8217;s a draft step-by-step guide to help you get started. Iterate and upgrade these steps and tell me what you learn!! 🙂 </h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a69201d7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a69201d7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3577" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Idea Generation</strong>: Host a community meeting or online forum where everyone can pitch ideas. The best community art projects resonate with the collective.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Consensus Building</strong>: Conduct surveys or use a voting mechanism to finalize the idea that resonates most. It&#8217;s not just about majority rule; consider the impact and feasibility too.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Planning</strong>: Draft a detailed plan, including the project&#8217;s scope, materials needed, estimated budget, and timeline. Work out who does what.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Fundraising</strong>: Identify potential sources of funding—grants, local businesses, crowdfunding—and launch your fundraising campaign.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Material Sourcing</strong>: Once the funds are secured, source the necessary materials and tools. Local partnerships can be gold here.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Team Assembly</strong>: Recruit community members based on skills and interests. The tech-savvy might handle documentation, while the artistically inclined work on design.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Building the Project</strong>: Start with a soft launch—a mini-version or a part of the full project—to test assumptions and make adjustments. Then scale to the full project.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Installation</strong>: Choose a highly visible and accessible location. Make sure you have the necessary permits and community buy-in.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Documentation</strong>: Document the process and the final outcome through photos, videos, and written stories. Share this across social media and local press.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Warehousing</strong>: If the art project is not permanent, have a plan for storing materials. Community centers or local businesses might offer space.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maintenance</strong>: Assign a team or create a schedule for community members to keep the project in good shape.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Upgrades</strong>: Plan for upgrades or extensions. The art project can evolve, just like the community it represents.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Community Engagement</strong>: Keep the community involved, not just as spectators but as active participants, for the life cycle of the art project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6920c49&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6920c49" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="632" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18.jpg?resize=1024%2C632&#038;ssl=1" alt="" class="wp-image-3578" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1024%2C632&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=300%2C185&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=768%2C474&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1536%2C948&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=2048%2C1264&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Appendix: Blind Spots &amp; Considerations</h3>
+
+
+
+<p class="wp-block-paragraph">In any community art project, there are bound to be overlooked elements that can make or break the endeavor. To ensure that our art not only touches souls but also builds a stronger, more inclusive community, we need to confront these blind spots head-on.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921469&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921469" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="624" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18.jpg?resize=1024%2C624&#038;ssl=1" alt="" class="wp-image-3579" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1024%2C624&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=300%2C183&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=768%2C468&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1536%2C936&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=2048%2C1248&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<ol class="wp-block-list">
+<li><strong>Inclusivity</strong> &#8211; Ensure your project is accessible to everyone in the community. Consider ramps, translations, and sensory-friendly environments to make your project inclusive.</li>
+
+
+
+<li><strong>Environmental Impact</strong> &#8211; Art shouldn’t cost the Earth. Make sustainability a cornerstone of your project, from material selection to disposal methods.</li>
+
+
+
+<li><strong>Legal Considerations</strong> &#8211; Navigating the sea of zoning laws, permits, and copyrights is critical. Consult with experts to ensure that your project complies with all local, state, and federal regulations.</li>
+
+
+
+<li><strong>Emotional Safety</strong> &#8211; Art provokes thought, but it shouldn&#8217;t provoke harm. Ensure your project doesn’t inadvertently marginalize or offend members of the community.</li>
+
+
+
+<li><strong>Disassembly Plan</strong> &#8211; If your project has an expiration date, have a responsible and environmentally friendly disassembly and disposal plan in place.</li>
+
+
+
+<li><strong>Historical Context</strong> &#8211; Does your project acknowledge or ignore the community&#8217;s cultural and historical nuances? Sensitivity to context enriches the project&#8217;s layers of meaning.</li>
+
+
+
+<li><strong>Conflict Resolution</strong> &#8211; Prepare for disagreements by having a clear conflict resolution or mediation strategy in place.</li>
+
+
+
+<li><strong>Digital Extensions</strong> &#8211; In our interconnected world, creating a digital component to your art project can widen its reach and deepen its impact.</li>
+
+
+
+<li><strong>Feedback Mechanism</strong> &#8211; How will the community&#8217;s voice be integrated throughout the life cycle of the project? Consider surveys, public meetings, and social media as feedback channels.</li>
+
+
+
+<li><strong>Spiritual Connection</strong> &#8211; Art often reaches places words cannot. Consider if there&#8217;s a spiritual dimension to your project that can touch people at an even deeper level.</li>
+</ol>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921d41&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921d41" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244.jpg?resize=1024%2C498&#038;ssl=1" alt="" class="wp-image-3580" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1536%2C747&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=2048%2C996&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-for-creatives/">AI for Creatives</a> collection. See also: <a href="https://kriskrug.co/2024/10/28/kicking-ass-in-2025-a-techartists-guide-to-creative-survival/">Kicking Ass in 2025: A Techartist&#8217;s Guide to Creative Survival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-content.rendered.html
@@ -1,0 +1,434 @@
+
+<h2 class="wp-block-heading">Building Community Through Art: A Guide to Navigating the Complexities of Community Art Projects</h2>
+
+
+
+<p class="wp-block-paragraph"><em>by Kris Krüg, Cyber Love Garden c0-organizer, Photographer, Creative Technologist, and Community Catalyst</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together.&#8221; This mantra doesn&#8217;t just apply to the digital world. It&#8217;s equally valid in the sphere of community art projects, where technology can be a medium and the communal experience can be the message.</em></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691a7a7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691a7a7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3585" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-25.png?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Why Community Art Matters</h2>
+
+
+
+<p class="wp-block-paragraph">If a picture&#8217;s worth a thousand words, then a community art project is worth a thousand conversations. Not just any small talk, but those layered dialogues that happen when people come together to create something greater than themselves. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691af75&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691af75" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="575" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591.jpg?resize=1024%2C575&#038;ssl=1" alt="" class="wp-image-3581" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1024%2C575&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=300%2C168&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=768%2C431&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=1536%2C863&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=2048%2C1150&amp;ssl=1 2048w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=350%2C197&amp;ssl=1 350w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=528%2C297&amp;ssl=1 528w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-productions0U6A7591-scaled.jpg?resize=860%2C484&amp;ssl=1 860w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">It&#8217;s not just art; it&#8217;s a shared journey, an ongoing narrative of who we are and what we aspire to become as a community. &#8220;Everything is interesting. Look closer.&#8221;.  In community art, this call to look closer becomes a collective endeavor.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691b867&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691b867" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3571" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/soundcave-70-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button><figcaption class="wp-element-caption">photos by Kris Krüg</figcaption></figure>
+
+
+
+<h2 class="wp-block-heading">The Genesis: Idea and Consensus</h2>
+
+
+
+<p class="wp-block-paragraph">An art project starts as a spark—an idea. This spark is useless without oxygen, the community&#8217;s collective breath. Host gatherings, be they physical meetups or virtual hangouts, where people can contribute ideas freely. Once a sea of ideas is before you, how do you navigate? </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691bff8&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691bff8" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3572" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/39641325005_11e2563a25_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Democracy is your compass. Use a voting system, but remember, it&#8217;s not just a popularity contest; the idea needs to be feasible and meaningful. Aim for consensus, not just majority rule.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691c935&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691c935" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="598" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&#038;ssl=1" alt="" class="wp-image-3582" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1024%2C598&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=300%2C175&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=768%2C448&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=1536%2C897&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/image-24.png?resize=2048%2C1195&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Nitty-Gritty: Planning and Fundraising</h2>
+
+
+
+<p class="wp-block-paragraph">Get the idea down on paper—sketch it, write it, code it, whatever your medium. Create a comprehensive plan covering the design, materials, labor, budget, and timeline. </p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691d1fd&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691d1fd" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3583" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/32386654064_dd14afc071_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph">Unless you’re tapping into the Bank of Love and Imagination, you&#8217;ll need funds. Grants, crowdfunding, local business sponsorships—there are as many ways to raise money as there are to spend it.</p>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<h2 class="wp-block-heading">The Real Work: Building and Installing</h2>
+
+
+
+<p class="wp-block-paragraph">Crafting the project can be both the most challenging and the most fulfilling part. Don&#8217;t go it alone. Assemble a ragtag crew of volunteers, each with their unique skills and quirks. Keep in mind, you&#8217;re not just building an art project; you&#8217;re building a community. Document the journey, for every hammer hit and paint stroke is a page in your collective story.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691daef&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691daef" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3573" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/asscamp-village-49-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">The Final Frontier: Maintenance and Evolution</h2>
+
+
+
+<p class="wp-block-paragraph">Art, like a garden, requires tending. Assign caretakers or make a community schedule. Consider seasonal upgrades to keep the project fresh. If your art piece is a &#8220;portal entryway,&#8221; think of how you can change it to reflect different themes or community milestones.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691e37f&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691e37f" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3574" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/33074320802_c5a6e37472_k.jpg?w=2048&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Beyond the Art: Lifelong Community Engagement</h2>
+
+
+
+<p class="wp-block-paragraph">The art project may be &#8216;complete,&#8217; but its lifecycle is far from over. Keep the community engaged through events, social media, or good old-fashioned meetups. Make your art project a living entity that grows and evolves with the community it represents.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f172&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f172" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="548" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18.jpg?resize=1024%2C548&#038;ssl=1" alt="" class="wp-image-3575" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1024%2C548&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=300%2C161&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=768%2C411&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=1536%2C822&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A4818_SUN_OMF18-scaled.jpg?resize=2048%2C1096&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><em>&#8220;Technology is best when it brings people together,&#8221; but let&#8217;s not forget that the oldest form of technology is storytelling. Through community art, we are all storytellers, and the narrative we create together is our shared legacy.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>Keep looking closer. Keep building. Keep dreaming.</em></p>
+
+
+
+<p class="wp-block-paragraph"><em>—Kris Krüg</em></p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a691f9f1&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a691f9f1" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3576" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5852_SAT_OMF18-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h2 class="wp-block-heading">Here&#8217;s a draft step-by-step guide to help you get started. Iterate and upgrade these steps and tell me what you learn!! 🙂 </h2>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a69201d7&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a69201d7" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="683" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o.jpg?resize=1024%2C683&#038;ssl=1" alt="" class="wp-image-3577" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1024%2C683&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=768%2C512&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=1536%2C1024&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/Okeechobee-Music-Festival-2016-Florida-Kulture-Haus_25503117195_o-scaled.jpg?resize=2048%2C1365&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="wp-block-paragraph"><strong>Idea Generation</strong>: Host a community meeting or online forum where everyone can pitch ideas. The best community art projects resonate with the collective.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Consensus Building</strong>: Conduct surveys or use a voting mechanism to finalize the idea that resonates most. It&#8217;s not just about majority rule; consider the impact and feasibility too.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Planning</strong>: Draft a detailed plan, including the project&#8217;s scope, materials needed, estimated budget, and timeline. Work out who does what.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Fundraising</strong>: Identify potential sources of funding—grants, local businesses, crowdfunding—and launch your fundraising campaign.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Material Sourcing</strong>: Once the funds are secured, source the necessary materials and tools. Local partnerships can be gold here.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Team Assembly</strong>: Recruit community members based on skills and interests. The tech-savvy might handle documentation, while the artistically inclined work on design.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Building the Project</strong>: Start with a soft launch—a mini-version or a part of the full project—to test assumptions and make adjustments. Then scale to the full project.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Installation</strong>: Choose a highly visible and accessible location. Make sure you have the necessary permits and community buy-in.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Documentation</strong>: Document the process and the final outcome through photos, videos, and written stories. Share this across social media and local press.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Warehousing</strong>: If the art project is not permanent, have a plan for storing materials. Community centers or local businesses might offer space.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Maintenance</strong>: Assign a team or create a schedule for community members to keep the project in good shape.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Upgrades</strong>: Plan for upgrades or extensions. The art project can evolve, just like the community it represents.</p>
+
+
+
+<p class="wp-block-paragraph"><strong>Community Engagement</strong>: Keep the community involved, not just as spectators but as active participants, for the life cycle of the art project.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6920c49&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6920c49" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="632" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18.jpg?resize=1024%2C632&#038;ssl=1" alt="" class="wp-image-3578" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1024%2C632&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=300%2C185&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=768%2C474&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=1536%2C948&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A5762_SAT_OMF18-scaled.jpg?resize=2048%2C1264&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<h3 class="wp-block-heading">Appendix: Blind Spots &amp; Considerations</h3>
+
+
+
+<p class="wp-block-paragraph">In any community art project, there are bound to be overlooked elements that can make or break the endeavor. To ensure that our art not only touches souls but also builds a stronger, more inclusive community, we need to confront these blind spots head-on.</p>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921469&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921469" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="624" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18.jpg?resize=1024%2C624&#038;ssl=1" alt="" class="wp-image-3579" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1024%2C624&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=300%2C183&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=768%2C468&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=1536%2C936&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/KK__0U6A3875_THUR_OMF18-scaled.jpg?resize=2048%2C1248&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<ol class="wp-block-list">
+<li><strong>Inclusivity</strong> &#8211; Ensure your project is accessible to everyone in the community. Consider ramps, translations, and sensory-friendly environments to make your project inclusive.</li>
+
+
+
+<li><strong>Environmental Impact</strong> &#8211; Art shouldn’t cost the Earth. Make sustainability a cornerstone of your project, from material selection to disposal methods.</li>
+
+
+
+<li><strong>Legal Considerations</strong> &#8211; Navigating the sea of zoning laws, permits, and copyrights is critical. Consult with experts to ensure that your project complies with all local, state, and federal regulations.</li>
+
+
+
+<li><strong>Emotional Safety</strong> &#8211; Art provokes thought, but it shouldn&#8217;t provoke harm. Ensure your project doesn’t inadvertently marginalize or offend members of the community.</li>
+
+
+
+<li><strong>Disassembly Plan</strong> &#8211; If your project has an expiration date, have a responsible and environmentally friendly disassembly and disposal plan in place.</li>
+
+
+
+<li><strong>Historical Context</strong> &#8211; Does your project acknowledge or ignore the community&#8217;s cultural and historical nuances? Sensitivity to context enriches the project&#8217;s layers of meaning.</li>
+
+
+
+<li><strong>Conflict Resolution</strong> &#8211; Prepare for disagreements by having a clear conflict resolution or mediation strategy in place.</li>
+
+
+
+<li><strong>Digital Extensions</strong> &#8211; In our interconnected world, creating a digital component to your art project can widen its reach and deepen its impact.</li>
+
+
+
+<li><strong>Feedback Mechanism</strong> &#8211; How will the community&#8217;s voice be integrated throughout the life cycle of the project? Consider surveys, public meetings, and social media as feedback channels.</li>
+
+
+
+<li><strong>Spiritual Connection</strong> &#8211; Art often reaches places words cannot. Consider if there&#8217;s a spiritual dimension to your project that can touch people at an even deeper level.</li>
+</ol>
+
+
+
+<figure data-wp-context="{&quot;imageId&quot;:&quot;6a863a6921d41&quot;}" data-wp-interactive="core/image" data-wp-key="6a863a6921d41" class="wp-block-image size-large wp-lightbox-container"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" data-wp-class--hide="state.isContentHidden" data-wp-class--show="state.isContentVisible" data-wp-init="callbacks.setButtonStyles" data-wp-on--click="actions.showLightbox" data-wp-on--load="callbacks.setButtonStyles" data-wp-on--pointerdown="actions.preloadImage" data-wp-on--pointerenter="actions.preloadImageWithDelay" data-wp-on--pointerleave="actions.cancelPreload" data-wp-on-window--resize="callbacks.setButtonStyles" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244.jpg?resize=1024%2C498&#038;ssl=1" alt="" class="wp-image-3580" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=1536%2C747&amp;ssl=1 1536w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/10/20190826_200244-scaled.jpg?resize=2048%2C996&amp;ssl=1 2048w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><button
+			class="lightbox-trigger"
+			type="button"
+			aria-haspopup="dialog"
+			data-wp-bind--aria-label="state.thisImage.triggerButtonAriaLabel"
+			data-wp-init="callbacks.initTriggerButton"
+			data-wp-on--click="actions.showLightbox"
+			data-wp-style--right="state.thisImage.buttonRight"
+			data-wp-style--top="state.thisImage.buttonTop"
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="none" viewBox="0 0 12 12">
+				<path fill="#fff" d="M2 0a2 2 0 0 0-2 2v2h1.5V2a.5.5 0 0 1 .5-.5h2V0H2Zm2 10.5H2a.5.5 0 0 1-.5-.5V8H0v2a2 2 0 0 0 2 2h2v-1.5ZM8 12v-1.5h2a.5.5 0 0 0 .5-.5V8H12v2a2 2 0 0 1-2 2H8Zm2-12a2 2 0 0 1 2 2v2h-1.5V2a.5.5 0 0 0-.5-.5H8V0h2Z" />
+			</svg>
+		</button></figure>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-for-creatives/">AI for Creatives</a> collection. See also: <a href="https://kriskrug.co/2024/10/28/kicking-ass-in-2025-a-techartists-guide-to-creative-survival/">Kicking Ass in 2025: A Techartist&#8217;s Guide to Creative Survival</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/before/post-3567-identity.json
@@ -1,0 +1,23 @@
+{
+  "id": 3567,
+  "slug": "community-art-project-development-process-guide",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/",
+  "modified": "2026-07-24T14:39:46",
+  "modified_gmt": "2026-07-24T22:39:46",
+  "type": "post",
+  "featured_media": 3584,
+  "categories": [
+    1665
+  ],
+  "content_source": "public_rest_rendered",
+  "content_raw_missing": true,
+  "content_rendered_bytes": 41410,
+  "content_raw_bytes": null,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true,
+  "has_kriskrug_com_contact": false,
+  "has_kriskrug_co_contact": false,
+  "has_cyber_love_garden_href": false,
+  "note": "WP creds missing. content.raw.html is the public content.rendered stand-in for --from-files. Live --apply must GET context=edit and slug-check before any PATCH."
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-830/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-830/targets.json
@@ -1,0 +1,113 @@
+{
+  "issue": 830,
+  "parent": 402,
+  "blocked_by": 826,
+  "live_reconfirm": "2026-08-19T23:21:16Z",
+  "status": "prepared_not_applied",
+  "snapshot_note": "WP creds were unset. before/ bodies for 2819/2661/3567 are public content.rendered stand-ins. Page 12316 raw is the 2026-07-01 topic-hub source pack, which still matches live rendered except WP img attrs.",
+  "garden_url": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/",
+  "garden_blurb": "Art, AI, and XR in a burn camp built for it.",
+  "forbidden_href_substrings": [
+    "kriskrug.com/contact"
+  ],
+  "keep_cards": [
+    {
+      "href": "https://kriskrug.co/2026/01/24/both-hands-full/",
+      "title": "Both Hands Full"
+    },
+    {
+      "href": "https://kriskrug.co/2026/05/15/your-taste-is-your-moat/",
+      "title": "Your taste is your moat"
+    }
+  ],
+  "keep_archive_href": "https://kriskrug.co/category/ai-creatives/",
+  "child1_gate": {
+    "id": 2819,
+    "slug": "exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out",
+    "forbidden_href_substring": "kriskrug.com/contact",
+    "required_href_substring": "https://kriskrug.co/contact/"
+  },
+  "destination": {
+    "id": 2650,
+    "kind": "posts",
+    "slug": "the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld",
+    "url": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/",
+    "featured_media": 2654,
+    "write_target": false
+  },
+  "items": [
+    {
+      "id": 12316,
+      "kind": "pages",
+      "slug": "ai-for-creatives",
+      "url": "https://kriskrug.co/ai-for-creatives/",
+      "modified_gmt_at_reconfirm": "2026-07-01T20:27:40",
+      "find": "          <h3>Your taste is your moat</h3>\n          <p>Why creative judgment becomes more valuable as production gets easier.</p>\n        </div>\n      </a>\n    </article>\n    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/category/ai-creatives/\">\n",
+      "replace": "          <h3>Your taste is your moat</h3>\n          <p>Why creative judgment becomes more valuable as production gets easier.</p>\n        </div>\n      </a>\n    </article>\n    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/05/WalksWithASwagger_year_2055_film_still_farshot_20_happy_solarpu_c1c61961-c4e4-418e-b9fc-37b576b73d21-1.png?resize=640,400&amp;ssl=1\" alt=\"The Cyber Love Garden at Otherworld\" loading=\"lazy\">\n        <div>\n          <h3>The Cyber Love Garden</h3>\n          <p>Art, AI, and XR in a burn camp built for it.</p>\n        </div>\n      </a>\n    </article>\n    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/category/ai-creatives/\">\n",
+      "anchors": [
+        {
+          "row": 26,
+          "text": "The Cyber Love Garden",
+          "href": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/",
+          "match": "card"
+        }
+      ],
+      "preserve_cards": true
+    },
+    {
+      "id": 2819,
+      "kind": "posts",
+      "slug": "exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out",
+      "url": "https://kriskrug.co/2023/08/16/exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out/",
+      "modified_gmt_at_reconfirm": "2026-08-18T02:16:05",
+      "find": "was not only an artistic experiment but a rich exploration of creativity, community, and technological innovation. Here&#8217;s a glimpse into our journey.</p>",
+      "replace": "was not only an artistic experiment but a rich exploration of creativity, community, and technological innovation. Here&#8217;s a glimpse into our journey. This Discord round was the remote cousin of <a href=\"https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/\">the garden where we ran this in person</a>.</p>",
+      "anchors": [
+        {
+          "row": 27,
+          "text": "the garden where we ran this in person",
+          "href": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/"
+        }
+      ],
+      "preserve_footer": true,
+      "preserve_contact": true
+    },
+    {
+      "id": 2661,
+      "kind": "posts",
+      "slug": "headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona",
+      "url": "https://kriskrug.co/2023/07/06/headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:39:47",
+      "find": "See you on the dance floor!</p>",
+      "replace": "See you on the dance floor! Start with <a href=\"https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/\">what we built at Otherworld</a>.</p>",
+      "anchors": [
+        {
+          "row": 28,
+          "text": "what we built at Otherworld",
+          "href": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/"
+        }
+      ],
+      "preserve_footer": true
+    },
+    {
+      "id": 3567,
+      "kind": "posts",
+      "slug": "community-art-project-development-process-guide",
+      "url": "https://kriskrug.co/2023/10/15/community-art-project-development-process-guide/",
+      "modified_gmt_at_reconfirm": "2026-07-24T22:39:46",
+      "find": "the communal experience can be the message.</em></p>",
+      "find_variants": [
+        "the communal experience can be the message.</p>"
+      ],
+      "replace": "the communal experience can be the message.</em> The Cyber Love Garden is <a href=\"https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/\">a worked example of all of this</a>.</p>",
+      "anchors": [
+        {
+          "row": 29,
+          "text": "a worked example of all of this",
+          "href": "https://kriskrug.co/2023/05/30/the-cyber-love-garden-a-crossroads-of-art-and-ai-at-otherworld/"
+        }
+      ],
+      "preserve_footer": true
+    }
+  ]
+}

--- a/scripts/apply_issue_830_cyber_love_garden.py
+++ b/scripts/apply_issue_830_cyber_love_garden.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Issue #830: add Cyber Love Garden to /ai-for-creatives/ and three spokes.
+
+Dry-run by default. Writes are gated on ID->slug match, exact text-match
+insertion, child-1 (#826) 2819 contact-href proof, and a fresh context=edit
+snapshot.
+
+    python3 scripts/apply_issue_830_cyber_love_garden.py --from-files
+    make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py'
+    make varlock-run CMD='python3 scripts/apply_issue_830_cyber_love_garden.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-830"
+TARGETS_PATH = PACK / "targets.json"
+BEFORE_DIR = PACK / "before"
+AFTER_DIR = PACK / "after"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-830-cyber-love-garden"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+APOS_FORMS = ("&#8217;", "\u2019", "'")
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-830"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def apos_variants(text: str) -> list[str]:
+    variants = {text}
+    for src in APOS_FORMS:
+        if src in text:
+            for dst in APOS_FORMS:
+                variants.add(text.replace(src, dst))
+    return list(variants)
+
+
+def find_candidates(spec: dict) -> list[str]:
+    needles = [spec["find"], *spec.get("find_variants", [])]
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for needle in needles:
+        for variant in apos_variants(needle):
+            if variant not in seen:
+                seen.add(variant)
+                expanded.append(variant)
+    return expanded
+
+
+def pick_find(body: str, spec: dict) -> str:
+    ones = [needle for needle in find_candidates(spec) if body.count(needle) == 1]
+    if spec["find"] in ones:
+        return spec["find"]
+    if len(ones) == 1:
+        return ones[0]
+    if len(ones) > 1:
+        ones.sort(key=len, reverse=True)
+        return ones[0]
+    counts = {needle: body.count(needle) for needle in find_candidates(spec)}
+    observed = max(counts.values()) if counts else 0
+    raise ValueError(
+        f"{spec['id']}: find needle occurs {observed} times; expected 1. "
+        "Insert by text match, not a stale block index."
+    )
+
+
+def already_applied(body: str, spec: dict) -> bool:
+    return all(anchor_present(body, row) for row in spec["anchors"])
+
+
+def anchor_present(body: str, row: dict) -> bool:
+    if row.get("match") == "card":
+        return row["href"] in body and f"<h3>{row['text']}</h3>" in body
+    return f'<a href="{row["href"]}">{row["text"]}</a>' in body
+
+
+def inserted_fragment(spec: dict) -> str:
+    find = spec["find"]
+    replace = spec["replace"]
+    prefix = os.path.commonprefix([find, replace])
+    find_rest = find[len(prefix) :]
+    replace_rest = replace[len(prefix) :]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def build_replace(find: str, spec: dict) -> str:
+    if find == spec["find"]:
+        return spec["replace"]
+    added = inserted_fragment(spec)
+    if find.endswith("</p>") and spec["find"].endswith("</p>"):
+        return find[: -len("</p>")] + added + "</p>"
+    raise ValueError(f"{spec['id']}: cannot map replace onto find variant")
+
+
+def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
+    if already_applied(body, spec):
+        return None
+    find = pick_find(body, spec)
+    replace = build_replace(find, spec)
+    added = inserted_fragment(spec)
+    if "\u2014" in added or "\u2013" in added:
+        raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
+    if any(ord(char) > 127 for char in added):
+        raise ValueError(f"{spec['id']}: inserted copy is not ASCII; use NCR")
+    rewritten = body.replace(find, replace, 1)
+    if spec.get("preserve_cards"):
+        for card in targets["keep_cards"]:
+            if body.count(card["href"]) != rewritten.count(card["href"]):
+                raise ValueError(f"{spec['id']}: existing card href {card['href']} changed")
+            title = f"<h3>{card['title']}</h3>"
+            if body.count(title) != rewritten.count(title):
+                raise ValueError(f"{spec['id']}: existing card title {card['title']!r} changed")
+        archive = targets["keep_archive_href"]
+        if body.count(archive) != rewritten.count(archive):
+            raise ValueError(f"{spec['id']}: archive card href changed")
+    if spec.get("preserve_footer"):
+        if body.count(FOOTER_SENTINEL) != rewritten.count(FOOTER_SENTINEL):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+    if spec.get("preserve_contact"):
+        for needle in (
+            targets["child1_gate"]["forbidden_href_substring"],
+            targets["child1_gate"]["required_href_substring"],
+        ):
+            if body.count(needle) != rewritten.count(needle):
+                raise ValueError(f"{spec['id']}: contact href {needle} count changed")
+    for forbidden in targets["forbidden_href_substrings"]:
+        if forbidden in rewritten and forbidden not in body:
+            raise ValueError(f"{spec['id']}: forbidden href {forbidden} was added")
+    for row in spec["anchors"]:
+        if row.get("match") == "card":
+            if rewritten.count(row["href"]) != 1:
+                raise ValueError(f"{spec['id']}: expected one garden card href")
+            if rewritten.count(f"<h3>{row['text']}</h3>") != 1:
+                raise ValueError(f"{spec['id']}: expected one {row['text']!r} card title")
+            if targets["garden_blurb"] not in rewritten:
+                raise ValueError(f"{spec['id']}: garden card blurb missing")
+        else:
+            needle = f'<a href="{row["href"]}">{row["text"]}</a>'
+            if rewritten.count(needle) != 1:
+                raise ValueError(f"{spec['id']}: expected one {needle!r}")
+    return rewritten
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    if live.get("id") != spec["id"]:
+        sys.exit(f"[ABORT] {spec['id']}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: slug is {live.get('slug')!r}, "
+            f"expected {spec['slug']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def extract_body(live: dict) -> str:
+    content = live.get("content")
+    if isinstance(content, dict):
+        if isinstance(content.get("raw"), str):
+            return content["raw"]
+        if isinstance(content.get("rendered"), str):
+            return content["rendered"]
+    sys.exit(f"[ABORT] {live.get('id')}: no content.raw or content.rendered.")
+
+
+def child1_is_live(header: str, targets: dict) -> tuple[bool, list[str]]:
+    gate = targets["child1_gate"]
+    live = request(
+        f"{BASE_URL}/wp-json/wp/v2/posts/{gate['id']}?context=edit",
+        header,
+    )
+    notes: list[str] = []
+    if live.get("slug") != gate["slug"]:
+        notes.append(f"{gate['id']} slug {live.get('slug')!r}")
+        return False, notes
+    body = extract_body(live)
+    if gate["forbidden_href_substring"] in body:
+        notes.append(f"{gate['id']} still has {gate['forbidden_href_substring']}")
+        return False, notes
+    if gate["required_href_substring"] not in body:
+        notes.append(f"{gate['id']} missing {gate['required_href_substring']}")
+        return False, notes
+    notes.append(f"{gate['id']} contact repair live")
+    return True, notes
+
+
+def plan_item(spec: dict, body: str, targets: dict) -> dict | None:
+    rewritten = rewrite_body(body, spec, targets)
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: exact href+anchor already present.")
+        return None
+    return {"spec": spec, "before": body, "after": rewritten}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for row in spec["anchors"]:
+        print(f"        row {row['row']}: {row['text']!r} -> {row['href']}")
+
+
+def write_after_files(planned: list[dict]) -> None:
+    AFTER_DIR.mkdir(parents=True, exist_ok=True)
+    for item in planned:
+        spec = item["spec"]
+        path = AFTER_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+        path.write_text(item["after"], encoding="utf-8")
+        print(f"[AFTER] {path}")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    print_plan(item)
+    if not do_apply:
+        return
+    spec = item["spec"]
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_item(spec, raw_body(live), load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    allowed = {row["id"] for row in load_targets()["items"]}
+    post_id = snapshot.get("id")
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #830 set.")
+    spec = next(row for row in load_targets()["items"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(live, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def load_before_body(spec: dict) -> str:
+    path = BEFORE_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+    if not path.is_file():
+        sys.exit(f"[ABORT] missing before-file {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #830 Cyber Love Garden hub links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-files", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    parser.add_argument(
+        "--allow-before-826",
+        action="store_true",
+        help="Unsafe. Bypass the child-1 2819 contact-href gate. Do not use on production.",
+    )
+    args = parser.parse_args()
+    targets = load_targets()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, auth_header(), args.apply)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id:
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+
+    if args.from_files:
+        planned = []
+        for spec in rows:
+            try:
+                item = plan_item(spec, load_before_body(spec), targets)
+            except ValueError as exc:
+                sys.exit(f"[ABORT] {exc}")
+            if item is not None:
+                planned.append(item)
+                print_plan(item)
+        if not planned:
+            print("[OK] nothing pending.")
+            return 0
+        write_after_files(planned)
+        print("[FROM-FILES] wrote after/ payloads. No WordPress writes.")
+        return 0
+
+    header = auth_header()
+    if args.apply and not args.allow_before_826:
+        ready, notes = child1_is_live(header, targets)
+        for note in notes:
+            print(f"[826] {note}")
+        if not ready:
+            sys.exit(
+                "[ABORT] #826 2819 contact-href repair is not live. "
+                "Do not PATCH 12316/2819/2661/3567 yet."
+            )
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_item(spec, raw_body(live), targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            item["live"] = live
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Pass --apply after #826 2819 "
+            "contact repair is live and KK approves."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_830_cyber_love_garden.py
+++ b/scripts/tests/test_apply_issue_830_cyber_love_garden.py
@@ -1,0 +1,319 @@
+"""Offline safety tests for the issue #830 Cyber Love Garden hub helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_830_cyber_love_garden.py"
+SPEC = importlib.util.spec_from_file_location(
+    "apply_issue_830_cyber_love_garden", SCRIPT
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+GARDEN = TARGETS["garden_url"]
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def before_body(item_id: int) -> str:
+    spec = spec_by_id(item_id)
+    return (
+        MODULE.BEFORE_DIR / f"{spec['kind'][:-1]}-{item_id}-content.raw.html"
+    ).read_text(encoding="utf-8")
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    return {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else before_body(spec["id"])},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_830_cyber_love_garden.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue830CyberLoveGardenTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+
+    def _patch_request(self, calls, *, gate_ready=False):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/posts/2819" in url:
+                live = json.loads(json.dumps(self.lives[2819]))
+                if not gate_ready:
+                    live["content"] = {
+                        "raw": (
+                            '<p>If this resonates, '
+                            '<a href="http://www.kriskrug.com/contact">'
+                            "connect with me</a>.</p>"
+                        )
+                    }
+                elif body is not None and "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                    self.lives[2819] = live
+                return live
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_rows_26_through_29(self):
+        ids = [row["id"] for row in TARGETS["items"]]
+        self.assertEqual(ids, [12316, 2819, 2661, 3567])
+        self.assertEqual(spec_by_id(12316)["slug"], "ai-for-creatives")
+        self.assertEqual(
+            spec_by_id(2819)["slug"],
+            "exquisite-corpse-collaborative-ai-art-experiment-on-discord-w-midjourney-zoom-out",
+        )
+        self.assertEqual(
+            spec_by_id(2661)["slug"],
+            "headed-to-burning-man-shambhala-or-coachella-ignite-your-festival-persona",
+        )
+        self.assertEqual(
+            spec_by_id(3567)["slug"], "community-art-project-development-process-guide"
+        )
+        self.assertEqual(TARGETS["destination"]["id"], 2650)
+        self.assertFalse(TARGETS["destination"]["write_target"])
+        self.assertNotIn(2650, ids)
+        anchors = [
+            (row["row"], row["text"], row["href"])
+            for spec in TARGETS["items"]
+            for row in spec["anchors"]
+        ]
+        self.assertEqual(
+            anchors,
+            [
+                (26, "The Cyber Love Garden", GARDEN),
+                (27, "the garden where we ran this in person", GARDEN),
+                (28, "what we built at Otherworld", GARDEN),
+                (29, "a worked example of all of this", GARDEN),
+            ],
+        )
+
+    def test_rewrite_12316_adds_garden_card_and_keeps_existing_cards(self):
+        spec = spec_by_id(12316)
+        before = before_body(12316)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn("<h3>The Cyber Love Garden</h3>", after)
+        self.assertIn(TARGETS["garden_blurb"], after)
+        self.assertIn(GARDEN, after)
+        self.assertEqual(
+            before.count("https://kriskrug.co/2026/01/24/both-hands-full/"),
+            after.count("https://kriskrug.co/2026/01/24/both-hands-full/"),
+        )
+        self.assertEqual(
+            before.count("https://kriskrug.co/2026/05/15/your-taste-is-your-moat/"),
+            after.count("https://kriskrug.co/2026/05/15/your-taste-is-your-moat/"),
+        )
+        self.assertEqual(before.count("<h3>Both Hands Full</h3>"), 1)
+        self.assertEqual(after.count("<h3>Both Hands Full</h3>"), 1)
+        self.assertEqual(before.count("<h3>Your taste is your moat</h3>"), 1)
+        self.assertEqual(after.count("<h3>Your taste is your moat</h3>"), 1)
+        self.assertLess(after.find("Your taste is your moat"), after.find("The Cyber Love Garden"))
+        self.assertLess(
+            after.find("The Cyber Love Garden"), after.find("AI creatives archive")
+        )
+        self.assertNotIn("\u2014", MODULE.inserted_fragment(spec))
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_2819_inserts_garden_sentence_and_leaves_contact_alone(self):
+        spec = spec_by_id(2819)
+        before = before_body(2819)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn("the garden where we ran this in person", after)
+        self.assertIn(GARDEN, after)
+        self.assertEqual(
+            before.count("https://kriskrug.co/contact/"),
+            after.count("https://kriskrug.co/contact/"),
+        )
+        self.assertEqual(before.count("kriskrug.com/contact"), 0)
+        self.assertEqual(after.count("kriskrug.com/contact"), 0)
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        garden = after.find("the garden where we ran this in person")
+        contact = after.find("https://kriskrug.co/contact/")
+        footer = after.find("kk-collection-footer")
+        self.assertGreater(contact, garden)
+        self.assertGreater(footer, garden)
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_2661_inserts_before_footer(self):
+        spec = spec_by_id(2661)
+        before = before_body(2661)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertLess(
+            after.find("what we built at Otherworld"), after.find("kk-collection-footer")
+        )
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        self.assertIn(GARDEN, after)
+
+    def test_rewrite_3567_follows_the_intro(self):
+        spec = spec_by_id(3567)
+        before = before_body(3567)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        intro = after.find("the communal experience can be the message.")
+        example = after.find("a worked example of all of this")
+        footer = after.find("kk-collection-footer")
+        self.assertGreater(example, intro)
+        self.assertGreater(footer, example)
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+
+    def test_rewrite_3567_accepts_raw_without_em(self):
+        spec = spec_by_id(3567)
+        raw = (
+            "<p>where technology can be a medium and the communal experience "
+            "can be the message.</p>\n"
+            '<p class="kk-collection-footer">footer</p>'
+        )
+        after = MODULE.rewrite_body(raw, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn("a worked example of all of this", after)
+        self.assertIn(GARDEN, after)
+
+    def test_stale_block_index_is_ignored_text_match_wins(self):
+        spec = spec_by_id(2819)
+        before = before_body(2819)
+        self.assertIn("glimpse into our journey", before)
+        self.assertIn(spec["find"], before)
+        self.assertEqual(before.count(spec["find"]), 1)
+
+    def test_missing_needle_aborts(self):
+        spec = spec_by_id(2661)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>no dance floor</p>", spec, TARGETS)
+
+    def test_from_files_writes_after_payloads_and_does_not_call_wordpress(self):
+        calls = []
+        after_dir = self.tmp_path / "after"
+        with (
+            mock.patch.object(MODULE, "AFTER_DIR", after_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--from-files"))
+        self.assertEqual(calls, [])
+        self.assertTrue((after_dir / "page-12316-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-2819-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-2661-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-3567-content.raw.html").is_file())
+        self.assertFalse((after_dir / "post-2650-content.raw.html").exists())
+
+    def test_live_dry_run_performs_no_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls, gate_ready=True)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12316]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--allow-before-826", "--item-id", "12316")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_refuses_when_826_contact_repair_is_not_live(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "2661")
+        self.assertIn("#826", str(caught.exception))
+        self.assertIn("2819", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE,
+                "request",
+                side_effect=self._patch_request(calls, gate_ready=True),
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "2819"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn("the garden where we ran this in person", writes[0]["content"])
+        self.assertIn("https://kriskrug.co/contact/", writes[0]["content"])
+        self.assertNotIn("kriskrug.com/contact", writes[0]["content"])
+        self.assertIn("kk-collection-footer", writes[0]["content"])
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("#826", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #830", apply_md)
+        self.assertNotIn("Fixes #402", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply-ready pack for [#830](https://github.com/WalksWithASwagger/kriskrug-wp/issues/830): add a Cyber Love Garden card on `/ai-for-creatives/` and three inbound spokes to post 2650. **Prepared, not applied.**

**Do not apply until KK says go.** `--apply` GETs post 2819 and aborts if the dead `kriskrug.com/contact` href is back.

## Related Issue

Refs #830

Leaves #830 and #402 open (payload prepared, not applied).

## Changes

- `content/drafts/2026-08-02-seo-authority-hubs/fix-830/` — APPLY.md, targets.json, before/after snapshots
- `scripts/apply_issue_830_cyber_love_garden.py` — dry-run default, `--from-files`, slug/ID checks, `--restore`
- `scripts/tests/test_apply_issue_830_cyber_love_garden.py` — 14 offline tests

## Type of Change

- [x] Content update (payload only)
- [x] Documentation update

## Testing

- [x] `python3 -m unittest scripts.tests.test_apply_issue_830_cyber_love_garden` (14 tests, OK)
- Live public GET 2026-08-19: 12316 has Both Hands Full + Taste cards and no garden card; 2819 / 2661 / 3567 have no 2650 link; 2819 already uses `kriskrug.co/contact/`

## Deployment Notes

- [x] No special deployment steps required
- Do **not** run `--apply` from this PR without KK approval
- Do **not** retouch post 2650 or repair the 2819 contact href here

## Additional Notes

`WP_USER` / `WP_APP_PASSWORD` were unset, so 2819 / 2661 / 3567 before-files are public `content.rendered` stand-ins. Live `--apply` still GETs real `content.raw` and still requires slug/ID checks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c4f-22a9-7df9-9466-dea6653bf59e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c4f-22a9-7df9-9466-dea6653bf59e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


