### PR TITLE
fix: refresh #832 raw content guard

### DIFF
--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/APPLY.md
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/APPLY.md
@@ -17,7 +17,7 @@ No REST POST / PATCH / DELETE in this session. WP_USER / WP_APP_PASSWORD were un
 |---|---|---|---|---:|---|---|---|
 | 4495 | post | `inside-the-innaugural-vancouver-ai-community-meetup` | `/2024/01/28/inside-the-innaugural-vancouver-ai-community-meetup/` | 200 | **no** | yes (3) | Baked footer present. |
 | 9197 | post | `vancouver-ai-meetup-16-where-tech-creativity-and-community-collide` | `/2025/05/11/vancouver-ai-meetup-16-where-tech-creativity-and-community-collide/` | 200 | **no** | yes (1) | Baked footer present. |
-| 8418 | post | `vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap` | `/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/` | 200 | **no** | yes (1) | Baked footer present. Empty `<p>` then footer. |
+| 8418 | post | `vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap` | `/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/` | 200 | **no** | yes (1) | Baked footer present. Authenticated raw block terminus reconfirmed 2026-08-28. |
 | 6815 | post | `august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics` | `/2024/09/01/august-vancouver-ai-community-meetup-recap-hackers-hustlers-heretics` | 200 | **no** | yes (1) | No `kk-collection-footer`. Ends on the Related hub line. One AWS `/events/` URL is unrelated. |
 | 6251 | post | `creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights` | `/2024/07/08/creativity-in-the-age-of-ai-vancouver-ai-community-meetup-june-2024-highlights/` | 200 | **no** | yes (1) | `meetup.com/vancouver-ai-meetup/events/` is not the hub. Footer present. |
 | 5768 | post | `june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines` | `/2024/06/02/june-vancouver-ai-community-meetup-recap-a-confluence-of-minds-and-machines/` | 200 | **no** | yes (1) | No footer. Has `/ai-events/` plus a Northeastern `/events/` URL. |
@@ -31,7 +31,7 @@ The live `/events/` card still talks about Luma and registration. Do not copy an
 
 ## Snapshot gaps
 
-- No `context=edit` `content.raw` for posts 4495, 9197, 8418, 6815, 6251, 5768, 4348. Those `before/*-content.raw.html` files are public `content.rendered` stand-ins so `--from-files` can run offline. The first authenticated dry-run must recut `find` if a live raw needle misses.
+- No committed `context=edit` `content.raw` fixture for posts 4495, 9197, 8418, 6815, 6251, 5768, 4348. Their `before/*-content.raw.html` files are public `content.rendered` stand-ins so `--from-files` can run offline. Post 8418's authenticated raw terminus was reconfirmed on 2026-08-28 at the unchanged `modified_gmt` and is pinned in `targets.json` with raw SHA-256 `ebf28d1f...bf3a4a15`; the rendered stand-in remains an explicit alternate for offline characterization. Recut any other `find` if a future authenticated dry run misses.
 - Page 2250 has public rendered only. That is enough to prove this pack never mutates it. There is no 2250 `content.raw` in the pack.
 - Page 12315 raw is the 2026-07-01 backup. Live `modified_gmt` is still `2026-07-01T20:27:36`, and the Browse AI events button text is unchanged.
 
@@ -60,7 +60,7 @@ Content only. Titles, slugs, dates, status, featured media, tags, categories, an
 |---|---|---|
 | 4495 | toast line ending `community!</p>` | trailing sentence, exact anchor `we still do this every month, and the next one is on the calendar` (row 18) |
 | 9197 | `converge to shape our collective future.</p>` | trailing sentence, exact anchor `the next one` (row 19) |
-| 8418 | empty paragraph immediately before the baked footer | new paragraph, exact anchor `come to the next one` (row 20) |
+| 8418 | raw empty paragraph block immediately before the baked footer; rendered stand-in retained as an explicit offline alternate | new paragraph, exact anchor `come to the next one` (row 20) |
 | 6815 | Related hub sentence (keeps the `/vancouver-ai/` link) | trailing sentence, exact anchor `the current calendar` (row 21) |
 | 6251 | Host sign-off line | new paragraph before the footer, exact anchor `where the next one lands` (row 22) |
 | 5768 | `continue to explore, create, and inspire together.</p>` | trailing sentence, exact anchor `still monthly, still free, still worth the trip` (row 23) |

--- a/content/drafts/2026-08-02-seo-authority-hubs/fix-832/targets.json
+++ b/content/drafts/2026-08-02-seo-authority-hubs/fix-832/targets.json
@@ -99,8 +99,15 @@
       "slug": "vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap",
       "url": "https://kriskrug.co/2025/03/02/vancouver-ai-the-community-building-bcs-ai-future-february-meetup-recap/",
       "modified_gmt_at_reconfirm": "2026-06-29T04:30:15",
-      "find": "<p class=\"wp-block-paragraph\"></p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>",
-      "replace": "<p class=\"wp-block-paragraph\">If you are nearby, <a href=\"https://kriskrug.co/events/\">come to the next one</a>.</p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>",
+      "raw_sha256_at_reconfirm": "ebf28d1f71511b70d9023e34e3143ca02ff7d5835fe5dccd8572e622bf3a4a15",
+      "find": "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->\n<p class=\"kk-collection-footer\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>\n<!-- /wp:paragraph -->",
+      "replace": "<!-- wp:paragraph -->\n<p>If you are nearby, <a href=\"https://kriskrug.co/events/\">come to the next one</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph {\"className\":\"kk-collection-footer\"} -->\n<p class=\"kk-collection-footer\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>\n<!-- /wp:paragraph -->",
+      "alternate_rewrites": [
+        {
+          "find": "<p class=\"wp-block-paragraph\"></p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>",
+          "replace": "<p class=\"wp-block-paragraph\">If you are nearby, <a href=\"https://kriskrug.co/events/\">come to the next one</a>.</p>\n\n\n\n<p class=\"kk-collection-footer wp-block-paragraph\">Part of the <a href=\"https://kriskrug.co/vancouver-ai/\">Vancouver AI Ecosystem</a> collection.</p>"
+        }
+      ],
       "anchors": [
         {
           "row": 20,

--- a/scripts/apply_issue_832_events_routing.py
+++ b/scripts/apply_issue_832_events_routing.py
@@ -134,9 +134,31 @@ def already_applied(body: str, spec: dict) -> bool:
     )
 
 
-def inserted_fragment(spec: dict) -> str:
-    find = spec["find"]
-    replace = spec["replace"]
+def rewrite_pairs(spec: dict) -> list[tuple[str, str]]:
+    pairs = [(spec["find"], spec["replace"])]
+    pairs.extend(
+        (row["find"], row["replace"])
+        for row in spec.get("alternate_rewrites", [])
+    )
+    return pairs
+
+
+def select_rewrite_pair(body: str, spec: dict) -> tuple[str, str]:
+    pairs = rewrite_pairs(spec)
+    counts = [body.count(find) for find, _ in pairs]
+    if sum(counts) != 1:
+        raise ValueError(
+            f"{spec['id']}: find variants occur {counts}; expected exactly one "
+            "single match. Insert by text match, not a stale block index."
+        )
+    return pairs[counts.index(1)]
+
+
+def inserted_fragment(
+    spec: dict, find: str | None = None, replace: str | None = None
+) -> str:
+    find = spec["find"] if find is None else find
+    replace = spec["replace"] if replace is None else replace
     prefix = os.path.commonprefix([find, replace])
     find_rest = find[len(prefix) :]
     replace_rest = replace[len(prefix) :]
@@ -159,15 +181,8 @@ def rewrite_body(body: str, spec: dict, targets: dict) -> str | None:
         raise ValueError(f"{spec['id']}: refused; page 2250 is not in the write set")
     if already_applied(body, spec):
         return None
-    find = spec["find"]
-    replace = spec["replace"]
-    count = body.count(find)
-    if count != 1:
-        raise ValueError(
-            f"{spec['id']}: find needle occurs {count} times; expected 1. "
-            "Insert by text match, not a stale block index."
-        )
-    added = inserted_fragment(spec)
+    find, replace = select_rewrite_pair(body, spec)
+    added = inserted_fragment(spec, find, replace)
     if "\u2014" in added or "\u2013" in added:
         raise ValueError(f"{spec['id']}: inserted copy contains a dash codepoint")
     if any(ord(char) > 127 for char in added):

--- a/scripts/tests/test_apply_issue_832_events_routing.py
+++ b/scripts/tests/test_apply_issue_832_events_routing.py
@@ -181,6 +181,27 @@ class ApplyIssue832EventsRoutingTests(unittest.TestCase):
         self.assertGreater(listed, anchor)
         self.assertGreater(footer, listed)
 
+    def test_rewrite_8418_accepts_authenticated_raw_block_shape(self):
+        spec = spec_by_id(8418)
+        before = f"<p>existing body</p>\n\n{spec['find']}"
+        after = MODULE.rewrite_body(before, spec, TARGETS)
+        self.assertIsNotNone(after)
+        self.assertIn(
+            '<a href="https://kriskrug.co/events/">come to the next one</a>',
+            after,
+        )
+        self.assertEqual(
+            before.count("kk-collection-footer"),
+            after.count("kk-collection-footer"),
+        )
+        self.assertIsNone(MODULE.rewrite_body(after, spec, TARGETS))
+
+    def test_rewrite_8418_refuses_ambiguous_raw_and_rendered_variants(self):
+        spec = spec_by_id(8418)
+        alternate = spec["alternate_rewrites"][0]["find"]
+        with self.assertRaises(ValueError):
+            MODULE.rewrite_body(f"{spec['find']}\n{alternate}", spec, TARGETS)
+
     def test_rewrite_12315_adds_calendar_and_keeps_browse_ai_events(self):
         spec = spec_by_id(12315)
         before = before_body(12315)


### PR DESCRIPTION
## Summary

- refresh post 8418's #832 transform against the authenticated Gutenberg raw block shape
- retain the existing rendered fixture as an explicit offline characterization alternate
- fail closed when neither or more than one representation matches
- pin the unchanged live modified timestamp and raw SHA-256 evidence in the apply packet

## Verification

- `make verify`
- `make varlock-run CMD='scripts/notion-to-wp/.venv/bin/python scripts/apply_issue_832_events_routing.py'`

The full local suite is green, and the authenticated dry run plans all eight owned targets while continuing to hard-refuse page 2250.

No WordPress writes, snapshots, restores, cache actions, or page 2250 changes were performed.

Refs #832.
