### PR TITLE
[PRESS KIT] Add verified producer copy + voice deck

### DIFF
--- a/content/source-packs/content-architecture-2026/press-kit/copy-deck.md
+++ b/content/source-packs/content-architecture-2026/press-kit/copy-deck.md
@@ -1,0 +1,174 @@
+# Press Kit v2 Producer Copy Deck
+
+Status: Track A draft source for issue #877. Nothing here changes WordPress.
+
+Last source review: 2026-08-22.
+
+Use this key throughout the deck:
+
+- **CURRENT:** wording or a fact already present on a public owned page or in a settled decision.
+- **PROPOSED:** reusable press-kit wording derived from current sources. It still needs editorial approval.
+- **PENDING:** do not publish until the named fact or decision is confirmed.
+- Bracketed claim IDs such as `[C3]` map to the claim-level Sources table.
+
+## Identity, pronunciation, location, and availability
+
+- **CURRENT display name:** **Kris Krüg**. Issue #735 settled the umlaut for human-facing theme surfaces on 2026-08-16. The deployed schema source keeps a diacritic-free ASCII alternate name for discovery. Use the umlaut by default; do not treat the alternate as the display name. `[C1]`
+- **PENDING pronunciation:** Kris has not supplied a verified phonetic spelling or audio pronunciation in the reviewed sources. Do not guess. Add it only after Kris confirms it. `[C11]`
+- **PENDING location freshness:** “Vancouver-based” appears in a public 2024 owned bio and the repo schema source, but it does not appear in the reviewed current EPK, About, or Speaking body copy. Keep location out of the production bio until Kris confirms that it is still the wording he wants. `[C2]`
+- **CURRENT booking route:** send media, keynote, workshop, and collaboration inquiries through [kriskrug.co/contact](https://kriskrug.co/contact/). The public pages ask for the audience, topic or goal, format, timing, location or platform, and useful prep links. `[C3]`
+- **CURRENT availability boundary:** the site invites inquiries but does not promise dates, travel, turnaround, or general remote/in-person media availability. The homepage says workshops can be remote or in person; do not generalize that line to every format. `[C4]`
+
+## PENDING #735: booking descriptor and bios
+
+This entire section depends on the remaining #735 decisions. It is complete as a decision packet, not an approved canon. Do not copy these role strings into a public payload until the issue has a dated final ruling.
+
+### What #735 has and has not decided
+
+- **Settled:** display the person name as **Kris Krüg**. The repo schema retains the diacritic-free spelling only as an ASCII alternate. `[C1]`
+- **Still open:** choose the organization styling **BC + AI** or **BC+AI**. The reviewed landing pages and homepage currently use the spaced form, while #735 remains open and no dated final decision note was found. Use the placeholder `{BC_AI_NAME}` until the ruling lands. `[C5]`
+- **Still open:** choose one descriptor set. Current public and repo surfaces disagree. `[C6]`
+
+Current descriptor candidates:
+
+1. **Homepage:** “AI keynote speaker · Creative technologist · Community builder”
+2. **Current EPK:** “AI commentator, podcast guest, and event host”
+3. **About:** “photographer, creative technologist, community builder, speaker, and field-note person”
+4. **Schema job title:** “AI Keynote Speaker and Creative Technologist”
+5. **Shipped pattern:** “Executive Director {BC_AI_NAME} · Lead Curator, Futureproof Festival · Techartist & Culture Hacker”
+
+### One-line booking descriptor
+
+**PROPOSED:** Kris Krüg is an AI keynote speaker, creative technologist, photographer, community builder, and host who makes complicated technology human, useful, and alive. `[C6][C7]`
+
+Five-second test: it says who Kris is, what he does for a room, and why a producer would bring him in.
+
+### 25-word bio
+
+**PROPOSED, 25 words:** Kris Krüg is an AI keynote speaker, creative technologist, photographer, community builder, and host who makes complicated technology human, useful, practical, and alive for audiences. `[C6][C7]`
+
+### 75-word bio
+
+**PROPOSED, 75 words:** Kris Krüg is an AI keynote speaker, creative technologist, photographer, community builder, and host. He helps audiences understand fast-moving AI tools without flattening the creative, ethical, and political questions that make them matter. His talks and conversations mix field stories, practical workflows, live demos, cultural critique, and good friction about authorship, labor, trust, consent, taste, and power. Bring him in when the room needs clear language, honest tension, and a useful question underneath the hype. `[C6][C7][C8]`
+
+### 150-word bio
+
+**PROPOSED, 150 words:** Kris Krüg is an AI keynote speaker, creative technologist, photographer, community builder, and host. He helps audiences understand fast-moving AI tools without flattening the creative, ethical, and political questions that make them matter. His talks and conversations mix field stories, practical workflows, live demos, cultural critique, and good friction about authorship, labor, trust, consent, taste, and power. Bring him in when the room needs clear language, honest tension, and a useful question underneath the hype. Across keynotes, workshops, interviews, commentary, hosting, and moderation, he connects generative AI to creative practice, responsible deployment, community infrastructure, and the human judgment behind the tools. His public work spans two decades of documenting technology, art, activism, conferences, and communities, alongside current rooms built around AI literacy and public conversation. Producers can expect warmth, curiosity, sharp cultural analysis, real examples, and enough weirdness to keep the exchange from sounding like a press release on air. `[C6][C7][C8][C9]`
+
+## Formats
+
+These are producer-ready descriptions of formats already supported by the current public EPK, Speaking page, homepage, or Contact page.
+
+| Format | PROPOSED producer line | Evidence |
+|---|---|---|
+| Interview | Interviews for podcasts, produced video, and live rooms that can move from practical tools to the cultural and ethical questions underneath them. | `[C7][C8]` |
+| Keynote | Story-rich talks that combine field experience, useful live demos, creative practice, and hard questions about power, trust, authorship, and human agency. | `[C7][C8]` |
+| Workshop | Hands-on sessions where people test tools, build a real workflow, and leave with language and an artifact they can use. | `[C4][C7]` |
+| Host or moderator | Warm, sharp facilitation for panels, salons, podcasts, livestreams, and rooms with too many acronyms. | `[C7]` |
+| Commentary | Plain-language AI commentary that stays curious and critical without stripping away ethics, creativity, politics, or lived experience. | `[C7][C8]` |
+
+Do not add remote availability, travel range, runtime, rate, or schedule language to these descriptions without a current public source or Kris's approval.
+
+## Topics and interview angles
+
+These are prompts, not claims that every appearance covers every topic. A producer should pick the tension that fits the audience.
+
+1. **Both Hands Full:** How do we hold AI's capability and its costs at the same time, then make a useful choice? `[C8]`
+2. **AI for creative people:** What changes for photographers, filmmakers, writers, designers, and artists when making gets cheap but taste does not? `[C8][C10]`
+3. **Responsible AI in practice:** What do bias, privacy, provenance, labor, trust, consent, and authenticity look like before deployment? `[C8]`
+4. **Human judgment after the demo:** Which decisions should stay with people when AI can draft, summarize, generate, and automate? `[C8]`
+5. **AI literacy through community:** What can recurring public rooms teach faster than a hype deck or a one-off training session? `[C7][C9]`
+6. **Punk Rock AI:** How can people use powerful tools without becoming obedient to them or sanding off their own taste? `[C8]`
+7. **From tool panic to practice:** What helps a room move from anxiety or novelty toward repeatable, responsible work? `[C8]`
+8. **Synthetic media and trust:** What happens to authorship, documentary evidence, journalism, and audience relationships when convincing media gets easy to generate? `[C10]`
+
+## Voice and mood
+
+Use these as direction for copy, interviews, and design. They describe the current public voice; they are not claims about personality offstage.
+
+| Word | Apply it | Refuse it | Evidence |
+|---|---|---|---|
+| Human | Explain the tool through people, judgment, and consequences. | Clinical product-demo language that treats people as an afterthought. | `[C7][C8]` |
+| Curious | Find the useful question underneath the obvious one. | False certainty, canned predictions, or guru posture. | `[C7]` |
+| Warm | Help the guest, host, and room do good work together. | Corporate cheerleading or a detached expert performance. | `[C7]` |
+| Sharp | Name authorship, labor, power, trust, consent, and refusal directly. | Empty provocation or contrarian theatre. | `[C7][C8]` |
+| Weird | Keep the strange human edge and creative rebellion visible. | Random zany copy, cyberpunk costume, or weirdness without a point. | `[C7][C8]` |
+| Useful | Leave the audience with language, a frame, or a next move. | Tool lists, hype, or abstraction with nothing to do on Monday. | `[C4][C8]` |
+
+## Public booking route and canonical links
+
+### CURRENT owned-site links
+
+- Booking and media inquiries: <https://kriskrug.co/contact/>
+- Current media EPK: <https://kriskrug.co/podcast-guesting-page-epk/>
+- About: <https://kriskrug.co/about/>
+- Speaking: <https://kriskrug.co/speaking/>
+- Work: <https://kriskrug.co/work/>
+- Photography: <https://kriskrug.co/photography/>
+- Writing: <https://kriskrug.co/writing/>
+
+### CURRENT project links already used on the owned site
+
+These project URLs are linked from the current homepage or Speaking page. `[C12]`
+
+- `{BC_AI_NAME}`: <https://bc-ai.ca/>. Keep the placeholder until #735 closes.
+- Vancouver AI: <https://vancouver.ai/>
+- Futureproof Festival: <https://www.futureproof.website/>
+- Both Hands Full: <https://www.bothhandsfull.com/>
+- Punk Rock AI: <https://www.punkrockai.com/>
+
+Do not substitute a private email, phone number, calendar URL, or unpublished booking note for the public contact route.
+
+## Media-introduction templates
+
+### Minimal introduction, usable before #735 closes
+
+**PROPOSED:** Today I am joined by Kris Krüg. We are talking about [topic], [specific tension], and what people can actually do next. Kris, welcome.
+
+### Full introduction, blocked on #735
+
+**PENDING:** Today I am joined by Kris Krüg, [paste the approved one-line descriptor]. We are talking about [topic], [specific tension], and what people can actually do next. Kris, welcome.
+
+Do not improvise an award, client list, audience size, superlative, current title, or availability claim into either introduction.
+
+## Image-credit template
+
+**PROPOSED:** Photo: [photographer]. [Event or location, month and year, only if verified]. [Usage or rights statement copied exactly from the asset manifest.]
+
+Keep the credit attached wherever the image travels. Do not write “courtesy of,” “free to use,” or a reuse license unless the asset-specific manifest supports it.
+
+## Sources
+
+### Claim-level source table
+
+| Claim | What it supports | Public evidence | Local evidence or decision record |
+|---|---|---|---|
+| C1 | Display name is Kris Krüg; `person_alt` holds the diacritic-free ASCII schema alternate; #735's partial name ruling | [About](https://kriskrug.co/about/) displays the umlaut in its title and portrait alt | [#735 comment](https://github.com/WalksWithASwagger/kriskrug-wp/issues/735#issuecomment-5310983164); `fixes/schema-snippets-deployed.php` lines 59-69 |
+| C2 | “Vancouver-based” has public evidence but needs a freshness check before press use | [AlphaPrism / Autolume bio](https://kriskrug.co/2024/12/02/autolume-post-photographic-cybernetic-portraiture/) | `fixes/schema-snippets-deployed.php` line 69; `content/source-packs/keynotes-2026/wp-payloads/podcast-guesting-page-epk.html` lines 267-270, evidence only |
+| C3 | Public inquiry route and useful brief fields | [Contact](https://kriskrug.co/contact/); [current EPK](https://kriskrug.co/podcast-guesting-page-epk/) | `content/source-packs/content-architecture-2026/wp-payloads/contact.html`; `content/source-packs/content-architecture-2026/wp-payloads/podcast-guesting-page-epk.html` |
+| C4 | Workshop format and the narrow remote/in-person claim; no general availability promise | [Homepage](https://kriskrug.co/) service cards; [Contact](https://kriskrug.co/contact/) | `theme/kk-aurora/templates/front-page.html` lines 67-99; `content/source-packs/content-architecture-2026/wp-payloads/contact.html` |
+| C5 | Organization-name spacing remains a #735 decision despite current spaced usage | [Homepage](https://kriskrug.co/); [About](https://kriskrug.co/about/); [current EPK](https://kriskrug.co/podcast-guesting-page-epk/) | [#735](https://github.com/WalksWithASwagger/kriskrug-wp/issues/735); `theme/kk-aurora/CHANGELOG.md` lines 30-36 records a conflicting “per #735” note without the final decision note required by the issue |
+| C6 | Descriptor drift and the candidate role strings | [Homepage](https://kriskrug.co/); [About](https://kriskrug.co/about/); [current EPK](https://kriskrug.co/podcast-guesting-page-epk/) | [#735](https://github.com/WalksWithASwagger/kriskrug-wp/issues/735); `fixes/schema-snippets-deployed.php` lines 68-69; `theme/kk-aurora/patterns/hero-gradient.php` line 23 |
+| C7 | Current roles, interview/commentary framing, host energy, booking formats, and plain-language approach | [current EPK](https://kriskrug.co/podcast-guesting-page-epk/); [Speaking](https://kriskrug.co/speaking/); [Contact](https://kriskrug.co/contact/) | `content/source-packs/content-architecture-2026/wp-payloads/podcast-guesting-page-epk.html`; `content/source-packs/content-architecture-2026/wp-payloads/speaking.html` |
+| C8 | Topic language: creative practice, responsible AI, human judgment, live demos, authorship, labor, trust, consent, taste, and power | [current EPK](https://kriskrug.co/podcast-guesting-page-epk/); [Speaking](https://kriskrug.co/speaking/); [About](https://kriskrug.co/about/) | Same three canonical payloads under `content/source-packs/content-architecture-2026/wp-payloads/` |
+| C9 | Two decades documenting technology, art, activism, conferences, and communities; current AI-literacy and public-room work | [About](https://kriskrug.co/about/); [Homepage](https://kriskrug.co/) | `content/source-packs/content-architecture-2026/about-bio-source-map-2026-07-07.md`; `content/source-packs/content-architecture-2026/wp-payloads/about.html` |
+| C10 | Proposed synthetic-media, journalism, creator-rights, and media-futures angles | [current EPK](https://kriskrug.co/podcast-guesting-page-epk/) supports authorship, trust, and consent | `content/source-packs/keynotes-2026/wp-payloads/podcast-guesting-page-epk.html` lines 233-259, evidence-only draft; do not treat its copy as approved |
+| C11 | No verified pronunciation field was found; the deck must not invent one | Reviewed current [EPK](https://kriskrug.co/podcast-guesting-page-epk/), [About](https://kriskrug.co/about/), [Speaking](https://kriskrug.co/speaking/), [Homepage](https://kriskrug.co/), and [Contact](https://kriskrug.co/contact/) | Reviewed canonical EPK, About, Speaking, and Contact payloads; searched the repo source pack and #735 decision record |
+| C12 | Canonical public project URLs already linked by the owned site | [Homepage](https://kriskrug.co/); [Speaking](https://kriskrug.co/speaking/) | `theme/kk-aurora/templates/front-page.html`; `content/source-packs/content-architecture-2026/wp-payloads/speaking.html` |
+
+### Source hierarchy and conflicts
+
+1. Prefer the current public EPK, About, Speaking, Homepage, and Contact pages for wording and public facts.
+2. Use `content/source-packs/content-architecture-2026/wp-payloads/` as the canonical repo source chain, while remembering that public readback is production truth.
+3. Use `content/source-packs/keynotes-2026/wp-payloads/podcast-guesting-page-epk.html` only as evidence and an idea bank. It contains broader availability and media claims that are intentionally not promoted here.
+4. Let #735 control the unresolved organization spacing and descriptor set. This deck records the conflict; it does not settle it.
+5. Let the issue #878 asset manifest control image rights and final credit language. This deck supplies only the template.
+
+## Producer handoff checklist
+
+- Replace no `{...}` placeholder until its source decision is recorded.
+- Confirm pronunciation and location directly with Kris before adding either to public copy.
+- Choose one approved bio length; do not splice descriptors from different versions.
+- Keep the public contact route instead of publishing private contact or calendar details.
+- Attach a claim source to any new title, client, award, outlet, audience size, format, or availability statement.
+- Copy the exact image credit and usage note from the rights-aware asset manifest.


### PR DESCRIPTION
## Summary

- adds the one-line descriptor plus exact 25-, 75-, and 150-word bio drafts
- gives producers current formats, eight interview angles, six voice/mood rules, public links, and media/image-credit templates
- separates CURRENT, PROPOSED, and PENDING wording so the deck leaves the #735 brand-canon decision open
- maps every factual press claim to one of 12 public/local evidence rows
- records the settled umlaut ruling while leaving organization spacing and the descriptor set open

## Verification

- `voicecheck.py --json .../copy-deck.md`: PASS, 0 findings; manual facet pass used The ED with The Host for warmth
- issue marker `rg`: PASS
- banned marketing-term `rg`: PASS, no matches
- private email/phone/calendar scan: PASS, no matches
- word counts: PASS, exact 25 / 75 / 150
- claim-key audit: PASS, C1-C12 all used and all have source rows
- `git diff --cached --check`: PASS
- staged/committed scope: one owned file only

## Human decisions still needed

- #735: choose `BC + AI` or `BC+AI`
- #735: choose the canonical descriptor set
- confirm Kris's pronunciation before adding a phonetic field
- confirm whether “Vancouver-based” is still desired press-kit wording
- #878 remains the authority for asset rights and final image credits

No WordPress content was changed, staged, or published.

Closes #877

