### PR TITLE
docs: refresh alt text approval gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The operations + content hub for [kriskrug.co](https://kriskrug.co/) — a Pagel
 
 1. [`docs/current-state/README.md`](docs/current-state/README.md) — current-state front door; run `make status-readonly` for live counters
 2. [`docs/current-state/CURRENT-STATE-2026-07-30.md`](docs/current-state/CURRENT-STATE-2026-07-30.md) — declared snapshot for drift/morning-truth (Makefile default)
-3. [`docs/current-state/WORK-PLAN-2026-08-25.md`](docs/current-state/WORK-PLAN-2026-08-25.md) — **day runbook** (issue #4 restored the two wrong-identity writes and applied two corrected targets before stopping safely; correct media 7637 repo-side, then seek a new approval for remaining media 6985/7637/8871; hub packs #829-#832 need a separate approval; supersedes 2026-08-24)
+3. [`docs/current-state/WORK-PLAN-2026-08-25.md`](docs/current-state/WORK-PLAN-2026-08-25.md) — **day runbook** (issue #4 restored the two wrong-identity writes, applied corrected media 6014/6126, and merged the corrected 7637 proposal; exact live approval is now required for remaining media 6985/7637/8871; hub packs #829-#832 need a separate approval; supersedes 2026-08-24)
 4. [`docs/current-state/MASTER-PLAN-2026-07-30.md`](docs/current-state/MASTER-PLAN-2026-07-30.md) — hygiene + lane sequencing plan of record
 5. [`docs/current-state/TWO-TRACK-MODEL.md`](docs/current-state/TWO-TRACK-MODEL.md) — the active operating model
 6. [`docs/current-state/INCIDENT-2026-05-15-overwritten-post.md`](docs/current-state/INCIDENT-2026-05-15-overwritten-post.md) — postmortem with the safety rules every agent must follow

--- a/docs/current-state/CURRENT-STATE-2026-07-30.md
+++ b/docs/current-state/CURRENT-STATE-2026-07-30.md
@@ -29,7 +29,7 @@ Master sequence: [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md). Lates
 
 | Gate | Issue | Status |
 |---|---|---|
-| Alt-text residual correction | #4 | Three media writes remain; media 7637 needs a corrected reviewed proposal before a new live approval |
+| Alt-text residual correction | #4 | Media 6985, 7637, and 8871 have current reviewed proposals and exact authenticated dry runs; live writes require fresh approval naming those three IDs |
 | Measured publisher batch | #339 | All nine identities are current; exact approval is still required for two SEO overwrites and five content payloads |
 | Testimonials live deploy | #602 | Reopened 2026-08-28; live page 2409 is still the legacy 19-card body and needs its snapshot/editorial/approval gate |
 | Site redesign epic | #403 | Track B roadmap; split into lane-scoped PRs |

--- a/docs/current-state/README.md
+++ b/docs/current-state/README.md
@@ -6,7 +6,7 @@ Ops truth for [kriskrug.co](https://kriskrug.co/). Every May and June 2026 plan 
 
 Read these first:
 
-1. **[WORK-PLAN-2026-08-25.md](WORK-PLAN-2026-08-25.md)**, active runbook (issue #4 restored the two wrong-identity writes and applied corrected media 6014/6126 before stopping safely; correct media 7637 repo-side, then seek a new approval for remaining media 6985/7637/8871 before authority-hub applies; use `make status-readonly` for live counters)
+1. **[WORK-PLAN-2026-08-25.md](WORK-PLAN-2026-08-25.md)**, active runbook (issue #4 restored the two wrong-identity writes, applied corrected media 6014/6126, and merged the tested 7637 correction; seek a new approval naming remaining media 6985/7637/8871 before authority-hub applies; use `make status-readonly` for live counters)
 2. **[CURRENT-STATE-2026-07-30.md](CURRENT-STATE-2026-07-30.md)**, declared snapshot for morning-truth drift checks (compare it with a fresh `make status-readonly` run)
 3. **[MASTER-PLAN-2026-07-30.md](MASTER-PLAN-2026-07-30.md)**, truth then reclaim then product lanes (hygiene phases complete)
 4. Run `make status-readonly` for current signals; use the newest **[reports/morning-truth-*.md](reports/)** only as durable checkpoint evidence

--- a/docs/current-state/WORK-PLAN-2026-08-25.md
+++ b/docs/current-state/WORK-PLAN-2026-08-25.md
@@ -3,8 +3,9 @@
 **Status:** Session 1 audit complete; the identity-repair gate was partially
 executed and stopped correctly on a semantic mismatch. Media 6729 and 11774
 were restored, and corrected media 6014 and 6126 were applied and verified.
-Media 6985, 7637, and 8871 remain untouched; 7637 needs a corrected reviewed
-proposal before a new live approval. **Supersedes**
+PR #913 merged the tested, reviewed 7637 correction. Fresh authenticated dry
+runs verify media 6985, 7637, and 8871 remain untouched, exactly identified,
+and ready for a new approval naming those three IDs. **Supersedes**
 [`WORK-PLAN-2026-08-24.md`](WORK-PLAN-2026-08-24.md), whose Batch 3 sessions
 are complete. **Plan of record:**
 [`MASTER-PLAN-2026-07-30.md`](MASTER-PLAN-2026-07-30.md).
@@ -21,17 +22,19 @@ run, identity verification, a private snapshot, and exact readback.
   Corrected targets 6014 and 6126 were then applied and verified. The selector
   now returns 75 `already-applied` targets plus three `would-write` targets:
   6985, 7637, and 8871.
-- The proposed alt for 7637 described media 6985. File hashes and visual
-  inspection proved the assets differ, so the approved stop rule prevented all
-  three remaining writes. A tested, reviewed 7637 proposal is the next repo
-  change; it does not authorize a live apply.
+- The original proposed alt for 7637 described media 6985. File hashes and
+  visual inspection proved the assets differ, so the approved stop rule
+  prevented all three remaining writes. PR #913 then merged the tested,
+  visually reviewed 7637 correction. Fresh authenticated dry runs on 2026-08-28
+  verify all three exact identities, empty current alts, and one `would-write`
+  result per target; they do not authorize a live apply.
 - All 73 Batch 3 pre-write snapshots are mode 0600.
 - The post-stop 216-route recount completed with zero fetch errors: 1,076
   violation occurrences / 1,075 unique page-source violations.
 - Inventory batches 4-6 remain parked; #829-#832 remain unapplied.
 - Aurora live/repo are both 1.6.9 and WordPress is 7.0.4 as of the 2026-08-28
-  readback. Three stale `/private/tmp` worktree registrations are prunable but
-  remain untouched pending the separate #738 cleanup approval.
+  readback. The main worktree is clean and no extra worktrees are registered;
+  #738 is closed.
 
 ## Session 1: resolve issue #4's small ambiguous remainder — complete
 
@@ -77,25 +80,23 @@ Acceptance:
 - Page 6815 and `/home/` are decision-ready, not silently changed.
 - The 18 missing-attribute findings are reproducibly classified.
 
-## Identity-repair gate: partial execution, new approval required
+## Identity-repair gate: repo correction complete, live approval required
 
 Do not start the authority-hub lane with known wrong attachment metadata still
 outstanding.
 
 Completed with exact snapshots and readbacks: restore 6729 and 11774; apply
-6014 and 6126. The semantic disagreement on 7637 triggered the required stop.
+6014 and 6126. The semantic disagreement on 7637 triggered the required stop;
+PR #913 corrected it and pinned the 6985/7637 distinction in regression tests.
 
-1. In a repo-only PR, correct only the 7637 proposal after visual review and
-   add a regression that distinguishes it from 6985. Do not make a live write.
-2. After that PR merges, obtain a new explicit approval for live media writes
-   6985, 7637, and 8871.
-3. Under that approval, dry-run and apply each item separately with exact
+1. Obtain a new explicit approval for live media writes 6985, 7637, and 8871.
+2. Under that approval, dry-run and apply each item separately with exact
    ID/upload path, private snapshot, authenticated readback, and cache-bypassed
    public verification.
-4. Re-run the broad path-aware media dry run. Expected final state: 78/78
+3. Re-run the broad path-aware media dry run. Expected final state: 78/78
    `already-applied`, zero refused identities. Recount the 216 routes and update
    issue #4.
-5. Stop on any drift or disagreement. Do not touch page 6815, `/home/`, the 18
+4. Stop on any drift or disagreement. Do not touch page 6815, `/home/`, the 18
    missing attributes, archive batches 4-6, or #829-#832 in this gate.
 
 ## Session 2: resume the ready authority-hub lane


### PR DESCRIPTION
## Summary
- replace stale media-7637 prerequisite text with the merged PR #913 truth
- record the current authenticated dry-run state for media 6985, 7637, and 8871
- remove the obsolete extra-worktree warning from the active runbook

## Verification
- make docs-truth-check
- git diff --check

Refs #4