### PR TITLE
fix: ignore negated issue closing references

### DIFF
--- a/scripts/reconcile_backlog.py
+++ b/scripts/reconcile_backlog.py
@@ -37,7 +37,8 @@ REPORTS = ROOT / "docs/current-state/reports"
 CLOSING_REF = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
 NEGATED_CLOSING_PREFIX = re.compile(
     r"\b(?:(?:do(?:es)?|did|will|would|should|must|can|could|is|are|was|were)\s+not|"
-    r"cannot|can't|won't)\s+(?:auto-)?$",
+    r"cannot|can't|won't|doesn't|didn't|shouldn't|mustn't|wouldn't|couldn't)"
+    r"\s+(?:auto-)?$",
     re.IGNORECASE,
 )
 # bare "#12" mention — weak signal (epic refs, progress notes)

--- a/scripts/reconcile_backlog.py
+++ b/scripts/reconcile_backlog.py
@@ -35,6 +35,11 @@ ROOT = Path(__file__).resolve().parent.parent
 REPORTS = ROOT / "docs/current-state/reports"
 # "Fixes #12" / "closed #12" — should have auto-closed on merge to default branch
 CLOSING_REF = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+NEGATED_CLOSING_PREFIX = re.compile(
+    r"\b(?:(?:do(?:es)?|did|will|would|should|must|can|could|is|are|was|were)\s+not|"
+    r"cannot|can't|won't)\s+(?:auto-)?$",
+    re.IGNORECASE,
+)
 # bare "#12" mention — weak signal (epic refs, progress notes)
 MENTION_REF = re.compile(r"#(\d+)")
 
@@ -124,6 +129,17 @@ def merged_unpruned_branches() -> list[str]:
     return out
 
 
+def closing_refs(text: str) -> set[int]:
+    """Return affirmative closing references, excluding explicit negations."""
+    refs = set()
+    for match in CLOSING_REF.finditer(text):
+        prefix = re.sub(r"[*_`~]", "", text[max(0, match.start() - 64) : match.start()])
+        if NEGATED_CLOSING_PREFIX.search(prefix):
+            continue
+        refs.add(int(match.group(1)))
+    return refs
+
+
 def issues_referenced_by_merged_prs(issues: list[dict], prs: list[dict]) -> tuple[dict, dict]:
     """Return ({issue#: [(pr#, when)]}, ...) for closing-keyword refs and mention-only refs.
 
@@ -135,7 +151,7 @@ def issues_referenced_by_merged_prs(issues: list[dict], prs: list[dict]) -> tupl
     mention: dict[int, list] = {}
     for pr in prs:
         text = f"{pr.get('title','')} {pr.get('body','') or ''} {pr.get('headRefName','')}"
-        closes = {int(m) for m in CLOSING_REF.findall(text)}
+        closes = closing_refs(text)
         mentions = {int(m) for m in MENTION_REF.findall(text)} - closes
         when = (pr.get("mergedAt", "") or "")[:10]
         for num in closes:
@@ -151,7 +167,7 @@ def stale_wishlist(issues: list[dict], stale_days: int) -> list[tuple]:
     cutoff = _now() - dt.timedelta(days=stale_days)
     out = []
     for i in issues:
-        labels = {l["name"] for l in i.get("labels", [])}
+        labels = {label["name"] for label in i.get("labels", [])}
         updated = _parse(i.get("updatedAt", ""))
         if "enhancement" in labels and updated and updated < cutoff:
             out.append((i["number"], i["title"], updated.date().isoformat()))

--- a/scripts/tests/test_reconcile_backlog.py
+++ b/scripts/tests/test_reconcile_backlog.py
@@ -33,6 +33,38 @@ class RefMatchingTests(unittest.TestCase):
         self.assertIn(255, closing)
         self.assertNotIn(255, mention)
 
+    def test_negated_closing_keywords_remain_weak_mentions(self):
+        phrases = (
+            "Did not close #14",
+            "Does not auto-close #14",
+            "Cloud regeneration cannot close #14",
+            "This will not resolve #14",
+        )
+        for body in phrases:
+            with self.subTest(body=body):
+                prs = [{
+                    "number": 103,
+                    "title": "status",
+                    "body": body,
+                    "headRefName": "status-only",
+                    "mergedAt": "2026-06-04T00:00:00Z",
+                }]
+                closing, mention = rb.issues_referenced_by_merged_prs(self.issues, prs)
+                self.assertEqual(closing, {})
+                self.assertIn(14, mention)
+
+    def test_positive_closing_reference_survives_negated_reference(self):
+        prs = [{
+            "number": 104,
+            "title": "finish",
+            "body": "The prep did not close #14. This final change fixes #14.",
+            "headRefName": "finish-14",
+            "mergedAt": "2026-06-05T00:00:00Z",
+        }]
+        closing, mention = rb.issues_referenced_by_merged_prs(self.issues, prs)
+        self.assertIn(14, closing)
+        self.assertNotIn(14, mention)
+
     def test_reference_to_unknown_issue_ignored(self):
         prs = [{"number": 102, "title": "t", "body": "Fixes #9999", "headRefName": "z", "mergedAt": "2026-06-03T00:00:00Z"}]
         closing, mention = rb.issues_referenced_by_merged_prs(self.issues, prs)

--- a/scripts/tests/test_reconcile_backlog.py
+++ b/scripts/tests/test_reconcile_backlog.py
@@ -37,7 +37,9 @@ class RefMatchingTests(unittest.TestCase):
         phrases = (
             "Did not close #14",
             "Does not auto-close #14",
+            "Does **not** close #14",
             "Cloud regeneration cannot close #14",
+            "This doesn't close #14",
             "This will not resolve #14",
         )
         for body in phrases:


### PR DESCRIPTION
## Summary

- make the report-only backlog reconciler distinguish affirmative GitHub closing keywords from explicit negations
- keep negated references in the weak mention-only section
- preserve a later affirmative reference to the same issue
- replace one ambiguous local variable name so the normal Ruff gate passes

## Why

The live reconciler incorrectly promoted four deliberately open issues into its high-precision drift section because merged PR prose said:

- `Did not close #339`
- `Does not close #480`
- `cannot close #731`
- `Does not auto-close #742`

All four issue bodies and comments prove their acceptance criteria remain incomplete. After this change, the real GitHub-backed report shows zero high-precision hits and retains those issues as weak mentions.

## Verification

- red test reproduced all four phrases before implementation
- `python3 -m unittest scripts.tests.test_reconcile_backlog -v` (9 passed)
- `ruff check scripts/reconcile_backlog.py scripts/tests/test_reconcile_backlog.py`
- real `python3 scripts/reconcile_backlog.py --stale-days 90`: 41 issues, 55 merged PRs, zero high-precision false positives
- `make verify`: 608 operational, 12 SEO inventory, and 68 SEO/link-safety tests; remaining gates green

No issue state, WordPress state, or branch cleanup is performed by the script.
