### PR TITLE
[CONTENT] Prepare Most Benevolent Outcomes link pack

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/README.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/README.md
@@ -26,7 +26,8 @@ Three files:
 | `fix-827/` | #827 | Applied and verified 2026-08-18; see `docs/current-state/reports/issue-827-applied-20260818.md` |
 | `fix-828/` | #828 | Drafted and dry-run verified; Kris voice review and a fresh live approval remain |
 | `fix-829/` to `fix-832/` | #829-#832 | Prepared only; each needs its own live approval |
-| No pack yet | #833-#834 | Issue scope only; #834 remains blocked on #829 and #833 |
+| `fix-833/` | #833 | Prepared only; needs its own live approval before #834 can be recut |
+| No pack yet | #834 | Issue scope only; remains blocked on #829 and #833 |
 
 ## Method
 

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-833/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-833/APPLY.md
@@ -1,0 +1,66 @@
+# #833 APPLY: Most Benevolent Outcomes links
+
+**Prepared, not applied. No live write has been made.** This pack needs a fresh explicit live approval before any single-item `--apply` command.
+
+Parent: #402. This is child 8 of 9. It owns six exact links across five objects and writes content only.
+
+## Order and boundaries
+
+- #826 must remain live: post 3814 must be in AI Ethics category 1678 and out of category 1757. The script checks this before every live dry-run, apply, and restore.
+- Apply #833 before #834. Both touch post 11700, and #834 must rebase its exact selector after #833 is verified live.
+- Do not recategorize post 3814, create a spiritual hub, alter titles, schema, theme files, or the collection footer.
+- Do not touch #834's glossary link on post 11700. The script preserves the existing `/glossary/` href count.
+- Do not close #833, #402, or #339 when this repo-only pack merges.
+
+## Exact write set
+
+| Row | Object | Exact anchor | Destination |
+|---:|---|---|---|
+| 1 | page 3948 | `there is a prayer I actually say about this` | post 3814 |
+| 2 | post 11936 | `I say a prayer about this most mornings, which is either funny or the whole point` | post 3814 |
+| 3 | post 11358 | `I have my own version of the seance` | post 3814 |
+| 4 | post 11700 | `the optimistic version of the same argument` | post 3814 |
+| 5 | post 3814 | `the rest of my lens, written out plainly` | `/the-kk-worldview/` |
+| 6 | post 3814 | `the less mystical version of this, which is how I actually practice it` | `/ai-ethics/` |
+
+Every live object is pinned by ID, slug, status, date, title, and categories where applicable. A missing or duplicate insertion marker aborts. Existing exact anchors are skipped.
+
+## Commands
+
+```bash
+python3 -m unittest scripts.tests.test_apply_issue_833_mbo_links
+
+# Offline validation. No credentials or network.
+python3 scripts/apply_issue_833_mbo_links.py --from-spec
+
+# Authenticated live GET dry-run. No snapshot and no write.
+make varlock-run CMD='python3 scripts/apply_issue_833_mbo_links.py'
+
+# Only after reviewing the dry-run and giving fresh explicit live approval.
+# Apply one object at a time, then independently verify it before continuing.
+make varlock-run CMD='python3 scripts/apply_issue_833_mbo_links.py --apply --item-id 3948'
+```
+
+`--apply` refuses without exactly one `--item-id`. The payload contains only `content`. Immediately before writing, the script refetches the object, revalidates its identity, and recomputes the transform. It writes a private mode-0600 snapshot, sends one content update, and checks an independent authenticated `content.raw` readback.
+
+## Rollback
+
+Snapshots live under `backup/issue-833-mbo-links/` and are excluded from Git.
+
+```bash
+# Dry-run the restore first.
+make varlock-run CMD='python3 scripts/apply_issue_833_mbo_links.py --restore backup/issue-833-mbo-links/rest-page-3948-before-<stamp>.json'
+
+# A restore is also a live write and needs fresh explicit live approval.
+make varlock-run CMD='python3 scripts/apply_issue_833_mbo_links.py --restore backup/issue-833-mbo-links/rest-page-3948-before-<stamp>.json --apply'
+```
+
+Restore refuses snapshots outside the five-object #833 write set, revalidates the snapshot and current live identity, snapshots the current state, restores content only, and checks authenticated readback.
+
+## After each approved apply
+
+1. Run the same item dry-run and expect `[SKIP]`.
+2. Read the target page logged out and confirm the exact anchor once.
+3. Confirm the collection footer still appears once on posts.
+4. On post 11700, confirm the `/glossary/` href count is unchanged. Then and only then recut #834's selector.
+5. Record the snapshot path and verification result on #833. Keep it open until all five objects are live and verified.

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-833/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-833/targets.json
@@ -1,0 +1,119 @@
+{
+  "issue": 833,
+  "parent": 402,
+  "blocked_by": 826,
+  "status": "prepared_not_applied",
+  "dependency_gate": {
+    "id": 3814,
+    "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+    "status": "publish",
+    "required_category": 1678,
+    "forbidden_category": 1757
+  },
+  "items": [
+    {
+      "id": 3948,
+      "kind": "pages",
+      "slug": "the-kk-worldview",
+      "status": "publish",
+      "date": "2023-11-03T07:47:30",
+      "title": "The KK Worldview",
+      "operations": [
+        {
+          "row": 1,
+          "text": "there is a prayer I actually say about this",
+          "href": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+          "find": "<!-- /wp:list -->\n\n<!-- wp:paragraph -->\n<p>This is but one lens",
+          "replace": "<!-- /wp:list -->\n\n<!-- wp:paragraph -->\n<p>If you want the spiritual version, <a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">there is a prayer I actually say about this</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>This is but one lens"
+        }
+      ]
+    },
+    {
+      "id": 11936,
+      "kind": "posts",
+      "slug": "you-cant-drink-data",
+      "status": "publish",
+      "date": "2026-05-23T15:00:00",
+      "title": "You Can't Drink Data",
+      "categories": [1678],
+      "operations": [
+        {
+          "row": 2,
+          "text": "I say a prayer about this most mornings, which is either funny or the whole point",
+          "href": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+          "find": "I've never believed that. So I laced up and went downtown to march.</p>",
+          "replace": "I've never believed that. So I laced up and went downtown to march. <a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">I say a prayer about this most mornings, which is either funny or the whole point</a>.</p>"
+        }
+      ]
+    },
+    {
+      "id": 11358,
+      "kind": "posts",
+      "slug": "spa-at-the-end-of-time",
+      "status": "publish",
+      "date": "2026-02-20T09:36:35",
+      "title": "Spa at the End of Time",
+      "categories": [1678],
+      "preserve_footer": true,
+      "operations": [
+        {
+          "row": 3,
+          "text": "I have my own version of the seance",
+          "href": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+          "kind": "append_to_paragraph",
+          "find": "voiced like a medium receiving transmissions",
+          "append_html": " <a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">I have my own version of the seance</a>."
+        }
+      ]
+    },
+    {
+      "id": 11700,
+      "kind": "posts",
+      "slug": "punk-rock-ai",
+      "status": "publish",
+      "date": "2026-05-04T10:18:11",
+      "title": "Punk Rock AI",
+      "categories": [1678],
+      "preserve_footer": true,
+      "preserve_href_counts": [
+        "/glossary/"
+      ],
+      "operations": [
+        {
+          "row": 4,
+          "text": "the optimistic version of the same argument",
+          "href": "https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/",
+          "find": "The lifeboat is the posse. Room for one more.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->",
+          "replace": "The lifeboat is the posse. Room for one more.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>If you want <a href=\"https://kriskrug.co/2023/11/04/the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things/\">the optimistic version of the same argument</a>, read the prayer I say most mornings.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->"
+        }
+      ]
+    },
+    {
+      "id": 3814,
+      "kind": "posts",
+      "slug": "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+      "status": "publish",
+      "date": "2023-11-04T05:39:20",
+      "title": "Most Benevolent Outcomes Prayer for AI & All Living Things",
+      "categories": [1678],
+      "preserve_footer": true,
+      "operations": [
+        {
+          "row": 5,
+          "text": "the rest of my lens, written out plainly",
+          "href": "https://kriskrug.co/the-kk-worldview/",
+          "find": "<p>This prayer was shared with me by a friend this summer and I've been able to share it with many others since then.</p>",
+          "replace": "<p>This prayer was shared with me by a friend this summer and I've been able to share it with many others since then. You can read <a href=\"https://kriskrug.co/the-kk-worldview/\">the rest of my lens, written out plainly</a> on the worldview page.</p>"
+        },
+        {
+          "row": 6,
+          "text": "the less mystical version of this, which is how I actually practice it",
+          "href": "https://kriskrug.co/ai-ethics/",
+          "kind": "append_to_paragraph",
+          "find": "May our MBOs help us navigate these unknown waters",
+          "append_html": " For <a href=\"https://kriskrug.co/ai-ethics/\">the less mystical version of this, which is how I actually practice it</a>, start with the AI ethics hub."
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/apply_issue_833_mbo_links.py
+++ b/scripts/apply_issue_833_mbo_links.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Prepare or apply the six issue #833 MBO links.
+
+Dry-run by default. Live writes are single-item only and use exact identity,
+dependency, snapshot, content-only payload, and authenticated readback gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACK = REPO_ROOT / "content/drafts/2026-08-02-seo-authority-hubs/fix-833"
+TARGETS_PATH = PACK / "targets.json"
+SNAPSHOT_DIR = REPO_ROOT / "backup" / "issue-833-mbo-links"
+BASE_URL = "https://kriskrug.co"
+FOOTER_OPEN = '<!-- wp:paragraph {"className":"kk-collection-footer"} -->'
+
+
+def load_targets() -> dict:
+    return json.loads(TARGETS_PATH.read_text(encoding="utf-8"))
+
+
+def auth_header() -> str:
+    user = os.getenv("WP_API_USERNAME") or os.getenv("WP_USER")
+    password = os.getenv("WP_API_PASSWORD") or os.getenv("WP_APP_PASSWORD")
+    if not user or not password:
+        sys.exit("[ABORT] WordPress credentials unresolved. Run through Varlock.")
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+def request(url: str, header: str, payload: dict | None = None) -> dict:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Authorization": header, "User-Agent": "kriskrug-ops/issue-833"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        url, data=data, headers=headers, method="POST" if data else "GET"
+    )
+    with urllib.request.urlopen(req, timeout=90) as response:
+        return json.load(response)
+
+
+def anchor_html(operation: dict) -> str:
+    return f'<a href="{operation["href"]}">{operation["text"]}</a>'
+
+
+def inserted_fragment(operation: dict) -> str:
+    if operation.get("kind") == "append_to_paragraph":
+        return operation["append_html"]
+    find = operation["find"]
+    replace = operation["replace"]
+    prefix_length = 0
+    for before, after in zip(find, replace):
+        if before != after:
+            break
+        prefix_length += 1
+    find_rest = find[prefix_length:]
+    replace_rest = replace[prefix_length:]
+    while find_rest and replace_rest and find_rest[-1] == replace_rest[-1]:
+        find_rest = find_rest[:-1]
+        replace_rest = replace_rest[:-1]
+    return replace_rest
+
+
+def fixture_body(spec: dict) -> str:
+    parts = []
+    if spec.get("preserve_href_counts"):
+        parts.append('<p><a href="https://kriskrug.co/glossary/">Glossary</a></p>')
+    for operation in spec["operations"]:
+        if operation.get("kind") == "append_to_paragraph":
+            parts.append(f"<p>Before <strong>{operation['find']}</strong> after.</p>")
+        else:
+            parts.append(operation["find"])
+    if spec["id"] == 3948:
+        parts.append(" in a much larger story.</p>")
+    if spec["id"] == 3814:
+        parts.append('<h3 class="wp-block-heading">How To Practice MBOs</h3>')
+    if spec.get("preserve_footer"):
+        if FOOTER_OPEN not in "\n".join(parts):
+            parts.append(FOOTER_OPEN)
+        parts.extend(
+            [
+                '<p class="kk-collection-footer">Footer</p>',
+                "<!-- /wp:paragraph -->",
+            ]
+        )
+    return "\n".join(parts)
+
+
+def rewrite_operation(body: str, operation: dict, item_id: int) -> str:
+    find = operation["find"]
+    count = body.count(find)
+    if count != 1:
+        raise ValueError(
+            f"{item_id}: row {operation['row']} marker occurs {count} times; expected 1"
+        )
+    if operation.get("kind") != "append_to_paragraph":
+        return body.replace(find, operation["replace"], 1)
+    marker_at = body.index(find)
+    paragraph_at = body.rfind("<p", 0, marker_at)
+    paragraph_end = body.find("</p>", marker_at)
+    if paragraph_at < 0 or paragraph_end < 0:
+        raise ValueError(
+            f"{item_id}: row {operation['row']} paragraph boundary missing"
+        )
+    return body[:paragraph_end] + operation["append_html"] + body[paragraph_end:]
+
+
+def rewrite_body(body: str, spec: dict) -> str | None:
+    original = body
+    rewritten = body
+    changed = False
+    for operation in spec["operations"]:
+        anchor = anchor_html(operation)
+        anchor_count = rewritten.count(anchor)
+        if anchor_count == 1:
+            continue
+        if anchor_count != 0:
+            raise ValueError(
+                f"{spec['id']}: row {operation['row']} anchor occurs {anchor_count} times"
+            )
+        added = inserted_fragment(operation)
+        if "\u2014" in added or "\u2013" in added:
+            raise ValueError(
+                f"{spec['id']}: row {operation['row']} adds a dash codepoint"
+            )
+        rewritten = rewrite_operation(rewritten, operation, spec["id"])
+        if rewritten.count(anchor) != 1:
+            raise ValueError(
+                f"{spec['id']}: row {operation['row']} anchor count is not 1"
+            )
+        changed = True
+    if not changed:
+        return None
+    if spec.get("preserve_footer"):
+        if original.count(FOOTER_OPEN) != 1 or rewritten.count(FOOTER_OPEN) != 1:
+            raise ValueError(f"{spec['id']}: collection footer structure drifted")
+        original_footer = original[original.index(FOOTER_OPEN) :]
+        rewritten_footer = rewritten[rewritten.index(FOOTER_OPEN) :]
+        if original_footer != rewritten_footer:
+            raise ValueError(f"{spec['id']}: collection footer content changed")
+        footer_at = rewritten.find(FOOTER_OPEN)
+        for operation in spec["operations"]:
+            if rewritten.find(anchor_html(operation)) > footer_at:
+                raise ValueError(
+                    f"{spec['id']}: row {operation['row']} landed after footer"
+                )
+    for href in spec.get("preserve_href_counts") or []:
+        if original.count(href) != rewritten.count(href):
+            raise ValueError(f"{spec['id']}: {href} href count changed")
+    if spec["id"] == 3814:
+        ethics_at = rewritten.find(spec["operations"][1]["text"])
+        heading_at = rewritten.find("How To Practice MBOs")
+        if heading_at >= 0 and ethics_at > heading_at:
+            raise ValueError("3814: AI ethics link landed after How To Practice MBOs")
+    return rewritten
+
+
+def raw_body(item: dict) -> str:
+    content = item.get("content")
+    body = content.get("raw") if isinstance(content, dict) else None
+    if not isinstance(body, str):
+        sys.exit(f"[ABORT] {item.get('id')}: content.raw missing from context=edit")
+    return body
+
+
+def validate_identity(live: dict, spec: dict) -> None:
+    for field in ("id", "slug", "status", "date"):
+        if live.get(field) != spec[field]:
+            sys.exit(
+                f"[ABORT] {spec['id']}: {field} is {live.get(field)!r}, "
+                f"expected {spec[field]!r}."
+            )
+    title = live.get("title") or {}
+    observed_title = title.get("raw") or title.get("rendered")
+    if observed_title != spec["title"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: title is {observed_title!r}, expected {spec['title']!r}."
+        )
+    if "categories" in spec and live.get("categories") != spec["categories"]:
+        sys.exit(
+            f"[ABORT] {spec['id']}: categories is {live.get('categories')!r}, "
+            f"expected {spec['categories']!r}."
+        )
+
+
+def rest_url(spec: dict) -> str:
+    return f"{BASE_URL}/wp-json/wp/v2/{spec['kind']}/{spec['id']}?context=edit"
+
+
+def fetch_live(spec: dict, header: str) -> dict:
+    return request(rest_url(spec), header)
+
+
+def assert_dependency_live(header: str, targets: dict) -> None:
+    gate = targets["dependency_gate"]
+    live = request(
+        f"{BASE_URL}/wp-json/wp/v2/posts/{gate['id']}"
+        "?_fields=id,slug,status,categories",
+        header,
+    )
+    categories = list(live.get("categories") or [])
+    if (
+        live.get("id") != gate["id"]
+        or live.get("slug") != gate["slug"]
+        or live.get("status") != gate["status"]
+        or gate["required_category"] not in categories
+        or gate["forbidden_category"] in categories
+    ):
+        sys.exit(f"[ABORT] #826 dependency is not live: observed {live!r}")
+
+
+def write_snapshot(item: dict, stamp: str) -> Path:
+    SNAPSHOT_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SNAPSHOT_DIR.chmod(0o700)
+    kind = "page" if item.get("type") == "page" else "post"
+    path = SNAPSHOT_DIR / f"rest-{kind}-{item['id']}-before-{stamp}.json"
+    temporary = path.with_suffix(".json.tmp")
+    serialized = json.dumps(item, indent=2, ensure_ascii=False)
+    json.loads(serialized)
+    created = False
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        created = True
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        if json.loads(temporary.read_text(encoding="utf-8")) != item:
+            raise ValueError("snapshot readback differs from source")
+        temporary.chmod(0o600)
+        os.link(temporary, path)
+    except (OSError, ValueError) as exc:
+        sys.exit(f"[ABORT] snapshot creation failed for {path}: {exc}")
+    finally:
+        if created:
+            temporary.unlink(missing_ok=True)
+    print(f"[SNAPSHOT] {path}")
+    return path
+
+
+def plan_item(spec: dict, body: str) -> dict | None:
+    try:
+        after = rewrite_body(body, spec)
+    except ValueError as exc:
+        sys.exit(f"[ABORT] {exc}")
+    if after is None:
+        print(f"[SKIP] {spec['id']}: all exact #833 anchors already present")
+        return None
+    return {"spec": spec, "before": body, "after": after}
+
+
+def print_plan(item: dict) -> None:
+    spec = item["spec"]
+    print(
+        f"[PLAN] {spec['kind']}/{spec['id']} {spec['slug']}: "
+        f"{len(item['before'])} chars -> {len(item['after'])} chars"
+    )
+    for operation in spec["operations"]:
+        print(
+            f"        row {operation['row']}: {operation['text']!r} -> "
+            f"{operation['href']}"
+        )
+
+
+def apply_item(item: dict, header: str, stamp: str) -> None:
+    spec = item["spec"]
+    fresh = fetch_live(spec, header)
+    validate_identity(fresh, spec)
+    replanned = plan_item(spec, raw_body(fresh))
+    if replanned is None:
+        return
+    write_snapshot(fresh, stamp)
+    updated = request(rest_url(spec), header, {"content": replanned["after"]})
+    validate_identity(updated, spec)
+    readback = fetch_live(spec, header)
+    validate_identity(readback, spec)
+    if raw_body(readback) != replanned["after"]:
+        sys.exit(f"[ABORT] {spec['id']}: authenticated readback differs from payload")
+    print(f"[WROTE] {spec['id']} and verified content.raw readback")
+
+
+def restore_snapshot(path: Path, header: str, do_apply: bool, targets: dict) -> None:
+    snapshot = json.loads(path.read_text(encoding="utf-8"))
+    item_id = snapshot.get("id")
+    rows = [row for row in targets["items"] if row["id"] == item_id]
+    if not rows:
+        sys.exit(f"[ABORT] snapshot id {item_id} is not in the #833 write set")
+    spec = rows[0]
+    validate_identity(snapshot, spec)
+    print(f"[RESTORE] {item_id} from {path}")
+    if not do_apply:
+        print("[DRY-RUN] no WordPress restore write")
+        return
+    fresh = fetch_live(spec, header)
+    validate_identity(fresh, spec)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    write_snapshot(fresh, stamp)
+    request(rest_url(spec), header, {"content": raw_body(snapshot)})
+    readback = fetch_live(spec, header)
+    validate_identity(readback, spec)
+    if raw_body(readback) != raw_body(snapshot):
+        sys.exit(f"[ABORT] {item_id}: restore readback differs from snapshot")
+    print(f"[WROTE] {item_id} restored and verified")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply issue #833 MBO links safely.")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--from-spec", action="store_true")
+    parser.add_argument("--item-id", type=int)
+    parser.add_argument("--restore", type=Path)
+    args = parser.parse_args()
+    targets = load_targets()
+
+    if args.apply and args.item_id is None and args.restore is None:
+        sys.exit("[ABORT] --apply requires one exact --item-id")
+
+    if args.from_spec:
+        for spec in targets["items"]:
+            planned = plan_item(spec, fixture_body(spec))
+            if planned is None:
+                sys.exit(f"[ABORT] {spec['id']}: fixture unexpectedly already applied")
+            print_plan(planned)
+        print("[FROM-SPEC] all five transforms valid. No network or WordPress writes.")
+        return 0
+
+    header = auth_header()
+    assert_dependency_live(header, targets)
+
+    if args.restore:
+        restore_snapshot(args.restore, header, args.apply, targets)
+        return 0
+
+    rows = targets["items"]
+    if args.item_id is not None:
+        rows = [row for row in rows if row["id"] == args.item_id]
+        if not rows:
+            sys.exit(f"[ABORT] unknown --item-id {args.item_id}")
+
+    planned = []
+    for spec in rows:
+        live = fetch_live(spec, header)
+        validate_identity(live, spec)
+        item = plan_item(spec, raw_body(live))
+        if item is not None:
+            planned.append(item)
+            print_plan(item)
+
+    if not planned:
+        print("[OK] nothing pending")
+        return 0
+
+    if not args.apply:
+        print(
+            "[DRY-RUN] no WordPress writes. Fresh explicit live approval is required."
+        )
+        return 0
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    apply_item(planned[0], header, stamp)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_apply_issue_833_mbo_links.py
+++ b/scripts/tests/test_apply_issue_833_mbo_links.py
@@ -1,0 +1,251 @@
+"""Offline safety tests for the issue #833 MBO link package."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "apply_issue_833_mbo_links.py"
+SPEC = importlib.util.spec_from_file_location("apply_issue_833_mbo_links", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+TARGETS = MODULE.load_targets()
+
+
+def spec_by_id(item_id: int) -> dict:
+    return next(row for row in TARGETS["items"] if row["id"] == item_id)
+
+
+def fake_item(spec: dict, *, raw: str | None = None, slug: str | None = None) -> dict:
+    item = {
+        "id": spec["id"],
+        "slug": slug or spec["slug"],
+        "status": spec["status"],
+        "date": spec["date"],
+        "title": {"raw": spec["title"]},
+        "type": "page" if spec["kind"] == "pages" else "post",
+        "content": {"raw": raw if raw is not None else MODULE.fixture_body(spec)},
+    }
+    if "categories" in spec:
+        item["categories"] = list(spec["categories"])
+    return item
+
+
+def run_main(*args: str) -> int:
+    with (
+        mock.patch.object(sys, "argv", ["apply_issue_833_mbo_links.py", *args]),
+        mock.patch.object(MODULE, "auth_header", return_value="Basic offline-test"),
+    ):
+        return MODULE.main()
+
+
+class ApplyIssue833MboLinksTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.tmp_path = Path(self.tempdir.name)
+        self.lives = {row["id"]: fake_item(row) for row in TARGETS["items"]}
+        self.dependency = {
+            "id": 3814,
+            "slug": spec_by_id(3814)["slug"],
+            "status": "publish",
+            "categories": [1678],
+        }
+
+    def _patch_request(self, calls):
+        def fake_request(url, _header, payload=None):
+            calls.append((url, payload))
+            if "_fields=id,slug,status,categories" in url:
+                return json.loads(json.dumps(self.dependency))
+            kind = "pages" if "/pages/" in url else "posts"
+            item_id = int(url.split(f"/{kind}/")[1].split("?")[0])
+            live = json.loads(json.dumps(self.lives[item_id]))
+            if payload is not None:
+                live["content"] = {"raw": payload["content"]}
+                self.lives[item_id] = live
+            return live
+
+        return fake_request
+
+    def test_targets_cover_rows_one_through_six_and_exact_identities(self):
+        self.assertEqual(
+            [row["id"] for row in TARGETS["items"]],
+            [3948, 11936, 11358, 11700, 3814],
+        )
+        self.assertEqual(spec_by_id(3948)["slug"], "the-kk-worldview")
+        self.assertEqual(spec_by_id(11936)["slug"], "you-cant-drink-data")
+        self.assertEqual(spec_by_id(11358)["slug"], "spa-at-the-end-of-time")
+        self.assertEqual(spec_by_id(11700)["slug"], "punk-rock-ai")
+        self.assertEqual(
+            spec_by_id(3814)["slug"],
+            "the-power-of-most-benevolent-outcomes-a-prayer-for-blessings-for-all-living-things",
+        )
+        self.assertTrue(all(row["status"] == "publish" for row in TARGETS["items"]))
+        anchors = [
+            (operation["row"], operation["text"], operation["href"])
+            for spec in TARGETS["items"]
+            for operation in spec["operations"]
+        ]
+        self.assertEqual([row for row, _, _ in anchors], [1, 2, 3, 4, 5, 6])
+        self.assertEqual(
+            [text for _, text, _ in anchors],
+            [
+                "there is a prayer I actually say about this",
+                "I say a prayer about this most mornings, which is either funny or the whole point",
+                "I have my own version of the seance",
+                "the optimistic version of the same argument",
+                "the rest of my lens, written out plainly",
+                "the less mystical version of this, which is how I actually practice it",
+            ],
+        )
+
+    def test_each_fixture_rewrites_exactly_once_and_is_idempotent(self):
+        for spec in TARGETS["items"]:
+            with self.subTest(item_id=spec["id"]):
+                before = MODULE.fixture_body(spec)
+                after = MODULE.rewrite_body(before, spec)
+                self.assertIsNotNone(after)
+                for operation in spec["operations"]:
+                    self.assertEqual(after.count(MODULE.anchor_html(operation)), 1)
+                    self.assertNotIn("\u2014", MODULE.inserted_fragment(operation))
+                    self.assertNotIn("\u2013", MODULE.inserted_fragment(operation))
+                self.assertIsNone(MODULE.rewrite_body(after, spec))
+
+    def test_worldview_paragraph_lands_after_truth_list(self):
+        spec = spec_by_id(3948)
+        after = MODULE.rewrite_body(MODULE.fixture_body(spec), spec)
+        self.assertLess(
+            after.find("<!-- /wp:list -->"), after.find(spec["operations"][0]["text"])
+        )
+        self.assertLess(
+            after.find(spec["operations"][0]["text"]),
+            after.find("This is but one lens"),
+        )
+
+    def test_punk_rock_insert_is_final_paragraph_and_preserves_glossary_surface(self):
+        spec = spec_by_id(11700)
+        before = MODULE.fixture_body(spec)
+        after = MODULE.rewrite_body(before, spec)
+        anchor_at = after.find("the optimistic version of the same argument")
+        footer_at = after.find(MODULE.FOOTER_OPEN)
+        self.assertLess(anchor_at, footer_at)
+        self.assertEqual(before.count("/glossary/"), after.count("/glossary/"))
+        self.assertIn("Room for one more.</p>", after)
+
+    def test_3814_partial_state_adds_only_missing_row(self):
+        spec = spec_by_id(3814)
+        before = MODULE.fixture_body(spec)
+        row5 = spec["operations"][0]
+        partial = before.replace(row5["find"], row5["replace"], 1)
+        after = MODULE.rewrite_body(partial, spec)
+        self.assertIsNotNone(after)
+        self.assertEqual(after.count(MODULE.anchor_html(row5)), 1)
+        self.assertEqual(after.count(MODULE.anchor_html(spec["operations"][1])), 1)
+
+    def test_3814_ai_ethics_link_stays_before_how_to_heading(self):
+        spec = spec_by_id(3814)
+        after = MODULE.rewrite_body(MODULE.fixture_body(spec), spec)
+        self.assertLess(
+            after.find("the less mystical version of this"),
+            after.find("How To Practice MBOs"),
+        )
+
+    def test_missing_or_duplicate_needle_aborts(self):
+        spec = spec_by_id(11358)
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body("<p>wrong body</p>", spec)
+        duplicate = MODULE.fixture_body(spec) + spec["operations"][0]["find"]
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body(duplicate, spec)
+
+    def test_from_spec_validates_without_network(self):
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            self.assertEqual(0, run_main("--from-spec"))
+        self.assertEqual(calls, [])
+
+    def test_live_dry_run_uses_gets_only_and_creates_no_snapshot(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main())
+        self.assertFalse(snapshot_dir.exists())
+        self.assertEqual(len(calls), 6)
+        self.assertTrue(all(payload is None for _, payload in calls))
+
+    def test_apply_refuses_when_826_category_gate_is_not_live(self):
+        self.dependency["categories"] = [1757]
+        calls = []
+        with mock.patch.object(
+            MODULE, "request", side_effect=self._patch_request(calls)
+        ):
+            with self.assertRaises(SystemExit) as caught:
+                run_main("--apply", "--item-id", "3948")
+        self.assertIn("#826", str(caught.exception))
+        self.assertTrue(all(payload is None for _, payload in calls))
+
+    def test_slug_and_status_mismatches_abort_before_write(self):
+        for field, value, expected in (
+            ("slug", "wrong-slug", "slug is"),
+            ("status", "draft", "status is"),
+        ):
+            with self.subTest(field=field):
+                self.lives[11936] = fake_item(spec_by_id(11936))
+                self.lives[11936][field] = value
+                calls = []
+                with mock.patch.object(
+                    MODULE, "request", side_effect=self._patch_request(calls)
+                ):
+                    with self.assertRaises(SystemExit) as caught:
+                        run_main("--item-id", "11936")
+                self.assertIn(expected, str(caught.exception))
+                self.assertTrue(all(payload is None for _, payload in calls))
+
+    def test_single_item_apply_snapshots_writes_content_only_and_reads_back(self):
+        calls = []
+        snapshot_dir = self.tmp_path / "snapshots"
+        with (
+            mock.patch.object(MODULE, "SNAPSHOT_DIR", snapshot_dir),
+            mock.patch.object(
+                MODULE, "request", side_effect=self._patch_request(calls)
+            ),
+        ):
+            self.assertEqual(0, run_main("--apply", "--item-id", "3948"))
+        writes = [payload for _, payload in calls if payload is not None]
+        self.assertEqual(1, len(writes))
+        self.assertEqual(set(writes[0]), {"content"})
+        self.assertIn(
+            "there is a prayer I actually say about this", writes[0]["content"]
+        )
+        snapshots = list(snapshot_dir.glob("*.json"))
+        self.assertEqual(1, len(snapshots))
+        self.assertEqual(stat.S_IMODE(snapshots[0].stat().st_mode), 0o600)
+
+    def test_runbook_keeps_live_write_and_834_as_separate_gates(self):
+        runbook = (MODULE.PACK / "APPLY.md").read_text(encoding="utf-8")
+        self.assertIn("fresh explicit live approval", runbook)
+        self.assertIn("No live write has been made", runbook)
+        self.assertIn("#834", runbook)
+        self.assertIn("--restore", runbook)
+        self.assertNotIn("Fixes #833", runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the exact six-link #833 package for five WordPress objects
- pin ID, slug, status, date, title, and category identity before any write
- require the live #826 category dependency, a single `--item-id`, a private snapshot, content-only payload, and authenticated readback
- preserve collection footers byte for byte and preserve post 11700's `/glossary/` href count for #834
- update the authority-hub pack index

This PR prepares repo-side tooling only. No live WordPress write or snapshot was made, and #833 remains open for separate human review and fresh live approval.

## Verification

- `python3 -m unittest scripts.tests.test_apply_issue_833_mbo_links` (13 passed)
- `ruff format` / `ruff check` on the script and tests
- repo voice gate: 0 findings
- full KK voice audit: 0 findings
- authenticated WordPress GET-only dry-run: all five identities and six selectors exact; #826 dependency live
- `make verify` (606 operational, 12 SEO inventory, 68 SEO/link-safety tests; JS/plugin/theme/docs/PHP/PHPCS green)

## Ordering

#833 must be applied and verified before #834 is recut because both touch post 11700. This PR does not touch #834's glossary row.

Refs #833 and #402.
