### PR TITLE
docs: close out 2026-08-23 and record the open merge lane

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-08-23.md
+++ b/docs/current-state/WORK-PLAN-2026-08-23.md
@@ -18,6 +18,14 @@
 | #827 photography hub links | **live** 2026-08-18, issue closed. 1210 still unlinked (that is #828) |
 | Origin besides `main` | open PR heads only (hub packs #865 to #868, this runbook, drafts #887 to #891) |
 
+### Session-open commands changed 2026-08-23
+
+Run **`make doctor`** first. It reports WP credentials (under either name pair), venv, `gh` auth, tree cleanliness, live worktrees, and site reachability in one screen, read-only, never printing a secret.
+
+Credential trap worth knowing: this machine's vault supplies only `WP_API_USERNAME` / `WP_API_PASSWORD`. **`WP_USER` / `WP_APP_PASSWORD` resolve to nothing.** Seven scripts gated on the dead pair and silently ran unauthenticated, including the two behind `make status-readonly` and `make morning-truth`. All 20 scripts accept either pair now, and `scripts/tests/test_wp_credential_aliases.py` guards against a regression. Do not conclude credentials are missing because `WP_USER` is unset.
+
+`make status-readonly` also stopped dumping raw `gh --json` payloads: 43,217 bytes with 4 false credential errors, down to ~12,300 with none.
+
 ### Landed on `main` 2026-08-23
 
 | PR | What |
@@ -25,19 +33,70 @@
 | #870, #871 | `python-dotenv >=1.2.3` (root + `scripts/notion-to-wp`) |
 | #872 | `github/codeql-action/upload-sarif` 4.37.6 to 4.37.7 |
 | #864 | Archived three issue drafts whose children are closed. **Closed #744** (#339 stays open, as planned) |
-| #873 | Deleted `customize-for-kriskrug.sh` and `monitor-agents.sh`. **Closed #742** |
+| #873 | Deleted `customize-for-kriskrug.sh` and `monitor-agents.sh` |
+| #865 / #866 / #867 / #868 | Hub link payloads for #829 / #832 / #830 / #831. Prepared, **not applied**; those issues stay open |
+| #869 | This runbook, plus the first merge-path correction |
+| #887 / #888 / #889 / #890 | Press kit wave 1 (#878 assets, #877 copy deck, #879 brand reference) and AI policy wave 1 (#884). Those four issues closed |
+| #892 | Toolchain repair: WP credential aliasing, three dead workflows deleted, `make doctor`, `status-readonly` output fix |
+| #893 | Opened the merge lane to agents |
 
-## Merge lane: the queue cannot drain by review
+### Reopened after a false auto-close
 
-This is the blocker that stalled #864 to #873 for four days, and it will stall every future agent PR the same way.
+`#864` and `#873` carried lines like `Does **not** close #744` and `Did not close #339`. **GitHub's closing-keyword parser ignores negation**, so merging them closed #339, #742, and #744 anyway. All three were reopened the same day with an explanation.
 
-1. Every non-dependabot PR here is authored by **WalksWithASwagger**. Branch protection on `main` requires **1 approving review**, and GitHub does not let an author approve their own PR. There is no second reviewer on this repo.
-2. The designed escape hatch, the **`agent-safe-merge`** workflow, failed on every run: `Repo secret AGENT_MERGE_TOKEN is missing.` It never succeeded once in 33 runs, and was **deleted 2026-08-23**.
-3. What does work today: `enforce_admins` is **false** and KK holds admin, so `gh pr merge --squash --admin` goes through. Dependabot PRs have a different author and can take a normal approve plus merge.
+**Before merging any PR, check what it will actually close:**
 
-Required checks are `strict: true`, so every branch shows `BEHIND`. Check file overlap against `main` before an admin merge instead of assuming the stale base is safe.
+```bash
+gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){closingIssuesReferences(first:10){nodes{number}}}}}' \
+  -f o=WalksWithASwagger -f r=kriskrug-wp -F n=<pr>
+```
 
-**To fix the lane properly:** create a classic PAT with `repo` scope on an account with write access, add it as Actions secret `AGENT_MERGE_TOKEN`, and add the same value as Cursor Cloud secret `GH_TOKEN`. The workflow itself is deleted, so restoring that lane means re-adding it too. Until then, admin override is the path.
+Never write `does not close #N` in a PR body. Write `#N stays open` instead.
+
+## Merge lane: OPEN to agents (changed 2026-08-23)
+
+Agents merge their own PRs now. The house command is:
+
+```bash
+gh pr merge <n> --squash --delete-branch     # no --admin
+```
+
+**`main` protection as of 2026-08-23:**
+
+| setting | value |
+|---|---|
+| `required_approving_review_count` | **0** (was 1) |
+| required check | **`summary`** (was `Test PR / summary`, which matched nothing) |
+| `strict` (branch up to date) | true |
+| force pushes / branch deletion | blocked |
+| `enforce_admins` | false |
+
+**Two bugs were fixed to get here, and the second one mattered more.**
+
+1. **The review gate was unsatisfiable.** KK is the only collaborator and GitHub blocks self-approval, so the 1-review rule could never be met by anyone. Every merge used `--admin`.
+2. **The required check never matched.** The context was `Test PR / summary`, but the check run GitHub reports is named `summary`. `isRequired` came back false on every check, so the required check sat permanently "expected but missing" and every PR read `BLOCKED`. Because `--admin` also bypasses required checks, **CI was never actually enforced on this repo** until today.
+
+Net effect: merges are now *stricter* than before, not looser. CI is a real gate for the first time.
+
+**Verified both directions:** green PR [#893](https://github.com/WalksWithASwagger/kriskrug-wp/pull/893) merged with no `--admin`; deliberately red PR [#894](https://github.com/WalksWithASwagger/kriskrug-wp/pull/894) was refused with `the base branch policy prohibits the merge`, then closed.
+
+**When to still use `--admin`:** only when KK asks you to override a red or stale check. It is no longer the routine path.
+
+**If a PR reads `MERGEABLE/BLOCKED` with every check green,** suspect a required-context name mismatch again. Check with:
+
+```bash
+gh api repos/WalksWithASwagger/kriskrug-wp/branches/main/protection -q '.required_status_checks.contexts'
+gh api repos/WalksWithASwagger/kriskrug-wp/commits/<sha>/check-runs -q '.check_runs[].name'
+```
+
+**To revert the review requirement:**
+
+```bash
+gh api -X PATCH repos/WalksWithASwagger/kriskrug-wp/branches/main/protection/required_pull_request_reviews \
+  -F required_approving_review_count=1 -F dismiss_stale_reviews=true
+```
+
+**Not enforced:** theme / plugins / `inc/` gating is convention only. KK declined a CI path guard, so ask before merging those. Deploying to live WordPress is a separate act that always needs explicit KK approval.
 
 ## What does **not** need KK
 
@@ -56,9 +115,8 @@ Do **not** file more audit issues. Do **not** swarm #477 / #424 / #481 / homepag
 
 | Item | Why you |
 |---|---|
-| Merge or admin-merge #865 to #868 | Hub link payloads, drafts only. See the merge lane section above. |
 | Live apply #829, #830, #831, #832 | Packs are drafted. Still a live PATCH. Needs `WP_USER` + `WP_APP_PASSWORD` and an explicit go. |
-| **#4** alt-text batches 0 and 1 | Applier and dry-run are on #891. Dry run is clean. Needs creds and your go. |
+| **#4** alt-text batches 0 and 1 | Applier and dry-run are on #891 (still open, another session's work). Dry run is clean. Needs your go for the live write. |
 | **#828** rewrite of post 1210 | Only writing task in the #402 split. You own the voice. |
 | **#731** Boost critical CSS | wp-admin regenerates. App password 403s the data store. |
 | **#274** Search Console | Human only. |
@@ -100,4 +158,10 @@ The product holes already have issues. Sequencing, not filing:
 
 ---
 
-**Last verified:** 2026-08-23. Live `style.css` **1.6.9**, repo **1.6.9**. #870 / #871 / #872 / #864 / #873 merged today; #742 and #744 closed with them. Next: land #865 to #868, then hub `--apply` when KK says go. Run `make status-readonly` and a public `style.css` readback before acting.
+**Last verified:** 2026-08-23. Live `style.css` **1.6.9**, repo **1.6.9**. WordPress **7.0.4**.
+
+Merged today: #864, #865, #866, #867, #868, #869, #870, #871, #872, #873, #887, #888, #889, #890, #892, #893. Open: **#891 only** (another session's alt-text tooling). Open issues **43**.
+
+Reopened after false auto-closes: **#339**, **#742**, **#744**.
+
+Next: the hub `--apply` runs for #829 to #832, which now have working credentials and need only KK's go. Run `make doctor`, then `make status-readonly`, then a public `style.css` readback before acting.


### PR DESCRIPTION
Session closeout. The runbook still told agents the merge lane was blocked and that `--admin` was the only path; both stopped being true today.

## Changes

- **Merge lane section rewritten.** `main` requires 0 reviews, the required check is `summary`, agents merge with plain `gh pr merge --squash --delete-branch`. Includes the revert command and how to diagnose a required-context mismatch.
- **Records the 16 PRs merged today**, and notes that #829-#832 stay open because their payloads are prepared, not applied.
- **Documents the negated-close-keyword trap.** A PR body saying it does *not* shut issue N will shut it anyway, because GitHub's parser ignores negation. That is what wrongly shut #339, #742, and #744 earlier today. Adds the GraphQL pre-merge check and the rule: write "#N stays open", never the negated phrasing.
- **Adds the credential trap.** Only `WP_API_*` resolves on this machine, so an unset `WP_USER` is not evidence of missing credentials. Points at `make doctor`.
- **Drops merging from the "needs KK" table**, since it no longer does.

## Verification

| gate | result |
|---|---|
| `make test` (bare shell) | 0 failures |
| `make test` (under Varlock) | 0 failures |
| `make validate` | no coding standard violations |
| `scripts/docs_truth_check.py` | passed |
| relative links in the edited file | all resolve |
| secret-shaped strings in diff | 0 |
| issues this PR would shut | none |

Note: the first draft of this description tripped the very trap it documents, and the pre-merge GraphQL check caught it. Rephrased.

Docs only. No live WordPress writes.