### PR TITLE
content: defer speaking videos behind accessible facades

### DIFF
--- a/content/drafts/2026-07-26-speaking-page/payload-body.html
+++ b/content/drafts/2026-07-26-speaking-page/payload-body.html
@@ -106,6 +106,46 @@
   height: 100%;
   border: 0;
 }
+.kk-r9-pack .kk-speak-embed-facade {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: var(--kk-speak-ink);
+  color: var(--kk-speak-paper);
+  cursor: pointer;
+}
+.kk-r9-pack .kk-speak-embed-poster {
+  grid-area: 1 / 1;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.72;
+}
+.kk-r9-pack .kk-speak-embed-facade::before {
+  content: "▶";
+  grid-area: 1 / 1;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  padding-left: 0.25rem;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+.kk-r9-pack .kk-speak-embed-facade:hover {
+  color: var(--kk-speak-signal);
+}
+.kk-r9-pack .kk-speak-embed-facade:focus-visible {
+  outline: 3px solid var(--kk-speak-signal);
+  outline-offset: -3px;
+}
 .kk-r9-pack .kk-speak-tag {
   display: inline-block;
   margin: 0 0 0.45rem;
@@ -237,7 +277,12 @@
       <h3>Punk Rock AI</h3>
       <p>Kris Krüg: The perils and parallels of AI's future. Official CreativeMornings HQ recording.</p>
       <div class="kk-speak-embed">
-        <iframe src="https://www.youtube.com/embed/hYT-hsml_ds" title="Kris Krüg: The perils and parallels of AI's future at CreativeMornings Vancouver" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+        <button class="kk-speak-embed-facade" type="button" aria-label="Play Kris Krüg at CreativeMornings Vancouver">
+          <img class="kk-speak-embed-poster" src="https://kriskrug.co/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp" alt="" width="600" height="400" loading="lazy" decoding="async">
+        </button>
+        <template>
+          <iframe src="https://www.youtube-nocookie.com/embed/hYT-hsml_ds" title="Kris Krüg: The perils and parallels of AI's future at CreativeMornings Vancouver" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+        </template>
       </div>
       <p>Originally presented at CreativeMornings Vancouver.</p>
     </article>
@@ -246,7 +291,12 @@
       <h3>Both Hands Full</h3>
       <p>What creatives actually need to know about AI. Full keynote on Kris Krüg's channel.</p>
       <div class="kk-speak-embed">
-        <iframe src="https://www.youtube.com/embed/-c7mgY2aSgM?start=11" title="Both Hands Full: What Creatives Actually Need to Know About AI" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+        <button class="kk-speak-embed-facade" type="button" aria-label="Play Both Hands Full at LaSalle College Vancouver">
+          <img class="kk-speak-embed-poster" src="https://kriskrug.co/wp-content/themes/kk-aurora/assets/img/vancouver-ai-meetup-30-kris-community-600.webp" alt="" width="600" height="400" loading="lazy" decoding="async">
+        </button>
+        <template>
+          <iframe src="https://www.youtube-nocookie.com/embed/-c7mgY2aSgM?start=11" title="Both Hands Full: What Creatives Actually Need to Know About AI" loading="lazy" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
+        </template>
       </div>
       <p><a href="/2026/05/15/your-taste-is-your-moat/">Companion essay</a></p>
     </article>
@@ -301,4 +351,22 @@
 </section>
 
 </div>
+<script>
+(function () {
+  document.querySelectorAll(".kk-r9-pack .kk-speak-embed-facade").forEach(function (button) {
+    button.addEventListener("click", function () {
+      var embed = button.closest(".kk-speak-embed");
+      var template = embed && embed.querySelector("template");
+      if (!template) {
+        return;
+      }
+
+      var fragment = template.content.cloneNode(true);
+      var iframe = fragment.querySelector("iframe");
+      embed.replaceChildren(fragment);
+      iframe.focus();
+    }, { once: true });
+  });
+})();
+</script>
 <!-- /wp:html -->

--- a/scripts/tests/test_speaking_embed_contract.py
+++ b/scripts/tests/test_speaking_embed_contract.py
@@ -1,0 +1,123 @@
+import re
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PAYLOAD = (
+    ROOT
+    / "content"
+    / "drafts"
+    / "2026-07-26-speaking-page"
+    / "payload-body.html"
+)
+FIRST_PARTY_IMAGE_HOSTS = {"kriskrug.co", "www.kriskrug.co"}
+
+
+class EmbedParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.buttons = []
+        self.iframes = []
+        self.images = []
+
+    def handle_starttag(self, tag, attrs):
+        values = dict(attrs)
+        if tag == "button":
+            self.buttons.append(values)
+        elif tag == "iframe":
+            self.iframes.append(values)
+        elif tag == "img":
+            self.images.append(values)
+
+
+class SpeakingEmbedContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = PAYLOAD.read_text(encoding="utf-8")
+        cls.parser = EmbedParser()
+        cls.parser.feed(cls.html)
+
+    def test_embeds_start_behind_keyboard_accessible_facades(self):
+        wrappers = re.findall(
+            r'<div class="kk-speak-embed">(.*?)</div>', self.html, re.DOTALL
+        )
+        self.assertGreaterEqual(len(wrappers), 2)
+
+        for wrapper in wrappers:
+            parser = EmbedParser()
+            parser.feed(wrapper)
+            self.assertEqual(1, len(parser.buttons))
+            self.assertEqual(1, len(parser.iframes))
+            self.assertEqual(1, len(parser.images))
+            self.assertIn("<template", wrapper)
+
+            button = parser.buttons[0]
+            self.assertIn("kk-speak-embed-facade", button.get("class", "").split())
+            self.assertEqual("button", button.get("type"))
+            self.assertTrue(button.get("aria-label"))
+            self.assertNotEqual("-1", button.get("tabindex"))
+            self.assertNotIn("disabled", button)
+
+            poster = parser.images[0]
+            self.assertIn("kk-speak-embed-poster", poster.get("class", "").split())
+            self.assertEqual("lazy", poster.get("loading"))
+            self.assertEqual("", poster.get("alt"))
+            self.assertTrue(poster.get("width"))
+            self.assertTrue(poster.get("height"))
+
+        active_html = re.sub(
+            r"<template\b.*?</template>", "", self.html, flags=re.DOTALL
+        )
+        self.assertNotIn("<iframe", active_html.lower())
+
+    def test_deferred_iframes_are_private_lazy_and_accessible(self):
+        self.assertGreaterEqual(len(self.parser.iframes), 2)
+        for iframe in self.parser.iframes:
+            self.assertEqual("lazy", iframe.get("loading"))
+            self.assertTrue(iframe.get("title"))
+            serialized_attrs = " ".join(
+                f"{name}={value or ''}" for name, value in iframe.items()
+            ).lower()
+            self.assertNotIn("autoplay", serialized_attrs)
+
+            parsed = urlparse(iframe.get("src", ""))
+            self.assertEqual("https", parsed.scheme)
+            self.assertEqual("www.youtube-nocookie.com", parsed.hostname)
+            self.assertNotIn("autoplay", parse_qs(parsed.query))
+
+    def test_facade_click_loads_and_focuses_the_deferred_iframe(self):
+        self.assertIn(".kk-speak-embed-facade", self.html)
+        self.assertRegex(self.html, r"addEventListener\(['\"]click['\"]")
+        self.assertIn("template.content.cloneNode(true)", self.html)
+        self.assertIn("replaceChildren", self.html)
+        self.assertRegex(self.html, r"iframe\.focus\(\)")
+
+    def test_hero_stays_the_only_eager_media_candidate(self):
+        self.assertLess(
+            self.html.index('class="kk-speak-hero"'), self.html.index('id="watch"')
+        )
+        self.assertIn('loading="eager"', self.html)
+        self.assertIn('fetchpriority="high"', self.html)
+
+    def test_payload_does_not_hotlink_third_party_images(self):
+        self.assertGreaterEqual(len(self.parser.images), 1)
+        urls = []
+        for image in self.parser.images:
+            urls.append(image.get("src", ""))
+            urls.extend(
+                candidate.strip().split()[0]
+                for candidate in image.get("srcset", "").split(",")
+                if candidate.strip()
+            )
+
+        for url in urls:
+            parsed = urlparse(url)
+            if parsed.scheme:
+                self.assertIn(parsed.hostname, FIRST_PARTY_IMAGE_HOSTS, url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #640. Refs #419. This is the repo-side embed prerequisite for #904.

## Summary

- Replace the two initially active YouTube iframes with native-button, click-to-load facades.
- Keep each iframe inert inside a `<template>` until activation, then move focus into the loaded player.
- Use the privacy-preserving `www.youtube-nocookie.com` host with lazy loading, accessible titles, and no autoplay.
- Use the payload's one photographer-cleared, first-party stage image as the real lazy poster for both facades. No YouTube thumbnail is hotlinked.
- Add a focused contract test for facade behavior, poster presence, iframe hygiene, LCP ordering, and first-party image hosts.

This PR changes only the tracked draft payload and its test. It does not change page copy, schema, theme code, or live WordPress.

## Logged-out live baseline

Captured read-only on `2026-08-27T22:39:57.912Z` against `https://kriskrug.co/speaking/` with Lighthouse `13.4.1`, Chrome headless/incognito, mobile form factor, simulated throttling, and a fresh Lighthouse profile:

```text
Performance score: 0.90
LCP:               3032.9296 ms (3.0 s)
Transferred bytes: 912250 bytes (891 KiB)
YouTube documents: 0
```

Reproduction command:

```bash
npx --yes lighthouse@13.4.1 'https://kriskrug.co/speaking/' \
  --quiet \
  --chrome-path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \
  --chrome-flags='--headless --incognito --disable-gpu' \
  --only-categories=performance \
  --output=json \
  --output-path=stdout \
  --form-factor=mobile
```

The unauthenticated PageSpeed Insights API was also attempted first and returned HTTP `429 RESOURCE_EXHAUSTED` because the public API consumer had zero daily quota. The local Lighthouse result above is the usable baseline.

The post-deploy 25% ceiling from this run is `3791.162 ms`. It must be checked with the same method after an approved live apply.

## Red/green evidence

Before changing the payload, the new focused suite failed three contract checks: facades were absent, iframes used `www.youtube.com`, and no click loader existed. After adding a specific poster assertion, it also failed independently with `expected 1 image, got 0`. Both failures were observed before the corresponding markup changes.

Current focused result:

```text
python3 -m unittest scripts.tests.test_speaking_embed_contract -v
Ran 5 tests in 0.001s
OK
```

## Verification

- `make verify PYTHON=python3` — pass, including all Python suites, JavaScript syntax/harness, plugin and theme smokes, docs truth, 44 PHP syntax checks, and PHPCS/WPCS (`7 / 7`).
- `git diff --check` — pass.
- Inline payload script syntax via Node `new Function(...)` — pass.
- Local headless-Chrome keyboard check — before activation: 2 buttons, 2 posters, 0 active iframes. Pressing Enter on the first button produced exactly 1 active iframe, transferred focus to it, and loaded `https://www.youtube-nocookie.com/embed/hYT-hsml_ds`.

## Remaining gate

This PR deliberately leaves #640 open. Live application still requires KK approval, WordPress credentials, a pre-edit snapshot of page 1887, exact readback, and the same-method post-deploy Lighthouse comparison. No live write was made here.
