### PR TITLE
content(#831): apply-ready Matt McKenna hub links, not applied

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/APPLY.md
@@ -1,0 +1,143 @@
+# #831 APPLY: Matt McKenna hub links
+
+**Prepared, not applied. Do not PATCH until #826 is live and KK says go.**
+Script is dry-run by default. `--apply` is the only write switch, and it refuses unless the five #826 category fixes are already live (3330 out of `web-early-blog` / 1757 into `events-reports` / 1676).
+
+Parent: #402. This is child 6 of 9. Child 1 (#826) owns the 3330 recategorization. This pack does not recategorize 3330 and does not add a second 3183 link there.
+
+Do not close #831 or #402 when this runbook merges.
+
+## Live reconfirm (logged-out public REST + HTML GET, 2026-08-19T23:20Z)
+
+No REST POST / PATCH / DELETE in this session. WP creds were unset, so there is no authenticated `context=edit` `content.raw`. Public REST confirmed slug/ID pairs. Snapshots in `before/` are public `content.rendered` plus a reconstructed 12319 raw from the 2026-07-01 architecture payload.
+
+| ID | Kind | Slug | URL | HTTP | Internal body links | Notes |
+|---|---|---|---|---:|---:|---|
+| 12319 | page | `ai-conversations` | `/ai-conversations/` | 200 | **6** (none to 3183) | Three `aurora-media-card`s. Cache-busted HTML has **0** `matt-mckennas-decade-at-dent`. `modified_gmt` `2026-07-01T20:28:05`. |
+| 2833 | post | `dent-the-future-an-insiders-experiences-at-the-dent-conference` | `/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/` | 200 | 3 (1 body + footer pair) | Community paragraph already has Instagram `Matt McKenna`. No 3183 href. One `kk-collection-footer`. |
+| 2423 | post | `dent-2019-photo-recap-gallery` | `/2019/03/30/dent-2019-photo-recap-gallery/` | 200 | 2 (footer only) | Intro is block 1 of 25. Name also appears later in a figure caption. No 3183 href. One footer. |
+| 3183 | post | `coffee-community-and-sobriety-matt-mckennas-decade-at-dent` | `/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/` | 200 | 2 (footer to hub) | **Do not touch.** No spoke out. Featured media 3232. |
+| 3330 | post | `the-future-called-i-answered` | `/2023/09/29/the-future-called-i-answered/` | 200 | 6 including 3183 | **Do not touch.** Existing 3183 link stays. Categories already `[1676]`. |
+
+Five target URLs were 200: `/ai-conversations/`, the 3183 interview, 2833, 2423, and 3330.
+
+### #826 gate readback (public categories, not a write)
+
+Public REST on 2026-08-19 already shows the five #826 category moves: 3814 in 1678, **3330 in 1676 and out of 1757**, 1067 / 1063 / 1147 in 1756. The `--apply` gate would pass on that evidence. This pack is still **not applied**. KK still has to approve the diff.
+
+### Block recount (today's HTML, not the 2026-08-02 index)
+
+Walking `p / h2 / h3 / ul / ol / figure / blockquote` in `content.rendered`:
+
+- 12319 is a single HTML payload. The interview list is the "Listen and read" `aurora-proof-grid`. Insert the new card **before** the Conversations archive card, by text match on that archive href, not a card index.
+- 2833 community paragraph sits under `Connections and Community: More Than a Conference`. The name is already there, Instagram-linked. Wrap and expand that existing name. Do not add a second sentence.
+- 2423 intro is **block 1** (`Just back from Sante Fe... friends and collaborators.`). There is no stale "block 17". Insert the trailing sentence in that intro paragraph.
+
+Featured media 3232 is a wide banner whose filename contains a non-ASCII multiply sign. The card uses ASCII `image-12.png` from the 3183 body instead, same Photon `resize=640,400` pattern as the other hub cards.
+
+## Snapshot gaps
+
+- **No `content.raw` from live REST.** Public `context=view` omits it. Authenticated `context=edit` was not available.
+- Page **12319** `before/page-12319-content.raw.html` is reconstructed from `content/source-packs/content-architecture-2026/wp-payloads/topic-hubs/ai-conversations.html`. Public rendered matches that structure (WP only added `decoding="async"`, self-closing `img`, and `&#8217;`).
+- Posts **2833** and **2423** `content.raw.html` files are public `content.rendered` stand-ins. Live `--apply` re-fetches `context=edit` and aborts if the find needle is missing (for example if raw uses `real_mckenna/` with a trailing slash).
+- Posts **3183** and **3330** have identity-only snapshots. They are not in `items` and must stay an empty diff.
+
+## Identity (slug check before any write)
+
+Abort if any ID's live slug differs from `targets.json`. Never PATCH on ID alone.
+
+| ID | Required slug |
+|---:|---|
+| 12319 | `ai-conversations` |
+| 2833 | `dent-the-future-an-insiders-experiences-at-the-dent-conference` |
+| 2423 | `dent-2019-photo-recap-gallery` |
+
+## What the script writes
+
+Content only. Titles, slugs, dates, status, featured media, tags, categories, and SEO meta stay untouched.
+
+| ID | Find (exactly once) | Inserted copy |
+|---|---|---|
+| 12319 | archive-card `<article>` opening that links `/category/conversations-interviews/` | new `aurora-media-card` before it. Title `Matt McKenna's decade at DENT`. Blurb exactly `Ten years of DENT, ten years sober, and a coffee shop in Miami.` |
+| 2833 | Instagram-linked `Matt McKenna` in the DENT community paragraph | same `<a>`, new href to 3183, visible text `Matt McKenna, who has been at every single one` |
+| 2423 | `who have become friends and collaborators.` | trailing sentence in that same intro `<p>`. Exact anchor `I sat down with Matt McKenna a few years after this` |
+
+Inserted copy is ASCII. No em dashes. No NCR needed in the new card or sentences.
+
+Skip a row if that exact `href` + anchor already exists. 3330 is the known skip and is not in `items`.
+
+## Must not
+
+- Modify post 3183 body.
+- Modify post 3330 (existing 3183 link; category is #826).
+- Remove or rewrite the Shane Gibson, Sharad Khare, or Conversations archive cards on 12319.
+- Duplicate `kk-collection-footer`.
+- Bolt a second Matt McKenna sentence onto 2833 if the name is already in the community paragraph.
+- Run bulk `inject_links.py`.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_831_matt_mckenna
+
+# Offline dry-run: rewrite the snapshotted before-files into after/. No network.
+python3 scripts/apply_issue_831_matt_mckenna.py --from-files
+
+# Live GET dry-run: authenticated context=edit + printed diffs. No snapshot, no POST.
+make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py'
+
+# Apply only after #826 is live and KK approves that diff.
+make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py --apply'
+```
+
+`--item-id 12319` limits to one object. Re-run after a successful apply prints `[SKIP]`.
+
+`--apply` GETs the five #826 posts and aborts unless 3814 is out of 1757 into 1678, 3330 is out of 1757 into 1676, and 1067 / 1063 / 1147 are out of their wrong buckets into 1756.
+
+Snapshot dir (mode 0700, files 0600):
+`backup/issue-831-matt-mckenna/rest-<page|post>-<id>-before-<stamp>.json`
+
+## Rollback
+
+```bash
+make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py --restore backup/issue-831-matt-mckenna/rest-page-12319-before-<stamp>.json'
+make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py --restore backup/issue-831-matt-mckenna/rest-page-12319-before-<stamp>.json --apply'
+```
+
+Restore is dry-run by default. It refuses snapshots outside the three write IDs or a slug mismatch. Rollback body is the snapshotted `content.raw`.
+
+## After-apply logged-out gates
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/ai-conversations/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/
+curl -s -o /dev/null -w '%{http_code}\n' -L https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/
+
+curl -sL "https://kriskrug.co/ai-conversations/?cb=$RANDOM" | grep -n 'matt-mckennas-decade-at-dent'
+curl -sL "https://kriskrug.co/ai-conversations/?cb=$RANDOM" | grep -F "Matt McKenna's decade at DENT"
+curl -sL "https://kriskrug.co/ai-conversations/?cb=$RANDOM" | grep -F 'Ten years of DENT, ten years sober, and a coffee shop in Miami.'
+curl -sL "https://kriskrug.co/ai-conversations/?cb=$RANDOM" | grep -c 'shane-gibsons-ai-sales-dojo'
+curl -sL "https://kriskrug.co/ai-conversations/?cb=$RANDOM" | grep -c 'human-biography-podcast-w-sharad-khare'
+
+curl -sL "https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/?cb=$RANDOM" \
+  | grep -F 'Matt McKenna, who has been at every single one'
+curl -sL "https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/?cb=$RANDOM" \
+  | grep -F 'I sat down with Matt McKenna a few years after this'
+
+# footer count must match the pre-write snapshot
+curl -sL "https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/?cb=$RANDOM" \
+  | grep -c 'kk-collection-footer'
+curl -sL "https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/?cb=$RANDOM" \
+  | grep -c 'kk-collection-footer'
+```
+
+Expect: 12319 gains exactly one new interview card to 3183. Shane / Sharad / archive cards stay. 2833 and 2423 footer counts unchanged. 3330 and 3183 bodies unchanged.
+
+## Out of payload
+
+- Recategorizing 3330 (#826)
+- A second 3183 link on 3330
+- Post 3183 body edits
+- Hub cards on 12013 / 12318 / 12316
+- `inject_links.py`

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/page-12319-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/page-12319-content.raw.html
@@ -1,0 +1,78 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-conversations -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI conversations</p>
+  <h2 class="aurora-display-heading">Interviews, podcasts, and messy human signal.</h2>
+  <p class="aurora-page-lead">This hub collects conversations with builders, artists, technologists, media people, and community leaders working through the cultural side of AI. It is part interview archive, part listening room, part source trail.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Formats</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Interviews</h3>
+      <p>Longer conversations with people building, teaching, publishing, and experimenting at the edge of technology and culture.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Podcasts and guesting</h3>
+      <p>Producer-friendly topics and interview angles live on the EPK when you need to book Kris for a show.</p>
+      <p><a class="aurora-button" href="/podcast-guesting-page-epk/">Open EPK</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Public thinking</h3>
+      <p>Talks, panels, salons, and community rooms where AI gets translated into lived experience.</p>
+      <p><a class="aurora-button" href="/speaking/">Speaking</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Listen and read</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/blog-shane-bushido-ai-sales.png?resize=640,400&amp;ssl=1" alt="AI sales conversation graphic" loading="lazy">
+        <div>
+          <h3>Shane Gibson's AI sales dojo</h3>
+          <p>A conversation about sales, AI practice, and building useful systems.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/01/25/human-biography-podcast-w-sharad-khare/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/11/sharad-khare.png?resize=640,400&amp;ssl=1" alt="Sharad Khare Human Biography podcast graphic" loading="lazy">
+        <div>
+          <h3>Human Biography with Sharad Khare</h3>
+          <p>Identity, story, memory, and what gets preserved when technology changes.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/image-12.png?resize=640,400&amp;ssl=1" alt="Matt McKenna at DENT the Future" loading="lazy">
+        <div>
+          <h3>Matt McKenna's decade at DENT</h3>
+          <p>Ten years of DENT, ten years sober, and a coffee shop in Miami.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/conversations-interviews/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/kevin-friel-pixel-wizard.png?resize=640,400&amp;ssl=1" alt="Kevin Friel generative AI podcast graphic" loading="lazy">
+        <div>
+          <h3>Conversations archive</h3>
+          <p>More interviews and dialogue from the creative technology edge.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Book Kris for an interview</h2>
+    <p>For podcasts, panels, livestreams, or producer calls, send the audience, angle, format, and timing.</p>
+    <p><a class="aurora-button" href="/contact/">Start a booking conversation</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/post-2423-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/post-2423-content.raw.html
@@ -1,0 +1,98 @@
+
+<p class="wp-block-paragraph">Just back from Sante Fe where I was attending  <a href="https://dentthefuture.com/">DENT the Future</a> organized by <a href="http://www.jason-preston.com/">Jason Preston</a> and <a href="https://www.crunchbase.com/person/steve-broback">Steve Broback</a>. DENT is an &#8216;ideas and inspiration festival&#8217; featuring talks, workshops, adventures, projects, and goodtimes. We meet several times a year in places like Maui, Teluride and Napa and have formed a great support network of creative professionals who have become friends and collaborators. <a href="https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/">I sat down with Matt McKenna a few years after this</a>. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=1000%2C667&#038;ssl=1" alt="Sante Fe, New Mexico, USA for DENT" class="wp-image-2443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>People have long been telling me how much I&#8217;d enjoy New Mexico and Santa Fe definitely captivated my imagination. I enjoyed meeting so many Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations and the whole area is steeped in art and rich culture.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">My role at the event is Official Photographer and I&#8217;ve published a gallery of all the best images for your enjoyment. Pls check them out and share them around. If you&#8217;re featured in the images you&#8217;re welcome to download them and treat them as your own. While you&#8217;re here on my brand new website also pls put your email in the subscribe box and receive updates as they are published.  Here&#8217;s the photos. Enjoy!</p>
+
+
+
+<ul class="wp-block-list"><li><a href="https://www.facebook.com/kriskrug/media_set?set=a.10215956561300294">Facebook Gallery</a></li><li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">Flickr Gallery</a></li><li><a href="https://photos.app.goo.gl/hHK13fosEpDPTyDX7">Google Photos Gallery</a></li></ul>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="624" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=1000%2C624&#038;ssl=1" alt="" class="wp-image-2444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=300%2C187&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=768%2C479&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>This is my 6th trip to the DENT Conference and has grown into a strong community. It was great to see  so many people like buddy like Matt McKenna.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img loading="lazy" decoding="async" width="2000" height="395" src="https://i1.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?fit=780%2C154&amp;ssl=1" alt="" class="wp-image-2446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?w=2000&amp;ssl=1 2000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=300%2C59&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=768%2C152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=1024%2C202&amp;ssl=1 1024w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A big group of us snuck away before the conference to check out art sensation Meow Wolf&#8217;s Temple of Eternal Return Exhibition.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&#038;ssl=1" alt="Ellen Petry Leanse at Museum of Indian Arts &amp; Culture" class="wp-image-2439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A small group of us snuck away after Meow Wolf to check out  Museum of Indian Arts &amp; Culture where I was excited to check out Desiree Kane&#8217;s photography as part of the Standing Rock exhibit.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Jason and Steve kicking off DENT 2019 to a full house at La Fonda on the Plaza</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="507" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=1000%2C507&#038;ssl=1" alt="Karate sparring class with Steve Broback and Zoe Bell" class="wp-image-2441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=300%2C152&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=768%2C389&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Lots of fun activities throughout the week including Dungeons &amp; Dragons, art &amp; museum tours, a poker tournament and this karate sparring class with Steve Broback and Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Hopi and Navajo artist basket weaver artist Hopi &amp; Navajo artist Iva Honyestewa</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">A Hopi/Navajo basketmaker from Second Mesa, Arizona, <a href="https://en.wikipedia.org/wiki/Iva_Honyestewa">Iva Honyestewa</a> was mostly known as a sifter basket maker. During her artist residency at SAR, 2014 Eric and Barbara Dobkin Fellow at the <a href="https://sarweb.org/">School for Advanced Research</a>, however, Iva pioneered a completely new technique of basketry. Called pootsaya these baskets are a combination of the Second Mesa poota (coiled basket) and the more broadly made tutsaya (sifter basket). This new technique was a developed with the intention of bringing the sometimes fractured Hopi communities from which she comes together. Iva is currently only one of two people in the world working in this technique.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="700" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=1000%2C700&#038;ssl=1" alt="Barbara Rae-Venter" class="wp-image-2433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=300%2C210&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=768%2C538&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Barbara Rae-Venter is an retiree solving high profile cold cases.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://barbara.genealogyconsult.com/">Barbara</a> is a Search Angel with <a href="http://dnaadoption.org/">DNAAdoption.com</a> helping adoptees find their birth parents and also helps teach the autosomal DNA classes DNAadoption.com offers to help adoptees use their DNA to find birth relatives. As a volunteer with DNAadoption.com, Barbara volunteered her time to work on a project for the San Bernardino Sheriff’s Department Crimes Against Children Detail to identify, successfully, the immediate family of “Lisa”, a woman now in her 30s, who was abducted as an infant and did not know either who she was or where she was from.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=1000%2C667&#038;ssl=1" alt="Jill Heinerth" class="wp-image-2431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Underwater cave explorer Jill Heinreth shared her life&#8217;s work and talked about FEAR.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">More people have walked on the moon than have visited many of the places that Jill Heinerth has seen on Earth.&nbsp;Jill is a veteran of over thirty years of filming, photography, and exploration of underwater caves around the globe for&nbsp;<em>National Geographic</em>, educational institutions, and television networks worldwide.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="814" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=1000%2C814&#038;ssl=1" alt="Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life." class="wp-image-2429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=768%2C625&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Award-winning filmmakers, <a href="https://www.taynval.com/">Tay and Val</a> left successful media careers, closed their production company, wrapped work on their nationally televised television series P.S. I’m Sorry, and set off to travel the world by bicycle for a <a href="https://vimeo.com/90166204">documentary project to inspire dreams</a>. Six years, three continents, more than 400 public talks and national radio and TV appearances (in twelve countries), and 2 TEDx talks later, Tay and Val settled in the Pacific Northwest as City Artists of Seattle. Committed to helping visionary leaders meet their call to greatness with clear-eyed vision, groundedness, and deep trust – they work with leaders and businesses around the globe who hear the call to rise and say yes.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&#038;ssl=1" alt="Native American Glass Chandelier - La Fonda Hotel Sante Fe New Mexioco" class="wp-image-2427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Native American Glass Chandelier &#8211; La Fonda Hotel Sante Fe New Mexioco</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I can&#8217;t say enough about the art. Every nook and cranny of the hotel and the whole town of Santa Fe was full of beautiful Native American style art. I brought home blankets, pottery and turquoise jewelry for my friends and family. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=1000%2C667&#038;ssl=1" alt="William Coupon Portrait by Kris Krug" class="wp-image-2426" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Portrait photographer William Coupon portrait by KK</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2448" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>“And today’s youth desperately seek contact and attention from a generation of distracted parents addicted to their smartphones.”</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=1000%2C667&#038;ssl=1" alt="Zoe Bell" class="wp-image-2432" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Was fun to connect this year with badass Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&#038;ssl=1" alt="Ellen Petry Leanse" class="wp-image-2454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Friend and mentor Ellen Petry Leanse</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks for making it this far. Come to <a href="https://dentthefuture.com/">DENT</a> next time around and let&#8217;s hang! 🙂 Subscribe for updates pls.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/">DENT the Future: An Insider&#8217;s Experiences at the Dent Conference</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/post-2833-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/after/post-2833-content.raw.html
@@ -1,0 +1,136 @@
+
+<p class="wp-block-paragraph">As <a href="https://dentthefuture.com/conference">DENT&#8217;s</a> Official Photographer since 2014, I&#8217;ve had the unique opportunity to experience the conference from behind the lens. In this post, I&#8217;ll share some personal reflections, stories, and insights from my journey with DENT and the peeps that bring it to life.</p>
+
+
+
+<h2 class="wp-block-heading">Introduction: Discovering DENT</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://dentthefuture.com/">DENT the Future</a>, organized by <a href="https://www.linkedin.com/in/jpreston">Jason Preston</a> and <a href="http://stevebroback.com/about/">Steve Broback</a>, is an &#8216;ideas and inspiration festival&#8217; that has become a strong community of creative professionals. From Sante Fe to Maui, Teluride, and Napa, Dent offers talks, workshops, and good times, all reflected back to the world through my camera.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Nne9u1Lay20" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<h3 class="wp-block-heading">Sante Fe: A Cultural Experience</h3>
+
+
+
+<p class="wp-block-paragraph">My trips to Sante Fe for <a href="https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/">DENT</a> have captivated my imagination. Meeting Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations, and experiencing the rich art and culture has been a highlight.</p>
+
+
+
+<h2 class="wp-block-heading">Connections and Community: More Than a Conference</h2>
+
+
+
+<p class="wp-block-paragraph">DENT has grown into a support network of friends and collaborators. Seeing familiar faces like my buddy <a href="https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/">Matt McKenna, who has been at every single one</a>, and exploring art sensations like <a href="https://meowwolf.com/">Meow Wolf</a>&#8216;s <a href="https://meowwolf.com/visit/santa-fe">Temple of Eternal Return Exhibition</a>, has turned DENT into a family reunion of sorts.</p>
+
+
+
+<h3 class="wp-block-heading">Jason and Steve: The Heart of Dent</h3>
+
+
+
+<p class="wp-block-paragraph">Jason and Steve&#8217;s kickoff to DENT 2019 at La Fonda on the Plaza set the tone for an event filled with creativity and connection. Their leadership and vision have shaped DENT into what it is today.</p>
+
+
+
+<h2 class="wp-block-heading">Beyond Photography</h2>
+
+
+
+<p class="wp-block-paragraph">Beyond my role as Official Photographer, I&#8217;ve engaged in various activities at DENT, including karate sparring with Steve Broback and <a href="https://en.wikipedia.org/wiki/Zo%C3%AB_Bell">Zoe Bell</a>, Dungeons &amp; Dragons, art &amp; museum tours, and a poker tournament. These fun activities have added depth to my DENT experience.</p>
+
+
+
+<h3 class="wp-block-heading">Exploring Art and Culture</h3>
+
+
+
+<p class="wp-block-paragraph">A visit to the Museum of Indian Arts &amp; Culture and the chance to see Desiree Kane&#8217;s photography as part of the Standing Rock exhibit allowed me to connect with the local culture. Also, meeting Iva Honyestewa, a Hopi/Navajo basketmaker, and exploring her unique basketry technique was a fascinating experience.</p>
+
+
+
+<h2 class="wp-block-heading">Inspirational Voices: Personal Encounters</h2>
+
+
+
+<p class="wp-block-paragraph">From underwater cave explorer Jill Heinerth talking about fear to Tay &amp; Val&#8217;s extraordinary life journey, I&#8217;ve been inspired by many speakers at DENT. Barbara Rae-Venter&#8217;s work on high-profile cold cases and her dedication to helping adoptees find their birth parents left a lasting impression.</p>
+
+
+
+<h3 class="wp-block-heading">The Art of Santa Fe: A Visual Feast</h3>
+
+
+
+<p class="wp-block-paragraph">The art in Santa Fe, especially the Native American Glass Chandelier at La Fonda Hotel and the beautiful Native American style art throughout the town, has been a visual feast. I&#8217;ve even brought home blankets, pottery, and turquoise jewelry for my friends and family.</p>
+
+
+
+<p class="wp-block-paragraph">DENT Photography &amp; Photo Galleries</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157673016933510">DENT Space</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157673016933510">https://www.flickr.com/photos/kk/albums/72157673016933510</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157642906164325">DENT 2014</a>:</strong> <a href="https://www.flickr.com/photos/kk/albums/72157642906164325">https://www.flickr.com/photos/kk/albums/72157642906164325</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157651438430096">DENT 2015</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157651438430096">https://www.flickr.com/photos/kk/albums/72157651438430096</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157666173733016">DENT 2016</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157666173733016">https://www.flickr.com/photos/kk/albums/72157666173733016</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157678301027093">DENT 2017</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157678301027093">https://www.flickr.com/photos/kk/albums/72157678301027093</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157669493351129"><strong>DENT 2018</strong></a>: <a href="https://www.flickr.com/photos/kk/albums/72157669493351129">https://www.flickr.com/photos/kk/albums/72157669493351129</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">DENT 2019</a>: <a href="https://www.flickr.com/photos/kk/albums/72157677458163477">https://www.flickr.com/photos/kk/albums/72157677458163477</a></li>
+</ul>
+
+
+
+<h2 class="wp-block-heading">The Photowalk Tradition: Connecting Artists and Creatives</h2>
+
+
+
+<p class="wp-block-paragraph">Every year at DENT, I&#8217;ve had the pleasure of leading a photowalk for artists and creatives. It&#8217;s an opportunity that goes beyond the professional realm and invites photo enthusiasts to get together, hang out, and learn their gear in a collaborative environment.</p>
+
+
+
+<h3 class="wp-block-heading">Breaking the Ice: Portraits and Connections</h3>
+
+
+
+<p class="wp-block-paragraph">Many attendees are interested in making portraits but may feel intimidated to ask their subjects for permission. These photowalks serve as a great chance to break the ice, get to know other attendees, and venture out into the community where the conference is held. It&#8217;s a special part of DENT that fosters connection, creativity, and collaboration.</p>
+
+
+
+<h3 class="wp-block-heading">Conclusion: A Personal Invitation</h3>
+
+
+
+<p class="wp-block-paragraph">Thanks for joining me on this personal reflection of DENT. From photowalks to inspirational talks, DENT is more than a conference; it&#8217;s a part of my life. The friendships, connections, and memories I&#8217;ve made have shaped me both professionally and personally. Come to DENT next time around, and let&#8217;s hang!</p>
+
+
+
+<p class="wp-block-paragraph"><iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/5ALuENAKI7QhV1eHmEPUdj?utm_source=generator&amp;t=0" width="100%" height="352" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/07/28/future-in-review-conference-and-fire-podcast-an-insiders-view/">Future in Review Conference and FIRE Podcast: An Insider&#8217;s View</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-content.raw.html
@@ -1,0 +1,69 @@
+<!-- wp:html -->
+<!-- content-architecture-2026:topic-ai-conversations -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI conversations</p>
+  <h2 class="aurora-display-heading">Interviews, podcasts, and messy human signal.</h2>
+  <p class="aurora-page-lead">This hub collects conversations with builders, artists, technologists, media people, and community leaders working through the cultural side of AI. It is part interview archive, part listening room, part source trail.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Formats</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Interviews</h3>
+      <p>Longer conversations with people building, teaching, publishing, and experimenting at the edge of technology and culture.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Podcasts and guesting</h3>
+      <p>Producer-friendly topics and interview angles live on the EPK when you need to book Kris for a show.</p>
+      <p><a class="aurora-button" href="/podcast-guesting-page-epk/">Open EPK</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Public thinking</h3>
+      <p>Talks, panels, salons, and community rooms where AI gets translated into lived experience.</p>
+      <p><a class="aurora-button" href="/speaking/">Speaking</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Listen and read</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/blog-shane-bushido-ai-sales.png?resize=640,400&amp;ssl=1" alt="AI sales conversation graphic" loading="lazy">
+        <div>
+          <h3>Shane Gibson's AI sales dojo</h3>
+          <p>A conversation about sales, AI practice, and building useful systems.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/01/25/human-biography-podcast-w-sharad-khare/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/11/sharad-khare.png?resize=640,400&amp;ssl=1" alt="Sharad Khare Human Biography podcast graphic" loading="lazy">
+        <div>
+          <h3>Human Biography with Sharad Khare</h3>
+          <p>Identity, story, memory, and what gets preserved when technology changes.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/conversations-interviews/">
+        <img src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/kevin-friel-pixel-wizard.png?resize=640,400&amp;ssl=1" alt="Kevin Friel generative AI podcast graphic" loading="lazy">
+        <div>
+          <h3>Conversations archive</h3>
+          <p>More interviews and dialogue from the creative technology edge.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Book Kris for an interview</h2>
+    <p>For podcasts, panels, livestreams, or producer calls, send the audience, angle, format, and timing.</p>
+    <p><a class="aurora-button" href="/contact/">Start a booking conversation</a></p>
+  </div>
+</section>
+<!-- /wp:html -->

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-content.rendered.html
@@ -1,0 +1,69 @@
+
+<!-- content-architecture-2026:topic-ai-conversations -->
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">AI conversations</p>
+  <h2 class="aurora-display-heading">Interviews, podcasts, and messy human signal.</h2>
+  <p class="aurora-page-lead">This hub collects conversations with builders, artists, technologists, media people, and community leaders working through the cultural side of AI. It is part interview archive, part listening room, part source trail.</p>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Formats</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Interviews</h3>
+      <p>Longer conversations with people building, teaching, publishing, and experimenting at the edge of technology and culture.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Podcasts and guesting</h3>
+      <p>Producer-friendly topics and interview angles live on the EPK when you need to book Kris for a show.</p>
+      <p><a class="aurora-button" href="/podcast-guesting-page-epk/">Open EPK</a></p>
+    </article>
+    <article class="aurora-card">
+      <h3>Public thinking</h3>
+      <p>Talks, panels, salons, and community rooms where AI gets translated into lived experience.</p>
+      <p><a class="aurora-button" href="/speaking/">Speaking</a></p>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <p class="aurora-section-kicker">Listen and read</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2025/03/blog-shane-bushido-ai-sales.png?resize=640,400&amp;ssl=1" alt="AI sales conversation graphic" loading="lazy"/>
+        <div>
+          <h3>Shane Gibson&#8217;s AI sales dojo</h3>
+          <p>A conversation about sales, AI practice, and building useful systems.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/2025/01/25/human-biography-podcast-w-sharad-khare/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/11/sharad-khare.png?resize=640,400&amp;ssl=1" alt="Sharad Khare Human Biography podcast graphic" loading="lazy"/>
+        <div>
+          <h3>Human Biography with Sharad Khare</h3>
+          <p>Identity, story, memory, and what gets preserved when technology changes.</p>
+        </div>
+      </a>
+    </article>
+    <article class="aurora-media-card">
+      <a href="https://kriskrug.co/category/conversations-interviews/">
+        <img decoding="async" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2024/12/kevin-friel-pixel-wizard.png?resize=640,400&amp;ssl=1" alt="Kevin Friel generative AI podcast graphic" loading="lazy"/>
+        <div>
+          <h3>Conversations archive</h3>
+          <p>More interviews and dialogue from the creative technology edge.</p>
+        </div>
+      </a>
+    </article>
+  </div>
+</section>
+
+<section class="aurora-proof-section">
+  <div class="aurora-card">
+    <h2>Book Kris for an interview</h2>
+    <p>For podcasts, panels, livestreams, or producer calls, send the audience, angle, format, and timing.</p>
+    <p><a class="aurora-button" href="/contact/">Start a booking conversation</a></p>
+  </div>
+</section>
+

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/page-12319-identity.json
@@ -1,0 +1,14 @@
+{
+  "id": 12319,
+  "slug": "ai-conversations",
+  "status": "publish",
+  "link": "https://kriskrug.co/ai-conversations/",
+  "modified": "2026-07-01T12:28:05",
+  "modified_gmt": "2026-07-01T20:28:05",
+  "type": "page",
+  "content_raw_source": "reconstructed_from_2026-07-01_architecture_payload",
+  "content_raw_bytes": 3390,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": false,
+  "public_content_raw_available": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-content.raw.html
@@ -1,0 +1,98 @@
+
+<p class="wp-block-paragraph">Just back from Sante Fe where I was attending  <a href="https://dentthefuture.com/">DENT the Future</a> organized by <a href="http://www.jason-preston.com/">Jason Preston</a> and <a href="https://www.crunchbase.com/person/steve-broback">Steve Broback</a>. DENT is an &#8216;ideas and inspiration festival&#8217; featuring talks, workshops, adventures, projects, and goodtimes. We meet several times a year in places like Maui, Teluride and Napa and have formed a great support network of creative professionals who have become friends and collaborators. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=1000%2C667&#038;ssl=1" alt="Sante Fe, New Mexico, USA for DENT" class="wp-image-2443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>People have long been telling me how much I&#8217;d enjoy New Mexico and Santa Fe definitely captivated my imagination. I enjoyed meeting so many Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations and the whole area is steeped in art and rich culture.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">My role at the event is Official Photographer and I&#8217;ve published a gallery of all the best images for your enjoyment. Pls check them out and share them around. If you&#8217;re featured in the images you&#8217;re welcome to download them and treat them as your own. While you&#8217;re here on my brand new website also pls put your email in the subscribe box and receive updates as they are published.  Here&#8217;s the photos. Enjoy!</p>
+
+
+
+<ul class="wp-block-list"><li><a href="https://www.facebook.com/kriskrug/media_set?set=a.10215956561300294">Facebook Gallery</a></li><li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">Flickr Gallery</a></li><li><a href="https://photos.app.goo.gl/hHK13fosEpDPTyDX7">Google Photos Gallery</a></li></ul>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="624" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=1000%2C624&#038;ssl=1" alt="" class="wp-image-2444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=300%2C187&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=768%2C479&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>This is my 6th trip to the DENT Conference and has grown into a strong community. It was great to see  so many people like buddy like Matt McKenna.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img loading="lazy" decoding="async" width="2000" height="395" src="https://i1.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?fit=780%2C154&amp;ssl=1" alt="" class="wp-image-2446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?w=2000&amp;ssl=1 2000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=300%2C59&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=768%2C152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=1024%2C202&amp;ssl=1 1024w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A big group of us snuck away before the conference to check out art sensation Meow Wolf&#8217;s Temple of Eternal Return Exhibition.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&#038;ssl=1" alt="Ellen Petry Leanse at Museum of Indian Arts &amp; Culture" class="wp-image-2439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A small group of us snuck away after Meow Wolf to check out  Museum of Indian Arts &amp; Culture where I was excited to check out Desiree Kane&#8217;s photography as part of the Standing Rock exhibit.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Jason and Steve kicking off DENT 2019 to a full house at La Fonda on the Plaza</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="507" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=1000%2C507&#038;ssl=1" alt="Karate sparring class with Steve Broback and Zoe Bell" class="wp-image-2441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=300%2C152&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=768%2C389&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Lots of fun activities throughout the week including Dungeons &amp; Dragons, art &amp; museum tours, a poker tournament and this karate sparring class with Steve Broback and Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Hopi and Navajo artist basket weaver artist Hopi &amp; Navajo artist Iva Honyestewa</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">A Hopi/Navajo basketmaker from Second Mesa, Arizona, <a href="https://en.wikipedia.org/wiki/Iva_Honyestewa">Iva Honyestewa</a> was mostly known as a sifter basket maker. During her artist residency at SAR, 2014 Eric and Barbara Dobkin Fellow at the <a href="https://sarweb.org/">School for Advanced Research</a>, however, Iva pioneered a completely new technique of basketry. Called pootsaya these baskets are a combination of the Second Mesa poota (coiled basket) and the more broadly made tutsaya (sifter basket). This new technique was a developed with the intention of bringing the sometimes fractured Hopi communities from which she comes together. Iva is currently only one of two people in the world working in this technique.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="700" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=1000%2C700&#038;ssl=1" alt="Barbara Rae-Venter" class="wp-image-2433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=300%2C210&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=768%2C538&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Barbara Rae-Venter is an retiree solving high profile cold cases.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://barbara.genealogyconsult.com/">Barbara</a> is a Search Angel with <a href="http://dnaadoption.org/">DNAAdoption.com</a> helping adoptees find their birth parents and also helps teach the autosomal DNA classes DNAadoption.com offers to help adoptees use their DNA to find birth relatives. As a volunteer with DNAadoption.com, Barbara volunteered her time to work on a project for the San Bernardino Sheriff’s Department Crimes Against Children Detail to identify, successfully, the immediate family of “Lisa”, a woman now in her 30s, who was abducted as an infant and did not know either who she was or where she was from.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=1000%2C667&#038;ssl=1" alt="Jill Heinerth" class="wp-image-2431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Underwater cave explorer Jill Heinreth shared her life&#8217;s work and talked about FEAR.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">More people have walked on the moon than have visited many of the places that Jill Heinerth has seen on Earth.&nbsp;Jill is a veteran of over thirty years of filming, photography, and exploration of underwater caves around the globe for&nbsp;<em>National Geographic</em>, educational institutions, and television networks worldwide.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="814" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=1000%2C814&#038;ssl=1" alt="Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life." class="wp-image-2429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=768%2C625&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Award-winning filmmakers, <a href="https://www.taynval.com/">Tay and Val</a> left successful media careers, closed their production company, wrapped work on their nationally televised television series P.S. I’m Sorry, and set off to travel the world by bicycle for a <a href="https://vimeo.com/90166204">documentary project to inspire dreams</a>. Six years, three continents, more than 400 public talks and national radio and TV appearances (in twelve countries), and 2 TEDx talks later, Tay and Val settled in the Pacific Northwest as City Artists of Seattle. Committed to helping visionary leaders meet their call to greatness with clear-eyed vision, groundedness, and deep trust – they work with leaders and businesses around the globe who hear the call to rise and say yes.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&#038;ssl=1" alt="Native American Glass Chandelier - La Fonda Hotel Sante Fe New Mexioco" class="wp-image-2427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Native American Glass Chandelier &#8211; La Fonda Hotel Sante Fe New Mexioco</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I can&#8217;t say enough about the art. Every nook and cranny of the hotel and the whole town of Santa Fe was full of beautiful Native American style art. I brought home blankets, pottery and turquoise jewelry for my friends and family. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=1000%2C667&#038;ssl=1" alt="William Coupon Portrait by Kris Krug" class="wp-image-2426" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Portrait photographer William Coupon portrait by KK</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2448" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>“And today’s youth desperately seek contact and attention from a generation of distracted parents addicted to their smartphones.”</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=1000%2C667&#038;ssl=1" alt="Zoe Bell" class="wp-image-2432" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Was fun to connect this year with badass Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&#038;ssl=1" alt="Ellen Petry Leanse" class="wp-image-2454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Friend and mentor Ellen Petry Leanse</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks for making it this far. Come to <a href="https://dentthefuture.com/">DENT</a> next time around and let&#8217;s hang! 🙂 Subscribe for updates pls.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/">DENT the Future: An Insider&#8217;s Experiences at the Dent Conference</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-content.rendered.html
@@ -1,0 +1,98 @@
+
+<p class="wp-block-paragraph">Just back from Sante Fe where I was attending  <a href="https://dentthefuture.com/">DENT the Future</a> organized by <a href="http://www.jason-preston.com/">Jason Preston</a> and <a href="https://www.crunchbase.com/person/steve-broback">Steve Broback</a>. DENT is an &#8216;ideas and inspiration festival&#8217; featuring talks, workshops, adventures, projects, and goodtimes. We meet several times a year in places like Maui, Teluride and Napa and have formed a great support network of creative professionals who have become friends and collaborators. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=1000%2C667&#038;ssl=1" alt="Sante Fe, New Mexico, USA for DENT" class="wp-image-2443" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-23.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>People have long been telling me how much I&#8217;d enjoy New Mexico and Santa Fe definitely captivated my imagination. I enjoyed meeting so many Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations and the whole area is steeped in art and rich culture.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">My role at the event is Official Photographer and I&#8217;ve published a gallery of all the best images for your enjoyment. Pls check them out and share them around. If you&#8217;re featured in the images you&#8217;re welcome to download them and treat them as your own. While you&#8217;re here on my brand new website also pls put your email in the subscribe box and receive updates as they are published.  Here&#8217;s the photos. Enjoy!</p>
+
+
+
+<ul class="wp-block-list"><li><a href="https://www.facebook.com/kriskrug/media_set?set=a.10215956561300294">Facebook Gallery</a></li><li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">Flickr Gallery</a></li><li><a href="https://photos.app.goo.gl/hHK13fosEpDPTyDX7">Google Photos Gallery</a></li></ul>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="624" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=1000%2C624&#038;ssl=1" alt="" class="wp-image-2444" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=300%2C187&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-96-1.jpg?resize=768%2C479&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>This is my 6th trip to the DENT Conference and has grown into a strong community. It was great to see  so many people like buddy like Matt McKenna.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img loading="lazy" decoding="async" width="2000" height="395" src="https://i1.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?fit=780%2C154&amp;ssl=1" alt="" class="wp-image-2446" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?w=2000&amp;ssl=1 2000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=300%2C59&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=768%2C152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_134523-1.jpg?resize=1024%2C202&amp;ssl=1 1024w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A big group of us snuck away before the conference to check out art sensation Meow Wolf&#8217;s Temple of Eternal Return Exhibition.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1024" height="498" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&#038;ssl=1" alt="Ellen Petry Leanse at Museum of Indian Arts &amp; Culture" class="wp-image-2439" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=1024%2C498&amp;ssl=1 1024w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=300%2C146&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?resize=768%2C373&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/20190324_163523.jpg?w=2000&amp;ssl=1 2000w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>A small group of us snuck away after Meow Wolf to check out  Museum of Indian Arts &amp; Culture where I was excited to check out Desiree Kane&#8217;s photography as part of the Standing Rock exhibit.</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2447" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-131-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Jason and Steve kicking off DENT 2019 to a full house at La Fonda on the Plaza</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="507" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=1000%2C507&#038;ssl=1" alt="Karate sparring class with Steve Broback and Zoe Bell" class="wp-image-2441" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=300%2C152&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-106.jpg?resize=768%2C389&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Lots of fun activities throughout the week including Dungeons &amp; Dragons, art &amp; museum tours, a poker tournament and this karate sparring class with Steve Broback and Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2434" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-376.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Hopi and Navajo artist basket weaver artist Hopi &amp; Navajo artist Iva Honyestewa</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">A Hopi/Navajo basketmaker from Second Mesa, Arizona, <a href="https://en.wikipedia.org/wiki/Iva_Honyestewa">Iva Honyestewa</a> was mostly known as a sifter basket maker. During her artist residency at SAR, 2014 Eric and Barbara Dobkin Fellow at the <a href="https://sarweb.org/">School for Advanced Research</a>, however, Iva pioneered a completely new technique of basketry. Called pootsaya these baskets are a combination of the Second Mesa poota (coiled basket) and the more broadly made tutsaya (sifter basket). This new technique was a developed with the intention of bringing the sometimes fractured Hopi communities from which she comes together. Iva is currently only one of two people in the world working in this technique.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="700" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=1000%2C700&#038;ssl=1" alt="Barbara Rae-Venter" class="wp-image-2433" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=300%2C210&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-407.jpg?resize=768%2C538&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Barbara Rae-Venter is an retiree solving high profile cold cases.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph"><a href="https://barbara.genealogyconsult.com/">Barbara</a> is a Search Angel with <a href="http://dnaadoption.org/">DNAAdoption.com</a> helping adoptees find their birth parents and also helps teach the autosomal DNA classes DNAadoption.com offers to help adoptees use their DNA to find birth relatives. As a volunteer with DNAadoption.com, Barbara volunteered her time to work on a project for the San Bernardino Sheriff’s Department Crimes Against Children Detail to identify, successfully, the immediate family of “Lisa”, a woman now in her 30s, who was abducted as an infant and did not know either who she was or where she was from.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=1000%2C667&#038;ssl=1" alt="Jill Heinerth" class="wp-image-2431" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-506.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Underwater cave explorer Jill Heinreth shared her life&#8217;s work and talked about FEAR.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">More people have walked on the moon than have visited many of the places that Jill Heinerth has seen on Earth.&nbsp;Jill is a veteran of over thirty years of filming, photography, and exploration of underwater caves around the globe for&nbsp;<em>National Geographic</em>, educational institutions, and television networks worldwide.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="814" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=1000%2C814&#038;ssl=1" alt="Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life." class="wp-image-2429" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=300%2C244&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-591.jpg?resize=768%2C625&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Tay &amp; Val quit their jobs and their normal lives to chase their dreams and live an extraordinary life.</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Award-winning filmmakers, <a href="https://www.taynval.com/">Tay and Val</a> left successful media careers, closed their production company, wrapped work on their nationally televised television series P.S. I’m Sorry, and set off to travel the world by bicycle for a <a href="https://vimeo.com/90166204">documentary project to inspire dreams</a>. Six years, three continents, more than 400 public talks and national radio and TV appearances (in twelve countries), and 2 TEDx talks later, Tay and Val settled in the Pacific Northwest as City Artists of Seattle. Committed to helping visionary leaders meet their call to greatness with clear-eyed vision, groundedness, and deep trust – they work with leaders and businesses around the globe who hear the call to rise and say yes.</p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&#038;ssl=1" alt="Native American Glass Chandelier - La Fonda Hotel Sante Fe New Mexioco" class="wp-image-2427" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-452.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Native American Glass Chandelier &#8211; La Fonda Hotel Sante Fe New Mexioco</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">I can&#8217;t say enough about the art. Every nook and cranny of the hotel and the whole town of Santa Fe was full of beautiful Native American style art. I brought home blankets, pottery and turquoise jewelry for my friends and family. </p>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=1000%2C667&#038;ssl=1" alt="William Coupon Portrait by Kris Krug" class="wp-image-2426" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-428.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Portrait photographer William Coupon portrait by KK</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=1000%2C667&#038;ssl=1" alt="" class="wp-image-2448" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-212-1.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>“And today’s youth desperately seek contact and attention from a generation of distracted parents addicted to their smartphones.”</figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="1000" height="667" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=1000%2C667&#038;ssl=1" alt="Zoe Bell" class="wp-image-2432" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?w=1000&amp;ssl=1 1000w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=300%2C200&amp;ssl=1 300w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/03/dent2019-485.jpg?resize=768%2C512&amp;ssl=1 768w" sizes="auto, (max-width: 1000px) 100vw, 1000px" /><figcaption>Was fun to connect this year with badass Zoe Bell.<br /></figcaption></figure>
+
+
+
+<figure class="wp-block-image"><img data-recalc-dims="1" loading="lazy" decoding="async" width="683" height="1024" src="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&#038;ssl=1" alt="Ellen Petry Leanse" class="wp-image-2454" srcset="https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=683%2C1024&amp;ssl=1 683w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=200%2C300&amp;ssl=1 200w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?resize=768%2C1152&amp;ssl=1 768w, https://i0.wp.com/kriskrug.co/wp-content/uploads/2019/04/dent2019-790.jpg?w=1000&amp;ssl=1 1000w" sizes="auto, (max-width: 683px) 100vw, 683px" /><figcaption>Friend and mentor Ellen Petry Leanse</figcaption></figure>
+
+
+
+<p class="wp-block-paragraph">Thanks for making it this far. Come to <a href="https://dentthefuture.com/">DENT</a> next time around and let&#8217;s hang! 🙂 Subscribe for updates pls.</p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/">DENT the Future: An Insider&#8217;s Experiences at the Dent Conference</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2423-identity.json
@@ -1,0 +1,14 @@
+{
+  "id": 2423,
+  "slug": "dent-2019-photo-recap-gallery",
+  "status": "publish",
+  "link": "https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/",
+  "modified": "2026-06-28T20:39:59",
+  "modified_gmt": "2026-06-29T04:39:59",
+  "type": "post",
+  "content_raw_source": "public_content_rendered_standin",
+  "content_raw_bytes": 17335,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true,
+  "public_content_raw_available": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-content.raw.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-content.raw.html
@@ -1,0 +1,136 @@
+
+<p class="wp-block-paragraph">As <a href="https://dentthefuture.com/conference">DENT&#8217;s</a> Official Photographer since 2014, I&#8217;ve had the unique opportunity to experience the conference from behind the lens. In this post, I&#8217;ll share some personal reflections, stories, and insights from my journey with DENT and the peeps that bring it to life.</p>
+
+
+
+<h2 class="wp-block-heading">Introduction: Discovering DENT</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://dentthefuture.com/">DENT the Future</a>, organized by <a href="https://www.linkedin.com/in/jpreston">Jason Preston</a> and <a href="http://stevebroback.com/about/">Steve Broback</a>, is an &#8216;ideas and inspiration festival&#8217; that has become a strong community of creative professionals. From Sante Fe to Maui, Teluride, and Napa, Dent offers talks, workshops, and good times, all reflected back to the world through my camera.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Nne9u1Lay20" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<h3 class="wp-block-heading">Sante Fe: A Cultural Experience</h3>
+
+
+
+<p class="wp-block-paragraph">My trips to Sante Fe for <a href="https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/">DENT</a> have captivated my imagination. Meeting Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations, and experiencing the rich art and culture has been a highlight.</p>
+
+
+
+<h2 class="wp-block-heading">Connections and Community: More Than a Conference</h2>
+
+
+
+<p class="wp-block-paragraph">DENT has grown into a support network of friends and collaborators. Seeing familiar faces like my buddy <a href="https://www.instagram.com/real_mckenna">Matt McKenna</a>, and exploring art sensations like <a href="https://meowwolf.com/">Meow Wolf</a>&#8216;s <a href="https://meowwolf.com/visit/santa-fe">Temple of Eternal Return Exhibition</a>, has turned DENT into a family reunion of sorts.</p>
+
+
+
+<h3 class="wp-block-heading">Jason and Steve: The Heart of Dent</h3>
+
+
+
+<p class="wp-block-paragraph">Jason and Steve&#8217;s kickoff to DENT 2019 at La Fonda on the Plaza set the tone for an event filled with creativity and connection. Their leadership and vision have shaped DENT into what it is today.</p>
+
+
+
+<h2 class="wp-block-heading">Beyond Photography</h2>
+
+
+
+<p class="wp-block-paragraph">Beyond my role as Official Photographer, I&#8217;ve engaged in various activities at DENT, including karate sparring with Steve Broback and <a href="https://en.wikipedia.org/wiki/Zo%C3%AB_Bell">Zoe Bell</a>, Dungeons &amp; Dragons, art &amp; museum tours, and a poker tournament. These fun activities have added depth to my DENT experience.</p>
+
+
+
+<h3 class="wp-block-heading">Exploring Art and Culture</h3>
+
+
+
+<p class="wp-block-paragraph">A visit to the Museum of Indian Arts &amp; Culture and the chance to see Desiree Kane&#8217;s photography as part of the Standing Rock exhibit allowed me to connect with the local culture. Also, meeting Iva Honyestewa, a Hopi/Navajo basketmaker, and exploring her unique basketry technique was a fascinating experience.</p>
+
+
+
+<h2 class="wp-block-heading">Inspirational Voices: Personal Encounters</h2>
+
+
+
+<p class="wp-block-paragraph">From underwater cave explorer Jill Heinerth talking about fear to Tay &amp; Val&#8217;s extraordinary life journey, I&#8217;ve been inspired by many speakers at DENT. Barbara Rae-Venter&#8217;s work on high-profile cold cases and her dedication to helping adoptees find their birth parents left a lasting impression.</p>
+
+
+
+<h3 class="wp-block-heading">The Art of Santa Fe: A Visual Feast</h3>
+
+
+
+<p class="wp-block-paragraph">The art in Santa Fe, especially the Native American Glass Chandelier at La Fonda Hotel and the beautiful Native American style art throughout the town, has been a visual feast. I&#8217;ve even brought home blankets, pottery, and turquoise jewelry for my friends and family.</p>
+
+
+
+<p class="wp-block-paragraph">DENT Photography &amp; Photo Galleries</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157673016933510">DENT Space</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157673016933510">https://www.flickr.com/photos/kk/albums/72157673016933510</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157642906164325">DENT 2014</a>:</strong> <a href="https://www.flickr.com/photos/kk/albums/72157642906164325">https://www.flickr.com/photos/kk/albums/72157642906164325</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157651438430096">DENT 2015</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157651438430096">https://www.flickr.com/photos/kk/albums/72157651438430096</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157666173733016">DENT 2016</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157666173733016">https://www.flickr.com/photos/kk/albums/72157666173733016</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157678301027093">DENT 2017</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157678301027093">https://www.flickr.com/photos/kk/albums/72157678301027093</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157669493351129"><strong>DENT 2018</strong></a>: <a href="https://www.flickr.com/photos/kk/albums/72157669493351129">https://www.flickr.com/photos/kk/albums/72157669493351129</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">DENT 2019</a>: <a href="https://www.flickr.com/photos/kk/albums/72157677458163477">https://www.flickr.com/photos/kk/albums/72157677458163477</a></li>
+</ul>
+
+
+
+<h2 class="wp-block-heading">The Photowalk Tradition: Connecting Artists and Creatives</h2>
+
+
+
+<p class="wp-block-paragraph">Every year at DENT, I&#8217;ve had the pleasure of leading a photowalk for artists and creatives. It&#8217;s an opportunity that goes beyond the professional realm and invites photo enthusiasts to get together, hang out, and learn their gear in a collaborative environment.</p>
+
+
+
+<h3 class="wp-block-heading">Breaking the Ice: Portraits and Connections</h3>
+
+
+
+<p class="wp-block-paragraph">Many attendees are interested in making portraits but may feel intimidated to ask their subjects for permission. These photowalks serve as a great chance to break the ice, get to know other attendees, and venture out into the community where the conference is held. It&#8217;s a special part of DENT that fosters connection, creativity, and collaboration.</p>
+
+
+
+<h3 class="wp-block-heading">Conclusion: A Personal Invitation</h3>
+
+
+
+<p class="wp-block-paragraph">Thanks for joining me on this personal reflection of DENT. From photowalks to inspirational talks, DENT is more than a conference; it&#8217;s a part of my life. The friendships, connections, and memories I&#8217;ve made have shaped me both professionally and personally. Come to DENT next time around, and let&#8217;s hang!</p>
+
+
+
+<p class="wp-block-paragraph"><iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/5ALuENAKI7QhV1eHmEPUdj?utm_source=generator&amp;t=0" width="100%" height="352" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/07/28/future-in-review-conference-and-fire-podcast-an-insiders-view/">Future in Review Conference and FIRE Podcast: An Insider&#8217;s View</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-content.rendered.html
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-content.rendered.html
@@ -1,0 +1,136 @@
+
+<p class="wp-block-paragraph">As <a href="https://dentthefuture.com/conference">DENT&#8217;s</a> Official Photographer since 2014, I&#8217;ve had the unique opportunity to experience the conference from behind the lens. In this post, I&#8217;ll share some personal reflections, stories, and insights from my journey with DENT and the peeps that bring it to life.</p>
+
+
+
+<h2 class="wp-block-heading">Introduction: Discovering DENT</h2>
+
+
+
+<p class="wp-block-paragraph"><a href="https://dentthefuture.com/">DENT the Future</a>, organized by <a href="https://www.linkedin.com/in/jpreston">Jason Preston</a> and <a href="http://stevebroback.com/about/">Steve Broback</a>, is an &#8216;ideas and inspiration festival&#8217; that has become a strong community of creative professionals. From Sante Fe to Maui, Teluride, and Napa, Dent offers talks, workshops, and good times, all reflected back to the world through my camera.</p>
+
+
+
+<p class="wp-block-paragraph"><iframe loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/Nne9u1Lay20" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen=""></iframe></p>
+
+
+
+<h3 class="wp-block-heading">Sante Fe: A Cultural Experience</h3>
+
+
+
+<p class="wp-block-paragraph">My trips to Sante Fe for <a href="https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/">DENT</a> have captivated my imagination. Meeting Native Americans from Hopi, Zuni, Pueblo &amp; Navajo nations, and experiencing the rich art and culture has been a highlight.</p>
+
+
+
+<h2 class="wp-block-heading">Connections and Community: More Than a Conference</h2>
+
+
+
+<p class="wp-block-paragraph">DENT has grown into a support network of friends and collaborators. Seeing familiar faces like my buddy <a href="https://www.instagram.com/real_mckenna">Matt McKenna</a>, and exploring art sensations like <a href="https://meowwolf.com/">Meow Wolf</a>&#8216;s <a href="https://meowwolf.com/visit/santa-fe">Temple of Eternal Return Exhibition</a>, has turned DENT into a family reunion of sorts.</p>
+
+
+
+<h3 class="wp-block-heading">Jason and Steve: The Heart of Dent</h3>
+
+
+
+<p class="wp-block-paragraph">Jason and Steve&#8217;s kickoff to DENT 2019 at La Fonda on the Plaza set the tone for an event filled with creativity and connection. Their leadership and vision have shaped DENT into what it is today.</p>
+
+
+
+<h2 class="wp-block-heading">Beyond Photography</h2>
+
+
+
+<p class="wp-block-paragraph">Beyond my role as Official Photographer, I&#8217;ve engaged in various activities at DENT, including karate sparring with Steve Broback and <a href="https://en.wikipedia.org/wiki/Zo%C3%AB_Bell">Zoe Bell</a>, Dungeons &amp; Dragons, art &amp; museum tours, and a poker tournament. These fun activities have added depth to my DENT experience.</p>
+
+
+
+<h3 class="wp-block-heading">Exploring Art and Culture</h3>
+
+
+
+<p class="wp-block-paragraph">A visit to the Museum of Indian Arts &amp; Culture and the chance to see Desiree Kane&#8217;s photography as part of the Standing Rock exhibit allowed me to connect with the local culture. Also, meeting Iva Honyestewa, a Hopi/Navajo basketmaker, and exploring her unique basketry technique was a fascinating experience.</p>
+
+
+
+<h2 class="wp-block-heading">Inspirational Voices: Personal Encounters</h2>
+
+
+
+<p class="wp-block-paragraph">From underwater cave explorer Jill Heinerth talking about fear to Tay &amp; Val&#8217;s extraordinary life journey, I&#8217;ve been inspired by many speakers at DENT. Barbara Rae-Venter&#8217;s work on high-profile cold cases and her dedication to helping adoptees find their birth parents left a lasting impression.</p>
+
+
+
+<h3 class="wp-block-heading">The Art of Santa Fe: A Visual Feast</h3>
+
+
+
+<p class="wp-block-paragraph">The art in Santa Fe, especially the Native American Glass Chandelier at La Fonda Hotel and the beautiful Native American style art throughout the town, has been a visual feast. I&#8217;ve even brought home blankets, pottery, and turquoise jewelry for my friends and family.</p>
+
+
+
+<p class="wp-block-paragraph">DENT Photography &amp; Photo Galleries</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157673016933510">DENT Space</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157673016933510">https://www.flickr.com/photos/kk/albums/72157673016933510</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157642906164325">DENT 2014</a>:</strong> <a href="https://www.flickr.com/photos/kk/albums/72157642906164325">https://www.flickr.com/photos/kk/albums/72157642906164325</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157651438430096">DENT 2015</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157651438430096">https://www.flickr.com/photos/kk/albums/72157651438430096</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157666173733016">DENT 2016</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157666173733016">https://www.flickr.com/photos/kk/albums/72157666173733016</a> </li>
+
+
+
+<li><strong><a href="https://www.flickr.com/photos/kk/albums/72157678301027093">DENT 2017</a></strong>: <a href="https://www.flickr.com/photos/kk/albums/72157678301027093">https://www.flickr.com/photos/kk/albums/72157678301027093</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157669493351129"><strong>DENT 2018</strong></a>: <a href="https://www.flickr.com/photos/kk/albums/72157669493351129">https://www.flickr.com/photos/kk/albums/72157669493351129</a> </li>
+
+
+
+<li><a href="https://www.flickr.com/photos/kk/albums/72157677458163477">DENT 2019</a>: <a href="https://www.flickr.com/photos/kk/albums/72157677458163477">https://www.flickr.com/photos/kk/albums/72157677458163477</a></li>
+</ul>
+
+
+
+<h2 class="wp-block-heading">The Photowalk Tradition: Connecting Artists and Creatives</h2>
+
+
+
+<p class="wp-block-paragraph">Every year at DENT, I&#8217;ve had the pleasure of leading a photowalk for artists and creatives. It&#8217;s an opportunity that goes beyond the professional realm and invites photo enthusiasts to get together, hang out, and learn their gear in a collaborative environment.</p>
+
+
+
+<h3 class="wp-block-heading">Breaking the Ice: Portraits and Connections</h3>
+
+
+
+<p class="wp-block-paragraph">Many attendees are interested in making portraits but may feel intimidated to ask their subjects for permission. These photowalks serve as a great chance to break the ice, get to know other attendees, and venture out into the community where the conference is held. It&#8217;s a special part of DENT that fosters connection, creativity, and collaboration.</p>
+
+
+
+<h3 class="wp-block-heading">Conclusion: A Personal Invitation</h3>
+
+
+
+<p class="wp-block-paragraph">Thanks for joining me on this personal reflection of DENT. From photowalks to inspirational talks, DENT is more than a conference; it&#8217;s a part of my life. The friendships, connections, and memories I&#8217;ve made have shaped me both professionally and personally. Come to DENT next time around, and let&#8217;s hang!</p>
+
+
+
+<p class="wp-block-paragraph"><iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/5ALuENAKI7QhV1eHmEPUdj?utm_source=generator&amp;t=0" width="100%" height="352" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></p>
+
+
+
+<p class="kk-collection-footer wp-block-paragraph">Part of the <a href="https://kriskrug.co/ai-events/">Events and Reports</a> collection. See also: <a href="https://kriskrug.co/2023/07/28/future-in-review-conference-and-fire-podcast-an-insiders-view/">Future in Review Conference and FIRE Podcast: An Insider&#8217;s View</a>.</p>

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-2833-identity.json
@@ -1,0 +1,14 @@
+{
+  "id": 2833,
+  "slug": "dent-the-future-an-insiders-experiences-at-the-dent-conference",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/",
+  "modified": "2026-06-14T20:37:42",
+  "modified_gmt": "2026-06-15T04:37:42",
+  "type": "post",
+  "content_raw_source": "public_content_rendered_standin",
+  "content_raw_bytes": 7899,
+  "content_raw_has_style": false,
+  "content_raw_has_footer": true,
+  "public_content_raw_available": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-3183-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-3183-identity.json
@@ -1,0 +1,15 @@
+{
+  "id": 3183,
+  "slug": "coffee-community-and-sobriety-matt-mckennas-decade-at-dent",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/",
+  "modified": "2026-06-28T20:38:36",
+  "modified_gmt": "2026-06-29T04:38:36",
+  "type": "post",
+  "do_not_touch": true,
+  "featured_media": 3232,
+  "categories": [
+    1677
+  ],
+  "public_content_raw_available": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-3330-identity.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/before/post-3330-identity.json
@@ -1,0 +1,15 @@
+{
+  "id": 3330,
+  "slug": "the-future-called-i-answered",
+  "status": "publish",
+  "link": "https://kriskrug.co/2023/09/29/the-future-called-i-answered/",
+  "modified": "2026-08-17T18:15:57",
+  "modified_gmt": "2026-08-18T02:15:57",
+  "type": "post",
+  "do_not_touch": true,
+  "categories": [
+    1676
+  ],
+  "has_existing_3183_link": true,
+  "public_content_raw_available": false
+}

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-831/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-831/targets.json
@@ -1,0 +1,112 @@
+{
+  "issue": 831,
+  "parent": 402,
+  "blocked_by": 826,
+  "live_reconfirm": "2026-08-19T23:20:11Z",
+  "status": "prepared_not_applied",
+  "snapshot_note": "WP creds were unset. Public REST has no content.raw. Page 12319 raw is reconstructed from the 2026-07-01 architecture payload. Posts 2833 and 2423 use public content.rendered as a stand-in.",
+  "forbidden_href_substrings": [],
+  "preserve_existing_hrefs": [
+    "https://kriskrug.co/2025/03/01/shane-gibsons-ai-sales-dojo/",
+    "https://kriskrug.co/2025/01/25/human-biography-podcast-w-sharad-khare/",
+    "https://kriskrug.co/category/conversations-interviews/"
+  ],
+  "do_not_touch": [
+    {
+      "id": 3183,
+      "slug": "coffee-community-and-sobriety-matt-mckennas-decade-at-dent",
+      "reason": "no spoke out in the matrix; existing hub footer stays"
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "reason": "already links 3183; category is #826"
+    }
+  ],
+  "child1_gate": [
+    {
+      "id": 3814,
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "from_category": 1757,
+      "to_category": 1678
+    },
+    {
+      "id": 3330,
+      "slug": "the-future-called-i-answered",
+      "from_category": 1757,
+      "to_category": 1676
+    },
+    {
+      "id": 1067,
+      "slug": "hardcore-superstar-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1063,
+      "slug": "made-in-vancouver-photoshoot",
+      "from_category": 1662,
+      "to_category": 1756
+    },
+    {
+      "id": 1147,
+      "slug": "fashion-photoshoot-for-discollection",
+      "from_category": 1665,
+      "to_category": 1756
+    }
+  ],
+  "items": [
+    {
+      "id": 12319,
+      "kind": "pages",
+      "slug": "ai-conversations",
+      "url": "https://kriskrug.co/ai-conversations/",
+      "modified_gmt_at_reconfirm": "2026-07-01T20:28:05",
+      "find": "    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/category/conversations-interviews/\">",
+      "replace": "    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/\">\n        <img src=\"https://i0.wp.com/kriskrug.co/wp-content/uploads/2023/09/image-12.png?resize=640,400&amp;ssl=1\" alt=\"Matt McKenna at DENT the Future\" loading=\"lazy\">\n        <div>\n          <h3>Matt McKenna's decade at DENT</h3>\n          <p>Ten years of DENT, ten years sober, and a coffee shop in Miami.</p>\n        </div>\n      </a>\n    </article>\n    <article class=\"aurora-media-card\">\n      <a href=\"https://kriskrug.co/category/conversations-interviews/\">",
+      "anchors": [
+        {
+          "row": 15,
+          "text": "Matt McKenna's decade at DENT",
+          "href": "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/",
+          "link_style": "card"
+        }
+      ],
+      "preserve_existing_cards": true
+    },
+    {
+      "id": 2833,
+      "kind": "posts",
+      "slug": "dent-the-future-an-insiders-experiences-at-the-dent-conference",
+      "url": "https://kriskrug.co/2023/08/19/dent-the-future-an-insiders-experiences-at-the-dent-conference/",
+      "modified_gmt_at_reconfirm": "2026-06-15T04:37:42",
+      "find": "<a href=\"https://www.instagram.com/real_mckenna\">Matt McKenna</a>",
+      "replace": "<a href=\"https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/\">Matt McKenna, who has been at every single one</a>",
+      "anchors": [
+        {
+          "row": 16,
+          "text": "Matt McKenna, who has been at every single one",
+          "href": "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/"
+        }
+      ],
+      "preserve_footer": true
+    },
+    {
+      "id": 2423,
+      "kind": "posts",
+      "slug": "dent-2019-photo-recap-gallery",
+      "url": "https://kriskrug.co/2019/03/30/dent-2019-photo-recap-gallery/",
+      "modified_gmt_at_reconfirm": "2026-06-29T04:39:59",
+      "find": "who have become friends and collaborators.",
+      "replace": "who have become friends and collaborators. <a href=\"https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/\">I sat down with Matt McKenna a few years after this</a>.",
+      "anchors": [
+        {
+          "row": 17,
+          "text": "I sat down with Matt McKenna a few years after this",
+          "href": "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/"
+        }
+      ],
+      "preserve_footer": true
+    }
+  ]
+}

--- a/scripts/apply_issue_831_matt_mckenna.py
+++ b/scripts/apply_issue_831_matt_mckenna.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Issue #831: add Matt McKenna to the /ai-conversations/ hub.
+
+Dry-run by default. Writes are gated on ID->slug match, exact text-match
+insertion, child-1 (#826) category proof, and a fresh context=edit snapshot.
+
+    python3 scripts/apply_issue_831_matt_mckenna.py --from-files
+    make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py'
+    make varlock-run CMD='python3 scripts/apply_issue_831_matt_mckenna.py --apply'
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-831"
+TARGETS_PATH = PACK / "targets.json"
+BEFORE_DIR = PACK / "before"
+AFTER_DIR = PACK / "after"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-831-matt-mckenna"
+BASE_URL = "https://kriskrug.co"
+FOOTER_SENTINEL = "kk-collection-footer"
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-831"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.load(resp)
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    temporary_created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        temporary_created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] Snapshot creation failed for {path}: {exc}")
+    finally:
+        if temporary_created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit.")
+    return body
+
+
+def anchor_needle(row: dict) -> str:
+    return f'<a href="{row["href"]}">{row["text"]}</a>'
+
+
+def row_is_present(body: str, row: dict) -> bool:
+    if row.get("link_style") == "card":
+        return row["href"] in body and row["text"] in body
+    return anchor_needle(row) in body
+
+
+def already_applied(body: str, spec: dict) -> bool:
+    return all(row_is_present(body, row) for row in spec["anchors"])
+
+
+def inserted_fragment(spec: dict) -> str:
+    find = spec["find"]
+    replace = spec["replace"]
+    prefix = os.path.commonprefix([find, replace])
+    find_rest = find[len(prefix) :]
+    replace_rest = replace[len(prefix) :]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
+    if already_applied(body, spec):
+        return None
+    find = spec["find"]
+    replace = spec["replace"]
+    count = body.count(find)
+    if count != 1:
+        raise ValueError(
+            f"{spec['id']}: find needle occurs {count} times; expected 1. "
+            "Insert by text match, not a stale block index."
+        )
+    added = inserted_fragment(spec)
+    if "\u2014" in added or "\u2013" in added:
+        raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
+    if any(ord(char) > 127 for char in added):
+        raise ValueError(f"{spec['id']}: inserted copy is not ASCII; use NCR")
+    rewritten = body.replace(find, replace, 1)
+    if spec.get("preserve_existing_cards"):
+        for href in targets["preserve_existing_hrefs"]:
+            if rewritten.count(href) != body.count(href):
+                raise ValueError(f"{spec['id']}: existing card href {href} changed")
+        if rewritten.count("aurora-media-card") != body.count("aurora-media-card") + 1:
+            raise ValueError(f"{spec['id']}: expected exactly one new media card")
+    if spec.get("preserve_footer"):
+        if body.count(FOOTER_SENTINEL) != rewritten.count(FOOTER_SENTINEL):
+            raise ValueError(f"{spec['id']}: kk-collection-footer count changed")
+    for forbidden in targets.get("forbidden_href_substrings") or []:
+        if forbidden in rewritten and forbidden not in body:
+            raise ValueError(f"{spec['id']}: forbidden href {forbidden} was added")
+    for row in spec["anchors"]:
+        if row.get("link_style") == "card":
+            if rewritten.count(row["href"]) != 1 or rewritten.count(row["text"]) != 1:
+                raise ValueError(f"{spec['id']}: expected one card {row['text']!r}")
+            continue
+        needle = anchor_needle(row)
+        if rewritten.count(needle) != 1:
+            raise ValueError(f"{spec['id']}: expected one {needle!r}")
+    return rewritten
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    if live.get("id") != spec["id"]:
+        sys.exit(f"[ABORT] {spec['id']}: REST id is {live.get('id')!r}.")
+    if live.get("slug") != spec["slug"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: slug is {live.get('slug')!r}, "
+            f"expected {spec['slug']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def child1_is_live(header: str, targets: dict) -> tuple[bool, list[str]]:
+    notes: list[str] = []
+    ready = True
+    for row in targets["child1_gate"]:
+        live = request(
+            f"{BASE_URL}/wp-json/wp/v2/posts/{row['id']}?_fields=id,slug,categories",
+            header,
+        )
+        if live.get("slug") != row["slug"]:
+            ready = False
+            notes.append(f"{row['id']} slug {live.get('slug')!r}")
+            continue
+        cats = list(live.get("categories") or [])
+        if row["to_category"] not in cats or row["from_category"] in cats:
+            ready = False
+            notes.append(f"{row['id']} categories {cats}")
+        else:
+            notes.append(f"{row['id']} ok {cats}")
+    return ready, notes
+
+
+def plan_item(spec: dict, body: str, targets: dict) -> dict | None:
+    try:
+        rewritten = rewrite_body(body, spec, targets)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if rewritten is None:
+        print(f"[SKIP] {spec['id']}: exact href+anchor already present.")
+        return None
+    return {"spec": spec, "before": body, "after": rewritten}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for row in spec["anchors"]:
+        print(f"        row {row['row']}: {row['text']!r} -> {row['href']}")
+
+
+def write_after_files(planned: list[dict]) -> None:
+    AFTER_DIR.mkdir(parents=True, exist_ok=True)
+    for item in planned:
+        spec = item["spec"]
+        path = AFTER_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+        path.write_text(item["after"], encoding="utf-8")
+        print(f"[AFTER] {path}")
+
+
+def apply_item(item: dict, header: str, stamp: str, do_apply: bool) -> None:
+    print_plan(item)
+    if not do_apply:
+        return
+    spec = item["spec"]
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    replanned = plan_item(spec, raw_body(live), load_targets())
+    if replanned is None:
+        return
+    write_snapshot(live, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    print(f"[WROTE] {spec['id']}")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    allowed = {row["id"] for row in load_targets()["items"]}
+    post_id = snapshot.get("id")
+    if post_id not in allowed:
+        sys.exit(f"[ABORT] snapshot id {post_id} is not in the #831 set.")
+    spec = next(row for row in load_targets()["items"] if row["id"] == post_id)
+    validate_identity(snapshot, spec)
+    payload = {"content": raw_body(snapshot)}
+    print(f"[RESTORE] {post_id} from {path}")
+    if not do_apply:
+        return
+    live = fetch_live(spec, header)
+    validate_identity(live, spec)
+    write_snapshot(live, datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+    request(rest_url(spec), header, payload)
+    print(f"[WROTE] {post_id} restored")
+
+
+def load_before_body(spec: dict) -> str:
+    path = BEFORE_DIR / f"{spec['kind'][:-1]}-{spec['id']}-content.raw.html"
+    if not path.is_file():
+        sys.exit(f"[ABORT] missing before-file {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply issue #831 Matt McKenna hub links."
+    )
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-files", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    parser.add_argument(
+        "--allow-before-826",
+        action="store_true",
+        help="Unsafe. Bypass the child-1 category gate. Do not use on production.",
+    )
+    args = parser.parse_args()
+    targets = load_targets()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    if args.restore:
+        restore_snapshot(args.restore, auth_header(), args.apply)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id:
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+        forbidden = {row["id"] for row in targets["do_not_touch"]}
+        if args.item_id in forbidden:
+            sys.exit(f"[ABORT] {args.item_id} is do-not-touch for #831.")
+
+    if args.from_files:
+        planned = []
+        for spec in rows:
+            try:
+                item = plan_item(spec, load_before_body(spec), targets)
+            except ValueError as exc:
+                sys.exit(f"[ABORT] {exc}")
+            if item is not None:
+                planned.append(item)
+                print_plan(item)
+        if not planned:
+            print("[OK] nothing pending.")
+            return 0
+        write_after_files(planned)
+        print("[FROM-FILES] wrote after/ payloads. No WordPress writes.")
+        return 0
+
+    header = auth_header()
+    if args.apply and not args.allow_before_826:
+        ready, notes = child1_is_live(header, targets)
+        for note in notes:
+            print(f"[826] {note}")
+        if not ready:
+            sys.exit(
+                "[ABORT] #826 category fixes are not live. "
+                "Need 3330 out of 1757 into 1676. Do not PATCH 12319/2833/2423 yet."
+            )
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        try:
+            item = plan_item(spec, raw_body(live), targets)
+        except ValueError as exc:
+            sys.exit(f"[ABORT] {exc}")
+        if item is not None:
+            item["live"] = live
+            planned.append(item)
+
+    if not planned:
+        print("[OK] nothing pending.")
+        return 0
+
+    for item in planned:
+        apply_item(item, header, stamp, args.apply)
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Pass --apply after #826 is live and KK approves."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_831_matt_mckenna.py
+++ b/scripts/tests/test_apply_issue_831_matt_mckenna.py
@@ -1,0 +1,312 @@
+"""Offline safety tests for the issue #831 Matt McKenna hub helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_831_matt_mckenna.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_831_matt_mckenna", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def before_body(item_id: int) -> str:
+    spec = spec_by_id(item_id)
+    return (
+        MODULE.BEFORE_DIR / f"{spec['kind'][:-1]}-{item_id}-content.raw.html"
+    ).read_text(encoding="utf-8")
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    return {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else before_body(spec["id"])},
+    }
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_831_matt_mckenna.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue831MattMckennaTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+        self.gate = {
+            row["id"]: {
+                "id": row["id"],
+                "slug": row["slug"],
+                "categories": [row["from_category"]],
+            }
+            for row in TARGETS["child1_gate"]
+        }
+
+    def _patch_request(self, calls, *, gate_ready=False):
+        def fake_request(url, _header, body=None):
+            calls.append((url, body))
+            if "/posts/" in url and "context=edit" not in url:
+                post_id = int(url.split("/posts/")[1].split("?")[0])
+                live = json.loads(json.dumps(self.gate[post_id]))
+                if gate_ready:
+                    spec = next(
+                        row for row in TARGETS["child1_gate"] if row["id"] == post_id
+                    )
+                    live["categories"] = [spec["to_category"]]
+                return live
+            if "/pages/" in url:
+                item_id = int(url.split("/pages/")[1].split("?")[0])
+            else:
+                item_id = int(url.split("/posts/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if body is not None:
+                if "content" in body:
+                    live["content"] = {"raw": body["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_match_rows_15_through_17(self):
+        ids = [row["id"] for row in TARGETS["items"]]
+        self.assertEqual(ids, [12319, 2833, 2423])
+        self.assertEqual(spec_by_id(12319)["slug"], "ai-conversations")
+        self.assertEqual(
+            spec_by_id(2833)["slug"],
+            "dent-the-future-an-insiders-experiences-at-the-dent-conference",
+        )
+        self.assertEqual(spec_by_id(2423)["slug"], "dent-2019-photo-recap-gallery")
+        self.assertNotIn(3183, ids)
+        self.assertNotIn(3330, ids)
+        anchors = [
+            (row["row"], row["text"], row["href"])
+            for spec in TARGETS["items"]
+            for row in spec["anchors"]
+        ]
+        self.assertEqual(
+            anchors,
+            [
+                (
+                    15,
+                    "Matt McKenna's decade at DENT",
+                    "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/",
+                ),
+                (
+                    16,
+                    "Matt McKenna, who has been at every single one",
+                    "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/",
+                ),
+                (
+                    17,
+                    "I sat down with Matt McKenna a few years after this",
+                    "https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/",
+                ),
+            ],
+        )
+        gate_3330 = next(row for row in TARGETS["child1_gate"] if row["id"] == 3330)
+        self.assertEqual(gate_3330["from_category"], 1757)
+        self.assertEqual(gate_3330["to_category"], 1676)
+
+    def test_rewrite_12319_inserts_card_and_keeps_other_cards(self):
+        spec = spec_by_id(12319)
+        before = before_body(12319)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertEqual(before.count("aurora-media-card"), 3)
+        self.assertEqual(after.count("aurora-media-card"), 4)
+        self.assertIn("Matt McKenna's decade at DENT", after)
+        self.assertIn(
+            "Ten years of DENT, ten years sober, and a coffee shop in Miami.", after
+        )
+        self.assertIn("matt-mckennas-decade-at-dent", after)
+        for href in TARGETS["preserve_existing_hrefs"]:
+            self.assertEqual(before.count(href), after.count(href))
+        self.assertLess(
+            after.find("matt-mckennas-decade-at-dent"),
+            after.find("category/conversations-interviews/"),
+        )
+        self.assertNotIn("\u2014", MODULE.inserted_fragment(spec))
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_2833_wraps_existing_name_inline(self):
+        spec = spec_by_id(2833)
+        before = before_body(2833)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        community = after[
+            after.find("DENT has grown into a support network") : after.find(
+                "Jason and Steve"
+            )
+        ]
+        self.assertIn(
+            '<a href="https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/">Matt McKenna, who has been at every single one</a>',
+            community,
+        )
+        self.assertNotIn("instagram.com/real_mckenna", community)
+        self.assertIn(
+            "Seeing familiar faces like my buddy <a href=\"https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/\">Matt McKenna, who has been at every single one</a>, and exploring",
+            community,
+        )
+        self.assertEqual(community.count("</p>"), 1)
+        self.assertNotIn(
+            "I sat down with Matt McKenna a few years after this", after
+        )
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_2423_inserts_trailing_intro_sentence(self):
+        spec = spec_by_id(2423)
+        before = before_body(2423)
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        intro_end = after.find("who have become friends and collaborators.")
+        figure = after.find("<figure")
+        footer = after.find("kk-collection-footer")
+        self.assertGreater(figure, intro_end)
+        self.assertGreater(footer, after.find("I sat down with Matt McKenna"))
+        self.assertIn(
+            '<a href="https://kriskrug.co/2023/09/22/coffee-community-and-sobriety-matt-mckennas-decade-at-dent/">I sat down with Matt McKenna a few years after this</a>',
+            after,
+        )
+        self.assertEqual(
+            before.count("kk-collection-footer"), after.count("kk-collection-footer")
+        )
+        self.assertIn("Just back from Sante Fe", before)
+        self.assertEqual(before.count(spec["find"]), 1)
+
+    def test_stale_block_index_is_ignored_text_match_wins(self):
+        spec = spec_by_id(2423)
+        before = before_body(2423)
+        self.assertIn("Just back from Sante Fe", before)
+        self.assertIn(spec["find"], before)
+        self.assertEqual(before.count(spec["find"]), 1)
+
+    def test_missing_needle_aborts(self):
+        spec = spec_by_id(2833)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>no Matt here</p>", spec, TARGETS)
+
+    def test_from_files_writes_after_payloads_and_does_not_call_wordpress(self):
+        calls = []
+        after_dir = self.tmp_path / "after"
+        with (
+            mock.patch.object(MODULE, "AFTER_DIR", after_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--from-files"))
+        self.assertEqual(calls, [])
+        self.assertTrue((after_dir / "page-12319-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-2833-content.raw.html").is_file())
+        self.assertTrue((after_dir / "post-2423-content.raw.html").is_file())
+        self.assertFalse((after_dir / "post-3183-content.raw.html").is_file())
+        self.assertFalse((after_dir / "post-3330-content.raw.html").is_file())
+
+    def test_live_dry_run_performs_no_wordpress_writes(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertTrue(calls)
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_slug_mismatch_aborts_before_any_write(self):
+        self.lives[12319]["slug"] = "wrong-slug"
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--allow-before-826", "--item-id", "12319")
+        self.assertIn("slug is", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+        self.assertFalse(snapshot_dir.exists())
+
+    def test_apply_refuses_when_826_is_not_live(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "2423")
+        self.assertIn("#826", str(caught.exception))
+        self.assertIn("3330", str(caught.exception))
+        self.assertTrue(all(body is None for _, body in calls))
+
+    def test_apply_snapshots_then_posts_content_only(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE,
+                "request",
+                side_effect=self._patch_request(calls, gate_ready=True),
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "2423"))
+        writes = [body for _, body in calls if body is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn(
+            "I sat down with Matt McKenna a few years after this",
+            writes[0]["content"],
+        )
+        self.assertIn("kk-collection-footer", writes[0]["content"])
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_do_not_touch_item_id_is_refused(self):
+        with self.assertRaises(SystemExit) as caught:
+            run_main("--from-files", "--item-id", "3183")
+        self.assertIn("unknown --item-id", str(caught.exception))
+
+    def test_apply_md_does_not_claim_the_write_already_happened(self):
+        apply_md = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("Prepared, not applied", apply_md)
+        self.assertIn("--apply", apply_md)
+        self.assertIn("#826", apply_md)
+        self.assertNotIn("\u2014", apply_md)
+        self.assertNotIn("Fixes #831", apply_md)
+        self.assertNotIn("Fixes #402", apply_md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply-ready pack for [#831](https://github.com/WalksWithASwagger/kriskrug-wp/issues/831): add a Matt McKenna interview card on `/ai-conversations/` and two inbound spokes to post 3183. **Prepared, not applied.**

**Do not apply until KK says go.** `--apply` still gates on the #826 category moves.

## Related Issue

Refs #831

Leaves #831 and #402 open (payload prepared, not applied). Does **not** touch posts 3183 or 3330.

## Changes

- `content/drafts/2026-08-02-seo-authority-hubs/fix-831/` — APPLY.md, targets.json, before/after snapshots (3183/3330 identity only)
- `scripts/apply_issue_831_matt_mckenna.py` — dry-run default, `--from-files`, slug/ID checks, `--restore`
- `scripts/tests/test_apply_issue_831_matt_mckenna.py` — 13 offline tests

## Type of Change

- [x] Content update (payload only)
- [x] Documentation update

## Testing

- [x] `python3 -m unittest scripts.tests.test_apply_issue_831_matt_mckenna` (13 tests, OK)
- Live public GET 2026-08-19: 12319 has no 3183 card; 2833 has the Instagram name only; 2423 intro has no 3183 href; 3330 already links 3183 and is already in category 1676

## Deployment Notes

- [x] No special deployment steps required
- Do **not** run `--apply` from this PR without KK approval

## Additional Notes

`WP_USER` / `WP_APP_PASSWORD` were unset, so 2833 / 2423 before-files are public `content.rendered` stand-ins. Live `--apply` still GETs real `content.raw` and still requires slug/ID checks.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c4f-22a9-7df9-9466-dea6653bf59e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c4f-22a9-7df9-9466-dea6653bf59e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


