### PR TITLE
fix(#4): verify media writes with authenticated readback

### DIFF
--- a/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
+++ b/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
@@ -4,8 +4,10 @@ KK approved the original media and content batches on 2026-08-23,
 dry-run-first per
 `docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`. Those writes
 were applied and verified on 2026-08-24. The 76 inventory Batch 3 rows were
-then drafted from visual review, but **have not been approved for a live
-apply**. The ~1,070 archive-scope images (inventory batches 4-6) are parked.
+then drafted from visual review. Five Batch 3 canary attachments were applied
+and independently verified on 2026-08-24; KK then approved proceeding with
+the remaining 70 reviewed attachments. The ~1,070 archive-scope images
+(inventory batches 4-6) are parked and are not part of that approval.
 
 Batch names as approved:
 
@@ -13,9 +15,11 @@ Batch names as approved:
   `media-library-alt_text` surface holds 80 violation rows across 77 unique
   attachments. Media 6835 and 12646 were applied and verified on 2026-08-24.
   The remaining 76 rows cover 75 unique attachments in inventory Batch 3;
-  their strings are now drafted from visual review but remain local-only.
+  their strings were drafted from visual review. Five canaries are live and
+  verified; 70 approved attachments remain.
   **The broad `--batch media --apply` command now selects all 77 attachments.**
-  Do not run it unless KK explicitly approves the Batch 3 live scope.
+  Do not run it for Batch 3; the approved procedure still requires one exact
+  `--only-media-id` at a time.
 - **Batch 1 — 34 `post_content` alt insertions** (`--batch content`) across
   seven pages (2543, 2828, 3899, 6755, 6770, 7610, 7764). Applied one page at
   a time and independently verified as 34/34 `already-applied` on 2026-08-24.
@@ -47,6 +51,9 @@ Built-in safety, per write: live slug+ID (or media ID + file) verification
 against `inventory.csv` before any PATCH; full pre-write JSON snapshot to
 `.generated/alt-text-backfill/<run>/` (gitignored); existing different alt =
 CONFLICT, skipped, never overwritten; post-write readback verification.
+Authenticated media checks and readbacks use WordPress `context=edit` so a
+stale public REST cache cannot produce a false mismatch. Unauthenticated media
+dry runs add a cache-busting query parameter.
 Default is dry-run; `--apply` refuses to start without credentials. Exit code
 is 1 when any item is refused, conflicted, or fails readback.
 
@@ -79,6 +86,11 @@ whole batch blindly; inspect and restore only the target whose readback failed.
 - Content Batch 1: all seven pages applied one at a time with private snapshots;
   an independent authenticated dry run returned 34/34 `already-applied`.
 - Inventory Batch 3: 76 rows / 75 unique attachments drafted after inspecting
-  every rendered image; CSV and target-loader checks pass. No Batch 3 live
-  write has been made or approved.
+  every rendered image; CSV and target-loader checks pass. Media 12597, 12593,
+  12541, 12536, and 12528 are live and exact by authenticated and cache-bypassed
+  public readback. Their original apply reports showed false mismatches because
+  the old helper read a stale public REST response immediately after writing;
+  this helper now binds both media reads to authenticated edit context.
+- KK approved proceeding one attachment at a time with the remaining 70
+  reviewed Batch 3 IDs. That approval does not include inventory batches 4-6.
 - Inventory batches 4-6 remain parked.

--- a/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
+++ b/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
@@ -52,6 +52,7 @@ import os
 import re
 import stat
 import sys
+import time
 import urllib.request
 from pathlib import Path
 
@@ -129,6 +130,12 @@ def make_client() -> WPClient | None:
     if (env.get("WP_USER") or "").strip() and (env.get("WP_APP_PASSWORD") or "").strip():
         return WPClient.from_env()
     return None
+
+
+def get_media(media_id: str, client: WPClient | None) -> dict:
+    if client is not None:
+        return client.get(f"media/{media_id}", params={"context": "edit"})
+    return public_get(f"media/{media_id}?cb={time.time_ns()}")
 
 
 # ---------------------------------------------------------------------------
@@ -270,7 +277,7 @@ def run_media(client: WPClient | None, apply: bool, run_dir: Path, only_id: str 
     for t in targets:
         mid = t["media_id"]
         item = {"media_id": mid, "proposed_alt": t["proposed_alt"]}
-        live = public_get(f"media/{mid}")
+        live = get_media(mid, client)
         # slug+ID verification: right record, right file
         ok_id = str(live.get("id")) == mid
         ok_file = file_stem(live.get("source_url", "")) == file_stem(t["image_file"])
@@ -290,7 +297,7 @@ def run_media(client: WPClient | None, apply: bool, run_dir: Path, only_id: str 
             snap = snapshot(run_dir, f"media-{mid}-before", live)
             item["snapshot"] = str(snap)
             client.post(f"media/{mid}", {"alt_text": t["proposed_alt"]})
-            readback = public_get(f"media/{mid}")
+            readback = get_media(mid, client)
             item["readback_alt_text"] = readback.get("alt_text", "")
             item["status"] = (
                 "written-verified"

--- a/docs/current-state/WORK-PLAN-2026-08-24.md
+++ b/docs/current-state/WORK-PLAN-2026-08-24.md
@@ -48,12 +48,19 @@ Issue #4 execution state:
 - All 34 Batch 1 in-content rows across seven pages were applied one page at
   a time and independently verified as `already-applied`.
 - Inventory Batch 3 now has reviewed strings for **76 rows / 75 unique media
-  IDs**. No Batch 3 live write has been made.
-- Media 12597 passed the requested scoped dry run: credentials resolved,
-  ID and filename matched, live alt was empty, and status was `would-write`.
+  IDs**. The five-ID canary (12597, 12593, 12541, 12536, 12528) was applied
+  and independently verified by authenticated edit-context, cache-bypassed
+  public REST, and rendered-page readback.
+- Before the canary, media 12597 passed the requested scoped dry run:
+  credentials resolved, ID and filename matched, live alt was empty, and
+  status was `would-write`.
 - The media applier's broad selector now sees 77 unique targets: the two
   already-applied IDs plus the 75 Batch 3 IDs. Use `--only-media-id`; do not
   use broad `--batch media --apply` for this lane.
+- The canary exposed a false failure mode: immediate public REST readback was
+  cached even though authenticated and rendered readbacks were exact. The
+  applier now uses authenticated edit-context reads before the remaining 70
+  IDs.
 - Inventory batches 4-6 remain parked at roughly 1,070 archive images.
 
 ## Options and recommendation
@@ -72,10 +79,14 @@ hub payloads.
 
 ## Session 1: Batch 3 canary, maximum five attachments
 
+**Completed 2026-08-24.** Five writes were exact. All pre-write snapshots are
+private mode 0600. No sixth target was touched.
+
 ### Approval gate
 
 KK must explicitly approve the Batch 3 live canary. Approval to merge this
-plan or its inventory is not approval to write WordPress.
+plan or its inventory is not approval to write WordPress. **Satisfied before
+execution on 2026-08-24.**
 
 ### Steps
 
@@ -113,7 +124,9 @@ plan or its inventory is not approval to write WordPress.
 ### Approval gate
 
 Continue only if Session 1 is clean and KK explicitly approves the remaining
-Batch 3 IDs. A clean canary is evidence, not authorization.
+Batch 3 IDs. A clean canary is evidence, not authorization. **Satisfied:** KK
+approved shipping the readback correction and proceeding with the remaining
+reviewed Batch 3 scope on 2026-08-24.
 
 ### Steps
 
@@ -160,11 +173,12 @@ Batch 3 IDs. A clean canary is evidence, not authorization.
 ## Exact next-session prompt
 
 > Read WORK-PLAN-2026-08-24.md and the alt-text APPLY-RUNBOOK. Run doctor and
-> status-readonly. Confirm the Batch 3 inventory is on main. Ask KK for explicit
-> approval of the five-ID canary. If approved, dry-run then apply only 12597,
-> verify its private snapshot and exact authenticated readback, re-dry-run for
-> already-applied, then repeat one at a time for 12593, 12541, 12536, and 12528.
-> Stop after five writes and report; do not touch #829-#832.
+> status-readonly. Confirm the Batch 3 inventory and authenticated media-readback
+> correction are on main, then verify the five canaries are `already-applied`.
+> The remaining 70 reviewed IDs are approved: dry-run and apply each with its
+> exact `--only-media-id`, one at a time, stopping on any mismatch. Pause at
+> NCR-bearing media 5024 for exact authenticated readback, then complete the
+> lane, run the 216-route recount, and update issue #4. Do not touch #829-#832.
 
 ---
 

--- a/scripts/tests/test_alt_text_apply_batches.py
+++ b/scripts/tests/test_alt_text_apply_batches.py
@@ -64,9 +64,11 @@ def media_row(media_id: str, image_file: str, proposed_alt: str) -> dict[str, st
 class FakeClient:
     def __init__(self, get_responses: list[dict]):
         self.get_responses = iter(copy.deepcopy(get_responses))
+        self.gets: list[tuple[str, dict | None]] = []
         self.posts: list[tuple[str, dict]] = []
 
-    def get(self, _path: str, *, params: dict | None = None) -> dict:
+    def get(self, path: str, *, params: dict | None = None) -> dict:
+        self.gets.append((path, params))
         return next(self.get_responses)
 
     def post(self, path: str, payload: dict) -> dict:
@@ -225,6 +227,43 @@ class AltTextApplyBatchSafetyTests(unittest.TestCase):
         self.assertTrue(recovery.is_file())
         self.assertEqual(stat.S_IMODE(recovery.stat().st_mode), 0o600)
         self.assertEqual(report["items"][0]["status"], "restored-verified")
+
+    def test_media_apply_uses_authenticated_state_for_write_and_readback(self):
+        proposed = "Community members at an event"
+        rows = [media_row("100", "community.jpg", proposed)]
+        original = {
+            "id": 100,
+            "source_url": "https://kriskrug.co/wp-content/uploads/community.jpg",
+            "alt_text": "",
+        }
+        client = FakeClient([original, {**original, "alt_text": proposed}])
+
+        with (
+            mock.patch.object(MODULE, "load_rows", return_value=rows),
+            mock.patch.object(MODULE, "public_get", return_value=original) as public_get,
+        ):
+            report = MODULE.run_media(client, True, self.run_dir, "100")
+
+        self.assertEqual(report["items"][0]["status"], "written-verified")
+        self.assertEqual(
+            client.gets,
+            [
+                ("media/100", {"context": "edit"}),
+                ("media/100", {"context": "edit"}),
+            ],
+        )
+        public_get.assert_not_called()
+
+    def test_unauthenticated_media_read_bypasses_public_cache(self):
+        live = {"id": 100, "alt_text": ""}
+        with (
+            mock.patch.object(MODULE.time, "time_ns", return_value=123),
+            mock.patch.object(MODULE, "public_get", return_value=live) as public_get,
+        ):
+            result = MODULE.get_media("100", None)
+
+        self.assertEqual(result, live)
+        public_get.assert_called_once_with("media/100?cb=123")
 
     def test_content_restore_refuses_intervening_live_edits(self):
         rows = [content_row("100", "community.jpg", "New alt")]


### PR DESCRIPTION
## Summary
- use authenticated WordPress edit-context reads for media identity checks and post-write verification
- cache-bust unauthenticated media dry runs
- add regression coverage for the cached public REST false-mismatch and update the Batch 3 handoff

## Verification
- make test (544 unittest tests, 68 pytest tests, plugin/theme smoke gates: pass)
- make validate
- focused alt-text safety suite: 17 tests pass
- git diff --check

## Risk and rollback
Low and bounded to issue #4 media apply reads. No live write is part of this PR. Existing private pre-write snapshots remain the rollback path for later approved media applies.

Refs #4.