### PR TITLE
docs: refresh next sprint handoff

### DIFF
--- a/docs/current-state/WORK-PLAN-2026-08-25.md
+++ b/docs/current-state/WORK-PLAN-2026-08-25.md
@@ -135,20 +135,23 @@ Acceptance:
    traffic-prioritized, or permanently parked.
 5. Screen-reader testing and WCAG 2.1 AA verification for issue #4.
 6. The separate `/home/` redirect, unpublish, or maintain decision.
-7. #833 before #834; #828 remains a KK voice decision.
-8. #740 plan archival, #738/#749 laptop cleanup, and #737 backup-tree scope.
+7. Authority-hub sequence: #829 → #830 → #831 → #832 → #833; #834 follows
+   #829 because both touch post 12030. #828 remains a KK voice decision.
+8. #737's exact backup-tree archive decision. Cleanup issues #738, #740, and
+   #749 are closed; do not revive their stale scopes.
 
 ## Exact next implementation prompt
 
-> Work repo-only on the media-7637 correction from issue #4. Read AGENTS.md,
-> WORK-PLAN-2026-08-25.md, the issue #4 inventory, APPLY-RUNBOOK, and
-> `reports/issue-4-residual-audit-20260825.md`, plus the 2026-08-25 partial-run
-> issue comment. Inspect media 6985 and 7637 as distinct assets and correct only
-> the 7637 proposal with a regression that prevents their descriptions from
-> being interchanged. Run the focused alt-text tests and `make verify`; open a
-> bounded PR. Do not make a WordPress write. After merge, stop and request a
-> separate exact approval for 6985, 7637, and 8871. Do not touch page 6815,
-> `/home/`, the 18 missing attributes, archive batches 4-6, or #829-#832.
+> Prepare the remaining issue #4 media apply for exact targets 6985, 7637, and
+> 8871 only. Read AGENTS.md, WORK-PLAN-2026-08-25.md, the issue #4 inventory,
+> APPLY-RUNBOOK, `reports/issue-4-residual-audit-20260825.md`, and the latest
+> issue comment. Re-run the authenticated dry-run; verify each ID, attachment
+> URL, current empty alt, and reviewed proposal; then snapshot all three exact
+> objects. Do not write unless the current session has fresh approval naming
+> media 6985, 7637, and 8871. After approval, apply and read back one item at a
+> time, stopping on any drift. Do not touch page 6815, `/home/`, the missing
+> attributes, archive batches 4-6, or #829-#834. After issue #4, begin the hub
+> sequence at #829 using the same one-item snapshot/apply/readback discipline.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the completed media-7637 repo task with the exact three-media live gate
- record the authority-hub execution order and #829/#834 overlap
- mark #738, #740, and #749 closed while retaining #737 as the remaining cleanup decision

## Verification
- `make docs-truth-check`
- `git diff --check`

No live WordPress change.