### PR TITLE
fix: preserve Speaking play icon through WordPress

### DIFF
--- a/content/drafts/2026-07-26-speaking-page/payload-body.html
+++ b/content/drafts/2026-07-26-speaking-page/payload-body.html
@@ -126,7 +126,7 @@
   opacity: 0.72;
 }
 .kk-r9-pack .kk-speak-embed-facade::before {
-  content: "▶";
+  content: "\25B6";
   grid-area: 1 / 1;
   z-index: 1;
   display: grid;

--- a/scripts/tests/test_speaking_embed_contract.py
+++ b/scripts/tests/test_speaking_embed_contract.py
@@ -90,6 +90,8 @@ class SpeakingEmbedContractTests(unittest.TestCase):
 
     def test_facade_click_loads_and_focuses_the_deferred_iframe(self):
         self.assertIn(".kk-speak-embed-facade", self.html)
+        self.assertIn(r'content: "\25B6";', self.html)
+        self.assertNotIn('content: "▶";', self.html)
         self.assertRegex(self.html, r"addEventListener\(['\"]click['\"]")
         self.assertIn("template.content.cloneNode(true)", self.html)
         self.assertIn("replaceChildren", self.html)


### PR DESCRIPTION
WordPress normalized the literal play glyph to a question mark during the approved page-1887 apply, so the guard restored the prior body. This replaces that glyph with an ASCII CSS escape and adds a regression assertion. Focused Speaking tests: 16 passed. No live body or schema remains changed. Refs #640.