### PR TITLE
fix: preserve visual diff pairs during prune

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,5 +411,5 @@ visual-guard: ## Fail if any visual-regression binary is tracked or staged (#318
 visual-list: ## List baseline manifests and which still have images on disk
 	@$(VISUAL) list
 
-visual-prune: ## Delete old capture directories, keeping the newest KEEP (default 2)
-	@$(VISUAL) prune $(if $(KEEP),--keep $(KEEP),)
+visual-prune: ## Delete old capture dirs pair-safely; set DRY_RUN=1 to preview
+	@$(VISUAL) prune $(if $(KEEP),--keep $(KEEP),) $(if $(DRY_RUN),--dry-run,)

--- a/docs/current-state/AURORA-VISUAL-BASELINE-RUNBOOK.md
+++ b/docs/current-state/AURORA-VISUAL-BASELINE-RUNBOOK.md
@@ -25,7 +25,7 @@ Support commands:
 make visual-preflight                # Chromium + routes + storage guard, captures nothing
 make visual-guard                    # re-assert "no capture binary is tracked or staged"
 make visual-list                     # which manifests exist and which still have PNGs on disk
-make visual-prune KEEP=2             # delete old capture dirs; manifests are kept
+make visual-prune KEEP=2 DRY_RUN=1   # preview a pair-safe prune; manifests are kept
 ```
 
 All targets accept `ROUTES="home blog"` and `VIEWPORTS="desktop"` to narrow a run,
@@ -36,9 +36,13 @@ and `BASE_URL=` to point at a different origin.
 PNG capture directories are gitignored and have no gate value once their
 window's `diff-*.json` / `report-*.md` is committed. Keep the newest baseline
 and the newest pre/post pair; prune the rest after each deploy window closes
-with `make visual-prune KEEP=2`. Tracked manifests and reports stay. Exact
-delete lists go through KK first — see
-[`reports/visual-baseline-prune-proposal-749-2026-08-16.md`](reports/visual-baseline-prune-proposal-749-2026-08-16.md).
+with `make visual-prune KEEP=2`. `KEEP` is a minimum: when a retained candidate
+has a tracked diff, its baseline is retained too, so the command may keep more
+than two directories rather than split a pair. Preview with `DRY_RUN=1` and put
+the exact paths and sizes through KK before running the command without it.
+Tracked manifests and reports stay. The current approved-or-pending inventory
+belongs in a dated proposal; see
+[`reports/visual-baseline-prune-proposal-749-2026-08-28.md`](reports/visual-baseline-prune-proposal-749-2026-08-28.md).
 
 ## The deploy-step loop
 

--- a/docs/current-state/reports/visual-baseline-prune-proposal-749-2026-08-28.md
+++ b/docs/current-state/reports/visual-baseline-prune-proposal-749-2026-08-28.md
@@ -1,0 +1,49 @@
+# #749 visual-baseline prune proposal — 2026-08-28
+
+**Status:** proposal only. No capture directory has been deleted.
+
+`make visual-prune KEEP=2 DRY_RUN=1` now retains a tracked diff pair as one
+logical unit. The current dry-run keeps the newest complete pair
+`20260817T044445Z` → `20260817T045150Z` and proposes three older local PNG
+directories for deletion. Top-level manifests, diff JSON, and reports are
+tracked audit records and stay.
+
+## Keep
+
+| Run | Role | Size | Evidence |
+|---|---|---:|---|
+| `20260817T044445Z` | baseline | 272,488 KiB | `diff-20260817T045150Z.json` baseline |
+| `20260817T045150Z` | candidate | 295,808 KiB | newest tracked diff and report |
+
+Retained total: **568,296 KiB** (about **555 MiB**).
+
+## Exact delete list awaiting approval
+
+| Path | Role | Size |
+|---|---|---:|
+| `docs/current-state/reports/visual-baseline/20260811T033217Z/` | older candidate | 367,524 KiB |
+| `docs/current-state/reports/visual-baseline/20260817T044333Z/` | older baseline | 272,488 KiB |
+| `docs/current-state/reports/visual-baseline/20260817T044820Z/` | older candidate paired with `044333Z` | 287,676 KiB |
+
+Proposed reclaim: **927,688 KiB** (about **906 MiB**; the CLI reports
+**949.6 MB** in decimal units).
+
+## Verification already completed
+
+```text
+would remove docs/current-state/reports/visual-baseline/20260811T033217Z
+would remove docs/current-state/reports/visual-baseline/20260817T044333Z
+would remove docs/current-state/reports/visual-baseline/20260817T044820Z
+kept 2 run dir(s); would free 949.6 MB
+```
+
+All five directories were still present after the dry-run. The implementation
+has focused regression coverage for pair retention and non-destructive preview.
+
+## Approval phrase
+
+```text
+Approved: delete the exact three #749 capture directories in the 2026-08-28
+proposal with make visual-prune KEEP=2. Keep the 044445Z → 045150Z pair and all
+tracked manifests, diff JSON, and reports.
+```

--- a/docs/current-state/reports/visual-baseline/README.md
+++ b/docs/current-state/reports/visual-baseline/README.md
@@ -1,0 +1,17 @@
+# Visual-baseline artifact retention
+
+The run directories in this folder contain local, gitignored PNG captures.
+The top-level `manifest-*.json`, `diff-*.json`, and `report-*.md` files are the
+tracked audit record and are never removed by `visual-prune`.
+
+After a deploy window closes, retain the newest baseline and the newest complete
+pre/post diff pair. Preview the exact local deletion set first:
+
+```bash
+make visual-prune KEEP=2 DRY_RUN=1
+```
+
+`KEEP` is a minimum directory count. If a retained candidate has a tracked diff,
+its referenced baseline is retained too, so pair integrity can increase the
+actual number kept. Put the dry-run paths and sizes through KK for approval,
+then repeat the command without `DRY_RUN=1`.

--- a/scripts/tests/test_visual_baseline_prune.py
+++ b/scripts/tests/test_visual_baseline_prune.py
@@ -1,0 +1,132 @@
+import argparse
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import visual_baseline  # noqa: E402
+
+
+class VisualBaselinePruneTests(unittest.TestCase):
+    def test_keep_two_preserves_newest_complete_diff_pair(self):
+        runs = [
+            ("20260811T033217Z", "candidate", "2026-08-11T03:32:17+00:00"),
+            ("20260817T044333Z", "baseline", "2026-08-17T04:43:33+00:00"),
+            ("20260817T044445Z", "baseline", "2026-08-17T04:44:45+00:00"),
+            ("20260817T044820Z", "candidate", "2026-08-17T04:48:20+00:00"),
+            ("20260817T045150Z", "candidate", "2026-08-17T04:51:50+00:00"),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            artifact_root = repo_root / "docs/current-state/reports/visual-baseline"
+            artifact_root.mkdir(parents=True)
+            for run_id, kind, created_at in runs:
+                run_dir = artifact_root / run_id
+                run_dir.mkdir()
+                (run_dir / "capture.png").write_bytes(b"png")
+                (artifact_root / f"manifest-{run_id}.json").write_text(
+                    json.dumps(
+                        {"run_id": run_id, "kind": kind, "created_at": created_at}
+                    ),
+                    encoding="utf-8",
+                )
+            for baseline_run, candidate_run, created_at in (
+                (
+                    "20260817T044333Z",
+                    "20260817T044820Z",
+                    "2026-08-17T04:50:51+00:00",
+                ),
+                (
+                    "20260817T044445Z",
+                    "20260817T045150Z",
+                    "2026-08-17T04:54:20+00:00",
+                ),
+            ):
+                (artifact_root / f"diff-{candidate_run}.json").write_text(
+                    json.dumps(
+                        {
+                            "baseline_run": baseline_run,
+                            "candidate_run": candidate_run,
+                            "created_at": created_at,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+            previous_repo_root = visual_baseline.REPO_ROOT
+            previous_artifact_root = visual_baseline.ARTIFACT_ROOT
+            visual_baseline.REPO_ROOT = repo_root
+            visual_baseline.ARTIFACT_ROOT = artifact_root
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    visual_baseline.cmd_prune(argparse.Namespace(keep=2))
+            finally:
+                visual_baseline.REPO_ROOT = previous_repo_root
+                visual_baseline.ARTIFACT_ROOT = previous_artifact_root
+
+            remaining = {path.name for path in artifact_root.iterdir() if path.is_dir()}
+
+        self.assertEqual(
+            remaining,
+            {"20260817T044445Z", "20260817T045150Z"},
+        )
+
+    def test_dry_run_reports_victims_without_deleting_capture_dirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            artifact_root = repo_root / "docs/current-state/reports/visual-baseline"
+            artifact_root.mkdir(parents=True)
+            for run_id, kind, created_at in (
+                ("20260811T033217Z", "candidate", "2026-08-11T03:32:17+00:00"),
+                ("20260817T044445Z", "baseline", "2026-08-17T04:44:45+00:00"),
+                ("20260817T045150Z", "candidate", "2026-08-17T04:51:50+00:00"),
+            ):
+                run_dir = artifact_root / run_id
+                run_dir.mkdir()
+                (run_dir / "capture.png").write_bytes(b"png")
+                (artifact_root / f"manifest-{run_id}.json").write_text(
+                    json.dumps(
+                        {"run_id": run_id, "kind": kind, "created_at": created_at}
+                    ),
+                    encoding="utf-8",
+                )
+            (artifact_root / "diff-20260817T045150Z.json").write_text(
+                json.dumps(
+                    {
+                        "baseline_run": "20260817T044445Z",
+                        "candidate_run": "20260817T045150Z",
+                        "created_at": "2026-08-17T04:54:20+00:00",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            output = io.StringIO()
+            with (
+                mock.patch.object(visual_baseline, "REPO_ROOT", repo_root),
+                mock.patch.object(visual_baseline, "ARTIFACT_ROOT", artifact_root),
+                contextlib.redirect_stdout(output),
+            ):
+                visual_baseline.cmd_prune(
+                    argparse.Namespace(keep=2, dry_run=True)
+                )
+
+            remaining = {path.name for path in artifact_root.iterdir() if path.is_dir()}
+
+        self.assertEqual(
+            remaining,
+            {"20260811T033217Z", "20260817T044445Z", "20260817T045150Z"},
+        )
+        self.assertIn("would remove", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/visual_baseline.py
+++ b/scripts/visual_baseline.py
@@ -2011,18 +2011,47 @@ def cmd_guard(args: argparse.Namespace) -> int:
 
 
 def cmd_prune(args: argparse.Namespace) -> int:
-    """Delete capture directories, keeping the newest N. Manifests are kept."""
+    """Delete capture directories without splitting a tracked diff pair."""
     if not ARTIFACT_ROOT.exists():
         print("nothing to prune")
         return 0
-    dirs = sorted(p for p in ARTIFACT_ROOT.iterdir() if p.is_dir())
-    victims = dirs[: max(0, len(dirs) - args.keep)]
+    dirs = sorted(
+        (p for p in ARTIFACT_ROOT.iterdir() if p.is_dir()),
+        key=lambda p: (
+            _created_at(manifest_path(p.name)) or p.name,
+            p.name,
+        ),
+    )
+    baselines_by_candidate = {}
+    for diff_path in ARTIFACT_ROOT.glob("diff-*.json"):
+        result = json.loads(diff_path.read_text(encoding="utf-8"))
+        baseline_run = result.get("baseline_run")
+        candidate_run = result.get("candidate_run")
+        if baseline_run and candidate_run:
+            baselines_by_candidate[candidate_run] = baseline_run
+
+    available = {d.name for d in dirs}
+    retained = set()
+    for d in reversed(dirs):
+        if len(retained) >= max(0, args.keep):
+            break
+        retained.add(d.name)
+        baseline_run = baselines_by_candidate.get(d.name)
+        if baseline_run in available:
+            retained.add(baseline_run)
+
+    victims = [d for d in dirs if d.name not in retained]
     freed = 0
+    dry_run = getattr(args, "dry_run", False)
     for d in victims:
         freed += sum(f.stat().st_size for f in d.rglob("*") if f.is_file())
-        shutil.rmtree(d, ignore_errors=True)
-        print(f"removed {d.relative_to(REPO_ROOT)}")
-    print(f"kept {min(args.keep, len(dirs))} run dir(s); freed {freed / 1e6:.1f} MB")
+        if dry_run:
+            print(f"would remove {d.relative_to(REPO_ROOT)}")
+        else:
+            shutil.rmtree(d, ignore_errors=True)
+            print(f"removed {d.relative_to(REPO_ROOT)}")
+    action = "would free" if dry_run else "freed"
+    print(f"kept {len(retained)} run dir(s); {action} {freed / 1e6:.1f} MB")
     print(
         "Manifests are untouched — a lost baseline is one `make visual-baseline` away (§4.5.5)."
     )
@@ -2128,7 +2157,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.set_defaults(func=cmd_guard)
 
     p = sub.add_parser("prune", help="delete old capture directories (manifests kept)")
-    p.add_argument("--keep", type=int, default=2)
+    p.add_argument(
+        "--keep",
+        type=int,
+        default=2,
+        help="minimum run directories to retain; tracked diff pairs stay together",
+    )
+    p.add_argument("--dry-run", action="store_true", help="print victims without deleting")
     p.set_defaults(func=cmd_prune)
 
     return ap


### PR DESCRIPTION
## Summary

- retain tracked visual baseline/candidate pairs as one logical unit during prune
- add a non-destructive dry-run path and wire it through Make
- document retention semantics and the exact 2026-08-28 #749 approval list
- add regression tests for pair retention and dry-run safety

## Verification

- `make verify`
- `make visual-prune KEEP=2 DRY_RUN=1`

The real dry-run proposes deleting `033217Z`, `044333Z`, and `044820Z` (about 906 MiB) while retaining `044445Z → 045150Z`. No capture directory was deleted.

## Scope

This hardens the cleanup path and prepares the exact approval gate. Issue #749 remains open; actual local artifact deletion still requires KK approval.

Refs #749