### PR TITLE
content(#884): draft the Both Hands Full AI policy

### DIFF
--- a/content/source-packs/ai-policy-2026/SOURCE-MATRIX.md
+++ b/content/source-packs/ai-policy-2026/SOURCE-MATRIX.md
@@ -1,0 +1,101 @@
+# AI Policy Source Matrix
+
+This matrix supports the draft in `policy.md`. It separates sourced principles and observed local practice from proposed commitments that still require Kris Krüg's review. It is editorial evidence, not a claim that every external policy applies to KrisKrug.co.
+
+## Status legend
+
+| Status | Meaning |
+| --- | --- |
+| External principle | A transferable idea from a public policy. Language was adapted, not copied. |
+| Local practice evidence | A repo or KrisKrug.co source showing current practice or an existing refusal line. |
+| Proposed policy | A rule drafted for this page that requires Kris's approval before it becomes a public commitment. |
+| Unresolved human decision | A threshold, wording choice, or operational promise Kris must confirm. |
+
+## External research
+
+| ID | Source | Principle used | Adaptation and limits | Draft sections |
+| --- | --- | --- | --- | --- |
+| E01 | [Lara Kroeker Interactive, “My AI policy, the real version”](https://larakroekerinteractive.com/ai-guidelines/) | Name actual uses, explain workflow in plain language, distinguish scoped structured access from blanket access, publish an update date, and invite questions. | Used as the launching tone and specificity model. Rejected Lara's claims that the idea begins with her before AI and that she does not scrape sites because neither accurately describes Kris's broader workflow. No sentence was copied. | “I use AI a lot”; “Agents get lanes”; update line; closing invitation |
+| E02 | [Associated Press, updated newsroom AI standards, July 23, 2026](https://www.ap.org/the-definitive-source/announcements/ap-updates-newsroom-standards-for-artificial-intelligence/) | AI can assist research, summaries, transcription, translation, headlines, search support, and code while editorial judgment, verification, and accountability stay human. Material AI use should be disclosed, and synthetic news photography is prohibited. | Adapted the verification, materiality, and documentary distinctions. Kris is not adopting a newsroom ban on generated imagery or AI-written copy. | “Facts need receipts”; “What I will not fake”; “Synthetic media and disclosure”; “I own what ships” |
+| E03 | [The Guardian's approach to generative AI](https://www.theguardian.com/help/insideguardian/2023/jun/16/the-guardians-approach-to-generative-ai) | Require human oversight, a specific benefit for significant use, transparency with audiences, attention to bias, and respect for creator permission and fair reward. | Adapted as a benefit-and-harm test and creator-respect principle. The Guardian's editorial approval structure is not represented as Kris's workflow. | “Creators are not a moodboard vending machine”; “Cost is part of the prompt”; “I own what ships” |
+| E04 | [WIRED, “How WIRED Will Use Generative AI Tools”](https://www.wired.com/about/generative-ai-policy/) | Treat AI research as pointers that must be checked against original sources; distinguish brainstorming from publishing; disclose generated imagery and reject obvious imitation or infringement. | Adapted the original-source and visual-disclosure tests. Rejected WIRED's ban on AI-written and AI-edited editorial copy because full drafts are part of Kris's practice. | “Facts need receipts”; “Creators are not a moodboard vending machine”; “Synthetic media and disclosure” |
+| E05 | [Government of Canada guide on generative AI](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/responsible-use-ai/guide-use-generative-ai.html) | Risk depends on use and controls. The FASTER framework covers fairness, accountability, security, transparency, education, and relevance. Public tools and secured systems have different privacy boundaries. Bias, hallucinations, energy, water, labour, and hardware costs need consideration. | Adapted into a personal risk-tiering and data-minimization practice, not government compliance language. The federal prohibition on personal information in public tools informed the boundary but is not presented as legal advice to Kris. | “Private means private”; “Facts need receipts”; “Agents get lanes”; “Cost is part of the prompt” |
+| E06 | [Mangrove Web AI Policy](https://mangrove-web.com/ai-policy/) | Disclose AI's role in drafting the policy, protect client material in approved secured systems, avoid identifiable creator imitation, weigh cultural, social, labour, and environmental costs, and admit the policy will need correction. | Adapted the meta-disclosure and humility. Avoided its absolute “human-led” framing because Kris may use agents for complete first passes and bounded execution. | Proposed disclosure; “Creators are not a moodboard vending machine”; “Cost is part of the prompt”; “I own what ships” |
+| E07 | [A Great Idea, Ethical AI Policy for Mission-Driven Communications](https://www.agreatidea.com/ai-policy) | Protect lived experience and relationship-based collaboration, fair labour, original craft, and higher-care contexts such as identity, health, and safety. Acknowledge embedded AI features in ordinary software. | Adapted the relationship, labour, sensitivity, and embedded-feature principles. Did not copy the agency's narrower “light production support” use case. | “What has to be real first”; “Private means private”; “Cost is part of the prompt” |
+| E08 | [Buffer, creator AI-policy examples](https://buffer.com/resources/ai-content-policy/) | A short, specific explanation of actual uses and refusals can build audience understanding. Different creators draw different lines. | Used as a readability contrast. Rejected the example restriction against AI drafting because it would misstate Kris's practice. | Whole-page structure; “I use AI a lot” |
+
+## Local practice and voice evidence
+
+| ID | Source | Evidence | Adaptation and limits | Draft sections |
+| --- | --- | --- | --- | --- |
+| L01 | `content/drafts/2026-05-21-i-wont-fake-the-people-who-showed-up/post.md` | Kris's documentary line permits AI around the frame but refuses synthetic people, attendance, community, ceremony, evidence, and witness. It develops “Presence Is Provenance” and the art-adjacent-work principle. | This is Kris's draft writing, not an external policy. The public policy condenses its refusal lines and keeps illustration separate from documentary evidence. Publication status remains draft, so the matrix treats it as local practice evidence rather than a public promise already in force. | “What has to be real first”; “Send the machines”; “What I will not fake” |
+| L02 | `content/drafts/2026-05-21-speak-it-into-existence-ai-voice-first-workflows/post.md` | Names agents researching, comparing, drafting, refactoring, sorting, testing, building, checking, and updating. States that agents do bounded work while the human decides what ships and owns the consequences. | Supports the actual-use list and agent model. It does not prove every workflow meets every proposed privacy or disclosure rule. | “I use AI a lot”; “Agents get lanes”; “I own what ships” |
+| L03 | `content/drafts/2026-06-04-ai-keynote-slides-visual-workflow/post.md` | Shows generated visual experimentation, provenance from note to prompt to artifact, explicit selector review, rejection of generic output, and the continued value of real photographs as evidence that an idea lived in a room. | Supports honest acknowledgement of generated imagery and the candidate-versus-evidence distinction. It does not establish a site-wide disclosure convention, which remains a human decision below. | “Send the machines”; “What has to be real first”; “Synthetic media and disclosure” |
+| L04 | `content/drafts/pillars/ai-ethics-philosophy.html` | Frames Kris's approach as holding capability and critique together while working through power, bias, consent, sovereignty, and obligations to each other. | Supports the Both Hands Full framing. The draft adds operational commitments that the hub itself does not contain. | “The short version”; “Cost is part of the prompt” |
+| L05 | [`https://kriskrug.co/robots.txt`](https://kriskrug.co/robots.txt); `fixes/robots.txt` | Public AI and search crawlers are intentionally allowed for discovery and citation while admin and search routes remain disallowed. | Public readback on 2026-08-23 confirmed the same directive stance. Its `Last reviewed` comment says 2026-06-07 while the repo source says 2026-07-01, so the comments drift even though the allow/disallow rules support the policy claim. Crawler access does not settle copyright, attribution, imitation, or context questions. | “Creators are not a moodboard vending machine” |
+| L06 | `AGENTS.md`; `docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`; `docs/current-state/ACCESS_CHANNELS.md` | Repo rules require dry-runs, exact slug and ID checks, reversible steps, and human approval for risky live changes after a real overwrite incident. | Supports specific agent gates for this site. These operational rules do not prove the same controls exist in every external tool Kris uses. | “Agents get lanes, not the keys to everything” |
+| L07 | `content/drafts/2026-05-21-speak-it-into-existence-ai-voice-first-workflows/post.md`; `content/drafts/2026-06-04-ai-keynote-slides-visual-workflow/post.md`; this repo's agent workflow | Current materials explicitly include complete drafting, source work, code, tests, archive operations, visual generation, and bounded agent execution. | Supports the non-cute actual-use list. “Accessibility work” is phrased as support and candidates, not a claim that AI independently validates accessibility. | “I use AI a lot” |
+
+## Proposed policy and unresolved decisions
+
+| ID | Status | Proposed claim or question | Evidence or reason | Human gate |
+| --- | --- | --- | --- | --- |
+| P01 | Proposed policy | Treat this as a public transparency statement rather than legal terms, a privacy promise, or a client contract. | Issue #883 architecture decision. | Confirm page scope before payload work. |
+| P02 | Proposed policy | Use materiality as the disclosure test and label generated or materially altered photorealistic media near the artifact. | E02, E03, E04, E06 plus L01 and L03. | Kris must approve the threshold and examples. |
+| P03 | Proposed policy | Permit sensitive material in a deliberately selected secured workflow after checking access, retention, training use, sharing, data location where relevant, authority, and purpose. | E05, E06, E07. This avoids the false claim that private material never enters AI. | Kris must confirm this matches current provider settings and client/student agreements. |
+| P04 | Proposed policy | Reject prompts for a living creator's identifiable style and prefer owned, licensed, commissioned, or public-domain sources where practical. | E03, E04, E06, E07. | Kris must approve this as a durable refusal line. |
+| P05 | Proposed policy | Keep public AI/search crawling enabled for discovery and citation while rejecting plagiarism, cloning, impersonation, unattributed reuse, and context removal. | L05 and issue #883. | Confirm this remains the intended crawler stance at publication time. |
+| P06 | Proposed policy | Gate live, destructive, external-send, spending, sensitive-data, and high-human-stakes agent actions according to risk. | L02, L06, E05. | Confirm the list catches Kris's actual high-impact workflows. |
+| P07 | Proposed policy | Consider labour, cultural, bias, energy, water, hardware, and community costs when choosing whether and how to use AI. | E03, E05, E06, E07, L04. | Approve as a decision practice, not a measurable carbon claim. |
+| H01 | Unresolved human decision | Does substantial AI drafting of a public artifact require a disclosure every time, or only when authorship/context would materially change audience judgment? | Existing practice includes full drafts, but the repo does not show a consistent historical disclosure rule. | Decide before #885. Do not imply retroactive compliance. |
+| H02 | Unresolved human decision | Should older generated or materially altered media be labelled retroactively, and if so which routes are in scope? | This draft defines a forward-looking rule but no inventory has been audited. | Out of scope for #884; file a bounded follow-up if desired. |
+| H03 | Unresolved human decision | Which AI workspaces are verified for sensitive client, student, interview, or community material, under which settings? | No provider-by-provider security register was reviewed for this issue. | Required before naming any platform as approved. |
+| H04 | Unresolved human decision | Is the “living creator's identifiable style” line the intended boundary, or should it cover deceased creators and named studios too? | Public comparison policies vary, and model provenance remains opaque. | Kris chooses the durable wording. |
+| H05 | Unresolved human decision | Is the contact page the preferred route for corrections and policy challenges? | It is the current public owned contact route. | Confirm before publication. |
+
+## Claim-level crosswalk
+
+| Draft claim | Type | Support | Notes |
+| --- | --- | --- | --- |
+| Kris uses AI for research, transcription, synthesis, drafting, code, tests, archives, image work, and bounded agents. | Local practice evidence | L02, L03, L07 | Full first drafts are stated honestly; no “light assistance” fiction. |
+| Real witness, collaborators, source material, and lived experience precede documentary claims. | Local practice evidence + proposed policy | L01, L02, P02 | Kris must approve the public commitment. |
+| AI candidates do not become quotes, facts, citations, or code without source/test checks. | External principle + proposed policy | E02, E04, E05, L02 | “Every” is avoided because universal enforcement cannot be proven. |
+| Public/unmanaged tools and secured workspaces have different data boundaries. | External principle + proposed policy | E05, E06, E07, P03 | No provider is named approved. |
+| Public crawling is intentionally allowed for discovery and citation. | Local practice evidence | L05 | Must be rechecked at publication time. |
+| Creator imitation, competitor cloning, unattributed reuse, and plagiarism are refusal lines. | External principle + proposed policy | E01, E03, E04, E06, P04, P05 | Public research itself remains permitted. |
+| Synthetic illustration is permitted but documentary fabrication is refused. | Local practice evidence + proposed policy | L01, L03, E02, E04, P02 | Disclosure convention awaits approval. |
+| Agents receive bounded scopes, tests, source trails, rollback paths, and human gates for high-impact actions. | Local practice evidence + proposed policy | L02, L06, P06 | Applies directly to this repo; broader workflow coverage should be confirmed. |
+| Labour, cultural, environmental, bias, and power costs belong in tool choice. | External principle + local philosophy + proposed policy | E03, E05, E06, E07, L04, P07 | No quantitative footprint claim is made. |
+| Lara Kroeker's policy launched this drafting process, and the comparison set includes AP, the Guardian, WIRED, Government of Canada, Mangrove Web, A Great Idea, and Buffer. | External research record | E01-E08 | Public links in the draft preserve credit and make the research trail inspectable. |
+| Kris owns the decision, correction, and consequences of published work. | External principle + local practice evidence | E02, E03, E06, L02 | The proposed page makes the principle explicit. |
+
+## Absolute-language audit
+
+The required scan targets `always`, `never`, `only`, `all`, and `none` in `policy.md`.
+
+| Term / passage | Location | Verdict | Evidence or revision |
+| --- | --- | --- | --- |
+| “Here is the non-cute version of the list” | “I use AI a lot” | Not an absolute term. | Included here to show the list is illustrative, not exhaustive. |
+| `always` | No occurrence in draft body. | Pass | Avoided because universal enforcement is not evidenced. |
+| `never` | “a documentary photograph, recording, or transcript that never touched a life” | Keep as a definitional refusal line. | L01 supports the documentary boundary. This does not claim perfect detection. |
+| `only` | No occurrence in draft body. | Pass | Replaced with scoped conditions where needed. |
+| `all` | “not the keys to everything” is used instead of an all-access claim. | Pass | Avoids overstating technical enforcement across tools. |
+| `none` | No occurrence in draft body. | Pass | No universal absence claim is made. |
+
+## Red-team scenarios
+
+| Scenario | Draft outcome | Source / gate |
+| --- | --- | --- |
+| Client transcript | Keep it out of public tools. Use a secured workflow after verifying settings, authority, purpose, and minimum necessary data. | E05, E06, P03, H03 |
+| Student data | Treat as identifiable sensitive material. Do not use a public tool; a secured workflow still requires authority and data minimization. | E05, E07, P03, H03 |
+| Unpublished interview | Preserve the recording/transcript as source truth. Use AI in a secured, permitted workflow; check quotes against the source before publication. | L01, L02, E04, P03 |
+| AI headshot | Treat as synthetic illustration, not documentary proof or a real portrait. Label material photorealistic generation and do not imply a real sitting occurred. | L01, L03, P02 |
+| Documentary crowd image | Reject as evidence of attendance, community, diversity, ceremony, or consensus. Use real documentation or clearly separate speculative illustration. | L01, E02, P02 |
+| Hallucinated citation | Do not ship it. Resolve and inspect the original/authoritative source or remove the claim. | E02, E04, E05 |
+| Prompt to copy an artist's style | Reject the identifiable-style instruction and build an original reference set from permitted sources and role-based qualities. | E03, E04, E06, P04, H04 |
+| Agent attempts a live deploy | Stop at the human gate. Require exact target checks, dry-run or preview, rollback path, and explicit approval appropriate to the action. | L06, P06 |
+| AI-generated full first draft | Permitted. Check sources, edit for meaning and voice, own the result, and apply the approved material-disclosure threshold. | L02, E02, P02, H01 |
+
+## Drafting disclosure status
+
+AI assisted with research, comparison, drafting, and the first voice-check pass for these two files. The disclosure in `policy.md` remains explicitly **pending** because Kris Krüg has not yet reviewed or approved the final wording.

--- a/content/source-packs/ai-policy-2026/policy.md
+++ b/content/source-packs/ai-policy-2026/policy.md
@@ -1,0 +1,145 @@
+# How I Use AI (And Where I Draw the Line)
+
+> Draft for Kris Krüg's review. This is a proposed public transparency statement, not legal terms, a privacy policy, or a client contract.
+
+**Last updated: YYYY-MM-DD**
+
+## The short version: Both Hands Full
+
+I use AI a lot.
+
+Enough that a policy saying I use it to check grammar would be adorable and false. I use it for research, transcription, synthesis, complete first drafts, editing, code, tests, archives, accessibility work, image experiments, and agents that can carry a bounded task from issue to pull request.
+
+I also think the current AI stack is built on a magnificent compost heap of consent problems, labour problems, bias, concentrated power, cultural theft, and environmental cost. Useful does not mean clean. Critique does not require pretending the tools are useless.
+
+That is the posture I call **Both Hands Full**: capability in one hand, critique in the other, keep walking without dropping either one.
+
+My side of the bargain is simple. Start from real people and real source material. Check the receipts. Protect private information. Credit creators. Label synthetic work when it materially changes what the audience is seeing or reading. Give agents lanes, not the keys to the building. Own whatever ships.
+
+This page explains how I try to do that. It is a practice, not a purity certificate. If you see a gap between the policy and the work, I want to hear about it.
+
+## I use AI a lot
+
+Here is the non-cute version of the list:
+
+- research leads, public-source discovery, comparison, and synthesis;
+- transcription, interview maps, summaries, clip lists, and archive search;
+- outlines, rewrites, line edits, variants, and complete first drafts;
+- code, tests, debugging, documentation, and data cleanup;
+- accessibility support such as alt-text candidates and plain-language passes;
+- image generation, visual references, prompt packs, and composition experiments;
+- workflow automation and bounded agents that research, draft, test, sort, file, and build.
+
+Sometimes I speak the raw idea, ask a model to structure it, and rewrite from there. Sometimes an agent produces the whole first pass. Sometimes I keep one sentence. Sometimes the output goes straight into the compost.
+
+Counting machine-made words tells me less than the source trail does. I care whether the work began from something real, whether the result is true and fit for its job, whether the receipts survive, and whether I am willing to put my name beside it.
+
+## What has to be real first
+
+AI can organize an interview. It cannot conduct the relationship that made the interview possible.
+
+The lived experience, raw notes, photographs, recordings, named collaborators, community context, and editorial judgment have to come from people who were there. If the value of a piece depends on witness, trust, consent, expertise, or memory, those are source material, not decorative flavour for a prompt.
+
+That is especially true in community and documentary work. A transcript summary can help me find the moment. It cannot become a quote until I check the recording. An archive model can help me find the photograph. It cannot tell me whether the person pictured consented to this new use. A generated image can carry an idea. It cannot prove a room existed.
+
+Presence is provenance. Who showed up, who spoke, who made the thing, and who trusted me with the material stay attached to the work.
+
+## Send the machines after the art-adjacent work
+
+Models are good at carrying boxes.
+
+They can search thirty years of filenames, compare documents, find repeated patterns, turn notes into a rough structure, generate variants, build contact sheets, draft captions, write test cases, check links, and handle the administrative friction that keeps useful work stuck in a folder.
+
+They can also help me explore visual metaphors that cannot be photographed, prototype strange ideas, and make enough options for taste to become visible. The generator makes candidates. The human decides what belongs.
+
+That distinction matters. I want machines helping the real work travel farther. I do not want a pile of plausible output standing in for judgment, relationship, or craft.
+
+## What I will not fake
+
+I will not use AI to invent:
+
+- a person, quote, interview, source, testimonial, or credential;
+- attendance, diversity, consensus, intimacy, ceremony, community, joy, grief, or solidarity;
+- a client result, student outcome, media appearance, award, partnership, or endorsement;
+- evidence that an event happened or that a real person was present;
+- a documentary photograph, recording, or transcript that never touched a life.
+
+I will not replace someone who showed up with a synthetic almost-person because the deck needs a stronger hero image. I will not put generated words in a collaborator's mouth. I will not let a photorealistic crowd function as proof of a gathering.
+
+Illustration, satire, speculation, and clearly synthetic art are different jobs. They can be wild. The line is whether a reasonable person could mistake the artifact for evidence about a real person, event, community, or claim.
+
+## Facts need receipts
+
+AI output is an untrusted lead until it survives contact with a source.
+
+For factual public work, I trace material claims, names, dates, numbers, quotes, citations, and technical instructions back to original records or authoritative sources. For interviews, I check the recording or transcript. For code, I run the test. For a live system, I read back the actual state. When a model produces a citation that does not resolve to a source I can inspect, the citation does not ship.
+
+This does not make errors impossible. It makes the verification path visible and gives me somewhere honest to return when I need to correct one.
+
+## Private means private
+
+Public and consumer AI tools are not where I put credentials, private messages, client secrets, student records, personal health or financial information, unpublished third-party material, or identifiable data I do not have authority to process.
+
+Sensitive material may enter an intentionally selected secured workflow when the work calls for it. Before that happens, I need to verify the provider and workspace settings that matter for the job: access controls, retention, training use, sharing, data location where relevant, and who has permission to use the material. I minimize the data, de-identify it when practical, and keep the scope tied to the agreed purpose.
+
+If I cannot verify the setting or the authority, the material stays out. A logo that says "enterprise" is not a security review.
+
+Embedded AI complicates this because design, writing, analytics, scheduling, and productivity tools keep adding model features behind ordinary buttons. I review settings where they exist and choose a different path when the tool asks for more access than the job deserves.
+
+## Creators are not a moodboard vending machine
+
+My public site is intentionally open to search and AI crawlers for discovery and citation. That is the current `robots.txt` stance. Permission to discover a public page is not permission to erase its author, strip its context, impersonate its voice, or sell a knockoff.
+
+I use public-web research and reference material. I do not clone a competitor's page, launder someone else's writing through a model, copy code without understanding its licence, or prompt for a living creator's identifiable style. I prefer owned, licensed, commissioned, or public-domain source material where practical, and I keep attribution attached when the work depends on someone else's contribution.
+
+I cannot inspect the full training history of every model or promise that an output is free of influence, bias, or accidental resemblance. I can choose tools and inputs more carefully, reject obvious imitation, check suspicious language and imagery, and avoid pretending uncertainty has been solved.
+
+## Synthetic media and disclosure
+
+The disclosure test is materiality, not ritual.
+
+I disclose AI use when it meaningfully shaped what a reasonable audience would understand as the authorship, evidence, identity, or reality of the work. That includes generated or materially altered photorealistic images, cloned or synthetic voices, generated video presented near real events, substantial synthetic characters, and public work where the AI contribution is part of the point.
+
+Generated or materially altered media should be labelled near the artifact in a caption, credit, or clear note, especially when it could be mistaken for photography, recording, or documentation. Synthetic media does not get to hide in tiny metadata while doing the emotional work of a real witness.
+
+Routine assistance does not need a confetti cannon. Spellcheck, transcript cleanup, formatting, search suggestions, accessibility candidates, and small code completions do not each require a badge. Material full-draft or structural assistance should be disclosed when it meaningfully shaped the public artifact, even though I remain the editor and accountable author.
+
+The disclosure does not outsource responsibility to the tool. "The AI did it" is not a correction policy.
+
+## Agents get lanes, not the keys to everything
+
+I use agents because they can move real work, not because I want to cosplay a robot corporation.
+
+An agent gets a bounded objective, an owned set of files or systems, source material, acceptance criteria, tests, and a stop rule. Work that changes a live site, publishes publicly, deletes or overwrites material, touches sensitive data, sends a message, spends money, or carries high human stakes needs an explicit gate appropriate to that risk.
+
+For live WordPress work, that means dry-run first, exact slug and ID checks, a reversible path, and human approval before risky publication or updates. For code, it means a reviewable diff and tests. For research, it means a source trail. Autonomy should increase with evidence and reversibility, not with how confidently an agent describes itself.
+
+The human still decides what ships. The human still owns the consequences.
+
+## Cost is part of the prompt
+
+Every AI call sits inside a bigger system: training data gathered under murky consent, invisible moderation and labelling labour, creative livelihoods, cultural and language bias, concentrated infrastructure, energy, water, hardware, and communities asked to absorb the costs of data centres.
+
+I cannot calculate that whole ledger from a prompt box. I can ask whether the model is useful for this job, use a smaller or simpler method when it is enough, avoid generation for generation's sake, pay people for human work, and reject outputs that flatten communities into stereotypes.
+
+Sometimes the best AI workflow is a script. Sometimes it is a search box. Sometimes it is hiring the photographer, calling the person, reading the document, or leaving the blank space alone.
+
+## The source trail
+
+This policy started because [Lara Kroeker published one](https://larakroekerinteractive.com/ai-guidelines/) that says what she actually does. Thank you, Lara, for making specificity contagious.
+
+I also compared public guidance from the [Associated Press](https://www.ap.org/the-definitive-source/announcements/ap-updates-newsroom-standards-for-artificial-intelligence/), [the Guardian](https://www.theguardian.com/help/insideguardian/2023/jun/16/the-guardians-approach-to-generative-ai), [WIRED](https://www.wired.com/about/generative-ai-policy/), the [Government of Canada](https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/responsible-use-ai/guide-use-generative-ai.html), [Mangrove Web](https://mangrove-web.com/ai-policy/), [A Great Idea](https://www.agreatidea.com/ai-policy), and [Buffer's creator examples](https://buffer.com/resources/ai-content-policy/).
+
+Their boundaries differ. Good. A useful policy should describe a real practice, not average out a pile of industry etiquette.
+
+## I own what ships
+
+My name on the work means I own the choice to publish it, the source checks, the disclosures, the misses, and the consequences. Tools do not absorb accountability. Agents do not become the fall guy. If I get something wrong, the job is to acknowledge it, correct it, and improve the practice.
+
+This policy will change because the tools, contracts, embedded features, and my own practice will change. The refusal lines around fake people, fake evidence, stolen voice, and hidden accountability are the part I intend to keep carrying.
+
+Questions, challenges, or receipts I should see are welcome through [the contact page](https://kriskrug.co/contact/).
+
+### Proposed AI-assistance disclosure
+
+> **Pending Kris Krüg's review and approval:** AI assisted with research, source comparison, drafting, and voice checking for this policy. Kris Krüg reviewed, revised, and approved the final version and remains accountable for it.


### PR DESCRIPTION
## Summary

- drafts the personality-forward `How I Use AI (And Where I Draw the Line)` policy without pretending AI use stops at light editing
- covers complete drafts, generated imagery, public-web research, private/secured workflows, documentary refusal lines, creator imitation, bounded agents, verification, disclosure, labour, and environmental cost
- adds a claim-level source matrix separating external principles, local practice evidence, proposed commitments, and unresolved human decisions
- includes the required absolute-language audit and nine red-team scenarios
- records that live and repo `robots.txt` agree on crawler directives while their review-date comments drift

## Verification

- `rg` required-topic and red-team checks passed
- banned marketing-language scan returned no matches
- `voicecheck.py --json` returned 0 findings
- `git diff --cached --check` passed before commit
- live `https://kriskrug.co/robots.txt` readback confirmed the discovery/citation stance

## Human gates

Kris still needs to decide the material-disclosure threshold, approved secured workspaces, the durable creator-imitation boundary, any retroactive media labelling, and the public correction route. The proposed disclosure remains explicitly pending review.

No HTML, metadata, WordPress content, crawler changes, merge, or publication is included.

Closes #884
