### PR TITLE
[ACCESSIBILITY] Add exact post-content alt selector

### DIFF
--- a/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
+++ b/content/drafts/alt-text-backfill-2026-08-02/APPLY-RUNBOOK.md
@@ -5,25 +5,30 @@ dry-run-first per
 `docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`. Those writes
 were applied and verified on 2026-08-24. Batch 3 then made 73 media writes. A
 2026-08-25 path-aware authenticated re-audit found five duplicate-filename
-joins. Three had been protected before write. Two writes landed on unrelated
-attachments 6729 and 11774 and need rollback; the actual targets 6014, 6126,
-6985, 7637, and 8871 remain unapplied. The
-~1,070 archive-scope images (inventory batches 4-6) are parked and were not
-part of that approval.
+joins. Three had been protected before write. The two writes that landed on
+unrelated attachments 6729 and 11774 have been restored; corrected targets
+6014 and 6126 have been applied. Corrected targets 6985, 7637, and 8871 remain
+unapplied and require a new exact approval. The ~1,070 archive-scope images
+(inventory batches 4-6) are parked and were not part of that approval.
 
 Batch names as approved:
 
 - **Media library `alt_text` lane** (`--batch media`). The
   corrected `media-library-alt_text` surface holds 80 violation rows across 78 unique
   attachments. Media 6835 and 12646 were applied and verified on 2026-08-24.
-  Batch 3 has 71 intended attachments applied and five corrected pending
-  attachments. The 2026-08-25 path-aware authenticated dry run selects 78
-  total targets: 73 `already-applied` including media 6835 and 12646, and five
-  `would-write`. Media 6481 and 8211 are unrelated duplicate-filename
-  attachments and are not targets. Media 6729 and 11774 need rollback.
+  The corrected lane now has 75 intended attachments applied and three
+  pending attachments. The authenticated dry run selects 78 total targets:
+  75 `already-applied` including media 6835 and 12646, and three `would-write`.
+  Media 6481, 8211, 6729, and 11774 are unrelated duplicate-filename
+  attachments and are not targets.
 - **Batch 1 — 34 `post_content` alt insertions** (`--batch content`) across
   seven pages (2543, 2828, 3899, 6755, 6770, 7610, 7764). Applied one page at
   a time and independently verified as 34/34 `already-applied` on 2026-08-24.
+- **Exact content target** (`--only-page-id` plus
+  `--only-content-media-id`). This opts out of broad Batch 1 selection and
+  requires exactly one matching inventory row. It supports both page and post
+  REST resources. The page-6815/media-6835 path is repo-ready but has not been
+  applied and still needs separate live approval.
 
 ## Run it (session with WP_USER + WP_APP_PASSWORD in process env)
 
@@ -34,14 +39,21 @@ cd content/drafts/alt-text-backfill-2026-08-02
 python3 recount_live.py --top-routes-only
 
 # 1. Re-check current state; both commands are read-only without --apply.
-#    The media dry run returns 73 already-applied and 5 would-write targets.
+#    The media dry run returns 75 already-applied and 3 would-write targets.
 python3 apply_batches.py --batch media
 python3 apply_batches.py --batch content
 
-# 2. Historical one-item procedure; use only for an approved future correction.
+# 2. One-item media procedure; use only for an approved future correction.
 python3 apply_batches.py --batch media --only-media-id <id>
 python3 apply_batches.py --batch media --only-media-id <id> --apply
 python3 apply_batches.py --batch media --only-media-id <id>
+
+# 3. Read-only exact post-content check for page 6815 / media 6835.
+python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835
+
+# Run only after separate exact live approval, then repeat the dry run.
+python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835 --apply
+python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835
 ```
 
 Do not use the broad media `--apply` command for Batch 3. Apply one attachment
@@ -60,7 +72,9 @@ dry runs add a cache-busting query parameter.
 Default is dry-run; `--apply` refuses to start without credentials. Exit code
 is 1 when any item is refused, conflicted, or fails readback.
 
-`--only-page-id` / `--only-media-id` stage one target at a time if wanted.
+`--only-page-id` stages one approved Batch 1 page. `--only-media-id` stages one
+media-library target. A content row outside Batch 1 requires the exact paired
+`--only-page-id` and `--only-content-media-id` selectors.
 
 ## Roll back one written target
 
@@ -78,9 +92,9 @@ python3 apply_batches.py --batch media --restore .generated/alt-text-backfill/<r
 python3 apply_batches.py --batch content --restore .generated/alt-text-backfill/<run>/page-3899-before.json
 python3 apply_batches.py --batch content --restore .generated/alt-text-backfill/<run>/page-3899-before.json --apply
 
-# 2026-08-25 identity correction: preview again before any approved restore.
-python3 apply_batches.py --batch media --restore .generated/alt-text-backfill/20260825T033423Z-media-apply/media-6729-before.json
-python3 apply_batches.py --batch media --restore .generated/alt-text-backfill/20260825T033618Z-media-apply/media-11774-before.json
+# An exact content target must repeat both selectors during restore.
+python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835 --restore .generated/alt-text-backfill/<run>/post-6815-before.json
+python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835 --restore .generated/alt-text-backfill/<run>/post-6815-before.json --apply
 ```
 
 Restore requires WordPress credentials even for its dry run. Never restore a
@@ -90,7 +104,7 @@ restore additionally requires the snapshot's sibling apply report to contain
 one exact `written-verified` record, and refuses unless the live ID, upload
 path, and current alt still match that record.
 
-## State as of 2026-08-25
+## State as of 2026-08-28
 
 - Media 6835 and 12646: applied with private mode-0600 snapshots and verified
   by authenticated readback plus cache-bypassed public GET.
@@ -103,14 +117,16 @@ path, and current alt still match that record.
 - Media 5375 was the only reviewed filename-style replacement. PR #901 permits
   it only while the live value exactly matches the recorded inventory baseline;
   its write was exact and snapshotted.
-- Media 6481 and 8211 were correctly not written. The three protected rows
-  actually target attachments 6126, 6985, and 7637.
-- Media 6729 and 11774 were written but are duplicate files from different
-  upload months. The actual targets are 6014 and 8871. A published-content scan
-  found no use of the wrong attachments; both private snapshots contain the
-  prior empty alt, and authenticated restore previews return `would-restore`.
-- The path-aware authenticated media dry run returns 78 targets: 73
-  `already-applied`, five `would-write`, and zero identity failures. Full recount:
-  216/216 routes, zero fetch errors, 1,078
-  violation occurrences / 1,077 unique page-source violations.
+- Media 6481 and 8211 were correctly not written. Media 6729 and 11774 were
+  restored to their prior empty values after exact snapshot and drift checks.
+- Corrected targets 6014 and 6126 are applied and verified. Media 6985, 7637,
+  and 8871 remain unapplied; media 7637's asset-specific proposal was corrected
+  in PR #913.
+- The path-aware authenticated media dry run returns 78 targets: 75
+  `already-applied`, three `would-write`, and zero identity failures. Full recount:
+  216/216 routes, zero fetch errors, 1,076
+  violation occurrences / 1,075 unique page-source violations.
+- The exact authenticated dry run for page 6815 / media 6835 verifies the post
+  ID, slug, URL, one inventory row, and one empty-alt tag; it reports exactly
+  one `would-change`. No page-6815 write has been made.
 - Inventory batches 4-6 remain parked.

--- a/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
+++ b/content/drafts/alt-text-backfill-2026-08-02/apply_batches.py
@@ -10,9 +10,10 @@ Two batches, applied separately, from inventory.csv in this directory:
                    as needs-review and never written (a script must not invent
                    alt text).
   --batch content  Batch 1: the 34 ``post-content-block`` rows across seven
-                   site pages. Inserts each row's ``proposed_alt`` into the
-                   empty ``alt=""`` of the matching image block in the page's
-                   raw ``post_content``, then PATCHes the page.
+                   site pages. An exact page+media selector may instead stage
+                   one reviewed inventory row outside Batch 1. Inserts each
+                   selected ``proposed_alt`` into the empty ``alt=""`` of the
+                   matching image block in raw ``post_content``.
 
 Safety contract (docs/current-state/INCIDENT-2026-05-15-overwritten-post.md):
 
@@ -40,6 +41,7 @@ Usage:
   python3 apply_batches.py --batch content            # dry-run
   python3 apply_batches.py --batch content --apply    # live writes
   python3 apply_batches.py --batch content --only-page-id 3899 --apply
+  python3 apply_batches.py --batch content --only-page-id 6815 --only-content-media-id 6835
   python3 apply_batches.py --batch content --restore <snapshot.json>
   python3 apply_batches.py --batch content --restore <snapshot.json> --apply
 """
@@ -102,19 +104,55 @@ def media_targets(rows: list[dict[str, str]]) -> tuple[list[dict], list[dict]]:
     return list(by_media.values()), needs_review
 
 
-def content_targets(rows: list[dict[str, str]]) -> dict[str, list[dict]]:
-    """Batch-1 rows grouped by page ID. All are pages (tier 2-page)."""
-    batch1 = [r for r in rows if r["batch"] == "batch-1"]
-    for r in batch1:
+def content_targets(
+    rows: list[dict[str, str]],
+    only_page_id: str | None = None,
+    only_content_media_id: str | None = None,
+) -> dict[str, list[dict]]:
+    """Approved Batch-1 rows, or one exact opt-in page+media inventory row."""
+    if only_content_media_id:
+        if not only_page_id:
+            raise SystemExit("--only-content-media-id requires --only-page-id")
+        selected = [
+            r
+            for r in rows
+            if r["page_id"] == only_page_id
+            and r["media_id"] == only_content_media_id
+        ]
+        if len(selected) != 1:
+            raise SystemExit(
+                "expected exactly one inventory row for page "
+                f"{only_page_id} and media {only_content_media_id}; found {len(selected)}"
+            )
+    else:
+        selected = [r for r in rows if r["batch"] == "batch-1"]
+
+    for r in selected:
         if r["fix_surface"] != "post-content-block" or not r["proposed_alt"].strip():
             raise SystemExit(
-                f"unexpected batch-1 row shape for media {r['media_id']} on "
+                f"unexpected content row shape for media {r['media_id']} on "
                 f"{r['page_url']} (fix_surface={r['fix_surface']!r})"
             )
     pages: dict[str, list[dict]] = {}
-    for r in batch1:
+    for r in selected:
         pages.setdefault(r["page_id"], []).append(r)
     return pages
+
+
+def content_resource(page_rows: list[dict[str, str]]) -> str:
+    """Return the WP REST resource after refusing ambiguous inventory shapes."""
+    if not page_rows:
+        raise SystemExit("selected content target has no inventory rows")
+    if all(row["tier"] == "2-page" for row in page_rows):
+        return "pages"
+    dated_post = re.compile(r"/\d{4}/\d{2}/\d{2}/[^/]+/$")
+    if all(
+        row["tier"] != "2-page"
+        and dated_post.fullmatch(urlsplit(row["page_url"]).path) is not None
+        for row in page_rows
+    ):
+        return "posts"
+    raise SystemExit("selected content rows do not identify one unambiguous WP resource")
 
 
 # ---------------------------------------------------------------------------
@@ -349,20 +387,29 @@ def run_media(client: WPClient | None, apply: bool, run_dir: Path, only_id: str 
 
 
 def run_content(
-    client: WPClient | None, apply: bool, run_dir: Path, only_page: str | None
+    client: WPClient | None,
+    apply: bool,
+    run_dir: Path,
+    only_page: str | None,
+    only_content_media: str | None = None,
 ):
-    pages = content_targets(load_rows())
-    if only_page:
+    pages = content_targets(load_rows(), only_page, only_content_media)
+    if only_page and not only_content_media:
         pages = {k: v for k, v in pages.items() if k == only_page}
         if not pages:
             raise SystemExit(f"page {only_page!r} is not in the approved content batch")
     report = {
-        "batch": "content (batch 1)",
+        "batch": (
+            "content (exact inventory target)"
+            if only_content_media
+            else "content (batch 1)"
+        ),
         "mode": "APPLY" if apply else "DRY-RUN",
         "authenticated": client is not None,
         "pages": [],
     }
     for page_id, page_rows in sorted(pages.items(), key=lambda kv: int(kv[0])):
+        resource = content_resource(page_rows)
         expect_slug = page_rows[0]["page_slug"]
         expect_url = page_rows[0]["page_url"].rstrip("/")
         entry = {
@@ -370,13 +417,14 @@ def run_content(
             "expected_slug": expect_slug,
             "page_url": page_rows[0]["page_url"],
             "rows": len(page_rows),
+            "wp_resource": resource,
         }
         if client:
-            live = client.get(f"pages/{page_id}", params={"context": "edit"})
+            live = client.get(f"{resource}/{page_id}", params={"context": "edit"})
             html = live.get("content", {}).get("raw", "")
             surface = "content.raw"
         else:
-            live = public_get(f"pages/{page_id}")
+            live = public_get(f"{resource}/{page_id}")
             html = live.get("content", {}).get("rendered", "")
             surface = "content.rendered (unauthenticated fallback; apply needs raw)"
         live_slug = live.get("slug", "")
@@ -400,7 +448,13 @@ def run_content(
         changed = sum(r["tags_changed"] for r in results)
         blocked = [r for r in results if r["status"] in ("no-match", "conflict")]
         entry["tags_to_change"] = changed
-        if blocked:
+        exact_count_invalid = bool(
+            only_content_media
+            and (len(results) != 1 or results[0]["tags_matched"] != 1)
+        )
+        if exact_count_invalid:
+            entry["status"] = "REFUSED-exact-target-match-count"
+        elif blocked:
             entry["blocked_rows"] = len(blocked)
             entry["status"] = "REFUSED-blocked-rows"
         elif not apply:
@@ -410,10 +464,11 @@ def run_content(
         elif changed == 0:
             entry["status"] = "no-op"
         else:
-            snap = snapshot(run_dir, f"page-{page_id}-before", live)
+            snap = snapshot(run_dir, f"{resource[:-1]}-{page_id}-before", live)
             entry["snapshot"] = str(snap)
-            client.post(f"pages/{page_id}", {"content": new_html})
-            readback = client.get(f"pages/{page_id}", params={"context": "edit"})
+            endpoint = f"{resource}/{page_id}"
+            client.post(endpoint, {"content": new_html})
+            readback = client.get(endpoint, params={"context": "edit"})
             raw = readback.get("content", {}).get("raw", "")
             _, readback_results = apply_rows_to_html(raw, page_rows)
             missing = [
@@ -437,6 +492,8 @@ def run_restore(
     client: WPClient,
     apply: bool,
     run_dir: Path,
+    only_page_id: str | None = None,
+    only_content_media_id: str | None = None,
 ) -> dict:
     try:
         source = source.resolve(strict=True)
@@ -514,7 +571,7 @@ def run_restore(
         payload = {"alt_text": restore_value}
         snapshot_name = f"media-{saved_id}-before-restore"
     else:
-        pages = content_targets(load_rows())
+        pages = content_targets(load_rows(), only_page_id, only_content_media_id)
         page_rows = pages.get(saved_id)
         if page_rows is None:
             raise SystemExit(
@@ -528,7 +585,8 @@ def run_restore(
         restore_value = saved.get("content", {}).get("raw")
         if not isinstance(restore_value, str):
             raise SystemExit(f"snapshot page {saved_id} has no content.raw")
-        live = client.get(f"pages/{saved_id}", params={"context": "edit"})
+        resource = content_resource(page_rows)
+        live = client.get(f"{resource}/{saved_id}", params={"context": "edit"})
         live_link = (live.get("link") or "").rstrip("/")
         if (
             str(live.get("id")) != saved_id
@@ -544,9 +602,9 @@ def run_restore(
             raise SystemExit(
                 f"snapshot page {saved_id} cannot reproduce the approved applied state"
             )
-        endpoint = f"pages/{saved_id}"
+        endpoint = f"{resource}/{saved_id}"
         payload = {"content": restore_value}
-        snapshot_name = f"page-{saved_id}-before-restore"
+        snapshot_name = f"{resource[:-1]}-{saved_id}-before-restore"
 
     if current_value == restore_value:
         item["status"] = "already-restored"
@@ -591,16 +649,29 @@ def main() -> int:
     mode.add_argument("--apply", action="store_true", help="perform live writes")
     ap.add_argument("--only-media-id", help="restrict media batch to one attachment")
     ap.add_argument("--only-page-id", help="restrict content batch to one page")
+    ap.add_argument(
+        "--only-content-media-id",
+        help="with --only-page-id, select one exact post_content inventory row",
+    )
     ap.add_argument("--restore", type=Path, help="restore one pre-write snapshot")
     ap.add_argument("--json", type=Path, help="also write the report to this path")
     args = ap.parse_args()
 
-    if args.batch == "media" and args.only_page_id:
-        raise SystemExit("--only-page-id is a content selector, not a media selector")
+    if args.batch == "media" and (args.only_page_id or args.only_content_media_id):
+        raise SystemExit(
+            "--only-page-id/--only-content-media-id are content selectors, not media selectors"
+        )
     if args.batch == "content" and args.only_media_id:
         raise SystemExit("--only-media-id is a media selector, not a content selector")
-    if args.restore and (args.only_media_id or args.only_page_id):
-        raise SystemExit("--restore cannot be combined with --only-media-id/--only-page-id")
+    if args.only_content_media_id and not args.only_page_id:
+        raise SystemExit("--only-content-media-id requires --only-page-id")
+    if args.restore and args.only_media_id:
+        raise SystemExit("--restore cannot be combined with --only-media-id")
+    if args.restore and args.only_page_id and not args.only_content_media_id:
+        raise SystemExit(
+            "--restore with a content selector requires both --only-page-id and "
+            "--only-content-media-id"
+        )
 
     client = make_client()
     if args.restore and client is None:
@@ -617,11 +688,25 @@ def main() -> int:
 
     if args.restore:
         assert client is not None
-        report = run_restore(args.batch, args.restore, client, args.apply, run_dir)
+        report = run_restore(
+            args.batch,
+            args.restore,
+            client,
+            args.apply,
+            run_dir,
+            args.only_page_id,
+            args.only_content_media_id,
+        )
     elif args.batch == "media":
         report = run_media(client, args.apply, run_dir, args.only_media_id)
     else:
-        report = run_content(client, args.apply, run_dir, args.only_page_id)
+        report = run_content(
+            client,
+            args.apply,
+            run_dir,
+            args.only_page_id,
+            args.only_content_media_id,
+        )
 
     out = json.dumps(report, indent=2, ensure_ascii=False)
     print(out)

--- a/docs/current-state/WORK-PLAN-2026-08-25.md
+++ b/docs/current-state/WORK-PLAN-2026-08-25.md
@@ -125,10 +125,10 @@ Acceptance:
 
 ## What remains after these sessions
 
-1. Repo-only correction and review of the media-7637 proposal, followed by a
-   separate approval-gated apply for remaining targets 6985, 7637, and 8871.
-2. A tested post-aware one-row apply path and separate live approval for the
-   page-6815 media-6835 block.
+1. A separate approval-gated apply for remaining media targets 6985, 7637, and
+   8871; the media-7637 repo proposal is corrected and reviewed.
+2. Separate live approval for the page-6815 media-6835 block; its tested,
+   post-aware one-row apply and rollback path is repo-ready.
 3. Visual review and exact proposals for the 18 missing-alt-attribute images.
 4. KK's archive-scope decision for issue #4 batches 4-6 (~1,070 images): all,
    traffic-prioritized, or permanently parked.

--- a/scripts/tests/test_alt_text_apply_batches.py
+++ b/scripts/tests/test_alt_text_apply_batches.py
@@ -32,6 +32,7 @@ def content_row(
     return {
         "batch": "batch-1",
         "fix_surface": "post-content-block",
+        "tier": "2-page",
         "page_id": "3899",
         "page_slug": "about",
         "page_url": "https://kriskrug.co/about/",
@@ -467,6 +468,152 @@ class AltTextApplyBatchSafetyTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "not in the approved content batch"):
                 MODULE.run_content(None, False, self.run_dir, "999")
 
+    def test_content_target_selects_exact_page_and_media_outside_batch_one(self):
+        pages = MODULE.content_targets(MODULE.load_rows(), "6815", "6835")
+
+        self.assertEqual(list(pages), ["6815"])
+        self.assertEqual(len(pages["6815"]), 1)
+        self.assertEqual(pages["6815"][0]["media_id"], "6835")
+        self.assertEqual(
+            pages["6815"][0]["proposed_alt"],
+            "Vancouver AI meetup crowd standing shoulder to shoulder under magenta "
+            "light, watching something off frame",
+        )
+
+    def test_content_target_changes_only_the_exact_selected_image(self):
+        target = content_row("6835", "crowd-shot-vancovuer-ai-1024x683.jpeg", "Crowd alt")
+        target.update(
+            {
+                "batch": "batch-2",
+                "tier": "4-archive-sample",
+                "page_id": "6815",
+                "page_slug": "august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics",
+                "page_url": (
+                    "https://kriskrug.co/2024/09/01/"
+                    "august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics/"
+                ),
+            }
+        )
+        sibling = {**target, "batch": "batch-5", "media_id": "999", "image_file": "other.jpg"}
+        sibling["image_src"] = "https://kriskrug.co/wp-content/uploads/other.jpg"
+        original_html = (
+            '<img class="wp-image-6835" src="crowd-shot-vancovuer-ai-1024x683.jpeg" alt="">'
+            '<img class="wp-image-999" src="other.jpg" alt="">'
+        )
+        changed_html = original_html.replace(
+            'src="crowd-shot-vancovuer-ai-1024x683.jpeg" alt=""',
+            'src="crowd-shot-vancovuer-ai-1024x683.jpeg" alt="Crowd alt"',
+        )
+
+        def record(raw: str) -> dict:
+            return {
+                "id": 6815,
+                "slug": target["page_slug"],
+                "link": target["page_url"],
+                "status": "publish",
+                "content": {"raw": raw},
+            }
+
+        client = FakeClient([record(original_html), record(changed_html)])
+        with mock.patch.object(MODULE, "load_rows", return_value=[target, sibling]):
+            report = MODULE.run_content(
+                client, True, self.run_dir, "6815", "6835"
+            )
+
+        self.assertEqual(
+            client.posts,
+            [("posts/6815", {"content": changed_html})],
+        )
+        self.assertEqual(report["pages"][0]["rows"], 1)
+        self.assertEqual(report["pages"][0]["status"], "written-verified")
+
+    def test_content_media_selector_requires_exactly_one_page_row(self):
+        row = content_row("6835", "crowd.jpg", "Crowd alt")
+
+        with self.assertRaisesRegex(SystemExit, "requires --only-page-id"):
+            MODULE.content_targets([row], None, "6835")
+        with self.assertRaisesRegex(SystemExit, "expected exactly one inventory row"):
+            MODULE.content_targets([row, row.copy()], "3899", "6835")
+
+    def test_exact_content_target_refuses_multiple_matching_tags(self):
+        row = content_row("6835", "crowd.jpg", "Crowd alt")
+        row.update(
+            {
+                "batch": "batch-2",
+                "tier": "4-archive-sample",
+                "page_id": "6815",
+                "page_slug": "meetup-recap",
+                "page_url": "https://kriskrug.co/2024/09/01/meetup-recap/",
+            }
+        )
+        live = {
+            "id": 6815,
+            "slug": "meetup-recap",
+            "link": row["page_url"],
+            "status": "publish",
+            "content": {
+                "raw": (
+                    '<img class="wp-image-6835" src="crowd.jpg" alt="">'
+                    '<img class="wp-image-6835" src="crowd.jpg" alt="">'
+                )
+            },
+        }
+        client = FakeClient([live, live])
+
+        with mock.patch.object(MODULE, "load_rows", return_value=[row]):
+            report = MODULE.run_content(
+                client, True, self.run_dir, "6815", "6835"
+            )
+
+        self.assertEqual(client.posts, [])
+        self.assertEqual(
+            report["pages"][0]["status"], "REFUSED-exact-target-match-count"
+        )
+
+    def test_targeted_post_restore_uses_the_post_endpoint(self):
+        row = content_row("6835", "crowd.jpg", "Crowd alt")
+        row.update(
+            {
+                "batch": "batch-2",
+                "tier": "4-archive-sample",
+                "page_id": "6815",
+                "page_slug": "meetup-recap",
+                "page_url": "https://kriskrug.co/2024/09/01/meetup-recap/",
+            }
+        )
+        original = {
+            "id": 6815,
+            "slug": "meetup-recap",
+            "link": row["page_url"],
+            "status": "publish",
+            "content": {"raw": '<img class="wp-image-6835" src="crowd.jpg" alt="">'},
+        }
+        applied = copy.deepcopy(original)
+        applied["content"]["raw"] = (
+            '<img class="wp-image-6835" src="crowd.jpg" alt="Crowd alt">'
+        )
+        source = MODULE.snapshot(
+            self.run_dir / "source", "post-6815-before", original
+        )
+        client = FakeClient([applied, original])
+
+        with mock.patch.object(MODULE, "load_rows", return_value=[row]):
+            report = MODULE.run_restore(
+                "content",
+                source,
+                client,
+                True,
+                self.run_dir / "restore",
+                "6815",
+                "6835",
+            )
+
+        self.assertEqual(
+            client.posts,
+            [("posts/6815", {"content": original["content"]["raw"]})],
+        )
+        self.assertEqual(report["items"][0]["status"], "restored-verified")
+
     def test_proposed_alt_rejects_html_markup(self):
         with self.assertRaisesRegex(SystemExit, "HTML markup"):
             MODULE.set_tag_alt(
@@ -477,6 +624,14 @@ class AltTextApplyBatchSafetyTests(unittest.TestCase):
         cases = [
             (["--batch", "media", "--only-page-id", "3899"], "content selector"),
             (["--batch", "content", "--only-media-id", "100"], "media selector"),
+            (
+                ["--batch", "media", "--only-content-media-id", "100"],
+                "content selector",
+            ),
+            (
+                ["--batch", "content", "--only-content-media-id", "100"],
+                "requires --only-page-id",
+            ),
         ]
         for arguments, message in cases:
             with self.subTest(arguments=arguments):


### PR DESCRIPTION
## Summary
- add an exact page+media selector for one reviewed post-content inventory row
- route dated WordPress posts through the posts REST resource and preserve exact rollback support
- refuse ambiguous inventory rows and any live match count other than one
- refresh the issue #4 runbook and current work plan

## Safety
- default remains dry-run
- existing Batch 1 selection is unchanged
- no live WordPress writes were made
- authenticated dry-run for post 6815/media 6835 verified the exact ID, slug, URL, raw-content match, and one would-change tag

## Verification
- `python -m unittest scripts.tests.test_alt_text_apply_batches` (27 passed)
- `make verify` (579 operational, 12 SEO inventory, 68 SEO/link-safety, plugin/theme/docs/PHP/PHPCS green)

Relates to #4.