### PR TITLE
content: add Canada booking answer to Speaking payload

### DIFF
--- a/content/drafts/2026-07-26-speaking-page/payload-body.html
+++ b/content/drafts/2026-07-26-speaking-page/payload-body.html
@@ -217,6 +217,34 @@
   </div>
 </section>
 
+<section class="aurora-proof-section" id="booking-facts">
+  <p class="aurora-section-kicker">Planning a room</p>
+  <h2 class="aurora-display-heading">What your event team needs to know.</h2>
+  <p class="aurora-page-lead">Kris Krüg is an AI keynote speaker based in Vancouver, British Columbia, Canada. He offers keynotes, workshops, executive briefings, and hosting and moderation for leaders, creators, schools, nonprofits, companies, and public-interest technology audiences.</p>
+  <div class="aurora-proof-grid">
+    <article class="aurora-card">
+      <h3>Location</h3>
+      <p>Vancouver, British Columbia, Canada.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Formats</h3>
+      <p>Keynotes, workshops, executive briefings, and hosting and moderation.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Audiences and topics</h3>
+      <p>Creative teams, executives, schools, nonprofits, public sector groups, and cultural organizations. Topics include creative agency, human judgment, leadership, trust, consent, power, and organizational memory.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>What to send</h3>
+      <p>Include the audience, date, location, format, and the question your room is trying to answer.</p>
+    </article>
+    <article class="aurora-card">
+      <h3>Next step</h3>
+      <p><a href="/contact/">Contact Kris about your event</a>.</p>
+    </article>
+  </div>
+</section>
+
 <section class="aurora-proof-section" id="signature-keynotes">
   <p class="aurora-section-kicker">Signature keynotes</p>
   <h2 class="aurora-display-heading">The six-talk bank.</h2>

--- a/content/drafts/2026-07-26-speaking-page/payload-plan.md
+++ b/content/drafts/2026-07-26-speaking-page/payload-plan.md
@@ -32,11 +32,26 @@ The Meetup 30 frame reads as community-host energy, not keynote-buyer energy. Th
 
 ---
 
+## Booking claim-to-source matrix (#904)
+
+The Profound export identifies the planner question only. It is not a factual source. KK's 2026-08-27 ruling is authoritative for the location update: Vancouver only. Prior residence labels are retired.
+
+| Claim family | Visible claim | Current first-party source |
+|---|---|---|
+| Identity and location | Kris is an AI keynote speaker based in Vancouver, British Columbia, Canada. | KK ruling for #904, 2026-08-27; `fixes/schema-snippets-deployed.php` (`person_job`, `person_descr`) |
+| Formats | Keynotes, workshops, executive briefings, and hosting and moderation. | Existing Formats cards in `payload-body.html`; public page 1887 readback, 2026-08-27 |
+| Audiences and topics | Leaders, creators, creative teams, executives, schools, nonprofits, companies, public-interest technology audiences, public sector groups, and cultural organizations; creative agency, human judgment, leadership, trust, consent, power, and organizational memory. | `content/source-packs/keynotes-2026/talk-topic-bank.md`; existing Formats cards in `payload-body.html` |
+| Booking inputs | Audience, date, location, format, and the room's question. | Existing end-booking CTA in `payload-body.html`; public page 1887 readback, 2026-08-27 |
+| Next step | Contact Kris through `/contact/`. | Existing hero and end-booking links in `payload-body.html`; public page 1887 readback, 2026-08-27 |
+
+---
+
 ## Content changes (six-talk architecture)
 
 | Band | Change |
 |---|---|
 | Hero | Cleared Meetup 30 theme still (`loading="eager"`) + short support line + booking CTA |
+| Planner facts | Answer-first Vancouver, British Columbia, Canada identification + five source-backed booking facts from the matrix above |
 | Signature keynotes | Six cards from `talk-topic-bank.md`, in bank order. Status tags: delivered / available in development / program option |
 | Watch | Two lazy YouTube iframes: `hYT-hsml_ds` (CreativeMornings / Punk Rock AI) and `-c7mgY2aSgM` (LaSalle / Both Hands Full). CreativeMornings credit line included. |
 | Workshop add-ons | The seven topic-bank add-ons. Labeled as add-ons, not keynotes. |
@@ -69,7 +84,7 @@ Page-scoped CSS under `.kk-r9-pack` keeps the cream rail, hero media, and 16:9 e
 
 1. Confirm secrets: `WP_USER` + `WP_APP_PASSWORD` present (length check only).
 2. Authenticated GET page `1887`; write `backup/<timestamp>-speaking-419/page-1887-before.json` + rendered HTML.
-3. Dry-run: print payload bytes; confirm six `<h3>` talk titles; confirm `Responsible AI` absent from the keynote grid; confirm ≥2 youtube embed URLs; confirm hero `<img>` is the Meetup 30 theme asset; confirm CTA count ≥2.
+3. Dry-run: print payload bytes; confirm `booking-facts` appears before `signature-keynotes`; confirm five planning cards; confirm six `<h3>` talk titles; confirm `Responsible AI` absent from the keynote grid; confirm ≥2 youtube embed URLs; confirm hero `<img>` is the Meetup 30 theme asset; confirm CTA count ≥2.
 4. KK signs media constraint + copy + screenshots plan.
 5. Body-only REST update (`content` raw = `payload-body.html`). Do not send `title`.
 6. Purge Pagely page cache for `/speaking/`.
@@ -81,6 +96,8 @@ Page-scoped CSS under `.kk-r9-pack` keeps the cream rail, hero media, and 16:9 e
 ### Acceptance
 
 - [ ] Six talks match the topic bank. No seventh keynote card. Responsible AI is not in the grid.
+- [ ] The answer-first block appears before the keynote grid and identifies Kris as an AI keynote speaker based in Vancouver, British Columbia, Canada.
+- [ ] Five planning cards cover location, formats, audiences and topics, booking inputs, and the `/contact/` next step.
 - [ ] Screenshots at **1440** and **390**: Meetup 30 still visible without scrolling; hero CTA visible.
 - [ ] ≥2 talk videos embedded (CreativeMornings + LaSalle).
 - [ ] Booking CTA above fold **and** at page end.

--- a/scripts/tests/test_speaking_booking_facts.py
+++ b/scripts/tests/test_speaking_booking_facts.py
@@ -1,0 +1,150 @@
+import re
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEAKING_DIR = (
+    ROOT / "content" / "drafts" / "2026-07-26-speaking-page"
+)
+PAYLOAD = SPEAKING_DIR / "payload-body.html"
+PLAN = SPEAKING_DIR / "payload-plan.md"
+CANONICAL_TALKS = (
+    "Both Hands Full",
+    "Punk Rock AI / Creative Rebellion",
+    "Developing an AI Mindset",
+    "Compost AI",
+    "Leadership After the AI Point of No Return",
+    "Power, Taste, and Trust",
+)
+FORMAT_FAMILIES = (
+    "Keynotes",
+    "Workshops",
+    "Executive briefings",
+    "Hosting and moderation",
+)
+
+
+class VisibleTextParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.hidden_depth = 0
+        self.parts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag in {"script", "style", "template"}:
+            self.hidden_depth += 1
+
+    def handle_endtag(self, tag):
+        if tag in {"script", "style", "template"}:
+            self.hidden_depth -= 1
+
+    def handle_data(self, data):
+        if not self.hidden_depth and data.strip():
+            self.parts.append(data.strip())
+
+    def text(self):
+        return " ".join(self.parts)
+
+
+def section_with_id(html, section_id):
+    match = re.search(
+        rf'<section\b(?=[^>]*\bid="{re.escape(section_id)}")[^>]*>(.*?)</section>',
+        html,
+        re.DOTALL,
+    )
+    if not match:
+        return ""
+    return match.group(1)
+
+
+def visible_text(html):
+    parser = VisibleTextParser()
+    parser.feed(html)
+    return parser.text()
+
+
+class SpeakingBookingFactsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.html = PAYLOAD.read_text(encoding="utf-8")
+        cls.plan = PLAN.read_text(encoding="utf-8")
+        cls.booking_facts = section_with_id(cls.html, "booking-facts")
+        cls.booking_text = visible_text(cls.booking_facts)
+
+    def test_answer_first_block_precedes_keynote_grid_and_names_the_offer(self):
+        self.assertTrue(self.booking_facts, "booking-facts section is missing")
+        self.assertLess(
+            self.html.index('id="booking-facts"'),
+            self.html.index('id="signature-keynotes"'),
+        )
+        self.assertIn(
+            "Kris Krüg is an AI keynote speaker based in Vancouver, "
+            "British Columbia, Canada.",
+            self.booking_text,
+        )
+        for format_family in FORMAT_FAMILIES:
+            self.assertIn(format_family.lower(), self.booking_text.lower())
+
+    def test_five_planning_facts_cover_the_booking_path(self):
+        self.assertEqual(5, len(re.findall(r"<article\b", self.booking_facts)))
+        for heading in (
+            "Location",
+            "Formats",
+            "Audiences and topics",
+            "What to send",
+            "Next step",
+        ):
+            self.assertRegex(
+                self.booking_facts,
+                rf"<h3>{re.escape(heading)}</h3>",
+            )
+        for field in ("audience", "date", "location", "format", "question"):
+            self.assertIn(field, self.booking_text.lower())
+        self.assertIn('href="/contact/"', self.booking_facts)
+
+    def test_existing_six_talk_video_and_format_contracts_remain_intact(self):
+        keynotes = section_with_id(self.html, "signature-keynotes")
+        watch = section_with_id(self.html, "watch")
+
+        talk_titles = re.findall(r"<h3>(.*?)</h3>", keynotes, re.DOTALL)
+        self.assertEqual(list(CANONICAL_TALKS), talk_titles)
+        self.assertEqual(2, len(re.findall(r"<iframe\b", watch)))
+        for format_family in FORMAT_FAMILIES:
+            self.assertIn(f"<h3>{format_family}</h3>", self.html)
+
+    def test_booking_facts_do_not_add_unsupported_claims_or_old_location(self):
+        self.assertTrue(self.booking_facts, "booking-facts section is missing")
+        lowered = self.booking_text.lower()
+        for unsupported in (
+            "galiano",
+            "travel",
+            "nationwide",
+            "virtual",
+            "bilingual",
+            "fee",
+            "lead time",
+            "availability",
+        ):
+            self.assertNotIn(unsupported, lowered)
+        self.assertNotIn("$", self.booking_text)
+        self.assertNotIn("galiano", self.plan.lower())
+
+    def test_claim_to_source_matrix_covers_each_new_fact_family(self):
+        self.assertIn("## Booking claim-to-source matrix (#904)", self.plan)
+        for claim_family in (
+            "Identity and location",
+            "Formats",
+            "Audiences and topics",
+            "Booking inputs",
+            "Next step",
+        ):
+            self.assertRegex(
+                self.plan,
+                rf"(?m)^\| {re.escape(claim_family)} \|",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #904.

## Summary

- Add an answer-first planner block before the six-talk grid.
- Identify Kris as an AI keynote speaker based in Vancouver, British Columbia, Canada.
- Add five source-backed facts covering location, formats, audiences and topics, booking inputs, and the existing contact path.
- Record the claim-to-source matrix and the Vancouver-only ruling in the payload plan.
- Add a focused contract test that preserves the six talks, two prepared recordings, four format families, booking fields, and unsupported-claim boundary.

## Source boundary

The Profound export supplied query intent only. The copy uses KK’s Vancouver-only ruling, the current first-party schema description, the canonical talk-topic bank, and the existing live/page-payload booking contract. It adds no travel, fee, virtual-delivery, bilingual, availability, lead-time, competitor, schema, or market claims.

## Verification

- python3 scripts/tests/test_speaking_booking_facts.py: 5 tests passed
- focused booking + merged embed regressions: 10 tests passed
- voice gate: 0 violations
- make python-test PYTHON=python3: 558 operational, 12 SEO inventory, and 68 SEO backfill/link-safety tests passed
- make verify PYTHON=python3: passed JavaScript harness, plugin/theme smokes, docs truth, 44 PHP syntax checks, and PHPCS 7/7
- git diff --check: passed

## Deployment notes

Repo-side Track A preparation only. No live WordPress write, title or metadata change, schema change, theme edit, issue-label change, or merge was performed. Live page 1887 application remains a separate snapshot-first operation.