### PR TITLE
docs: archive stale FVAI launch packet

### DIFF
--- a/content/drafts/2026-09-09-fv-ai-launch/README.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/README.md
@@ -1,6 +1,8 @@
 # FV+AI Launch Packet — September 9, 2026
 
-**Status:** working draft; no Luma event created and nothing published or sent
+> **Archived August 22, 2026.** This entire directory is a superseded pre-launch draft. Do not use its schedule, Luma state, ticket model, copy, or artwork as current truth. The canonical live packet is [maintained in kk-kb](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai).
+
+**Status:** archived duplicate; retained only for repository history
 
 **Event date:** Wednesday, September 9, 2026
 

--- a/content/drafts/2026-09-09-fv-ai-launch/launch-plan.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/launch-plan.md
@@ -1,5 +1,7 @@
 # FV+AI September 9 Launch Plan
 
+> **Archived August 22, 2026.** This plan predates the live Luma event and is not operational. Use the [canonical kk-kb launch plan](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/launch-plan.md).
+
 ## Outcome
 
 Launch a credible, community-first Fraser Valley room under the BC + AI banner, with Darren Coleman as the local lead and a format that can become monthly without depending on Kris's physical presence.

--- a/content/drafts/2026-09-09-fv-ai-launch/luma-event-draft.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/luma-event-draft.md
@@ -1,5 +1,7 @@
 # Luma Draft — FV+AI Launch
 
+> **Archived August 22, 2026.** This draft predates the live event and contains superseded ticket, capacity, copy, and visual assumptions. Use the [canonical kk-kb Luma record](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/luma-event-draft.md).
+
 ## Event fields
 
 **Name:** FV+AI Launch: Fraser Valley Community Meetup

--- a/content/drafts/2026-09-09-fv-ai-launch/meeting-transcripts.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/meeting-transcripts.md
@@ -1,5 +1,7 @@
 # FV+AI Meeting Transcript Records
 
+> **Archived August 22, 2026.** This duplicate is retained for repository history. Use the [canonical kk-kb transcript record](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/meeting-transcripts.md).
+
 These records separate verbatim source material from reconstruction. The June call has no recording in the knowledge base, so its record is a source-grounded reconstruction. The July 31 section is an edited excerpt from the actual Office Hours transcript, whose source export did not contain timestamps or speaker labels.
 
 ## June 19, 2026 — Kris Krüg and Darren Coleman planning call

--- a/content/drafts/2026-09-09-fv-ai-launch/press-release-review.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/press-release-review.md
@@ -1,5 +1,7 @@
 # Review of Darren's August 10 FV+AI Press Release
 
+> **Archived August 22, 2026.** The release published August 11, and this duplicate review is no longer an active send gate. Use the [canonical kk-kb review](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/press-release-review.md).
+
 **Recommendation:** hold submission until the event link, profile link, time, and ownership language are corrected. The release has a sound regional premise and a usable Darren quote, but it is not yet aligned with the community-first story Darren says he wants.
 
 ## Must fix before submission

--- a/content/drafts/2026-09-09-fv-ai-launch/source-dossier.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/source-dossier.md
@@ -1,5 +1,7 @@
 # FV+AI Source Dossier
 
+> **Archived August 22, 2026.** This duplicate preserves an earlier research snapshot. Use the [canonical kk-kb source dossier](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/source-dossier.md).
+
 ## Executive read
 
 FV+AI is not a cold start. It grows from approximately ten Surrey gatherings, Darren Coleman's local business and Toastmasters network, and the regional-chapter pattern already proven in Comox Valley. Darren has offered the first venue, food, drinks, and local operational leadership. Kris has already approved the official BC + AI banner, the FV+AI shorthand, and the long-form name.

--- a/content/drafts/2026-09-09-fv-ai-launch/visual-notes.md
+++ b/content/drafts/2026-09-09-fv-ai-launch/visual-notes.md
@@ -1,5 +1,7 @@
 # FV+AI Visual Notes
 
+> **Archived August 22, 2026.** The artwork in this directory is superseded and must not be reused. Use the [canonical kk-kb visual record](https://github.com/WalksWithASwagger/kk-kb/tree/main/content/projects/02-bc-ai-ecosystem-nonprofit/community-programs/regional-chapters/fraser-valley-ai/visual-notes.md).
+
 ## Cover A — Fraser Valley mural
 
 **File:** `fvai-luma-cover-mural.png`  


### PR DESCRIPTION
## Summary

- mark every markdown file in the duplicate September 9 FV+AI draft packet as archived
- point each record to the canonical live packet in `kk-kb`
- explicitly block reuse of the superseded artwork and pre-launch Luma assumptions

Refs WalksWithASwagger/kk-kb#3391

## Verification

- `git diff --check`
- confirmed all seven markdown files contain the August 22 archive marker

## Safety boundary

- Documentation-only change. No WordPress, theme, Luma, email, or public-site write was performed.
