### PR TITLE
fix(#4): replace reviewed filename-style alt baselines

### DIFF
--- a/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
+++ b/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
@@ -50,7 +50,9 @@ results remain exact.
 Built-in safety, per write: live slug+ID (or media ID + file) verification
 against `inventory.csv` before any PATCH; full pre-write JSON snapshot to
 `.generated/alt-text-backfill/<run>/` (gitignored); existing different alt =
-CONFLICT, skipped, never overwritten; post-write readback verification.
+CONFLICT and skipped, except when a reviewed filename-style violation still
+exactly matches its recorded inventory baseline; post-write readback
+verification.
 Authenticated media checks and readbacks use WordPress `context=edit` so a
 stale public REST cache cannot produce a false mismatch. Unauthenticated media
 dry runs add a cache-busting query parameter.

--- a/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
+++ b/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
@@ -23,7 +23,8 @@ Safety contract (docs/current-state/INCIDENT-2026-05-15-overwritten-post.md):
   * Before any write the full live JSON record is snapshotted to a local
     gitignored directory (.generated/alt-text-backfill/<run>/).
   * An existing non-empty value that differs from the proposed string is a
-    CONFLICT and is skipped, never overwritten.
+    CONFLICT and is skipped. The only replacement allowed is a reviewed
+    filename-style violation that still exactly matches its inventory baseline.
   * Every write is read back and verified; a per-item report is printed and
     saved next to the snapshots.
 
@@ -283,12 +284,20 @@ def run_media(client: WPClient | None, apply: bool, run_dir: Path, only_id: str 
         ok_file = file_stem(live.get("source_url", "")) == file_stem(t["image_file"])
         item["verified_id"] = ok_id
         item["verified_file"] = ok_file
-        item["live_alt_text"] = live.get("alt_text", "")
+        live_alt = live.get("alt_text", "")
+        item["live_alt_text"] = live_alt
+        planned_filename_replacement = (
+            t["classification"] == "filename-style-alt-VIOLATION"
+            and bool(t.get("media_library_alt"))
+            and live_alt == t["media_library_alt"]
+        )
+        if planned_filename_replacement:
+            item["replacement_basis"] = "inventory-baseline"
         if not (ok_id and ok_file):
             item["status"] = "REFUSED-identity-mismatch"
-        elif live.get("alt_text") == t["proposed_alt"]:
+        elif live_alt == t["proposed_alt"]:
             item["status"] = "already-applied"
-        elif live.get("alt_text"):
+        elif live_alt and not planned_filename_replacement:
             item["status"] = "CONFLICT-existing-different-alt"
         elif not apply:
             item["status"] = "would-write"

--- a/scripts/tests/test_alt_text_apply_batches.py
+++ b/scripts/tests/test_alt_text_apply_batches.py
@@ -51,12 +51,20 @@ def page_record(raw: str) -> dict:
     }
 
 
-def media_row(media_id: str, image_file: str, proposed_alt: str) -> dict[str, str]:
+def media_row(
+    media_id: str,
+    image_file: str,
+    proposed_alt: str,
+    *,
+    classification: str = "empty-alt-VIOLATION",
+    media_library_alt: str = "",
+) -> dict[str, str]:
     return {
         "fix_surface": "media-library-alt_text",
-        "classification": "empty-alt-VIOLATION",
+        "classification": classification,
         "media_id": media_id,
         "image_file": image_file,
+        "media_library_alt": media_library_alt,
         "proposed_alt": proposed_alt,
     }
 
@@ -264,6 +272,59 @@ class AltTextApplyBatchSafetyTests(unittest.TestCase):
 
         self.assertEqual(result, live)
         public_get.assert_called_once_with("media/100?cb=123")
+
+    def test_media_apply_replaces_exact_inventoried_filename_alt(self):
+        current = "community_event_100.jpg"
+        proposed = "Community members at an event"
+        rows = [
+            media_row(
+                "100",
+                "community.jpg",
+                proposed,
+                classification="filename-style-alt-VIOLATION",
+                media_library_alt=current,
+            )
+        ]
+        original = {
+            "id": 100,
+            "source_url": "https://kriskrug.co/wp-content/uploads/community.jpg",
+            "alt_text": current,
+        }
+        client = FakeClient([original, {**original, "alt_text": proposed}])
+
+        with mock.patch.object(MODULE, "load_rows", return_value=rows):
+            report = MODULE.run_media(client, True, self.run_dir, "100")
+
+        self.assertEqual(report["items"][0]["status"], "written-verified")
+        self.assertEqual(report["items"][0]["replacement_basis"], "inventory-baseline")
+        self.assertEqual(client.posts, [("media/100", {"alt_text": proposed})])
+
+    def test_media_apply_preserves_non_filename_inventory_alt(self):
+        current = "Existing contextual alt"
+        rows = [
+            media_row(
+                "100",
+                "community.jpg",
+                "Different contextual alt",
+                classification="empty-alt-content-VIOLATION",
+                media_library_alt=current,
+            )
+        ]
+        live = {
+            "id": 100,
+            "source_url": "https://kriskrug.co/wp-content/uploads/community.jpg",
+            "alt_text": current,
+        }
+        client = FakeClient([live])
+
+        with mock.patch.object(MODULE, "load_rows", return_value=rows):
+            report = MODULE.run_media(client, True, self.run_dir, "100")
+
+        self.assertEqual(
+            report["items"][0]["status"], "CONFLICT-existing-different-alt"
+        )
+        self.assertEqual(client.posts, [])
+        self.assertFalse(self.run_dir.exists())
 
     def test_content_restore_refuses_intervening_live_edits(self):
         rows = [content_row("100", "community.jpg", "New alt")]


### PR DESCRIPTION
## Summary
- permit a non-empty media alt replacement only for a reviewed filename-style violation that still exactly matches inventory.csv
- preserve all other non-empty alts as hard conflicts
- add regression coverage for both the allowed exact-baseline path and the protected contextual-alt path

## Live dry-run evidence
- media 5375: would-write, replacement_basis=inventory-baseline
- media 6481: CONFLICT-existing-different-alt, no replacement basis
- media 8211: CONFLICT-existing-different-alt, no replacement basis

No live write is part of this PR.

## Verification
- make test (546 unittest tests, 68 pytest tests, all smoke gates pass)
- make validate
- focused alt-text safety suite: 19 tests pass
- git diff --check

## Risk and rollback
The exception is limited to exact approved filename-style baselines; any drift or meaningful current alt still fails closed. Live applies remain one exact media ID at a time with private pre-write snapshots and authenticated readback.

Refs #4.