### PR TITLE
docs: refresh sprint-zero truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 
 1. [`docs/current-state/README.md`](docs/current-state/README.md) — current-state front door; run `make status-readonly` for live counters
 2. [`docs/current-state/CURRENT-STATE-2026-07-30.md`](docs/current-state/CURRENT-STATE-2026-07-30.md) — declared snapshot for drift/morning-truth (Makefile default)
-3. [`docs/current-state/WORK-PLAN-2026-08-25.md`](docs/current-state/WORK-PLAN-2026-08-25.md) — **day runbook** (issue #4 read-only residual audit complete; repair two wrong duplicate-media writes and five corrected targets after approval, then resume hub packs #829-#832 after a separate approval; supersedes 2026-08-24)
+3. [`docs/current-state/WORK-PLAN-2026-08-25.md`](docs/current-state/WORK-PLAN-2026-08-25.md) — **day runbook** (issue #4 restored the two wrong-identity writes and applied two corrected targets before stopping safely; correct media 7637 repo-side, then seek a new approval for remaining media 6985/7637/8871; hub packs #829-#832 need a separate approval; supersedes 2026-08-24)
 4. [`docs/current-state/MASTER-PLAN-2026-07-30.md`](docs/current-state/MASTER-PLAN-2026-07-30.md) — hygiene + lane sequencing plan of record
 5. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 6. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow
@@ -86,7 +86,7 @@ This repo is CLI tooling + a WordPress theme/plugins line — there is **no loca
 Non-obvious caveats for future agents (the update script already installs deps):
 
 - The Python venv lives at `scripts/notion-to-wp/.venv` and **many `Makefile` targets call `scripts/notion-to-wp/.venv/bin/python` directly** (e.g. `seo-audit`, `seo-backfill`, `draft-queue-audit`). If that venv is missing those targets break, so it must exist — the update script (re)creates it.
-- PHP is **8.3** here (CI pins 8.2). This does not affect linting: `phpcs.xml.dist` sets `testVersion 8.1-` as a static target, so `make validate` / `make plugin-smoke` run fine on 8.3.
+- Local runtime versions vary by machine and image; run `php --version` before making a local-runtime claim (CI pins PHP 8.2). `phpcs.xml.dist` sets `testVersion 8.1-` as the static compatibility target, so local linting is intentionally decoupled from the installed PHP minor version.
 - Pixel gate (`make visual-preflight` / `visual-baseline` / `visual-diff`): Chromium is **not** always at `/opt/pw-browsers` in every Cloud image. If preflight FATAL, install Playwright locally under `~/.local/pw` with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, point `PLAYWRIGHT_BROWSERS_PATH=~/.local/pw-browsers`, and symlink Playwright's `chromium-1148` (+ headless shell) binaries to the system Chrome at `/opt/google/chrome/chrome`. Export `NODE_PATH=$HOME/.local/pw/node_modules` when invoking make targets. Official gate still compares **post-deploy live vs pre-deploy live** — a frozen baseline alone is not merge proof.
 - Theme SFTP deploy (`scripts/deploy_theme_sftp.py`): accepts `WP_SFTP_PASSWORD` in process env (Cloud), else macOS Keychain service `pagely-sftp-kriskrug`. Needs `paramiko` installed. REST `WP_APP_PASSWORD` cannot upload themes via Appearance → Themes.
 - Authenticated work needs **either** `WP_USER` + `WP_APP_PASSWORD` **or** `WP_API_USERNAME` + `WP_API_PASSWORD` (optional `NOTION_TOKEN`). Every script accepts both pairs as of 2026-08-23; `scripts/common.py` aliases the API names onto the legacy ones. On KK's laptop the Varlock vault supplies only the `WP_API_*` pair, so **do not conclude credentials are missing because `WP_USER` is unset** - run `make doctor`. Cursor Cloud secrets may use either pair. Laptop Varlock/1Password does **not** inject into this VM. After secret entry, verify with a redacted presence check (`WP_USER` length only) before assuming auth works; a long-lived agent pod that started before secrets were saved may still see them as unset until a new session boots with the secrets attached.
@@ -98,4 +98,4 @@ Non-obvious caveats for future agents (the update script already installs deps):
 
 ---
 
-**Instruction review:** 2026-08-13. Runtime state is deliberately not pinned here. Run `make status-readonly`, consult the current-state front door, and use public readback evidence before acting on live-state assumptions.
+**Instruction review:** 2026-08-28. Runtime state is deliberately not pinned here. Run `make status-readonly`, consult the current-state front door, and use public readback evidence before acting on live-state assumptions.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository is used for:
 1. **Site audits + state snapshots** of the live kriskrug.co WordPress install (see [`docs/current-state/`](docs/current-state/))
 2. **Content pipeline** — Notion → kriskrug.co publisher with safety guards (see [`scripts/notion-to-wp/`](scripts/notion-to-wp/))
 3. **Custom WordPress code** — schema markup, theme tweaks, helper plugins (see [`fixes/`](fixes/), [`inc/`](inc/), and [`plugins/`](plugins/))
-4. **Aurora theme work** — canonical theme source now tracked on `main` (merged via PR #129), with lane-scoped feature branches for larger slices; `aurora/v2` and `aurora/v3-reconcile` are preserved evidence/reconcile branches, not wholesale merge targets
+4. **Aurora theme work** — canonical theme source is tracked on `main`, with lane-scoped feature branches for bounded changes; verify any historical evidence branch still exists before relying on it
 5. **Issue tracking + project management** for fixes, content, and theme work
 
 ### Why a Separate Repo?
@@ -76,7 +76,7 @@ issues-to-create/                # Markdown drafts of GitHub issues waiting to b
 
 inc/                             # Custom WordPress modules (e.g., digital-composting CPT)
 
-skills/                          # Claude Code skills used in this repo
+.agents/skills/                  # Repository-local workflow skills
 .github/                         # PR validation plus parked historical agent-swarm definitions
 ```
 
@@ -103,7 +103,8 @@ Notion → kriskrug.co publishing, post-publish enrichment, schema maintenance, 
 
 - Publish a post: [`scripts/notion-to-wp/README.md`](scripts/notion-to-wp/README.md)
 - Enrichment + link-graph helper: [`scripts/notion-to-wp/text_polish.py`](scripts/notion-to-wp/text_polish.py)
-- Active backlog: [`docs/current-state/FIX_QUEUE.md`](docs/current-state/archive/FIX_QUEUE.md), [`docs/current-state/SITE-AUDIT-2026-05-16.md`](docs/current-state/archive/SITE-AUDIT-2026-05-16.md)
+- Active backlog: [open GitHub issues](https://github.com/WalksWithASwagger/kriskrug-wp/issues)
+- Historical audit evidence: [`FIX_QUEUE.md`](docs/current-state/archive/FIX_QUEUE.md) and [`SITE-AUDIT-2026-05-16.md`](docs/current-state/archive/SITE-AUDIT-2026-05-16.md); neither is an execution queue
 - Deployed schema: [`fixes/schema-snippets-deployed.php`](fixes/schema-snippets-deployed.php)
 
 ### Track B — Aurora theme (on `main` via lane-scoped branches)
@@ -114,18 +115,14 @@ FSE theme rebuild and polish. Touches `theme/kk-aurora/`, FSE templates, theme.j
   lane-scoped `codex/...` branch. Use `aurora/v3-reconcile` only as deferred
   evidence for specific theme-polish files, and keep `aurora/v2` references as
   historical context unless a dated handoff says otherwise.
-- Side-worktree safety refresh (2026-06-02): do not edit
-  `/Users/kk/Code/kriskrug-wp-aurora-keynote`
-  (`codex/aurora-keynote-redesign`), `/Users/kk/Code/kriskrug-wp-aurora-reconcile`
-  (`aurora/v3-reconcile`), or the locked
-  `/Users/kk/Code/kriskrug-wp/.claude/worktrees/agent-aec50fddbd7207f80`
-  (`aurora/v2`) directly. Treat them as evidence or historical side branches
-  unless a maintainer explicitly resumes one.
+- Worktree safety: run `git worktree list` before editing. Treat every listed
+  side worktree as owned until its branch, PR, and filesystem state are
+  verified; do not rely on hard-coded paths from historical handoffs.
 - Migration plan: [`docs/current-state/AURORA-MIGRATION-PLAN.md`](docs/current-state/archive/AURORA-MIGRATION-PLAN.md)
 
 ### Which track am I in?
 
-If you're editing a post, page, schema, redirect, or category → Track A. If you're editing theme files or FSE templates → Track B. Use the two-track model doc for historical context, but prefer the 2026-05-24 handoff docs for current branch/layout truth.
+If you're editing a post, page, schema, redirect, or category → Track A. If you're editing theme files or FSE templates → Track B. Use the two-track model for the decision rule and the current-state index plus a fresh `make status-readonly` run for current branch/layout truth.
 
 ## Getting Started
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,8 +13,8 @@ The canonical baseline snapshot and current handoffs live in [`docs/current-stat
 | File | What it covers |
 |---|---|
 | [`current-state/README.md`](current-state/README.md) | Index; front door pointers |
-| [`current-state/CURRENT-STATE-2026-07-30.md`](current-state/CURRENT-STATE-2026-07-30.md) | Declared snapshot for drift checks (WP 7.0.4; Aurora live and repo `main` in sync at 1.6.5, readback 2026-08-15) |
-| [`current-state/WORK-PLAN-2026-08-24.md`](current-state/WORK-PLAN-2026-08-24.md) | **Active two-session runbook** (finish reviewed Batch 3 alt text, then resume hub applies; supersedes 2026-08-23) |
+| [`current-state/CURRENT-STATE-2026-07-30.md`](current-state/CURRENT-STATE-2026-07-30.md) | Declared snapshot for drift checks; compare its dated values with `make status-readonly` |
+| [`current-state/WORK-PLAN-2026-08-25.md`](current-state/WORK-PLAN-2026-08-25.md) | **Active runbook**: correct the remaining issue #4 media identity, then resume approval-gated authority-hub applies |
 | [`current-state/MASTER-PLAN-2026-07-30.md`](current-state/MASTER-PLAN-2026-07-30.md) | Truth → reclaim → product lanes |
 | [`current-state/TWO-TRACK-MODEL.md`](current-state/TWO-TRACK-MODEL.md) | Active Track A / Track B decision rule |
 | [`current-state/ACCESS_CHANNELS.md`](current-state/ACCESS_CHANNELS.md) | MCP / REST / Chrome / SSH — what works today |
@@ -101,9 +101,9 @@ Each historical doc carries a `STATUS: Historical` banner at the top pointing at
 | [`../inc/`](../inc/) | Custom WordPress modules (currently: `digital-composting.php`) |
 | [`../issues-to-create/`](../issues-to-create/) | Markdown drafts of GitHub issues waiting to be filed |
 | [`../backup/`](../backup/) | Backup manifests (archives themselves are gitignored) |
-| [`../skills/`](../skills/) | Claude Code skills used by this repo |
+| [`../.agents/skills/`](../.agents/skills/) | Repository-local workflow skills |
 | [`../.github/`](../.github/) | Workflows, agent definitions, issue templates |
 
 ---
 
-**Last updated:** 2026-07-03. Added the latest morning-truth artifact. Note: this index does not exhaustively list every dated file under `docs/current-state/` - the June/July 2026 snapshots and closeouts are newer than some entries here, so treat `docs/current-state/` itself as the source of truth for the latest dated evidence. Update this index whenever you add or remove documentation, or whenever a doc's "Current vs Historical" status changes.
+**Last reviewed:** 2026-08-28. This index does not exhaustively list every dated file under `docs/current-state/`; use its front-door index and `make status-readonly` for current truth. Update this index whenever documentation is added, removed, or reclassified.

--- a/docs/current-state/CURRENT-STATE-2026-07-30.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-30.md
@@ -1,27 +1,27 @@
 # Current State Snapshot - 2026-07-30
 
-**Snapshot time:** 2026-07-30 (truth reset after debt/docs/bloat audit). Live counters and versions refreshed 2026-08-16: WordPress `7.0.4`; Aurora live `1.6.5`, repo `main` `1.6.6` (deploy owed).
+**Snapshot time:** 2026-07-30 truth reset; live counters and versions refreshed 2026-08-28 14:59Z: WordPress `7.0.4`; Aurora live and repo `main` both `1.6.9`.
 **Branch:** `main` (docs PR lands from lane-scoped branch)
 **Mode:** Ops hygiene (Phases 0–3) then Track A / Track B product lanes.
 
 This file is the declared snapshot for `make current-state-drift-check` / `make morning-truth` / `make status-readonly` (via `WORK_PLAN` / `WORK_PLAN_DEFAULT`).
 
-Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Latest dated runbook: [`WORK-PLAN-2026-08-24.md`](WORK-PLAN-2026-08-24.md).
+Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Latest dated runbook: [`WORK-PLAN-2026-08-25.md`](WORK-PLAN-2026-08-25.md).
 
 ## Verified State
 
-> **Counters refreshed 2026-08-13T00:46Z.** The two GitHub counters are the values `make current-state-drift-check` compares against. They can move as soon as a PR or issue changes, so re-read with the commands below before treating drift as a regression.
+> **Counters refreshed 2026-08-28T14:59Z after reopening #602.** These are the values `make current-state-drift-check` compares against. They can move as soon as a PR or issue changes, so re-read with the commands below before treating drift as a regression.
 
-- `origin/main` includes Aurora **1.6.6** (PR #751) and the merged Gorgeous Ghost draft package (PR #722).
-- Open PRs: `1` (`gh pr list --state open --limit 100 --json number --jq 'length'`, 2026-08-13T00:46Z): draft PR #710, intentionally parked for cherry-pick review rather than raw merge.
-- Open issues: `40` (`gh issue list --state open --limit 300 --json number --jq 'length'`, 2026-08-13T00:46Z).
+- `origin/main` was clean and synchronized before this docs-truth branch; its latest commit was PR #908 (`b918088`).
+- Open PRs: `0` (`gh pr list --state open --limit 100 --json number --jq 'length'`, 2026-08-28T14:59Z).
+- Open issues: `43` (`gh issue list --state open --limit 300 --json number --jq 'length'`, 2026-08-28T14:59Z). This includes correctly reopened Testimonials deploy issue #602.
 - Production still publicly reports WordPress `7.0.4`.
-- Live Aurora theme (`style.css` Version header): `1.6.5` (public readback 2026-08-16).
-- Repo Aurora theme (`theme/kk-aurora/` on `main`): `1.6.6`. Live and repo are **drifted**; next deploy window is 1.6.6.
+- Live Aurora theme (`style.css` Version header): `1.6.9` (public readback 2026-08-28).
+- Repo Aurora theme (`theme/kk-aurora/` on `main`): `1.6.9`; live and repo are in parity.
 - Theme deploy ledger: `theme/kk-aurora/CHANGELOG.md`. The public `style.css` readback is authoritative for what production runs, never the repo header.
-- WordPress draft queue: `0` scheduled posts, `65` draft posts, `4` draft pages.
-  - Authenticated read 2026-08-12. Unauthenticated cloud reads report `unavailable` / false zeros until `WP_USER` + `WP_APP_PASSWORD` are present — that zero is a **false zero**, not an empty queue.
-- WP public smoke: all eight public surfaces pass with expected WordPress `7.0.4` (`make wp7-smoke`, 2026-08-12).
+- WordPress draft queue: `0` scheduled posts, `66` draft posts, `4` draft pages.
+  - Authenticated read 2026-08-28. Unauthenticated reads report `unavailable`, not a trustworthy empty queue.
+- WP public smoke passes with expected WordPress `7.0.4` (`make status-readonly`, 2026-08-28).
 - `/projects/` → `301` to `/work/`.
 - Homepage reveal safety net: absent. GSAP/ScrollTrigger CDN: absent.
 
@@ -29,22 +29,23 @@ Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Lates
 
 | Gate | Issue | Status |
 |---|---|---|
-| Third-party script performance diet | #706 | High priority; swarm-ready; needs human review |
-| Speaking rebuild | #419 | High priority; content/UX; needs human review |
-| Testimonials live deploy | #602 | High priority; snapshot-gated production change |
+| Alt-text residual correction | #4 | Three media writes remain; media 7637 needs a corrected reviewed proposal before a new live approval |
+| Testimonials live deploy | #602 | Reopened 2026-08-28; live page 2409 is still the legacy 19-card body and needs its snapshot/editorial/approval gate |
+| Third-party script performance receipt | #706 | Script diet is live; matching post-change PSI evidence remains incomplete |
 | Repo bloat reduction | #318 | Inventory exists; cleanup remains a separate approved operation |
 | Site redesign epic | #403 | Track B roadmap; split into lane-scoped PRs |
 
 ## What changed since CURRENT-STATE-2026-07-16
 
-- Aurora **1.5.0** landed on `main` and live (cascade `@layer` + `--kk-*` tokens); #545 closed; live↔repo parity check exists (`make check-live-parity`).
-- Homepage newsletter rewrite (#416 / PR #505) is on `main` at 1.4.9 lineage and shipped with/under the 1.5.0 line.
-- Morning-truth cadence restored (#547 / #553).
-- Open issues moved ~77 → **40**; open PRs **1** (parked draft #710).
-- Competing “active” work plans (07-16 / 07-19 / 07-26) demoted; this snapshot + WORK-PLAN-2026-07-30 are the front door.
+- Aurora advanced to **1.6.9** on `main` and live; the live↔repo parity check remains the authority.
+- Issue #4 completed the broad Batch 3 media pass, restored two wrong-identity writes, and stopped safely with three reviewed/corrected targets remaining.
+- The Speaking rebuild is live with two click-to-load privacy-hosted video facades; #640 remains open for the missing before/after LCP receipt.
+- Testimonials issue #602 was reopened because its runbook-only PR closed it while the live page remained undeployed.
+- Open issues moved ~77 → **43**; open PRs were **0** at the 2026-08-28 refresh.
+- Competing work plans are historical; this snapshot plus `WORK-PLAN-2026-08-25.md` and a fresh `make status-readonly` run are the front door.
 
 ## Stash / secrets notes
 
 - Cloud agents need process env `WP_USER` / `WP_APP_PASSWORD` (optional `NOTION_TOKEN`). Laptop Varlock does not inject into Cloud.
 - Prefer [`.env.schema`](../../.env.schema); do not commit plaintext secrets. Rollout: [`VARLOCK-ROLLOUT-2026-07-16.md`](VARLOCK-ROLLOUT-2026-07-16.md).
-- `git stash list` was empty on 2026-08-12. The merged #722 feature worktree still exists locally; preserve it until cleanup is explicitly approved.
+- `git stash list` was empty on 2026-08-28. Three `/private/tmp` worktree registrations were prunable but not removed; cleanup remains approval-gated under #738.

--- a/docs/current-state/MASTER-PLAN-2026-07-30.md
+++ b/docs/current-state/MASTER-PLAN-2026-07-30.md
@@ -4,7 +4,9 @@
 **Lane:** Docs / ops first; then Track A or Track B — never interleaved in one commit.
 **Does not authorize** live WordPress writes, theme deploys, or history rewrite.
 
-Day runbook: [`WORK-PLAN-2026-08-24.md`](WORK-PLAN-2026-08-24.md). Declared snapshot: [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+Day runbook: [`WORK-PLAN-2026-08-25.md`](WORK-PLAN-2026-08-25.md). Declared snapshot: [`CURRENT-STATE-2026-07-30.md`](CURRENT-STATE-2026-07-30.md).
+
+**2026-08-28 reading note:** Phases 0–3 below record the July hygiene reset; do not execute their old branch or issue lists as a current queue. Use the dated runbook, the open GitHub issue list, and `make status-readonly` for current work.
 
 ## Goal
 

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -6,7 +6,7 @@ Ops truth for [kriskrug.co](https://kriskrug.co/). Every May and June 2026 plan 
 
 Read these first:
 
-1. **[WORK-PLAN-2026-08-25.md](WORK-PLAN-2026-08-25.md)**, active runbook (issue #4 residual audit complete; two wrong duplicate-media writes and five corrected targets await an approval-gated repair before authority-hub applies; use `make status-readonly` for live counters)
+1. **[WORK-PLAN-2026-08-25.md](WORK-PLAN-2026-08-25.md)**, active runbook (issue #4 restored the two wrong-identity writes and applied corrected media 6014/6126 before stopping safely; correct media 7637 repo-side, then seek a new approval for remaining media 6985/7637/8871 before authority-hub applies; use `make status-readonly` for live counters)
 2. **[CURRENT-STATE-2026-07-30.md](CURRENT-STATE-2026-07-30.md)**, declared snapshot for morning-truth drift checks (compare it with a fresh `make status-readonly` run)
 3. **[MASTER-PLAN-2026-07-30.md](MASTER-PLAN-2026-07-30.md)**, truth then reclaim then product lanes (hygiene phases complete)
 4. Run `make status-readonly` for current signals; use the newest **[reports/morning-truth-*.md](reports/)** only as durable checkpoint evidence
@@ -14,7 +14,7 @@ Read these first:
 6. **[INCIDENT-2026-05-15-overwritten-post.md](INCIDENT-2026-05-15-overwritten-post.md)**, slug/idempotency safety rules. Dated May, deliberately kept at top level: it is a standing safety rule, not a plan.
 7. **[../../.env.schema](../../.env.schema)** plus **[VARLOCK-ROLLOUT-2026-07-16.md](VARLOCK-ROLLOUT-2026-07-16.md)**, env contract (never read plaintext `.env`)
 
-**Live readback 2026-08-23:** WordPress last seen `7.0.4`. Aurora **live is `1.6.9`**, repo `main` is `1.6.9` (parity). Content applies #764 / #729 / #612 / **#826** / **#827** are live. Lab webring chrome (Dark Crystal + unofficial.city) is live on the homepage footer and `/work/` (surgical card insert, not a full `work.html` replace). #706 script diet is live at origin (Code Snippets id 22; pixel markers 0 on `/` and `/about/`). PSI mobile 2026-08-16 11:59 PDT is in [`reports/psi-mobile-2026-08-16.md`](reports/psi-mobile-2026-08-16.md) (TBT 10 ms; gtag still in the PSI trace). Receipts: [`reports/gate0-content-apply-20260817.md`](reports/gate0-content-apply-20260817.md), [`reports/issue-826-applied-20260818.md`](reports/issue-826-applied-20260818.md), [`reports/issue-827-applied-20260818.md`](reports/issue-827-applied-20260818.md), [`reports/aurora-168-live-deploy-20260817.md`](reports/aurora-168-live-deploy-20260817.md), [`reports/aurora-169-live-deploy-20260818.md`](reports/aurora-169-live-deploy-20260818.md). The public `style.css` readback remains authoritative for production theme state.
+**Live readback 2026-08-28 14:59Z:** WordPress `7.0.4`; Aurora live and repo `main` both `1.6.9`; 0 open PRs, 43 open issues, 0 scheduled posts, 66 draft posts, and 4 draft pages. Issue #602 was reopened after public page 2409 still showed the undeployed 19-card Testimonials body. Content applies #764 / #729 / #612 / **#826** / **#827** are live. Lab webring chrome (Dark Crystal + unofficial.city) is live on the homepage footer and `/work/` (surgical card insert, not a full `work.html` replace). #706 script diet is live at origin (Code Snippets id 22; pixel markers 0 on `/` and `/about/`), but its PSI closeout receipt remains open. Historical receipts: [`reports/gate0-content-apply-20260817.md`](reports/gate0-content-apply-20260817.md), [`reports/issue-826-applied-20260818.md`](reports/issue-826-applied-20260818.md), [`reports/issue-827-applied-20260818.md`](reports/issue-827-applied-20260818.md), [`reports/aurora-168-live-deploy-20260817.md`](reports/aurora-168-live-deploy-20260817.md), [`reports/aurora-169-live-deploy-20260818.md`](reports/aurora-169-live-deploy-20260818.md). Re-run `make status-readonly`; the public `style.css` readback remains authoritative for production theme state.
 
 ## Durable process docs (keep at top level)
 
@@ -29,7 +29,6 @@ Read these first:
 | [CSS-DEADCODE-OVERLAP-AUDIT.md](CSS-DEADCODE-OVERLAP-AUDIT.md) | Measured CSS debt feeding the rebuild |
 | [RECLAIM-LIST-2026-07-24.md](RECLAIM-LIST-2026-07-24.md) | #318/#369 reclaim proposal |
 | [reports/repo-bloat-318-next-steps-20260726.md](reports/repo-bloat-318-next-steps-20260726.md) | Executable A+D reclaim runbook |
-| [AGENT-MERGE-PATH-2026-07-26.md](AGENT-MERGE-PATH-2026-07-26.md) | Cloud merge / review path |
 | [ROLLBACK_PLAYBOOK.md](ROLLBACK_PLAYBOOK.md) | Prod undo order |
 | [BACKUP_PLAN.md](BACKUP_PLAN.md) | Backup pieces and gaps |
 | [ACCESS_CHANNELS.md](ACCESS_CHANNELS.md) | How we reach the site |
@@ -43,6 +42,7 @@ These are finished or single-issue documents that still sit at top level because
 | File | What it was |
 |---|---|
 | [SESSION-CLOSEOUT-2026-07-24.md](SESSION-CLOSEOUT-2026-07-24.md) | Track A closeout |
+| [AGENT-MERGE-PATH-2026-07-26.md](AGENT-MERGE-PATH-2026-07-26.md) | Historical record of the deleted `agent-safe-merge` workflow; current policy lives in `AGENTS.md` and `CONTRIBUTING.md` |
 | [REVIVE-AURORA-PORT-2026-07-24.md](REVIVE-AURORA-PORT-2026-07-24.md) / [REVIVE-AURORA-REVISIONS-2026-07-24.md](REVIVE-AURORA-REVISIONS-2026-07-24.md) | Revive cream port context |
 | [INTERACTION-STATES-GAP-INVENTORY.md](INTERACTION-STATES-GAP-INVENTORY.md) | First acceptance criterion of #424, dated 2026-07-25 |
 | [AURORA-SEO-TITLES-1.3.40-HANDOFF-2026-07-14.md](AURORA-SEO-TITLES-1.3.40-HANDOFF-2026-07-14.md) | #357 search-title handoff |
@@ -71,7 +71,7 @@ Every file below carries a `STATUS: Historical` banner in its first lines pointi
 
 ## Archive (#549 close-out, verified 2026-08-02)
 
-[`archive/`](archive/) holds **89 markdown files**: 4 that were already there plus **84 moved in commit `c369eef`** (PR #557, merged 2026-07-31). Every one was a `git mv` rename, so history is preserved and the moves are reversible. The diff for that commit against `docs/current-state/` is 84 `R`, 9 `M`, 6 `A`, and **zero `D`**. Verify with:
+At the #549 close-out, [`archive/`](archive/) held **89 markdown files**: 4 that were already there plus **84 moved in commit `c369eef`** (PR #557, merged 2026-07-31). It holds 102 as of 2026-08-28 after later plan archivals. Every #549 move was a `git mv` rename, so history is preserved and the moves are reversible. The diff for that commit against `docs/current-state/` is 84 `R`, 9 `M`, 6 `A`, and **zero `D`**. Verify with:
 
 ```
 git diff --name-status --find-renames c369eef^1 c369eef -- docs/current-state | cut -c1-1 | sort | uniq -c
@@ -90,7 +90,7 @@ Neither is a plan you execute from. Check with `ls docs/current-state/*.md | gre
 - `issues-to-create/README.md` line 5, to `archive/ISSUES-TO-CREATE-RECONCILIATION-2026-06-09.md`
 - `backup/2026-05-16/manifest.md` line 47, to `archive/FIX_QUEUE.md`
 
-**Current-doc surface is clean.** Scanning the 51 top-level `docs/current-state/*.md` plus `AGENTS.md`, `README.md`, `CONTRIBUTING.md` and `docs/INDEX.md` gives **0 broken relative links**. Every remaining break under `docs/current-state/` is inside `archive/`, which is historical by definition, plus one regex fragment in a `reports/` code block that a link scanner misreads as a link.
+**Top-level surface:** 43 `docs/current-state/*.md` files as of 2026-08-28. The #549 close-out scan found 0 broken relative links across the then-current top-level surface plus `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, and `docs/INDEX.md`; re-run the link check before making a new current claim.
 
 **Still broken, and out of scope for #549.** A repo-wide scan of 921 tracked `.md` files (509 relative link targets) finds 114 unresolved: 37 inside `archive/` itself, 77 elsewhere. None of the 77 is archive-move rot. They break down as pseudo-scheme placeholders the publisher rewrites (`photo:7750`, `media:11920`, `poster:3`, `img:mcluhan`), root-relative live-site URLs that resolve on kriskrug.co and never on disk (`/contact`, `/speaking/`), regex fragments inside fenced code blocks that a naive link scanner misreads, and `images/` binaries referenced by `content/drafts/` posts that were never committed (they exist in some working copies as untracked files, so this count is worktree-sensitive). The 37 inside `archive/` are the real move damage: 33 lost one directory level and resolve by prefixing `../`, 4 point at `fixes/` artifacts that no longer exist. Both sets sit outside `docs/current-state/` top level, nothing on the front door reads them, and repairing them is its own issue.
 
@@ -104,4 +104,4 @@ Neither is a plan you execute from. Check with `ls docs/current-state/*.md | gre
 
 ## Side-worktree safety
 
-Canonical new work starts from `main` on a lane-scoped branch. Do not edit legacy side worktrees (`aurora/v2`, `aurora/v3-reconcile`, aurora-keynote) unless a maintainer explicitly resumes one.
+Canonical new work starts from `main` on a lane-scoped branch. Run `git worktree list --porcelain` before editing or cleaning up; treat every listed side worktree as owned until its branch, PR, and filesystem state are verified.

--- a/docs/current-state/WORK-PLAN-2026-08-25.md
+++ b/docs/current-state/WORK-PLAN-2026-08-25.md
@@ -1,7 +1,10 @@
 # Work Plan 2026-08-25: repair alt-text identities, then resume hub applies
 
-**Status:** Session 1 audit complete; the identity-repair gate awaits explicit
-KK approval before Session 2. **Supersedes**
+**Status:** Session 1 audit complete; the identity-repair gate was partially
+executed and stopped correctly on a semantic mismatch. Media 6729 and 11774
+were restored, and corrected media 6014 and 6126 were applied and verified.
+Media 6985, 7637, and 8871 remain untouched; 7637 needs a corrected reviewed
+proposal before a new live approval. **Supersedes**
 [`WORK-PLAN-2026-08-24.md`](WORK-PLAN-2026-08-24.md), whose Batch 3 sessions
 are complete. **Plan of record:**
 [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
@@ -13,17 +16,22 @@ run, identity verification, a private snapshot, and exact readback.
 
 - Issue #4 Batch 1 is live and independently verified.
 - Batch 3 made 73 media writes. A path-aware audit found five
-  duplicate-filename joins: three protected rows and two writes to unrelated
-  attachments 6729 and 11774. Seventy-one intended Batch 3 attachments are
-  exact. The actual pending attachments are 6014, 6126, 6985, 7637, and 8871.
-  The corrected selector returns 73 `already-applied` targets including media
-  6835 and 12646, plus five `would-write` targets.
+  duplicate-filename joins, including wrong writes to attachments 6729 and
+  11774. Both wrong writes were restored from their exact private snapshots.
+  Corrected targets 6014 and 6126 were then applied and verified. The selector
+  now returns 75 `already-applied` targets plus three `would-write` targets:
+  6985, 7637, and 8871.
+- The proposed alt for 7637 described media 6985. File hashes and visual
+  inspection proved the assets differ, so the approved stop rule prevented all
+  three remaining writes. A tested, reviewed 7637 proposal is the next repo
+  change; it does not authorize a live apply.
 - All 73 Batch 3 pre-write snapshots are mode 0600.
-- The 216-route recount completed with zero fetch errors: 1,078 violation
-  occurrences / 1,077 unique page-source violations.
+- The post-stop 216-route recount completed with zero fetch errors: 1,076
+  violation occurrences / 1,075 unique page-source violations.
 - Inventory batches 4-6 remain parked; #829-#832 remain unapplied.
-- `main` is the only worktree, Aurora live/repo are both 1.6.9, and WordPress
-  is 7.0.4 as of the 2026-08-24 closeout readback.
+- Aurora live/repo are both 1.6.9 and WordPress is 7.0.4 as of the 2026-08-28
+  readback. Three stale `/private/tmp` worktree registrations are prunable but
+  remain untouched pending the separate #738 cleanup approval.
 
 ## Session 1: resolve issue #4's small ambiguous remainder — complete
 
@@ -69,22 +77,25 @@ Acceptance:
 - Page 6815 and `/home/` are decision-ready, not silently changed.
 - The 18 missing-attribute findings are reproducibly classified.
 
-## Identity-repair gate: approval required before Session 2
+## Identity-repair gate: partial execution, new approval required
 
 Do not start the authority-hub lane with known wrong attachment metadata still
 outstanding.
 
-1. Preview and restore media 6729 and 11774 one at a time from their exact
-   private snapshots. Require the sibling apply report, ID, upload path, and
-   current alt to match before either write. Authenticated readback must return
-   the prior empty alt.
-2. Dry-run and, if still exact, apply media 6014, 6126, 6985, 7637, and 8871
-   individually. Each needs exact ID/upload path, private snapshot,
-   authenticated readback, and cache-bypassed public verification.
-3. Re-run the broad path-aware media dry run. Expected final state: 78/78
+Completed with exact snapshots and readbacks: restore 6729 and 11774; apply
+6014 and 6126. The semantic disagreement on 7637 triggered the required stop.
+
+1. In a repo-only PR, correct only the 7637 proposal after visual review and
+   add a regression that distinguishes it from 6985. Do not make a live write.
+2. After that PR merges, obtain a new explicit approval for live media writes
+   6985, 7637, and 8871.
+3. Under that approval, dry-run and apply each item separately with exact
+   ID/upload path, private snapshot, authenticated readback, and cache-bypassed
+   public verification.
+4. Re-run the broad path-aware media dry run. Expected final state: 78/78
    `already-applied`, zero refused identities. Recount the 216 routes and update
    issue #4.
-4. Stop on any drift or disagreement. Do not touch page 6815, `/home/`, the 18
+5. Stop on any drift or disagreement. Do not touch page 6815, `/home/`, the 18
    missing attributes, archive batches 4-6, or #829-#832 in this gate.
 
 ## Session 2: resume the ready authority-hub lane
@@ -114,8 +125,8 @@ Acceptance:
 
 ## What remains after these sessions
 
-1. Approval-gated rollback of wrong media 6729 and 11774, followed by the five
-   actual targets 6014, 6126, 6985, 7637, and 8871.
+1. Repo-only correction and review of the media-7637 proposal, followed by a
+   separate approval-gated apply for remaining targets 6985, 7637, and 8871.
 2. A tested post-aware one-row apply path and separate live approval for the
    page-6815 media-6835 block.
 3. Visual review and exact proposals for the 18 missing-alt-attribute images.
@@ -128,21 +139,17 @@ Acceptance:
 
 ## Exact next implementation prompt
 
-> KK has explicitly approved the identity-repair gate in
-> WORK-PLAN-2026-08-25.md. Read AGENTS.md, that plan, the issue #4 inventory,
-> APPLY-RUNBOOK, and `reports/issue-4-residual-audit-20260825.md`. Run
-> `make doctor`, `make status-readonly`, and the alt-text helper tests. Work
-> only this gate. Preview, then restore media 6729 and 11774 one at a time from
-> their named private snapshots; require exact ID, upload path, current alt,
-> sibling apply record, and authenticated readback. Then dry-run and apply
-> corrected media 6014, 6126, 6985, 7637, and 8871 one at a time with private
-> snapshots, authenticated readback, and cache-bypassed public verification.
-> Finish with a broad path-aware dry run expecting 78/78 `already-applied`, a
-> 216-route recount, and issue #4 evidence. Stop on any drift. Do not touch
-> page 6815, `/home/`, the 18 missing attributes, archive batches 4-6, or
-> #829-#832.
+> Work repo-only on the media-7637 correction from issue #4. Read AGENTS.md,
+> WORK-PLAN-2026-08-25.md, the issue #4 inventory, APPLY-RUNBOOK, and
+> `reports/issue-4-residual-audit-20260825.md`, plus the 2026-08-25 partial-run
+> issue comment. Inspect media 6985 and 7637 as distinct assets and correct only
+> the 7637 proposal with a regression that prevents their descriptions from
+> being interchanged. Run the focused alt-text tests and `make verify`; open a
+> bounded PR. Do not make a WordPress write. After merge, stop and request a
+> separate exact approval for 6985, 7637, and 8871. Do not touch page 6815,
+> `/home/`, the 18 missing attributes, archive batches 4-6, or #829-#832.
 
 ---
 
-**Last verified:** 2026-08-25 local. Runtime counters remain
+**Last verified:** 2026-08-28 read-only audit. Runtime counters remain
 readbacks, not promises.

--- a/scripts/docs_truth_check.py
+++ b/scripts/docs_truth_check.py
@@ -67,7 +67,7 @@ KNOWN_STALE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
     (
         re.compile(r"Aurora\s*\**\s*`?1\.5\.0`?\s*\**\s*\(?\s*live\s*==?\s*repo", re.I),
-        "Aurora live==repo parity at 1.5.0 is stale; the 2026-08-02 public readback is live 1.5.7 against repo main 1.5.8. Cite a curl readback of the public style.css and name the direction of the gap.",
+        "Aurora live==repo parity at 1.5.0 is stale; rerun `make status-readonly`, read the public style.css, and name the measured versions.",
     ),
     (
         re.compile(r"Current live queue count is 43", re.I),
@@ -127,8 +127,76 @@ ACTIVE_GUIDANCE_PATHS = {
     Path("README.md"),
     Path("docs/INDEX.md"),
     Path("docs/current-state/README.md"),
-    Path("docs/current-state/WORK-PLAN-2026-08-23.md"),
+    Path("docs/current-state/CURRENT-STATE-2026-07-30.md"),
+    Path("docs/current-state/WORK-PLAN-2026-08-25.md"),
     Path("docs/current-state/MASTER-PLAN-2026-07-30.md"),
+}
+
+PATH_SCOPED_STALE_PATTERNS: dict[Path, list[tuple[re.Pattern[str], str]]] = {
+    Path("README.md"): [
+        (
+            re.compile(r"(?m)^\s*skills/\s+#"),
+            "The repository-local skill path is `.agents/skills/`, not a top-level `skills/` directory.",
+        ),
+        (
+            re.compile(r"(?m)^-\s+Active backlog:.*(?:FIX_QUEUE|SITE-AUDIT)", re.I),
+            "The active backlog is the open GitHub issue list; archived audit files are evidence only.",
+        ),
+    ],
+    Path("docs/INDEX.md"): [
+        (
+            re.compile(r"\[\s*`?\.\./skills/`?\s*\]\(\.\./skills/\)"),
+            "The documentation index must link repository-local skills at `../.agents/skills/`.",
+        ),
+        (
+            re.compile(r"WORK-PLAN-2026-08-24\.md.*(?:active|current).*runbook", re.I),
+            "The active documentation index must point to `WORK-PLAN-2026-08-25.md`.",
+        ),
+    ],
+    Path("docs/current-state/CURRENT-STATE-2026-07-30.md"): [
+        (
+            re.compile(r"(?:Latest dated runbook|front door)[^\n]*WORK-PLAN-2026-08-24\.md", re.I),
+            "The declared snapshot must point to `WORK-PLAN-2026-08-25.md`.",
+        ),
+        (
+            re.compile(r"Open PRs:\s*`1`[^\n]*#710", re.I),
+            "The parked PR #710 counter is stale; rerun `make status-readonly`.",
+        ),
+        (
+            re.compile(r"Open issues:\s*`40`", re.I),
+            "The 40-issue snapshot is stale; rerun `make status-readonly`.",
+        ),
+        (
+            re.compile(r"WordPress draft queue:[^\n]*`65`\s*draft posts", re.I),
+            "The 65-draft snapshot is stale; rerun `make status-readonly`.",
+        ),
+    ],
+    Path("docs/current-state/MASTER-PLAN-2026-07-30.md"): [
+        (
+            re.compile(r"Day runbook:[^\n]*WORK-PLAN-2026-08-24\.md", re.I),
+            "The master plan must point to `WORK-PLAN-2026-08-25.md`.",
+        ),
+    ],
+    Path("docs/current-state/README.md"): [
+        (
+            re.compile(r"AGENT-MERGE-PATH-2026-07-26\.md[^\n]*Cloud merge / review path", re.I),
+            "The deleted agent-safe-merge workflow is historical, not an active merge path.",
+        ),
+        (
+            re.compile(r"two wrong duplicate-media writes and five corrected targets await", re.I),
+            "The issue #4 front door predates the partial identity-repair execution; use the current three-target state.",
+        ),
+    ],
+    Path("AGENTS.md"): [
+        (
+            re.compile(r"PHP is\s+\*\*\d+\.\d+\*\*\s+here", re.I),
+            "Do not pin the installed local PHP minor version; tell agents to inspect the runtime.",
+        ),
+        (
+            re.compile(r"repair two wrong duplicate-media writes and five corrected targets", re.I),
+            "The issue #4 orientation predates the partial identity-repair execution; use the current three-target state.",
+        ),
+    ],
 }
 
 MERGE_POLICY_GUIDANCE_PATHS = {
@@ -269,6 +337,17 @@ def scan_file(repo_root: Path, path: Path) -> list[Finding]:
     findings: list[Finding] = []
     relative_path = path.relative_to(repo_root)
     text = path.read_text(encoding="utf-8")
+
+    for pattern, message in PATH_SCOPED_STALE_PATTERNS.get(relative_path, []):
+        for match in pattern.finditer(text):
+            findings.append(
+                Finding(
+                    relative_path,
+                    text.count("\n", 0, match.start()) + 1,
+                    message,
+                    match.group(0).strip(),
+                )
+            )
 
     if relative_path in ACTIVE_GUIDANCE_PATHS:
         for pattern in STALE_MORNING_TRUTH_FLOW_PATTERNS:

--- a/scripts/tests/test_docs_truth_check.py
+++ b/scripts/tests/test_docs_truth_check.py
@@ -23,7 +23,7 @@ class EphemeralMorningTruthGuidanceTests(unittest.TestCase):
     def test_active_guidance_rejects_routine_report_commit_flow(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            work_plan = repo_root / "docs/current-state/WORK-PLAN-2026-08-23.md"
+            work_plan = repo_root / "docs/current-state/WORK-PLAN-2026-08-25.md"
             work_plan.parent.mkdir(parents=True)
             work_plan.write_text(
                 "1. `make morning-truth` while online.\n"
@@ -89,6 +89,84 @@ class EphemeralMorningTruthGuidanceTests(unittest.TestCase):
             self.assertFalse(
                 any("morning-truth-checkpoint" in finding.message for finding in findings)
             )
+
+
+class ActiveFrontDoorRegressionTests(unittest.TestCase):
+    def test_current_work_plan_is_in_active_guidance_set(self):
+        self.assertIn(
+            Path("docs/current-state/WORK-PLAN-2026-08-25.md"),
+            docs_truth_check.ACTIVE_GUIDANCE_PATHS,
+        )
+
+    def test_rejects_superseded_active_runbook_links(self):
+        samples = {
+            "docs/INDEX.md": (
+                "| `WORK-PLAN-2026-08-24.md` | Active two-session runbook |\n"
+            ),
+            "docs/current-state/CURRENT-STATE-2026-07-30.md": (
+                "Latest dated runbook: WORK-PLAN-2026-08-24.md.\n"
+            ),
+            "docs/current-state/MASTER-PLAN-2026-07-30.md": (
+                "Day runbook: WORK-PLAN-2026-08-24.md.\n"
+            ),
+        }
+
+        for path, text in samples.items():
+            with self.subTest(path=path):
+                findings = scan_text(path, text)
+                self.assertTrue(
+                    any("WORK-PLAN-2026-08-25.md" in finding.message for finding in findings)
+                )
+
+    def test_rejects_nonexistent_top_level_skill_links(self):
+        samples = {
+            "README.md": "skills/  # Claude Code skills used in this repo\n",
+            "docs/INDEX.md": "| [`../skills/`](../skills/) | Skills |\n",
+        }
+
+        for path, text in samples.items():
+            with self.subTest(path=path):
+                findings = scan_text(path, text)
+                self.assertTrue(
+                    any(".agents/skills" in finding.message for finding in findings)
+                )
+
+    def test_rejects_archived_files_as_the_active_backlog(self):
+        findings = scan_text(
+            "README.md",
+            "- Active backlog: `FIX_QUEUE.md`, `SITE-AUDIT-2026-05-16.md`\n",
+        )
+
+        self.assertTrue(
+            any("open GitHub issue list" in finding.message for finding in findings)
+        )
+
+    def test_rejects_pinned_local_php_minor(self):
+        findings = scan_text(
+            "AGENTS.md",
+            "- PHP is **8.3** here (CI pins 8.2).\n",
+        )
+
+        self.assertTrue(
+            any("local PHP minor" in finding.message for finding in findings)
+        )
+
+    def test_rejects_pre_partial_issue_4_front_door_status(self):
+        samples = {
+            "AGENTS.md": (
+                "repair two wrong duplicate-media writes and five corrected targets\n"
+            ),
+            "docs/current-state/README.md": (
+                "two wrong duplicate-media writes and five corrected targets await repair\n"
+            ),
+        }
+
+        for path, text in samples.items():
+            with self.subTest(path=path):
+                findings = scan_text(path, text)
+                self.assertTrue(
+                    any("three-target state" in finding.message for finding in findings)
+                )
 
 
 class MergePolicyGuidanceTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- refresh the active documentation front doors, counters, runtime guidance, and worktree guidance from the 2026-08-28 audit
- correct issue #4 guidance after the partial identity-repair run stopped on the media-7637 semantic mismatch
- point the active backlog at GitHub, classify the deleted agent merge workflow as historical, and use the real `.agents/skills/` path
- add path-scoped docs-truth regressions for these stale states

## Verification

- `make verify`
  - 570 operational tests passed
  - 12 SEO inventory tests passed
  - 68 SEO backfill/link-safety tests passed
  - script-diet, plugin, theme, docs-truth, 44-file PHP syntax, and PHPCS gates passed
- focused docs-truth suite: 18 tests passed
- `git diff --check`

## Safety

Docs and local validation code only. No WordPress write, theme deploy, artifact pruning, branch cleanup, or issue closure is included. Issue #602 was separately reopened with fresh public readback evidence under the approved Sprint Zero gate.

Refs #4. Refs #602. Refs #738.