### PR TITLE
content: refresh issue 339 publisher guards

### DIFF
--- a/content/drafts/339-july-publisher-batch-2026-08-16/README.md
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/README.md
@@ -1,17 +1,17 @@
-# #339 July publisher batch, refreshed 2026-08-16
+# #339 July publisher batch, refreshed 2026-08-28
 
-**Status:** PREP ONLY. No live WordPress write. Credentials were not used.
+**Status:** PREP ONLY. Authenticated read-only guards refreshed; no live WordPress write.
 **Issue:** [#339](https://github.com/WalksWithASwagger/kriskrug-wp/issues/339)
 **Evidence report:** [`docs/current-state/reports/publisher-batch-refresh-339-20260816.md`](../../../docs/current-state/reports/publisher-batch-refresh-339-20260816.md)
 **Supersedes:** [`content/drafts/339-july-publisher-batch-checklist-2026-07-26.md`](../339-july-publisher-batch-checklist-2026-07-26.md) and the 2026-07-26 prep report.
 
-Live readback: `2026-08-17T02:20:44Z`. Aurora live `1.6.5` (public `style.css`). Repo `main` theme Version `1.6.6`. WordPress `7.0.4`.
+Authenticated readback: `2026-08-28T22:40:34Z`. Aurora live and repo `main` both `1.6.9`. WordPress `7.0.4`.
 
 ## DONE vs STILL OPEN
 
 | Item | Verdict | Why |
 |---|---|---|
-| Aurora 1.3.39 zip deploy | **DEAD / obsolete** | Live is 1.6.5. Do not upload that zip. OG/description work from that era needs a separate check against current 1.6.5 theme output. |
+| Aurora 1.3.39 zip deploy | **DEAD / obsolete** | Live is 1.6.9. Do not upload that zip. OG/description work from that era needs a separate check against current 1.6.9 theme output. |
 | #249 About YCDD sentence | **STILL OPEN** | `/about/` has 0 matches for `you can't drink data`. Opening paragraph still present. |
 | #328 Most Benevolent wraps | **STILL OPEN** | Needles present once each on 2950 and 2665. Zero hrefs to post 3814. |
 | #335 LOTR title/desc + footer pair | **STILL OPEN** | Public title is still `The Lord of the Rings Drinking Game \| Kris Krüg`. Footer still points at the AI companions post. |
@@ -22,9 +22,9 @@ Closed GitHub issues #249, #328, #335, #336, #342 were repo-side prep or measure
 
 ## Theme zip: strike this
 
-The #339 issue body still asks KK to approve deploying `kk-aurora-seo-metadata-1.3.39-20260713.zip`. **Strike that checkbox.** Production already runs Aurora **1.6.5**. Repo `main` is **1.6.6**. Uploading 1.3.39 would be a downgrade.
+The retired #339 contract asked KK to approve deploying `kk-aurora-seo-metadata-1.3.39-20260713.zip`. **Keep that action struck.** Production and repo `main` both run Aurora **1.6.9**. Uploading 1.3.39 would be a downgrade.
 
-Standard descriptions and per-post search titles are theme-owned (`inc/seo-title.php`, `inc/seo-meta-rest.php`). Sampled 1.6.5 routes already emit one `<meta name="description">`. Remaining OG/title-format questions belong with current theme output (and issues like #756), not with that zip.
+Standard descriptions and per-post search titles are theme-owned (`inc/seo-title.php`, `inc/seo-meta-rest.php`). Sampled 1.6.9 routes already emit one `<meta name="description">`. Remaining OG/title-format questions belong with current theme output, not with that zip.
 
 ## Payloads in this folder
 
@@ -37,7 +37,8 @@ Standard descriptions and per-post search titles are theme-owned (`inc/seo-title
 | `apply-342-both-hands-full.md` | Href-only on post 11171 |
 | `seo-meta-overwrite.json` | `--from-file` overwrite plan for posts 35 and 8802 |
 | `manifest.json` | Machine-readable verdicts and identity guards |
-| `live-evidence-compact.json` | Public REST + HTML head capture (no full HTML) |
+| `authenticated-guard-refresh-20260828.json` | Authenticated raw/desired hashes for the two previously drifted objects; no body content or credentials |
+| `live-evidence-compact.json` | Historical 2026-08-17 public REST + HTML head capture (no full HTML) |
 
 ## Shared apply rules (INCIDENT-2026-05-15)
 
@@ -64,7 +65,7 @@ Standard descriptions and per-post search titles are theme-owned (`inc/seo-title
 - [ ] Approve the four copy-preserving wraps (#328 and #336).
 - [ ] Approve the #335 footer pair.
 - [ ] Approve the #342 href-only replacement.
-- [ ] Acknowledge refreshed `modified` guards: page 1208 `2026-08-01T09:59:39`, post 11171 `2026-08-10T18:24:39`, post 12327 `2026-07-18T11:20:49`.
+- [ ] Acknowledge refreshed `modified` guards: page 1208 `2026-08-16T21:29:03`, post 11171 `2026-08-10T18:24:39`, post 12327 `2026-08-16T21:03:50`.
 - [ ] Dry-run evidence reviewed. Snapshot dir created.
 
 Out of scope: #331, #353, #340 bc-ai.net, GSC indexing quota, DNS/GA4, any live write in this PR.

--- a/content/drafts/339-july-publisher-batch-2026-08-16/apply-249-about-ycdd.md
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/apply-249-about-ycdd.md
@@ -3,7 +3,9 @@
 **Verdict:** STILL OPEN
 **Write target:** page `1208`, slug `about`, `https://kriskrug.co/about/`
 **Link target:** post `11936`, slug `you-cant-drink-data` (read-only; do not PATCH this post)
-**Live `modified`:** `2026-08-01T09:59:39` (refreshed; July handoff had `2026-07-01T11:33:51` then `2026-07-24T17:22:59`)
+**Live `modified`:** `2026-08-16T21:29:03` (authenticated refresh; the August 16 change was the #706 cache-purge title save)
+**Current raw:** 8,857 chars; SHA-256 `3171b2f41bfc919aba40640200cb2bafe76e75329ba736efec1713cd29135783`
+**Planned raw:** 9,075 chars; SHA-256 `857ea7af53db7dd2b5007123b0ac8efa86b0397c1e4baea5572c38c26b565b5b`
 **REST + HTML:** 200 / self-canonical `/about/`
 **Evidence:** public HTML count of `you can't drink data` is **0**. Count of `you-cant-drink-data` hrefs is **0**. The reserved paragraph is still present exactly once.
 
@@ -29,7 +31,7 @@ ASCII apostrophe in `can't`. No em dash. No other About copy.
 
 1. `GET /wp-json/wp/v2/pages/1208?context=edit&_fields=id,slug,status,modified,title,content`
 2. Save to `backup/<UTC>-july-publisher/before-page-1208-edit.json` plus public `https://kriskrug.co/about/` HTML and SHA-256.
-3. Abort unless `id=1208`, `slug=about`, `status=publish`, and `modified=2026-08-01T09:59:39` (or a KK-acknowledged newer guard after a fresh needle reconfirm).
+3. Abort unless `id=1208`, `slug=about`, `status=publish`, `modified=2026-08-16T21:29:03`, and raw SHA-256 `3171b2f41bfc919aba40640200cb2bafe76e75329ba736efec1713cd29135783` (or a KK-acknowledged newer guard after a fresh needle reconfirm).
 4. Abort unless FIND occurs exactly once in `content.raw`. Gutenberg wrappers around the `<p>` are fine; do not replace unrelated hero copy.
 5. `POST /wp-json/wp/v2/pages/1208` with `{"content": ...}` only.
 6. Readback: authenticated raw contains the new sentence once; cache-busted `/about/` grep for `you can't drink data` returns 1; YCDD URL still 200; page slug/title/status unchanged.

--- a/content/drafts/339-july-publisher-batch-2026-08-16/apply-335-lotr-seo-and-footer.md
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/apply-335-lotr-seo-and-footer.md
@@ -6,7 +6,7 @@
 **Live titles:** `The Lord of the Rings Drinking Game | Kris Krüg` and `McSweeney's Lists | Kris Krüg`
 **Evidence:** approved search title `...: 4 Original Rules` is absent. Public description is still the excerpt opener, not the approved rules summary. Both collection footers still recommend the 2023 AI companions post.
 
-Live REST now exposes `jetpack_seo_html_title` and `advanced_seo_description` on posts (Aurora 1.6.5, `inc/seo-meta-rest.php`). Both keys on post 35 are already non-empty, so this is an **overwrite**, not an additive backfill.
+Live REST exposes `jetpack_seo_html_title` and `advanced_seo_description` on posts (Aurora 1.6.9, `inc/seo-meta-rest.php`). Both keys on post 35 are already non-empty, so this is an **overwrite**, not an additive backfill.
 
 Do not change the public post title, excerpt, slug, date, or taxonomies.
 
@@ -31,7 +31,7 @@ scripts/notion-to-wp/.venv/bin/python scripts/seo-backfill/backfill_meta.py \
 
 No `--execute` until snapshot + KK overwrite tick. Apply the post 35 object first, then 8802 from the same file as part of #336.
 
-Public readback after write: document title becomes the approved search title (theme uses the meta value as the full `<title>`). Standard and OG descriptions should pick up the new description on current 1.6.5 output. Confirm on a cache-busted fetch; do not assume 1.3.39 zip behavior.
+Public readback after write: document title becomes the approved search title (theme uses the meta value as the full `<title>`). Standard and OG descriptions should pick up the new description on current 1.6.9 output. Confirm on a cache-busted fetch; do not assume 1.3.39 zip behavior.
 
 ## B. Footer pair
 

--- a/content/drafts/339-july-publisher-batch-2026-08-16/apply-336-ai-second-brain.md
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/apply-336-ai-second-brain.md
@@ -24,7 +24,7 @@ Modified guard: `2026-06-28T20:27:34`
 
 Same dry-run command as #335 (file contains both posts). Apply 8802 after 35.
 
-Public readback on current Aurora 1.6.5, not against 1.3.39 zip assumptions. Cache-bust the permalink.
+Public readback on current Aurora 1.6.9, not against 1.3.39 zip assumptions. Cache-bust the permalink.
 
 ## B. Inbound wraps
 
@@ -56,7 +56,9 @@ Live rendered context keeps an existing em dash after the phrase (`AI as a secon
 
 - Slug: `storyhive-haus-of-owl-jordan-dack`
 - URL: `https://kriskrug.co/2026/06/17/storyhive-haus-of-owl-jordan-dack/`
-- Modified guard: `2026-07-18T11:20:49` (refreshed; original July handoff had `2026-06-17T19:47:06`)
+- Modified guard: `2026-08-16T21:03:50` (authenticated refresh)
+- Current raw: 17,706 chars; SHA-256 `045c697906260becae376d39fcf0987911ac9c94e5d3b25def8a4f1b4a69981d`
+- Planned raw: 17,812 chars; SHA-256 `32a77f548f700cde5edd77e8c6959dda04d9aa229e852b8f860c8ce87f09b4bd`
 - Live needle count: 1
 - Live target-href count: 0
 

--- a/content/drafts/339-july-publisher-batch-2026-08-16/authenticated-guard-refresh-20260828.json
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/authenticated-guard-refresh-20260828.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "issue": 339,
+  "captured": "2026-08-28T22:40:34Z",
+  "mode": "authenticated-read-only",
+  "live_wordpress_write_performed": false,
+  "objects": [
+    {
+      "type": "page",
+      "id": 1208,
+      "slug": "about",
+      "status": "publish",
+      "modified": "2026-08-16T21:29:03",
+      "modified_gmt": "2026-08-17T05:29:03",
+      "content_raw_chars": 8857,
+      "content_raw_sha256": "3171b2f41bfc919aba40640200cb2bafe76e75329ba736efec1713cd29135783",
+      "find_count": 1,
+      "target_href_count": 0,
+      "desired_content_chars": 9075,
+      "desired_content_sha256": "857ea7af53db7dd2b5007123b0ac8efa86b0397c1e4baea5572c38c26b565b5b",
+      "changed_chars": 218
+    },
+    {
+      "type": "post",
+      "id": 12327,
+      "slug": "storyhive-haus-of-owl-jordan-dack",
+      "status": "publish",
+      "modified": "2026-08-16T21:03:50",
+      "modified_gmt": "2026-08-17T05:03:50",
+      "content_raw_chars": 17706,
+      "content_raw_sha256": "045c697906260becae376d39fcf0987911ac9c94e5d3b25def8a4f1b4a69981d",
+      "find_count": 1,
+      "target_href_count": 0,
+      "desired_content_chars": 17812,
+      "desired_content_sha256": "32a77f548f700cde5edd77e8c6959dda04d9aa229e852b8f860c8ce87f09b4bd",
+      "changed_chars": 106
+    }
+  ]
+}

--- a/content/drafts/339-july-publisher-batch-2026-08-16/manifest.json
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/manifest.json
@@ -1,14 +1,14 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "issue": 339,
-  "captured": "2026-08-17T02:20:44Z",
+  "captured": "2026-08-28T22:40:34Z",
   "live_wordpress_write_performed": false,
   "aurora": {
     "issue_body_zip": "1.3.39",
     "verdict": "obsolete",
-    "live_style_css": "1.6.5",
-    "repo_style_css": "1.6.6",
-    "note": "Do not upload kk-aurora-seo-metadata-1.3.39-20260713.zip or the 1.3.37 rollback zip. OG and standard-description ownership is theme-side on current 1.6.5. Check remaining snippet gaps against 1.6.5 output, not that zip."
+    "live_style_css": "1.6.9",
+    "repo_style_css": "1.6.9",
+    "note": "Do not upload kk-aurora-seo-metadata-1.3.39-20260713.zip or the 1.3.37 rollback zip. OG and standard-description ownership is theme-side on current 1.6.9. Check remaining snippet gaps against 1.6.9 output, not that zip."
   },
   "wp_generator": "WordPress 7.0.4",
   "items": [
@@ -17,7 +17,19 @@
       "verdict": "STILL OPEN",
       "write_kind": "content",
       "payload": "apply-249-about-ycdd.md",
-      "target": {"type": "page", "id": 1208, "slug": "about", "modified": "2026-08-01T09:59:39"}
+      "target": {
+        "type": "page",
+        "id": 1208,
+        "slug": "about",
+        "modified": "2026-08-16T21:29:03",
+        "modified_gmt": "2026-08-17T05:29:03",
+        "content_raw_chars": 8857,
+        "content_raw_sha256": "3171b2f41bfc919aba40640200cb2bafe76e75329ba736efec1713cd29135783",
+        "desired_content_chars": 9075,
+        "desired_content_sha256": "857ea7af53db7dd2b5007123b0ac8efa86b0397c1e4baea5572c38c26b565b5b",
+        "find_count": 1,
+        "target_href_count": 0
+      }
     },
     {
       "issue": 328,
@@ -47,7 +59,19 @@
       "target": {"type": "post", "id": 8802, "slug": "how-to-build-an-ai-second-brain-that-actually-works-for-you", "modified": "2026-06-28T20:27:34"},
       "sources": [
         {"type": "post", "id": 9774, "slug": "what-journalists-need-to-know-about-ai-right-now", "modified": "2026-06-14T20:05:53"},
-        {"type": "post", "id": 12327, "slug": "storyhive-haus-of-owl-jordan-dack", "modified": "2026-07-18T11:20:49"}
+        {
+          "type": "post",
+          "id": 12327,
+          "slug": "storyhive-haus-of-owl-jordan-dack",
+          "modified": "2026-08-16T21:03:50",
+          "modified_gmt": "2026-08-17T05:03:50",
+          "content_raw_chars": 17706,
+          "content_raw_sha256": "045c697906260becae376d39fcf0987911ac9c94e5d3b25def8a4f1b4a69981d",
+          "desired_content_chars": 17812,
+          "desired_content_sha256": "32a77f548f700cde5edd77e8c6959dda04d9aa229e852b8f860c8ce87f09b4bd",
+          "find_count": 1,
+          "target_href_count": 0
+        }
       ]
     },
     {
@@ -62,7 +86,7 @@
       "verdict": "DONE / DEAD",
       "write_kind": "none",
       "payload": null,
-      "note": "Aurora 1.3.39 zip deploy is obsolete. Live is 1.6.5."
+      "note": "Aurora 1.3.39 zip deploy is obsolete. Live and repo are 1.6.9."
     }
   ]
 }

--- a/content/drafts/339-july-publisher-batch-2026-08-16/seo-meta-overwrite.json
+++ b/content/drafts/339-july-publisher-batch-2026-08-16/seo-meta-overwrite.json
@@ -4,7 +4,7 @@
   "mode": "overwrite",
   "live_wordpress_write_performed": false,
   "captured": "2026-08-17T02:20:44Z",
-  "note": "KK must explicitly approve overwriting the live non-empty SEO fields. Additive backfill will skip both posts. Dry-run without --execute first. REST keys are registered on live Aurora 1.6.5 via theme inc/seo-meta-rest.php (#661/#677).",
+  "note": "KK must explicitly approve overwriting the live non-empty SEO fields. Additive backfill will skip both posts. Dry-run without --execute first. REST keys are registered on live Aurora 1.6.9 via theme inc/seo-meta-rest.php (#661/#677).",
   "items": [
     {
       "id": 35,

--- a/scripts/tests/test_issue_339_publisher_refresh.py
+++ b/scripts/tests/test_issue_339_publisher_refresh.py
@@ -8,6 +8,7 @@ PACKET = ROOT / "content/drafts/339-july-publisher-batch-2026-08-16"
 MANIFEST = PACKET / "manifest.json"
 SEO = PACKET / "seo-meta-overwrite.json"
 README = PACKET / "README.md"
+GUARD_REFRESH = PACKET / "authenticated-guard-refresh-20260828.json"
 
 EM_DASH = "\u2014"
 EN_DASH = "\u2013"
@@ -23,6 +24,7 @@ class Issue339PublisherRefreshTests(unittest.TestCase):
     def setUpClass(cls):
         cls.manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
         cls.seo = json.loads(SEO.read_text(encoding="utf-8"))
+        cls.guard_refresh = json.loads(GUARD_REFRESH.read_text(encoding="utf-8"))
 
     def test_packet_claims_no_live_write(self):
         self.assertFalse(self.manifest["live_wordpress_write_performed"])
@@ -33,8 +35,8 @@ class Issue339PublisherRefreshTests(unittest.TestCase):
         aurora = self.manifest["aurora"]
         self.assertEqual("obsolete", aurora["verdict"])
         self.assertEqual("1.3.39", aurora["issue_body_zip"])
-        self.assertEqual("1.6.5", aurora["live_style_css"])
-        self.assertEqual("1.6.6", aurora["repo_style_css"])
+        self.assertEqual("1.6.9", aurora["live_style_css"])
+        self.assertEqual("1.6.9", aurora["repo_style_css"])
         theme_item = next(
             i for i in self.manifest["items"] if i["issue"] == "theme-zip"
         )
@@ -94,7 +96,7 @@ class Issue339PublisherRefreshTests(unittest.TestCase):
             i["issue"]: i for i in self.manifest["items"] if isinstance(i["issue"], int)
         }
         self.assertEqual(
-            "2026-08-01T09:59:39",
+            "2026-08-16T21:29:03",
             by_issue[249]["target"]["modified"],
         )
         self.assertEqual(1208, by_issue[249]["target"]["id"])
@@ -105,16 +107,73 @@ class Issue339PublisherRefreshTests(unittest.TestCase):
         )
         self.assertEqual(11171, by_issue[342]["target"]["id"])
         self.assertEqual(
-            "2026-07-18T11:20:49",
+            "2026-08-16T21:03:50",
             by_issue[336]["sources"][1]["modified"],
         )
+
+    def test_authenticated_guard_refresh_locks_raw_and_planned_hashes(self):
+        self.assertEqual("authenticated-read-only", self.guard_refresh["mode"])
+        self.assertFalse(self.guard_refresh["live_wordpress_write_performed"])
+        guards = {row["id"]: row for row in self.guard_refresh["objects"]}
+        self.assertEqual({1208, 12327}, set(guards))
+        by_issue = {
+            row["issue"]: row
+            for row in self.manifest["items"]
+            if isinstance(row["issue"], int)
+        }
+        manifest_guards = {
+            1208: by_issue[249]["target"],
+            12327: by_issue[336]["sources"][1],
+        }
+
+        expected = {
+            1208: {
+                "modified": "2026-08-16T21:29:03",
+                "raw": "3171b2f41bfc919aba40640200cb2bafe76e75329ba736efec1713cd29135783",
+                "desired": "857ea7af53db7dd2b5007123b0ac8efa86b0397c1e4baea5572c38c26b565b5b",
+                "changed": 218,
+            },
+            12327: {
+                "modified": "2026-08-16T21:03:50",
+                "raw": "045c697906260becae376d39fcf0987911ac9c94e5d3b25def8a4f1b4a69981d",
+                "desired": "32a77f548f700cde5edd77e8c6959dda04d9aa229e852b8f860c8ce87f09b4bd",
+                "changed": 106,
+            },
+        }
+        for post_id, values in expected.items():
+            guard = guards[post_id]
+            self.assertEqual(values["modified"], guard["modified"])
+            self.assertEqual(values["raw"], guard["content_raw_sha256"])
+            self.assertEqual(values["desired"], guard["desired_content_sha256"])
+            self.assertEqual(values["changed"], guard["changed_chars"])
+            self.assertEqual(1, guard["find_count"])
+            self.assertEqual(0, guard["target_href_count"])
+            self.assertEqual(
+                guard["desired_content_chars"] - guard["content_raw_chars"],
+                guard["changed_chars"],
+            )
+            self.assertNotEqual(
+                guard["content_raw_sha256"], guard["desired_content_sha256"]
+            )
+            for key in (
+                "modified",
+                "modified_gmt",
+                "content_raw_chars",
+                "content_raw_sha256",
+                "desired_content_chars",
+                "desired_content_sha256",
+                "find_count",
+                "target_href_count",
+            ):
+                self.assertEqual(guard[key], manifest_guards[post_id][key])
 
     def test_readme_strikes_the_zip_and_points_at_the_report(self):
         readme = README.read_text(encoding="utf-8")
         self.assertIn("STILL OPEN", readme)
         self.assertIn("1.3.39", readme)
-        self.assertIn("1.6.5", readme)
+        self.assertIn("1.6.9", readme)
         self.assertIn("Do not upload", readme)
+        self.assertIn("authenticated-guard-refresh-20260828.json", readme)
         self.assertIn("publisher-batch-refresh-339-20260816.md", readme)
 
 


### PR DESCRIPTION
Refs #339

## Summary
- refresh page 1208 and post 12327 from authenticated `content.raw`
- lock exact current and planned hashes, sizes, timestamps, needle counts, and target-link counts
- refresh Aurora evidence to live/repo 1.6.9
- preserve the prep-only boundary and issue approval gate

## Read-only evidence
- page 1208: exact identity; one source paragraph; zero target hrefs; 8,857 → 9,075 chars
- post 12327: exact identity; one source phrase; zero target hrefs; 17,706 → 17,812 chars
- SEO overwrite dry-run: 2 planned, 0 failed
- no WordPress mutation or snapshot

## Verification
- 40 focused publisher tests
- `make verify` (612 operational tests, 12 SEO inventory tests, 68 SEO/link-safety tests, smoke checks, docs truth, PHP syntax, PHPCS)
- JSON validation and `git diff --check`

The issue remains open for exact payload approval and the later snapshot-first live session.