### PR TITLE
content(#879): export Aurora press kit brand reference

### DIFF
--- a/content/source-packs/content-architecture-2026/press-kit/brand-reference.json
+++ b/content/source-packs/content-architecture-2026/press-kit/brand-reference.json
@@ -1,0 +1,1058 @@
+{
+  "schema_version": 1,
+  "metadata": {
+    "generated_at_utc": "2026-08-23T01:14:33Z",
+    "timestamp_policy": "--check reuses the committed timestamp so clock time never creates drift.",
+    "theme": {
+      "name": {
+        "id": "theme_name",
+        "name": "Theme name",
+        "value": "KK Aurora",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/style.css",
+            "token": "Theme Name"
+          }
+        ]
+      },
+      "version": {
+        "id": "theme_version",
+        "name": "Theme version",
+        "value": "1.6.9",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/style.css",
+            "token": "Version"
+          }
+        ]
+      }
+    },
+    "source_files": [
+      {
+        "path": "theme/kk-aurora/theme.json",
+        "sha256": "e648ea8f9a3b34f9424e888d5f7eb3eac7ab0217175314ca050899fb79fa2208"
+      },
+      {
+        "path": "theme/kk-aurora/assets/css/02-tokens.css",
+        "sha256": "c1225b9a2e1405e07f388f43ea8cbc9dc1044484c69a582a3649bb4223ed4933"
+      },
+      {
+        "path": "theme/kk-aurora/style.css",
+        "sha256": "9174a53accc8dcc8bea2091793c7c46f9d5ef08960ac79bbc59ab0d184e90ea2"
+      }
+    ],
+    "publication_gate": "This exporter reads repository sources only. Before publication, run make status-readonly and verify that live and repository Aurora versions agree."
+  },
+  "colors": {
+    "surfaces": [
+      {
+        "id": "surface",
+        "name": "Primary surface",
+        "value": "#efe6d2",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-surface"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--paper",
+            "location": "settings.color.palette[slug=paper]"
+          }
+        ]
+      },
+      {
+        "id": "surface_sunk",
+        "name": "Sunk surface",
+        "value": "#e6dcc2",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-surface-sunk"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--surface",
+            "location": "settings.color.palette[slug=surface]"
+          }
+        ]
+      },
+      {
+        "id": "surface_raised",
+        "name": "Raised surface",
+        "value": "#e6dcc2",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-surface-raised"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--elevated",
+            "location": "settings.color.palette[slug=elevated]"
+          }
+        ]
+      }
+    ],
+    "ink_text": [
+      {
+        "id": "ink",
+        "name": "Primary ink",
+        "value": "#171310",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-ink"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--text-primary",
+            "location": "settings.color.palette[slug=text-primary]"
+          }
+        ]
+      },
+      {
+        "id": "ink_secondary",
+        "name": "Secondary ink",
+        "value": "#3d342c",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-ink-secondary"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--text-secondary",
+            "location": "settings.color.palette[slug=text-secondary]"
+          }
+        ]
+      },
+      {
+        "id": "ink_muted",
+        "name": "Muted ink",
+        "value": "#5c5044",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-ink-muted"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--text-muted",
+            "location": "settings.color.palette[slug=text-muted]"
+          }
+        ]
+      }
+    ],
+    "accent_action": [
+      {
+        "id": "accent",
+        "name": "Primary accent",
+        "value": "#9a2f14",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-accent"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--signal",
+            "location": "settings.color.palette[slug=signal]"
+          }
+        ]
+      },
+      {
+        "id": "accent_ink",
+        "name": "Accent text",
+        "value": "#9a2f14",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-accent-ink"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--signal-text",
+            "location": "settings.color.palette[slug=signal-text]"
+          }
+        ]
+      }
+    ],
+    "semantic": [
+      {
+        "id": "line",
+        "name": "Structure / line",
+        "value": "#d9cdb0",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-line"
+          },
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--muted",
+            "location": "settings.color.palette[slug=muted]"
+          }
+        ]
+      },
+      {
+        "id": "success",
+        "name": "Success",
+        "value": "#1f8a86",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--success",
+            "location": "settings.color.palette[slug=success]"
+          }
+        ]
+      },
+      {
+        "id": "warning",
+        "name": "Warning",
+        "value": "#e8b53a",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--warning",
+            "location": "settings.color.palette[slug=warning]"
+          }
+        ]
+      },
+      {
+        "id": "error",
+        "name": "Error",
+        "value": "#d94a1f",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--color--error",
+            "location": "settings.color.palette[slug=error]"
+          }
+        ]
+      }
+    ]
+  },
+  "typography": {
+    "font_families": [
+      {
+        "id": "display",
+        "name": "Display (Space Grotesk)",
+        "value": "'Space Grotesk', system-ui, -apple-system, sans-serif",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-family--display",
+            "location": "settings.typography.fontFamilies[slug=display]"
+          }
+        ]
+      },
+      {
+        "id": "body",
+        "name": "Body (DM Sans)",
+        "value": "'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-family--body",
+            "location": "settings.typography.fontFamilies[slug=body]"
+          }
+        ]
+      },
+      {
+        "id": "mono",
+        "name": "Monospace (JetBrains Mono)",
+        "value": "'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-family--mono",
+            "location": "settings.typography.fontFamilies[slug=mono]"
+          }
+        ]
+      }
+    ],
+    "type_scale": [
+      {
+        "id": "xs",
+        "name": "Extra Small",
+        "value": {
+          "default": "0.75rem",
+          "fluid_min": "0.75rem",
+          "fluid_max": "0.875rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--xs",
+            "location": "settings.typography.fontSizes[slug=xs]"
+          }
+        ]
+      },
+      {
+        "id": "sm",
+        "name": "Small",
+        "value": {
+          "default": "0.875rem",
+          "fluid_min": "0.875rem",
+          "fluid_max": "1rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--sm",
+            "location": "settings.typography.fontSizes[slug=sm]"
+          }
+        ]
+      },
+      {
+        "id": "base",
+        "name": "Base",
+        "value": {
+          "default": "1rem",
+          "fluid_min": "1rem",
+          "fluid_max": "1.125rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--base",
+            "location": "settings.typography.fontSizes[slug=base]"
+          }
+        ]
+      },
+      {
+        "id": "lg",
+        "name": "Large",
+        "value": {
+          "default": "1.125rem",
+          "fluid_min": "1.125rem",
+          "fluid_max": "1.25rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--lg",
+            "location": "settings.typography.fontSizes[slug=lg]"
+          }
+        ]
+      },
+      {
+        "id": "xl",
+        "name": "Extra Large",
+        "value": {
+          "default": "1.25rem",
+          "fluid_min": "1.25rem",
+          "fluid_max": "1.5rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--xl",
+            "location": "settings.typography.fontSizes[slug=xl]"
+          }
+        ]
+      },
+      {
+        "id": "2xl",
+        "name": "2X Large",
+        "value": {
+          "default": "1.5rem",
+          "fluid_min": "1.5rem",
+          "fluid_max": "2rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--2xl",
+            "location": "settings.typography.fontSizes[slug=2xl]"
+          }
+        ]
+      },
+      {
+        "id": "3xl",
+        "name": "3X Large",
+        "value": {
+          "default": "1.875rem",
+          "fluid_min": "1.875rem",
+          "fluid_max": "2.5rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--3xl",
+            "location": "settings.typography.fontSizes[slug=3xl]"
+          }
+        ]
+      },
+      {
+        "id": "4xl",
+        "name": "4X Large",
+        "value": {
+          "default": "2.25rem",
+          "fluid_min": "2.25rem",
+          "fluid_max": "3rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--4xl",
+            "location": "settings.typography.fontSizes[slug=4xl]"
+          }
+        ]
+      },
+      {
+        "id": "5xl",
+        "name": "5X Large",
+        "value": {
+          "default": "3rem",
+          "fluid_min": "3rem",
+          "fluid_max": "4.5rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--5xl",
+            "location": "settings.typography.fontSizes[slug=5xl]"
+          }
+        ]
+      },
+      {
+        "id": "hero",
+        "name": "Hero",
+        "value": {
+          "default": "3.5rem",
+          "fluid_min": "3.5rem",
+          "fluid_max": "7rem"
+        },
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--font-size--hero",
+            "location": "settings.typography.fontSizes[slug=hero]"
+          }
+        ]
+      }
+    ]
+  },
+  "layout": {
+    "widths": [
+      {
+        "id": "content_width",
+        "name": "Content width",
+        "value": "800px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.layout.contentSize",
+            "location": "settings.layout.contentSize"
+          }
+        ]
+      },
+      {
+        "id": "wide_width",
+        "name": "Wide width",
+        "value": "1280px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.layout.wideSize",
+            "location": "settings.layout.wideSize"
+          }
+        ]
+      },
+      {
+        "id": "measure",
+        "name": "Reading measure",
+        "value": "66ch",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-measure"
+          }
+        ]
+      }
+    ],
+    "breakpoints": [
+      {
+        "id": "small",
+        "name": "Small",
+        "value": "480px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-bp-sm"
+          }
+        ]
+      },
+      {
+        "id": "medium",
+        "name": "Medium",
+        "value": "768px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-bp-md"
+          }
+        ]
+      },
+      {
+        "id": "large",
+        "name": "Large",
+        "value": "1200px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/assets/css/02-tokens.css",
+            "token": "--kk-bp-lg"
+          }
+        ]
+      }
+    ]
+  },
+  "foundations": {
+    "spacing": [
+      {
+        "id": "10",
+        "name": "1",
+        "value": "0.25rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--10",
+            "location": "settings.spacing.spacingSizes[slug=10]"
+          }
+        ]
+      },
+      {
+        "id": "20",
+        "name": "2",
+        "value": "0.5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--20",
+            "location": "settings.spacing.spacingSizes[slug=20]"
+          }
+        ]
+      },
+      {
+        "id": "30",
+        "name": "3",
+        "value": "0.75rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--30",
+            "location": "settings.spacing.spacingSizes[slug=30]"
+          }
+        ]
+      },
+      {
+        "id": "40",
+        "name": "4",
+        "value": "1rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--40",
+            "location": "settings.spacing.spacingSizes[slug=40]"
+          }
+        ]
+      },
+      {
+        "id": "50",
+        "name": "5",
+        "value": "1.25rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--50",
+            "location": "settings.spacing.spacingSizes[slug=50]"
+          }
+        ]
+      },
+      {
+        "id": "60",
+        "name": "6",
+        "value": "1.5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--60",
+            "location": "settings.spacing.spacingSizes[slug=60]"
+          }
+        ]
+      },
+      {
+        "id": "70",
+        "name": "7",
+        "value": "1.75rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--70",
+            "location": "settings.spacing.spacingSizes[slug=70]"
+          }
+        ]
+      },
+      {
+        "id": "80",
+        "name": "8",
+        "value": "2rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--80",
+            "location": "settings.spacing.spacingSizes[slug=80]"
+          }
+        ]
+      },
+      {
+        "id": "90",
+        "name": "9",
+        "value": "2.5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--90",
+            "location": "settings.spacing.spacingSizes[slug=90]"
+          }
+        ]
+      },
+      {
+        "id": "100",
+        "name": "10",
+        "value": "3rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--100",
+            "location": "settings.spacing.spacingSizes[slug=100]"
+          }
+        ]
+      },
+      {
+        "id": "120",
+        "name": "12",
+        "value": "4rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--120",
+            "location": "settings.spacing.spacingSizes[slug=120]"
+          }
+        ]
+      },
+      {
+        "id": "160",
+        "name": "16",
+        "value": "5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--160",
+            "location": "settings.spacing.spacingSizes[slug=160]"
+          }
+        ]
+      },
+      {
+        "id": "200",
+        "name": "20",
+        "value": "6rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--200",
+            "location": "settings.spacing.spacingSizes[slug=200]"
+          }
+        ]
+      },
+      {
+        "id": "240",
+        "name": "24",
+        "value": "8rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--spacing--240",
+            "location": "settings.spacing.spacingSizes[slug=240]"
+          }
+        ]
+      }
+    ],
+    "radii": [
+      {
+        "id": "radius-sm",
+        "name": "Small",
+        "value": "0.25rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radiusSm",
+            "location": "settings.custom.border.radiusSm"
+          }
+        ]
+      },
+      {
+        "id": "radius-md",
+        "name": "Medium",
+        "value": "0.5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radiusMd",
+            "location": "settings.custom.border.radiusMd"
+          }
+        ]
+      },
+      {
+        "id": "radius-lg",
+        "name": "Large",
+        "value": "0.75rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radiusLg",
+            "location": "settings.custom.border.radiusLg"
+          }
+        ]
+      },
+      {
+        "id": "radius-xl",
+        "name": "Extra Large",
+        "value": "1rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radiusXl",
+            "location": "settings.custom.border.radiusXl"
+          }
+        ]
+      },
+      {
+        "id": "radius-2-xl",
+        "name": "2X Large",
+        "value": "1.5rem",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radius2xl",
+            "location": "settings.custom.border.radius2xl"
+          }
+        ]
+      },
+      {
+        "id": "radius-full",
+        "name": "Full / pill",
+        "value": "9999px",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "settings.custom.border.radiusFull",
+            "location": "settings.custom.border.radiusFull"
+          }
+        ]
+      }
+    ],
+    "shadows": [
+      {
+        "id": "sm",
+        "name": "Small",
+        "value": "0 1px 2px rgba(0, 0, 0, 0.5)",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--shadow--sm",
+            "location": "settings.shadow.presets[slug=sm]"
+          }
+        ]
+      },
+      {
+        "id": "md",
+        "name": "Medium",
+        "value": "0 4px 6px rgba(0, 0, 0, 0.4)",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--shadow--md",
+            "location": "settings.shadow.presets[slug=md]"
+          }
+        ]
+      },
+      {
+        "id": "lg",
+        "name": "Large",
+        "value": "0 10px 15px rgba(0, 0, 0, 0.3)",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--shadow--lg",
+            "location": "settings.shadow.presets[slug=lg]"
+          }
+        ]
+      },
+      {
+        "id": "xl",
+        "name": "Extra Large",
+        "value": "0 20px 25px rgba(0, 0, 0, 0.25)",
+        "provenance": [
+          {
+            "path": "theme/kk-aurora/theme.json",
+            "token": "--wp--preset--shadow--xl",
+            "location": "settings.shadow.presets[slug=xl]"
+          }
+        ]
+      }
+    ]
+  },
+  "buttons": [
+    {
+      "id": "background",
+      "name": "Background",
+      "value": "#9a2f14",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.color.background",
+          "location": "styles.elements.button.color.background"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--color--signal",
+          "location": "settings.color.palette[slug=signal]"
+        }
+      ]
+    },
+    {
+      "id": "text",
+      "name": "Text",
+      "value": "#efe6d2",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.color.text",
+          "location": "styles.elements.button.color.text"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--color--deep",
+          "location": "settings.color.palette[slug=deep]"
+        }
+      ]
+    },
+    {
+      "id": "font_family",
+      "name": "Font family",
+      "value": "'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.typography.fontFamily",
+          "location": "styles.elements.button.typography.fontFamily"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--font-family--body",
+          "location": "settings.typography.fontFamilies[slug=body]"
+        }
+      ]
+    },
+    {
+      "id": "font_size",
+      "name": "Font size",
+      "value": "1rem",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.typography.fontSize",
+          "location": "styles.elements.button.typography.fontSize"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--font-size--base",
+          "location": "settings.typography.fontSizes[slug=base]"
+        }
+      ]
+    },
+    {
+      "id": "font_weight",
+      "name": "Font weight",
+      "value": "600",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.typography.fontWeight",
+          "location": "styles.elements.button.typography.fontWeight"
+        }
+      ]
+    },
+    {
+      "id": "letter_spacing",
+      "name": "Letter spacing",
+      "value": "0",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "styles.elements.button.typography.letterSpacing",
+          "location": "styles.elements.button.typography.letterSpacing"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--custom--letter-spacing--normal",
+          "location": "settings.custom.letterSpacing.normal"
+        }
+      ]
+    },
+    {
+      "id": "padding-inline",
+      "name": "Inline padding",
+      "value": "1.5rem",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.paddingInline",
+          "location": "settings.custom.button.paddingInline"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--spacing--60",
+          "location": "settings.spacing.spacingSizes[slug=60]"
+        }
+      ]
+    },
+    {
+      "id": "padding-block",
+      "name": "Block padding",
+      "value": "0.75rem",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.paddingBlock",
+          "location": "settings.custom.button.paddingBlock"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--preset--spacing--30",
+          "location": "settings.spacing.spacingSizes[slug=30]"
+        }
+      ]
+    },
+    {
+      "id": "radius",
+      "name": "Radius",
+      "value": "0.5rem",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.radius",
+          "location": "settings.custom.button.radius"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--custom--border--radius-md",
+          "location": "settings.custom.border.radiusMd"
+        }
+      ]
+    },
+    {
+      "id": "radius-pill",
+      "name": "Pill radius",
+      "value": "9999px",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.radiusPill",
+          "location": "settings.custom.button.radiusPill"
+        },
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "--wp--custom--border--radius-full",
+          "location": "settings.custom.border.radiusFull"
+        }
+      ]
+    },
+    {
+      "id": "min-height",
+      "name": "Minimum height",
+      "value": "44px",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.minHeight",
+          "location": "settings.custom.button.minHeight"
+        }
+      ]
+    },
+    {
+      "id": "mobile-min-height",
+      "name": "Mobile minimum height",
+      "value": "48px",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.mobileMinHeight",
+          "location": "settings.custom.button.mobileMinHeight"
+        }
+      ]
+    },
+    {
+      "id": "icon-size",
+      "name": "Icon size",
+      "value": "1.125rem",
+      "provenance": [
+        {
+          "path": "theme/kk-aurora/theme.json",
+          "token": "settings.custom.button.iconSize",
+          "location": "settings.custom.button.iconSize"
+        }
+      ]
+    }
+  ],
+  "missing_or_noncanonical": [
+    {
+      "concept": "icon_system",
+      "status": "missing",
+      "reason": "The canonical Aurora sources do not define an icon family or usage rules.",
+      "checked_sources": [
+        "theme/kk-aurora/theme.json",
+        "theme/kk-aurora/assets/css/02-tokens.css"
+      ]
+    },
+    {
+      "concept": "logo_usage_rules",
+      "status": "missing",
+      "reason": "Logo files, clear-space rules, and lockups belong to the rights-cleared asset manifest.",
+      "checked_sources": [
+        "theme/kk-aurora/theme.json",
+        "theme/kk-aurora/assets/css/02-tokens.css"
+      ]
+    },
+    {
+      "concept": "photography_treatment",
+      "status": "missing",
+      "reason": "The canonical Aurora token sources do not define editorial photography rules.",
+      "checked_sources": [
+        "theme/kk-aurora/theme.json",
+        "theme/kk-aurora/assets/css/02-tokens.css"
+      ]
+    },
+    {
+      "concept": "brand_gradients",
+      "status": "noncanonical_for_press_kit",
+      "reason": "Gradient presets exist in theme.json but have no current --kk-* semantic role; they are intentionally omitted from press-kit guidance.",
+      "checked_sources": [
+        "theme/kk-aurora/theme.json",
+        "theme/kk-aurora/assets/css/02-tokens.css"
+      ]
+    },
+    {
+      "concept": "duotone_treatments",
+      "status": "noncanonical_for_press_kit",
+      "reason": "Duotone presets exist in theme.json but have no current --kk-* semantic role; they are intentionally omitted from press-kit guidance.",
+      "checked_sources": [
+        "theme/kk-aurora/theme.json",
+        "theme/kk-aurora/assets/css/02-tokens.css"
+      ]
+    }
+  ]
+}

--- a/content/source-packs/content-architecture-2026/press-kit/brand-reference.md
+++ b/content/source-packs/content-architecture-2026/press-kit/brand-reference.md
@@ -1,0 +1,149 @@
+# Aurora Brand Reference
+
+Generated 2026-08-23T01:14:33Z from KK Aurora 1.6.9.
+
+This is a repository-derived reference, not proof of the live theme. Before publication, run `make status-readonly` and confirm live/repo Aurora version agreement.
+
+Source aliases:
+
+- `theme.json`: `theme/kk-aurora/theme.json`
+- `02-tokens.css`: `theme/kk-aurora/assets/css/02-tokens.css`
+- `style.css`: `theme/kk-aurora/style.css`
+
+## Surfaces
+
+| Role | Value | Source |
+|---|---|---|
+| Primary surface | `#efe6d2` | 02-tokens.css `--kk-surface` → theme.json `--wp--preset--color--paper` |
+| Sunk surface | `#e6dcc2` | 02-tokens.css `--kk-surface-sunk` → theme.json `--wp--preset--color--surface` |
+| Raised surface | `#e6dcc2` | 02-tokens.css `--kk-surface-raised` → theme.json `--wp--preset--color--elevated` |
+
+## Ink and text
+
+| Role | Value | Source |
+|---|---|---|
+| Primary ink | `#171310` | 02-tokens.css `--kk-ink` → theme.json `--wp--preset--color--text-primary` |
+| Secondary ink | `#3d342c` | 02-tokens.css `--kk-ink-secondary` → theme.json `--wp--preset--color--text-secondary` |
+| Muted ink | `#5c5044` | 02-tokens.css `--kk-ink-muted` → theme.json `--wp--preset--color--text-muted` |
+
+## Accent and action
+
+| Role | Value | Source |
+|---|---|---|
+| Primary accent | `#9a2f14` | 02-tokens.css `--kk-accent` → theme.json `--wp--preset--color--signal` |
+| Accent text | `#9a2f14` | 02-tokens.css `--kk-accent-ink` → theme.json `--wp--preset--color--signal-text` |
+
+## Semantic colors
+
+| Role | Value | Source |
+|---|---|---|
+| Structure / line | `#d9cdb0` | 02-tokens.css `--kk-line` → theme.json `--wp--preset--color--muted` |
+| Success | `#1f8a86` | theme.json `--wp--preset--color--success` |
+| Warning | `#e8b53a` | theme.json `--wp--preset--color--warning` |
+| Error | `#d94a1f` | theme.json `--wp--preset--color--error` |
+
+## Font families
+
+| Role | Value | Source |
+|---|---|---|
+| Display (Space Grotesk) | `'Space Grotesk', system-ui, -apple-system, sans-serif` | theme.json `--wp--preset--font-family--display` |
+| Body (DM Sans) | `'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` | theme.json `--wp--preset--font-family--body` |
+| Monospace (JetBrains Mono) | `'JetBrains Mono', 'Fira Code', 'Consolas', 'Monaco', monospace` | theme.json `--wp--preset--font-family--mono` |
+
+## Type scale
+
+| Role | Value | Source |
+|---|---|---|
+| Extra Small | `0.75rem (fluid 0.75rem–0.875rem)` | theme.json `--wp--preset--font-size--xs` |
+| Small | `0.875rem (fluid 0.875rem–1rem)` | theme.json `--wp--preset--font-size--sm` |
+| Base | `1rem (fluid 1rem–1.125rem)` | theme.json `--wp--preset--font-size--base` |
+| Large | `1.125rem (fluid 1.125rem–1.25rem)` | theme.json `--wp--preset--font-size--lg` |
+| Extra Large | `1.25rem (fluid 1.25rem–1.5rem)` | theme.json `--wp--preset--font-size--xl` |
+| 2X Large | `1.5rem (fluid 1.5rem–2rem)` | theme.json `--wp--preset--font-size--2xl` |
+| 3X Large | `1.875rem (fluid 1.875rem–2.5rem)` | theme.json `--wp--preset--font-size--3xl` |
+| 4X Large | `2.25rem (fluid 2.25rem–3rem)` | theme.json `--wp--preset--font-size--4xl` |
+| 5X Large | `3rem (fluid 3rem–4.5rem)` | theme.json `--wp--preset--font-size--5xl` |
+| Hero | `3.5rem (fluid 3.5rem–7rem)` | theme.json `--wp--preset--font-size--hero` |
+
+## Layout widths
+
+| Role | Value | Source |
+|---|---|---|
+| Content width | `800px` | theme.json `settings.layout.contentSize` |
+| Wide width | `1280px` | theme.json `settings.layout.wideSize` |
+| Reading measure | `66ch` | 02-tokens.css `--kk-measure` |
+
+## Breakpoints
+
+| Role | Value | Source |
+|---|---|---|
+| Small | `480px` | 02-tokens.css `--kk-bp-sm` |
+| Medium | `768px` | 02-tokens.css `--kk-bp-md` |
+| Large | `1200px` | 02-tokens.css `--kk-bp-lg` |
+
+## Spacing
+
+| Role | Value | Source |
+|---|---|---|
+| 1 | `0.25rem` | theme.json `--wp--preset--spacing--10` |
+| 2 | `0.5rem` | theme.json `--wp--preset--spacing--20` |
+| 3 | `0.75rem` | theme.json `--wp--preset--spacing--30` |
+| 4 | `1rem` | theme.json `--wp--preset--spacing--40` |
+| 5 | `1.25rem` | theme.json `--wp--preset--spacing--50` |
+| 6 | `1.5rem` | theme.json `--wp--preset--spacing--60` |
+| 7 | `1.75rem` | theme.json `--wp--preset--spacing--70` |
+| 8 | `2rem` | theme.json `--wp--preset--spacing--80` |
+| 9 | `2.5rem` | theme.json `--wp--preset--spacing--90` |
+| 10 | `3rem` | theme.json `--wp--preset--spacing--100` |
+| 12 | `4rem` | theme.json `--wp--preset--spacing--120` |
+| 16 | `5rem` | theme.json `--wp--preset--spacing--160` |
+| 20 | `6rem` | theme.json `--wp--preset--spacing--200` |
+| 24 | `8rem` | theme.json `--wp--preset--spacing--240` |
+
+## Radii
+
+| Role | Value | Source |
+|---|---|---|
+| Small | `0.25rem` | theme.json `settings.custom.border.radiusSm` |
+| Medium | `0.5rem` | theme.json `settings.custom.border.radiusMd` |
+| Large | `0.75rem` | theme.json `settings.custom.border.radiusLg` |
+| Extra Large | `1rem` | theme.json `settings.custom.border.radiusXl` |
+| 2X Large | `1.5rem` | theme.json `settings.custom.border.radius2xl` |
+| Full / pill | `9999px` | theme.json `settings.custom.border.radiusFull` |
+
+## Shadows
+
+| Role | Value | Source |
+|---|---|---|
+| Small | `0 1px 2px rgba(0, 0, 0, 0.5)` | theme.json `--wp--preset--shadow--sm` |
+| Medium | `0 4px 6px rgba(0, 0, 0, 0.4)` | theme.json `--wp--preset--shadow--md` |
+| Large | `0 10px 15px rgba(0, 0, 0, 0.3)` | theme.json `--wp--preset--shadow--lg` |
+| Extra Large | `0 20px 25px rgba(0, 0, 0, 0.25)` | theme.json `--wp--preset--shadow--xl` |
+
+## Buttons
+
+| Role | Value | Source |
+|---|---|---|
+| Background | `#9a2f14` | theme.json `styles.elements.button.color.background` → theme.json `--wp--preset--color--signal` |
+| Text | `#efe6d2` | theme.json `styles.elements.button.color.text` → theme.json `--wp--preset--color--deep` |
+| Font family | `'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif` | theme.json `styles.elements.button.typography.fontFamily` → theme.json `--wp--preset--font-family--body` |
+| Font size | `1rem` | theme.json `styles.elements.button.typography.fontSize` → theme.json `--wp--preset--font-size--base` |
+| Font weight | `600` | theme.json `styles.elements.button.typography.fontWeight` |
+| Letter spacing | `0` | theme.json `styles.elements.button.typography.letterSpacing` → theme.json `--wp--custom--letter-spacing--normal` |
+| Inline padding | `1.5rem` | theme.json `settings.custom.button.paddingInline` → theme.json `--wp--preset--spacing--60` |
+| Block padding | `0.75rem` | theme.json `settings.custom.button.paddingBlock` → theme.json `--wp--preset--spacing--30` |
+| Radius | `0.5rem` | theme.json `settings.custom.button.radius` → theme.json `--wp--custom--border--radius-md` |
+| Pill radius | `9999px` | theme.json `settings.custom.button.radiusPill` → theme.json `--wp--custom--border--radius-full` |
+| Minimum height | `44px` | theme.json `settings.custom.button.minHeight` |
+| Mobile minimum height | `48px` | theme.json `settings.custom.button.mobileMinHeight` |
+| Icon size | `1.125rem` | theme.json `settings.custom.button.iconSize` |
+
+## Missing or noncanonical
+
+| Concept | Status | Why |
+|---|---|---|
+| icon_system | missing | The canonical Aurora sources do not define an icon family or usage rules. |
+| logo_usage_rules | missing | Logo files, clear-space rules, and lockups belong to the rights-cleared asset manifest. |
+| photography_treatment | missing | The canonical Aurora token sources do not define editorial photography rules. |
+| brand_gradients | noncanonical_for_press_kit | Gradient presets exist in theme.json but have no current --kk-* semantic role; they are intentionally omitted from press-kit guidance. |
+| duotone_treatments | noncanonical_for_press_kit | Duotone presets exist in theme.json but have no current --kk-* semantic role; they are intentionally omitted from press-kit guidance. |

--- a/scripts/export_press_kit_brand.py
+++ b/scripts/export_press_kit_brand.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Export canonical Aurora brand data for the press kit."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+THEME_JSON = "theme/kk-aurora/theme.json"
+TOKENS_CSS = "theme/kk-aurora/assets/css/02-tokens.css"
+STYLE_CSS = "theme/kk-aurora/style.css"
+OUTPUT_JSON = "content/source-packs/content-architecture-2026/press-kit/brand-reference.json"
+OUTPUT_MARKDOWN = "content/source-packs/content-architecture-2026/press-kit/brand-reference.md"
+
+CSS_DECLARATION = re.compile(r"^\s*(--kk-[a-z0-9-]+)\s*:\s*([^;]+);", re.MULTILINE)
+CSS_REFERENCE = re.compile(r"^var\((--[a-z0-9-]+)\)$")
+
+
+class ExportError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ExportPaths:
+    repo_root: Path
+    theme_json: Path
+    tokens_css: Path
+    style_css: Path
+    output_json: Path
+    output_markdown: Path
+
+    @classmethod
+    def from_root(cls, repo_root: Path) -> "ExportPaths":
+        root = repo_root.resolve()
+        return cls(
+            repo_root=root,
+            theme_json=root / THEME_JSON,
+            tokens_css=root / TOKENS_CSS,
+            style_css=root / STYLE_CSS,
+            output_json=root / OUTPUT_JSON,
+            output_markdown=root / OUTPUT_MARKDOWN,
+        )
+
+
+@dataclass(frozen=True)
+class Sources:
+    paths: ExportPaths
+    theme: dict[str, Any]
+    tokens_text: str
+    style_text: str
+    css_tokens: dict[str, str]
+    theme_name: str
+    theme_version: str
+    registry: dict[str, dict[str, Any]]
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ExportError(f"cannot read {path}: {exc}") from exc
+
+
+def parse_header_value(style_text: str, field: str) -> str:
+    match = re.search(rf"^\s*{re.escape(field)}:\s*(.+?)\s*$", style_text, re.MULTILINE)
+    if not match:
+        raise ExportError(f"style.css has no {field} header")
+    return match.group(1)
+
+
+def parse_css_tokens(tokens_text: str) -> dict[str, str]:
+    return {name: value.strip() for name, value in CSS_DECLARATION.findall(tokens_text)}
+
+
+def kebab_case(name: str) -> str:
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", name)
+    value = re.sub(r"([A-Za-z])(\d+)", r"\1-\2", value)
+    value = re.sub(r"(\d+)([A-Za-z])", r"\1-\2", value)
+    return value.lower()
+
+
+def source(path: str, token: str, location: str | None = None) -> dict[str, str]:
+    result = {"path": path, "token": token}
+    if location:
+        result["location"] = location
+    return result
+
+
+def build_registry(theme: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    settings = theme.get("settings", {})
+    registry: dict[str, dict[str, Any]] = {}
+
+    preset_specs = (
+        (settings.get("color", {}).get("palette", []), "color", "color", "settings.color.palette"),
+        (
+            settings.get("typography", {}).get("fontFamilies", []),
+            "font-family",
+            "fontFamily",
+            "settings.typography.fontFamilies",
+        ),
+        (
+            settings.get("typography", {}).get("fontSizes", []),
+            "font-size",
+            "size",
+            "settings.typography.fontSizes",
+        ),
+        (
+            settings.get("spacing", {}).get("spacingSizes", []),
+            "spacing",
+            "size",
+            "settings.spacing.spacingSizes",
+        ),
+        (
+            settings.get("shadow", {}).get("presets", []),
+            "shadow",
+            "shadow",
+            "settings.shadow.presets",
+        ),
+    )
+    for entries, preset_type, value_key, location in preset_specs:
+        for entry in entries:
+            slug = entry["slug"]
+            token = f"--wp--preset--{preset_type}--{slug}"
+            registry[token] = {
+                "value": entry[value_key],
+                "source": source(THEME_JSON, token, f"{location}[slug={slug}]"),
+            }
+
+    def walk_custom(value: Any, key_parts: list[str], json_parts: list[str]) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                walk_custom(child, [*key_parts, kebab_case(key)], [*json_parts, key])
+            return
+        token = "--wp--custom--" + "--".join(key_parts)
+        registry[token] = {
+            "value": value,
+            "source": source(THEME_JSON, token, ".".join(json_parts)),
+        }
+
+    walk_custom(settings.get("custom", {}), [], ["settings", "custom"])
+    return registry
+
+
+def load_sources(paths: ExportPaths) -> Sources:
+    theme_text = read_text(paths.theme_json)
+    tokens_text = read_text(paths.tokens_css)
+    style_text = read_text(paths.style_css)
+    try:
+        theme = json.loads(theme_text)
+    except json.JSONDecodeError as exc:
+        raise ExportError(f"invalid JSON in {paths.theme_json}: {exc}") from exc
+
+    css_tokens = parse_css_tokens(tokens_text)
+    if not css_tokens:
+        raise ExportError(f"no --kk-* tokens found in {paths.tokens_css}")
+    return Sources(
+        paths=paths,
+        theme=theme,
+        tokens_text=tokens_text,
+        style_text=style_text,
+        css_tokens=css_tokens,
+        theme_name=parse_header_value(style_text, "Theme Name"),
+        theme_version=parse_header_value(style_text, "Version"),
+        registry=build_registry(theme),
+    )
+
+
+def resolve_value(raw_value: Any, registry: dict[str, dict[str, Any]]) -> tuple[Any, list[dict[str, str]]]:
+    value = raw_value
+    provenance: list[dict[str, str]] = []
+    visited: set[str] = set()
+    while isinstance(value, str):
+        match = CSS_REFERENCE.fullmatch(value.strip())
+        if not match:
+            break
+        token = match.group(1)
+        if token in visited:
+            raise ExportError(f"circular token reference: {token}")
+        visited.add(token)
+        if token not in registry:
+            raise ExportError(f"unresolved canonical token: {token}")
+        definition = registry[token]
+        provenance.append(definition["source"])
+        value = definition["value"]
+    return value, provenance
+
+
+def item(item_id: str, name: str, value: Any, provenance: list[dict[str, str]]) -> dict[str, Any]:
+    if not provenance:
+        raise ExportError(f"{item_id} has no canonical provenance")
+    return {"id": item_id, "name": name, "value": value, "provenance": provenance}
+
+
+def semantic_item(sources: Sources, item_id: str, name: str, alias: str) -> dict[str, Any]:
+    if alias not in sources.css_tokens:
+        raise ExportError(f"missing semantic token: {alias}")
+    value, resolved_sources = resolve_value(sources.css_tokens[alias], sources.registry)
+    return item(
+        item_id,
+        name,
+        value,
+        [source(TOKENS_CSS, alias), *resolved_sources],
+    )
+
+
+def preset_item(
+    sources: Sources,
+    preset_type: str,
+    entry: dict[str, Any],
+    value: Any,
+) -> dict[str, Any]:
+    token = f"--wp--preset--{preset_type}--{entry['slug']}"
+    if token not in sources.registry:
+        raise ExportError(f"missing preset token: {token}")
+    return item(entry["slug"], entry["name"], value, [sources.registry[token]["source"]])
+
+
+def css_literal_item(sources: Sources, item_id: str, name: str, token: str) -> dict[str, Any]:
+    if token not in sources.css_tokens:
+        raise ExportError(f"missing canonical token: {token}")
+    value, resolved_sources = resolve_value(sources.css_tokens[token], sources.registry)
+    return item(item_id, name, value, [source(TOKENS_CSS, token), *resolved_sources])
+
+
+def nested_value(data: dict[str, Any], keys: tuple[str, ...]) -> Any | None:
+    value: Any = data
+    for key in keys:
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    return value
+
+
+def direct_theme_item(
+    sources: Sources,
+    item_id: str,
+    name: str,
+    keys: tuple[str, ...],
+) -> dict[str, Any] | None:
+    raw_value = nested_value(sources.theme, keys)
+    if raw_value is None:
+        return None
+    token = ".".join(keys)
+    value, resolved_sources = resolve_value(raw_value, sources.registry)
+    return item(
+        item_id,
+        name,
+        value,
+        [source(THEME_JSON, token, token), *resolved_sources],
+    )
+
+
+def custom_item(
+    sources: Sources,
+    item_id: str,
+    name: str,
+    key_parts: tuple[str, ...],
+) -> dict[str, Any] | None:
+    keys = ("settings", "custom", *key_parts)
+    raw_value = nested_value(sources.theme, keys)
+    if raw_value is None:
+        return None
+    token = ".".join(keys)
+    value, resolved_sources = resolve_value(raw_value, sources.registry)
+    return item(
+        item_id,
+        name,
+        value,
+        [source(THEME_JSON, token, token), *resolved_sources],
+    )
+
+
+def compact(items: list[dict[str, Any] | None]) -> list[dict[str, Any]]:
+    return [entry for entry in items if entry is not None]
+
+
+def missing_categories(theme: dict[str, Any]) -> list[dict[str, Any]]:
+    color = theme.get("settings", {}).get("color", {})
+    gradients = color.get("gradients", [])
+    duotones = color.get("duotone", [])
+    return [
+        {
+            "concept": "icon_system",
+            "status": "missing",
+            "reason": "The canonical Aurora sources do not define an icon family or usage rules.",
+            "checked_sources": [THEME_JSON, TOKENS_CSS],
+        },
+        {
+            "concept": "logo_usage_rules",
+            "status": "missing",
+            "reason": "Logo files, clear-space rules, and lockups belong to the rights-cleared asset manifest.",
+            "checked_sources": [THEME_JSON, TOKENS_CSS],
+        },
+        {
+            "concept": "photography_treatment",
+            "status": "missing",
+            "reason": "The canonical Aurora token sources do not define editorial photography rules.",
+            "checked_sources": [THEME_JSON, TOKENS_CSS],
+        },
+        {
+            "concept": "brand_gradients",
+            "status": "noncanonical_for_press_kit" if gradients else "missing",
+            "reason": (
+                "Gradient presets exist in theme.json but have no current --kk-* semantic role; "
+                "they are intentionally omitted from press-kit guidance."
+                if gradients
+                else "No canonical brand-gradient system is defined."
+            ),
+            "checked_sources": [THEME_JSON, TOKENS_CSS],
+        },
+        {
+            "concept": "duotone_treatments",
+            "status": "noncanonical_for_press_kit" if duotones else "missing",
+            "reason": (
+                "Duotone presets exist in theme.json but have no current --kk-* semantic role; "
+                "they are intentionally omitted from press-kit guidance."
+                if duotones
+                else "No canonical duotone treatment is defined."
+            ),
+            "checked_sources": [THEME_JSON, TOKENS_CSS],
+        },
+    ]
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_reference(sources: Sources, generated_at: str) -> dict[str, Any]:
+    settings = sources.theme.get("settings", {})
+    color = settings.get("color", {})
+    typography = settings.get("typography", {})
+
+    font_families = [
+        preset_item(sources, "font-family", entry, entry["fontFamily"])
+        for entry in typography.get("fontFamilies", [])
+    ]
+    type_scale = []
+    for entry in typography.get("fontSizes", []):
+        value: dict[str, Any] = {"default": entry["size"]}
+        if isinstance(entry.get("fluid"), dict):
+            value["fluid_min"] = entry["fluid"].get("min")
+            value["fluid_max"] = entry["fluid"].get("max")
+        type_scale.append(preset_item(sources, "font-size", entry, value))
+
+    layout = compact(
+        [
+            direct_theme_item(sources, "content_width", "Content width", ("settings", "layout", "contentSize")),
+            direct_theme_item(sources, "wide_width", "Wide width", ("settings", "layout", "wideSize")),
+            css_literal_item(sources, "measure", "Reading measure", "--kk-measure"),
+        ]
+    )
+    breakpoints = [
+        css_literal_item(sources, "small", "Small", "--kk-bp-sm"),
+        css_literal_item(sources, "medium", "Medium", "--kk-bp-md"),
+        css_literal_item(sources, "large", "Large", "--kk-bp-lg"),
+    ]
+
+    spacing = [
+        preset_item(sources, "spacing", entry, entry["size"])
+        for entry in settings.get("spacing", {}).get("spacingSizes", [])
+    ]
+    radius_names = {
+        "radiusSm": "Small",
+        "radiusMd": "Medium",
+        "radiusLg": "Large",
+        "radiusXl": "Extra Large",
+        "radius2xl": "2X Large",
+        "radiusFull": "Full / pill",
+    }
+    radii = compact(
+        [custom_item(sources, kebab_case(key), radius_names.get(key, key), ("border", key)) for key in settings.get("custom", {}).get("border", {})]
+    )
+    shadows = [
+        preset_item(sources, "shadow", entry, entry["shadow"])
+        for entry in settings.get("shadow", {}).get("presets", [])
+    ]
+
+    button_style_specs = (
+        ("background", "Background", ("styles", "elements", "button", "color", "background")),
+        ("text", "Text", ("styles", "elements", "button", "color", "text")),
+        ("font_family", "Font family", ("styles", "elements", "button", "typography", "fontFamily")),
+        ("font_size", "Font size", ("styles", "elements", "button", "typography", "fontSize")),
+        ("font_weight", "Font weight", ("styles", "elements", "button", "typography", "fontWeight")),
+        ("letter_spacing", "Letter spacing", ("styles", "elements", "button", "typography", "letterSpacing")),
+    )
+    button_custom_names = {
+        "paddingInline": "Inline padding",
+        "paddingBlock": "Block padding",
+        "radius": "Radius",
+        "radiusPill": "Pill radius",
+        "minHeight": "Minimum height",
+        "mobileMinHeight": "Mobile minimum height",
+        "iconSize": "Icon size",
+    }
+    buttons = compact(
+        [direct_theme_item(sources, item_id, name, keys) for item_id, name, keys in button_style_specs]
+        + [
+            custom_item(sources, kebab_case(key), button_custom_names.get(key, key), ("button", key))
+            for key in settings.get("custom", {}).get("button", {})
+        ]
+    )
+
+    theme_name = item(
+        "theme_name",
+        "Theme name",
+        sources.theme_name,
+        [source(STYLE_CSS, "Theme Name")],
+    )
+    theme_version = item(
+        "theme_version",
+        "Theme version",
+        sources.theme_version,
+        [source(STYLE_CSS, "Version")],
+    )
+
+    return {
+        "schema_version": 1,
+        "metadata": {
+            "generated_at_utc": generated_at,
+            "timestamp_policy": "--check reuses the committed timestamp so clock time never creates drift.",
+            "theme": {"name": theme_name, "version": theme_version},
+            "source_files": [
+                {"path": THEME_JSON, "sha256": sha256(sources.paths.theme_json)},
+                {"path": TOKENS_CSS, "sha256": sha256(sources.paths.tokens_css)},
+                {"path": STYLE_CSS, "sha256": sha256(sources.paths.style_css)},
+            ],
+            "publication_gate": (
+                "This exporter reads repository sources only. Before publication, run make status-readonly "
+                "and verify that live and repository Aurora versions agree."
+            ),
+        },
+        "colors": {
+            "surfaces": [
+                semantic_item(sources, "surface", "Primary surface", "--kk-surface"),
+                semantic_item(sources, "surface_sunk", "Sunk surface", "--kk-surface-sunk"),
+                semantic_item(sources, "surface_raised", "Raised surface", "--kk-surface-raised"),
+            ],
+            "ink_text": [
+                semantic_item(sources, "ink", "Primary ink", "--kk-ink"),
+                semantic_item(sources, "ink_secondary", "Secondary ink", "--kk-ink-secondary"),
+                semantic_item(sources, "ink_muted", "Muted ink", "--kk-ink-muted"),
+            ],
+            "accent_action": [
+                semantic_item(sources, "accent", "Primary accent", "--kk-accent"),
+                semantic_item(sources, "accent_ink", "Accent text", "--kk-accent-ink"),
+            ],
+            "semantic": [
+                semantic_item(sources, "line", "Structure / line", "--kk-line"),
+                *[
+                    preset_item(sources, "color", entry, entry["color"])
+                    for entry in color.get("palette", [])
+                    if entry.get("slug") in {"success", "warning", "error"}
+                ],
+            ],
+        },
+        "typography": {"font_families": font_families, "type_scale": type_scale},
+        "layout": {"widths": layout, "breakpoints": breakpoints},
+        "foundations": {"spacing": spacing, "radii": radii, "shadows": shadows},
+        "buttons": buttons,
+        "missing_or_noncanonical": missing_categories(sources.theme),
+    }
+
+
+def flatten_json_tokens(value: Any, parts: tuple[str, ...] = ()) -> set[str]:
+    tokens: set[str] = set()
+    if isinstance(value, dict):
+        for key, child in value.items():
+            tokens.update(flatten_json_tokens(child, (*parts, key)))
+    elif not isinstance(value, list) and parts:
+        tokens.add(".".join(parts))
+    return tokens
+
+
+def available_source_tokens(sources: Sources) -> set[tuple[str, str]]:
+    available = {(TOKENS_CSS, token) for token in sources.css_tokens}
+    available.update((THEME_JSON, token) for token in flatten_json_tokens(sources.theme))
+    available.update((THEME_JSON, token) for token in sources.registry)
+    available.update({(STYLE_CSS, "Theme Name"), (STYLE_CSS, "Version")})
+    return available
+
+
+def source_label(entry: dict[str, str]) -> str:
+    aliases = {THEME_JSON: "theme.json", TOKENS_CSS: "02-tokens.css", STYLE_CSS: "style.css"}
+    return f"{aliases[entry['path']]} `{entry['token']}`"
+
+
+def display_value(value: Any) -> str:
+    if isinstance(value, dict):
+        default = value.get("default", "")
+        minimum = value.get("fluid_min")
+        maximum = value.get("fluid_max")
+        if minimum and maximum:
+            return f"{default} (fluid {minimum}–{maximum})"
+        return str(default)
+    return str(value)
+
+
+def render_table(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "_No canonical values found._\n"
+    lines = ["| Role | Value | Source |", "|---|---|---|"]
+    for entry in items:
+        provenance = " → ".join(source_label(value) for value in entry["provenance"])
+        lines.append(f"| {entry['name']} | `{display_value(entry['value'])}` | {provenance} |")
+    return "\n".join(lines) + "\n"
+
+
+def render_markdown(reference: dict[str, Any]) -> str:
+    metadata = reference["metadata"]
+    theme = metadata["theme"]
+    lines = [
+        "# Aurora Brand Reference",
+        "",
+        (
+            f"Generated {metadata['generated_at_utc']} from "
+            f"{theme['name']['value']} {theme['version']['value']}."
+        ),
+        "",
+        "This is a repository-derived reference, not proof of the live theme. "
+        "Before publication, run `make status-readonly` and confirm live/repo Aurora version agreement.",
+        "",
+        "Source aliases:",
+        "",
+        f"- `theme.json`: `{THEME_JSON}`",
+        f"- `02-tokens.css`: `{TOKENS_CSS}`",
+        f"- `style.css`: `{STYLE_CSS}`",
+        "",
+    ]
+
+    sections = (
+        ("Surfaces", reference["colors"]["surfaces"]),
+        ("Ink and text", reference["colors"]["ink_text"]),
+        ("Accent and action", reference["colors"]["accent_action"]),
+        ("Semantic colors", reference["colors"]["semantic"]),
+        ("Font families", reference["typography"]["font_families"]),
+        ("Type scale", reference["typography"]["type_scale"]),
+        ("Layout widths", reference["layout"]["widths"]),
+        ("Breakpoints", reference["layout"]["breakpoints"]),
+        ("Spacing", reference["foundations"]["spacing"]),
+        ("Radii", reference["foundations"]["radii"]),
+        ("Shadows", reference["foundations"]["shadows"]),
+        ("Buttons", reference["buttons"]),
+    )
+    for heading, entries in sections:
+        lines.extend([f"## {heading}", "", render_table(entries).rstrip(), ""])
+
+    lines.extend(
+        [
+            "## Missing or noncanonical",
+            "",
+            "| Concept | Status | Why |",
+            "|---|---|---|",
+        ]
+    )
+    for entry in reference["missing_or_noncanonical"]:
+        lines.append(f"| {entry['concept']} | {entry['status']} | {entry['reason']} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(reference: dict[str, Any]) -> str:
+    return json.dumps(reference, indent=2, ensure_ascii=False) + "\n"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def rendered_export(paths: ExportPaths, generated_at: str) -> tuple[str, str]:
+    reference = build_reference(load_sources(paths), generated_at)
+    return render_json(reference), render_markdown(reference)
+
+
+def write_export(paths: ExportPaths, generated_at: str | None = None) -> None:
+    json_text, markdown_text = rendered_export(paths, generated_at or utc_now())
+    paths.output_json.parent.mkdir(parents=True, exist_ok=True)
+    paths.output_json.write_text(json_text, encoding="utf-8")
+    paths.output_markdown.write_text(markdown_text, encoding="utf-8")
+
+
+def committed_timestamp(path: Path) -> str:
+    try:
+        reference = json.loads(path.read_text(encoding="utf-8"))
+        value = reference["metadata"]["generated_at_utc"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return "1970-01-01T00:00:00Z"
+    return value if isinstance(value, str) else "1970-01-01T00:00:00Z"
+
+
+def check_export(paths: ExportPaths) -> list[Path]:
+    generated_at = committed_timestamp(paths.output_json)
+    expected_json, expected_markdown = rendered_export(paths, generated_at)
+    expected = {
+        paths.output_json: expected_json,
+        paths.output_markdown: expected_markdown,
+    }
+    drifted = []
+    for path, content in expected.items():
+        try:
+            current = path.read_text(encoding="utf-8")
+        except OSError:
+            current = None
+        if current != content:
+            drifted.append(path)
+    return drifted
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if generated references are stale")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument("--generated-at", help=argparse.SUPPRESS)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    paths = ExportPaths.from_root(args.repo_root)
+    try:
+        if args.check:
+            drifted = check_export(paths)
+            if drifted:
+                for path in drifted:
+                    print(f"DRIFT: {path.relative_to(paths.repo_root)}", file=sys.stderr)
+                return 1
+            print("PASS: press-kit brand references match canonical Aurora sources")
+            return 0
+        write_export(paths, generated_at=args.generated_at)
+    except ExportError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(f"WROTE: {OUTPUT_JSON}")
+    print(f"WROTE: {OUTPUT_MARKDOWN}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_export_press_kit_brand.py
+++ b/scripts/tests/test_export_press_kit_brand.py
@@ -1,0 +1,242 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import export_press_kit_brand as exporter  # noqa: E402
+
+
+GENERATED_AT = "2026-08-23T01:00:00Z"
+
+
+def fixture_theme() -> dict:
+    return {
+        "settings": {
+            "layout": {"contentSize": "40rem", "wideSize": "64rem"},
+            "color": {
+                "palette": [
+                    {"slug": "paper", "name": "Paper", "color": "#f5f0e6"},
+                    {"slug": "surface", "name": "Panel", "color": "#e9e0cf"},
+                    {"slug": "elevated", "name": "Raised", "color": "#eee5d5"},
+                    {"slug": "text-primary", "name": "Ink", "color": "#191512"},
+                    {"slug": "text-secondary", "name": "Ink Secondary", "color": "#40372f"},
+                    {"slug": "text-muted", "name": "Ink Muted", "color": "#61564b"},
+                    {"slug": "signal", "name": "Signal", "color": "#a4381e"},
+                    {"slug": "signal-text", "name": "Signal Text", "color": "#8c2d18"},
+                    {"slug": "muted", "name": "Line", "color": "#d8ccb6"},
+                    {"slug": "deep", "name": "Button Ink", "color": "#f5f0e6"},
+                    {"slug": "success", "name": "Success", "color": "#267e76"},
+                    {"slug": "warning", "name": "Warning", "color": "#dba52e"},
+                    {"slug": "error", "name": "Error", "color": "#c94321"},
+                ],
+                "gradients": [
+                    {
+                        "slug": "legacy-neon",
+                        "name": "Legacy Neon",
+                        "gradient": "linear-gradient(#00E5FF, #0D0D12)",
+                    }
+                ],
+                "duotone": [
+                    {"slug": "legacy-duo", "name": "Legacy Duo", "colors": ["#0D0D12", "#00E5FF"]}
+                ],
+            },
+            "typography": {
+                "fontFamilies": [
+                    {"slug": "display", "name": "Display", "fontFamily": "Example Display, sans-serif"},
+                    {"slug": "body", "name": "Body", "fontFamily": "Example Body, sans-serif"},
+                ],
+                "fontSizes": [
+                    {
+                        "slug": "base",
+                        "name": "Base",
+                        "size": "1rem",
+                        "fluid": {"min": "1rem", "max": "1.125rem"},
+                    },
+                    {"slug": "xl", "name": "Extra Large", "size": "1.25rem"},
+                ],
+            },
+            "spacing": {
+                "spacingSizes": [
+                    {"slug": "20", "name": "2", "size": "0.5rem"},
+                    {"slug": "60", "name": "6", "size": "1.5rem"},
+                ]
+            },
+            "shadow": {
+                "presets": [
+                    {"slug": "sm", "name": "Small", "shadow": "0 1px 2px rgb(0 0 0 / 20%)"}
+                ]
+            },
+            "custom": {
+                "border": {"radiusSm": "0.25rem", "radiusMd": "0.5rem"},
+                "button": {
+                    "paddingInline": "var(--wp--preset--spacing--60)",
+                    "paddingBlock": "var(--wp--preset--spacing--20)",
+                    "radius": "var(--wp--custom--border--radius-md)",
+                    "minHeight": "44px",
+                },
+            },
+        },
+        "styles": {
+            "elements": {
+                "button": {
+                    "color": {
+                        "background": "var(--wp--preset--color--signal)",
+                        "text": "var(--wp--preset--color--deep)",
+                    },
+                    "typography": {"fontWeight": "600"},
+                }
+            }
+        },
+    }
+
+
+TOKENS_CSS = """@layer tokens {
+  :root {
+    --kk-surface: var(--wp--preset--color--paper);
+    --kk-surface-sunk: var(--wp--preset--color--surface);
+    --kk-surface-raised: var(--wp--preset--color--elevated);
+    --kk-ink: var(--wp--preset--color--text-primary);
+    --kk-ink-secondary: var(--wp--preset--color--text-secondary);
+    --kk-ink-muted: var(--wp--preset--color--text-muted);
+    --kk-accent: var(--wp--preset--color--signal);
+    --kk-accent-ink: var(--wp--preset--color--signal-text);
+    --kk-line: var(--wp--preset--color--muted);
+    --kk-measure: 66ch;
+    --kk-bp-sm: 480px;
+    --kk-bp-md: 768px;
+    --kk-bp-lg: 1200px;
+  }
+}
+"""
+
+
+def write_fixture(repo_root: Path) -> exporter.ExportPaths:
+    paths = exporter.ExportPaths.from_root(repo_root)
+    paths.theme_json.parent.mkdir(parents=True)
+    paths.tokens_css.parent.mkdir(parents=True)
+    paths.output_json.parent.mkdir(parents=True)
+    paths.theme_json.write_text(json.dumps(fixture_theme()), encoding="utf-8")
+    paths.tokens_css.write_text(TOKENS_CSS, encoding="utf-8")
+    paths.style_css.write_text("/*\nTheme Name: Fixture Aurora\nVersion: 9.8.7\n*/\n", encoding="utf-8")
+    return paths
+
+
+def guidance_items(value):
+    if isinstance(value, dict):
+        if "value" in value and "provenance" in value:
+            yield value
+            return
+        for child in value.values():
+            yield from guidance_items(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from guidance_items(child)
+
+
+class SourceLoadingTests(unittest.TestCase):
+    def test_loads_theme_version_and_semantic_aliases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sources = exporter.load_sources(write_fixture(Path(tmp)))
+
+        self.assertEqual(sources.theme_name, "Fixture Aurora")
+        self.assertEqual(sources.theme_version, "9.8.7")
+        self.assertEqual(
+            sources.css_tokens["--kk-surface"],
+            "var(--wp--preset--color--paper)",
+        )
+
+
+class ReferenceBuildTests(unittest.TestCase):
+    def test_output_order_and_role_mapping_are_stable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sources = exporter.load_sources(write_fixture(Path(tmp)))
+            first = exporter.build_reference(sources, GENERATED_AT)
+            second = exporter.build_reference(sources, GENERATED_AT)
+
+        self.assertEqual(
+            [item["id"] for item in first["colors"]["surfaces"]],
+            ["surface", "surface_sunk", "surface_raised"],
+        )
+        self.assertEqual(first, second)
+        self.assertEqual(first["colors"]["surfaces"][0]["value"], "#f5f0e6")
+        self.assertEqual(
+            [source["token"] for source in first["colors"]["surfaces"][0]["provenance"]],
+            ["--kk-surface", "--wp--preset--color--paper"],
+        )
+
+    def test_every_guidance_item_points_to_an_existing_source_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sources = exporter.load_sources(write_fixture(Path(tmp)))
+            reference = exporter.build_reference(sources, GENERATED_AT)
+            available = exporter.available_source_tokens(sources)
+
+        items = list(guidance_items(reference))
+        self.assertGreater(len(items), 20)
+        for item in items:
+            with self.subTest(item=item["id"]):
+                self.assertTrue(item["provenance"])
+                for source in item["provenance"]:
+                    self.assertIn((source["path"], source["token"]), available)
+
+    def test_committed_sources_support_every_exported_provenance(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        sources = exporter.load_sources(exporter.ExportPaths.from_root(repo_root))
+        reference = exporter.build_reference(sources, GENERATED_AT)
+        available = exporter.available_source_tokens(sources)
+
+        for item in guidance_items(reference):
+            with self.subTest(item=item["id"]):
+                for source in item["provenance"]:
+                    self.assertIn((source["path"], source["token"]), available)
+
+    def test_missing_categories_are_reported_without_exporting_old_neon_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sources = exporter.load_sources(write_fixture(Path(tmp)))
+            reference = exporter.build_reference(sources, GENERATED_AT)
+
+        missing = {item["concept"]: item["status"] for item in reference["missing_or_noncanonical"]}
+        serialized = json.dumps(reference)
+        self.assertEqual(missing["icon_system"], "missing")
+        self.assertEqual(missing["brand_gradients"], "noncanonical_for_press_kit")
+        self.assertEqual(missing["duotone_treatments"], "noncanonical_for_press_kit")
+        self.assertNotIn("#00E5FF", serialized)
+        self.assertNotIn("#0D0D12", serialized)
+
+
+class CheckModeTests(unittest.TestCase):
+    def test_check_passes_then_fails_when_a_source_token_drifts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            paths = write_fixture(repo_root)
+            exporter.write_export(paths, generated_at=GENERATED_AT)
+
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                self.assertEqual(exporter.main(["--repo-root", str(repo_root), "--check"]), 0)
+
+            theme = json.loads(paths.theme_json.read_text(encoding="utf-8"))
+            theme["settings"]["color"]["palette"][0]["color"] = "#ffffff"
+            paths.theme_json.write_text(json.dumps(theme), encoding="utf-8")
+            committed_json = paths.output_json.read_text(encoding="utf-8")
+            committed_markdown = paths.output_markdown.read_text(encoding="utf-8")
+
+            stderr = io.StringIO()
+            with redirect_stdout(io.StringIO()), redirect_stderr(stderr):
+                result = exporter.main(["--repo-root", str(repo_root), "--check"])
+            checked_json = paths.output_json.read_text(encoding="utf-8")
+            checked_markdown = paths.output_markdown.read_text(encoding="utf-8")
+
+        self.assertEqual(result, 1)
+        self.assertIn("brand-reference.json", stderr.getvalue())
+        self.assertIn("brand-reference.md", stderr.getvalue())
+        self.assertEqual(checked_json, committed_json)
+        self.assertEqual(checked_markdown, committed_markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a standard-library exporter for canonical Aurora press-kit guidance
- resolve semantic `--kk-*` roles through their `theme.json` presets with per-item provenance
- export human-readable Markdown plus machine-readable JSON for color, type, layout, spacing, radii, shadows, and buttons
- classify unbound gradients, duotones, icons, logo rules, and photography treatment as missing or noncanonical instead of inventing guidance
- add deterministic fixtures, actual-source provenance coverage, and non-writing drift checks

## Verification

- `python3 scripts/export_press_kit_brand.py`
- `python3 scripts/export_press_kit_brand.py --check`
- `python3 -m unittest scripts.tests.test_export_press_kit_brand` — 6 passed
- `python3 -m json.tool content/source-packs/content-architecture-2026/press-kit/brand-reference.json >/dev/null`
- `git diff --check -- scripts/export_press_kit_brand.py scripts/tests/test_export_press_kit_brand.py content/source-packs/content-architecture-2026/press-kit/brand-reference.json content/source-packs/content-architecture-2026/press-kit/brand-reference.md`

## Safety

- repository sources only; no WordPress read or write
- no Aurora source changes
- publication remains gated on a fresh `make status-readonly` live/repo version agreement

Closes #879
