### PR TITLE
docs: editing a PR body does not undo an established closing link

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-08-23.md
+++ b/docs/current-state/WORK-PLAN-2026-08-23.md
@@ -51,7 +51,18 @@ gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$
   -f o=WalksWithASwagger -f r=kriskrug-wp -F n=<pr>
 ```
 
-Never write `does not close #N` in a PR body. Write `#N stays open` instead.
+Never write the negated phrasing in a PR body. Write `#N stays open` instead.
+
+**Editing the description afterwards does not reliably undo this.** PR [#895](https://github.com/WalksWithASwagger/kriskrug-wp/pull/895) was opened with the trap in its body, edited before merge, and the GraphQL query above then returned an empty list, yet merging still shut #339 a second time. GitHub honoured the link established when the PR was created.
+
+Two rules follow:
+
+1. Get the phrasing right **before** opening the PR. Treat an edit as a partial fix at best.
+2. Check issue state **after** the merge, not only before:
+
+```bash
+gh issue list --state open --limit 200 --json number -q '[.[].number]|sort|tostring'
+```
 
 ## Merge lane: OPEN to agents (changed 2026-08-23)
 


### PR DESCRIPTION
Follow-up to the closeout PR, which demonstrated the failure mode on itself.

PR #895 was opened with the negated-keyword phrasing in its description. It was edited before merge, and the GraphQL `closingIssuesReferences` query then returned an empty list. Merging still shut issue 339 a second time, because GitHub honoured the link established when the PR was created.

Adds the two rules that actually hold:

1. Get the phrasing right **before** opening the PR. An edit is a partial fix at best.
2. Verify issue state **after** merging, not only before.

Issue 339 has been reopened with an explanation on the thread.

`scripts/docs_truth_check.py` passes. Docs only. This PR intentionally names no issue next to a linking keyword.